### PR TITLE
fix(appList): use active filterType from uiState instead of stale _ra…

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -284,8 +284,7 @@ class AppListViewModel(
     fun updateFilter(filter: String) {
         viewModelScope.launch {
             // We need to know current filter type to update properly
-            // We read from _rawState because uiState might be updating asynchronously
-            val currentType = _rawState.value.filterType
+            val currentType = uiState.value.filterType
             preferenceRepository.updateAppFilter(currentType, filter)
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,8 +46,8 @@ org.gradle.welcome=never
 # APPLICATION VERSIONING (REPRODUCIBLE BUILD SETUP)
 # -----------------------------------------------------------------------------
 # Kept as fallback for clean builds
-initialVersionCode=1814
+initialVersionCode=1815
 # REQUIRED: The active source of truth for your release manager
-# Logic: 1813 -> 1.81.3 (based on math: code/1000 . code%1000/10 . code%10)
-versionCode=1814
-versionName=1.81.4
+# Logic: 1815 -> 1.81.5 (based on math: code/1000 . code%1000/10 . code%10)
+versionCode=1815
+versionName=1.81.5


### PR DESCRIPTION
…wState

When updating app list filters, AppListViewModel previously read the current FilterType from _rawState.value. Since _rawState contains raw metadata (e.g. apps lists, loading/privilege flags) and does not update when preferences are modified, its filterType remained stuck at the default (FilterType.Source). As a result, when state filters (like 'Frozen') were selected, they were incorrectly persisted in DataStore as source filters, resulting in query mismatches and showing an empty list.

Reading from uiState.value.filterType ensures the current user-selected filter type is retrieved and stored correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Application version updated to 1.81.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->