### PR TITLE
feat(adaptive): implement adaptive layout & navigation polish

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="corretto-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -239,6 +239,12 @@ dependencies {
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
 
+    // Adaptive Layouts
+    implementation(libs.androidx.adaptive)
+    implementation(libs.androidx.adaptive.layout)
+    implementation(libs.androidx.adaptive.navigation)
+    implementation(libs.androidx.adaptive.navigation3)
+
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
@@ -55,6 +56,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
+import android.content.res.Configuration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -63,6 +66,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.window.core.layout.WindowSizeClass
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import coil3.compose.AsyncImage
 import com.valhalla.thor.BuildConfig
@@ -79,7 +85,7 @@ import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class, ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun AppInfoDetailsScreen(
     packageName: String,
@@ -88,7 +94,9 @@ fun AppInfoDetailsScreen(
     onBack: () -> Unit,
     onNavigateToPermissionManager: (packageName: String, appName: String) -> Unit,
     onAppAction: (AppClickAction) -> Unit = {},
-    viewModel: AppInfoDetailsViewModel = org.koin.androidx.compose.koinViewModel()
+    viewModel: AppInfoDetailsViewModel = org.koin.androidx.compose.koinViewModel(),
+    showOnlyHeaderAndActions: Boolean = false,
+    showOnlyTabs: Boolean = false
 ) {
     val state by viewModel.uiState.collectAsState()
     val context = LocalContext.current
@@ -108,29 +116,41 @@ fun AppInfoDetailsScreen(
     var showUninstallConfirmation by remember { mutableStateOf(false) }
     var showFreezeConfirmation by remember { mutableStateOf(false) }
 
+    val adaptiveInfo = currentWindowAdaptiveInfoV2()
+    val isWideScreen = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+    val configuration = LocalConfiguration.current
+    val isLandscapePhone = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE &&
+            configuration.smallestScreenWidthDp < 600
+    val showTopBar = !showOnlyTabs
+
     Scaffold(
         topBar = {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                IconButton(onClick = onBack) {
-                    Icon(
-                        painter = painterResource(R.drawable.round_close),
-                        contentDescription = stringResource(R.string.cd_close),
-                        tint = MaterialTheme.colorScheme.onSurface
+            if (showTopBar) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.background)
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val showCloseButton = !isWideScreen || (showOnlyHeaderAndActions && isLandscapePhone)
+                    if (showCloseButton) {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                painter = painterResource(R.drawable.round_close),
+                                contentDescription = stringResource(R.string.cd_close),
+                                tint = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(16.dp))
+                    }
+                    Text(
+                        text = stringResource(R.string.app_details_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Black,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
                 }
-                Spacer(modifier = Modifier.width(16.dp))
-                Text(
-                    text = stringResource(R.string.app_details_title),
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Black,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
             }
         },
         contentWindowInsets = WindowInsets(0, 0, 0, 0)
@@ -188,111 +208,126 @@ fun AppInfoDetailsScreen(
                     val pagerState = rememberPagerState(pageCount = { tabTitles.size })
 
                     val animatedVisibilityScope = LocalNavAnimatedContentScope.current
-                    Column(modifier = Modifier.fillMaxSize()) {
-                        // 1. Header (Icon + Name + Chips)
-                        AppDetailsHeader(
-                            appInfo = appInfo,
-                            sharedTransitionScope = sharedTransitionScope,
-                            animatedVisibilityScope = animatedVisibilityScope
-                        )
+                    val leftPaneScrollState = rememberScrollState()
 
-                        // 2. Action buttons
-                        AppDetailsActionRow(
-                            appInfo = appInfo,
-                            isRoot = state.isRoot,
-                            isShizuku = state.isShizuku,
-                            isDhizuku = state.isDhizuku,
-                            isInFreezer = state.isInFreezer,
-                            onLaunch = {
-                                val intent =
-                                    context.packageManager.getLaunchIntentForPackage(packageName)
-                                if (intent != null) context.startActivity(intent)
-                                else Toast.makeText(
-                                    context,
-                                    context.getString(R.string.cannot_launch_app),
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            },
-                            onSystemSettings = {
-                                val intent =
-                                    android.content.Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                                        .apply {
-                                            data = android.net.Uri.parse("package:$packageName")
-                                        }
-                                context.startActivity(intent)
-                            },
-                            onFreezeToggle = { freeze ->
-                                if (freeze && appInfo.isSystem) {
-                                    showFreezeConfirmation = true
-                                } else {
-                                    viewModel.toggleFreezerState(packageName, appInfo.appName, freeze)
-                                }
-                            },
-                            onSuspendToggle = {
-                                viewModel.toggleSuspendState(packageName, it)
-                            },
-                            onForceStop = {
-                                viewModel.forceStopApp(packageName)
-                            },
-                            onManagePermissions = {
-                                onNavigateToPermissionManager(packageName, appInfo.appName ?: "")
-                            },
-                            onToggleFreezerMembership = {
-                                viewModel.addOrRemoveFromFreezer(packageName)
-                            },
-                            onClearCache = {
-                                viewModel.clearCache(packageName)
-                            },
-                            onClearData = {
-                                showClearDataConfirmation = true
-                            },
-                            onUninstall = {
-                                showUninstallConfirmation = true
-                            },
-                            onShare = {
-                                onAppAction(AppClickAction.Share(appInfo))
-                            }
-                        )
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .then(
+                                if (showOnlyHeaderAndActions) Modifier.verticalScroll(leftPaneScrollState)
+                                else Modifier
+                            )
+                    ) {
+                        if (!showOnlyTabs) {
+                            // 1. Header (Icon + Name + Chips)
+                            AppDetailsHeader(
+                                appInfo = appInfo,
+                                sharedTransitionScope = sharedTransitionScope,
+                                animatedVisibilityScope = animatedVisibilityScope
+                            )
 
-                        Spacer(modifier = Modifier.height(8.dp))
-
-                        // 3. SecondaryScrollableTabRow
-                        SecondaryScrollableTabRow(
-                            selectedTabIndex = pagerState.currentPage,
-                            containerColor = MaterialTheme.colorScheme.background,
-                            contentColor = MaterialTheme.colorScheme.onSurface,
-                            edgePadding = 16.dp
-                        ) {
-                            tabTitles.forEachIndexed { index, title ->
-                                Tab(
-                                    selected = pagerState.currentPage == index,
-                                    onClick = {
-                                        coroutineScope.launch {
-                                            pagerState.animateScrollToPage(index)
-                                        }
-                                    },
-                                    text = {
-                                        Text(
-                                            text = title,
-                                            fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Medium,
-                                            style = MaterialTheme.typography.titleSmall
-                                        )
+                            // 2. Action buttons
+                            AppDetailsActionRow(
+                                appInfo = appInfo,
+                                isRoot = state.isRoot,
+                                isShizuku = state.isShizuku,
+                                isDhizuku = state.isDhizuku,
+                                isInFreezer = state.isInFreezer,
+                                onLaunch = {
+                                    val intent =
+                                        context.packageManager.getLaunchIntentForPackage(packageName)
+                                    if (intent != null) context.startActivity(intent)
+                                    else Toast.makeText(
+                                        context,
+                                        context.getString(R.string.cannot_launch_app),
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                },
+                                onSystemSettings = {
+                                    val intent =
+                                        android.content.Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                                            .apply {
+                                                data = android.net.Uri.parse("package:$packageName")
+                                            }
+                                    context.startActivity(intent)
+                                },
+                                onFreezeToggle = { freeze ->
+                                    if (freeze && appInfo.isSystem) {
+                                        showFreezeConfirmation = true
+                                    } else {
+                                        viewModel.toggleFreezerState(packageName, appInfo.appName, freeze)
                                     }
-                                )
-                            }
+                                },
+                                onSuspendToggle = {
+                                    viewModel.toggleSuspendState(packageName, it)
+                                },
+                                onForceStop = {
+                                    viewModel.forceStopApp(packageName)
+                                },
+                                onManagePermissions = {
+                                    onNavigateToPermissionManager(packageName, appInfo.appName ?: "")
+                                },
+                                onToggleFreezerMembership = {
+                                    viewModel.addOrRemoveFromFreezer(packageName)
+                                },
+                                onClearCache = {
+                                    viewModel.clearCache(packageName)
+                                },
+                                onClearData = {
+                                    showClearDataConfirmation = true
+                                },
+                                onUninstall = {
+                                    showUninstallConfirmation = true
+                                },
+                                onShare = {
+                                    onAppAction(AppClickAction.Share(appInfo))
+                                }
+                            )
                         }
 
-                        HorizontalPager(
-                            state = pagerState,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .weight(1f)
-                        ) { page ->
-                            when (page) {
-                                0 -> GeneralTabScreen(details = details)
-                                1 -> PermissionsTabScreen(permissions = details.permissions)
-                                2 -> ComponentsTabScreen(details = details)
-                                3 -> LibsAndFeaturesTabScreen(details = details)
+                        if (!showOnlyHeaderAndActions) {
+                            if (!showOnlyTabs) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                            }
+
+                            // 3. SecondaryScrollableTabRow
+                            SecondaryScrollableTabRow(
+                                selectedTabIndex = pagerState.currentPage,
+                                containerColor = MaterialTheme.colorScheme.background,
+                                contentColor = MaterialTheme.colorScheme.onSurface,
+                                edgePadding = 16.dp
+                            ) {
+                                tabTitles.forEachIndexed { index, title ->
+                                    Tab(
+                                        selected = pagerState.currentPage == index,
+                                        onClick = {
+                                            coroutineScope.launch {
+                                                pagerState.animateScrollToPage(index)
+                                            }
+                                        },
+                                        text = {
+                                            Text(
+                                                text = title,
+                                                fontWeight = if (pagerState.currentPage == index) FontWeight.Bold else FontWeight.Medium,
+                                                style = MaterialTheme.typography.titleSmall
+                                            )
+                                        }
+                                    )
+                                }
+                            }
+
+                            HorizontalPager(
+                                state = pagerState,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .weight(1f)
+                            ) { page ->
+                                when (page) {
+                                    0 -> GeneralTabScreen(details = details)
+                                    1 -> PermissionsTabScreen(permissions = details.permissions)
+                                    2 -> ComponentsTabScreen(details = details)
+                                    3 -> LibsAndFeaturesTabScreen(details = details)
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -93,7 +93,11 @@ fun FreezerScreen(
     var hasCheckedAutoPrompt by rememberSaveable { mutableStateOf(false) }
 
     val disabledAppsNotInFreezer = remember(state.allInstalledApps, state.freezerPackageNames) {
-        state.allInstalledApps.filter { !it.enabled && it.packageName !in state.freezerPackageNames }
+        state.allInstalledApps.filter { 
+            !it.enabled && 
+            it.packageName !in state.freezerPackageNames &&
+            !it.isSystem
+        }
     }
 
     LaunchedEffect(state.isLoading, state.hasShownDisabledAppsPrompt, disabledAppsNotInFreezer) {

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.window.core.layout.WindowSizeClass
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.PrivilegeMode
@@ -52,6 +55,7 @@ import com.valhalla.thor.presentation.installer.InstallerViewModel
 import com.valhalla.thor.presentation.installer.PortableInstaller
 import org.koin.androidx.compose.koinViewModel
 
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun HomeScreen(
     onNavigateToApps: () -> Unit,
@@ -78,6 +82,9 @@ fun HomeScreen(
         }
     }
 
+    val adaptiveInfo = currentWindowAdaptiveInfoV2()
+    val isWideScreen = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -85,7 +92,7 @@ fun HomeScreen(
             .verticalScroll(rememberScrollState())
             .padding(bottom = 100.dp) // Nav bar space
     ) {
-        // 1. Header
+        // 1. Header (full width always)
         DashboardHeader(
             isRoot = state.isRootAvailable,
             isShizuku = state.isShizukuAvailable,
@@ -99,108 +106,215 @@ fun HomeScreen(
 
         Spacer(Modifier.height(8.dp))
 
-        // 2. Summary Cards
-        SummaryStatRow(
-            activeCount = state.activeAppCount,
-            frozenCount = state.frozenAppCount,
-            suspendedCount = state.suspendedAppCount,
-            onActiveClick = onNavigateToApps,
-            onFrozenClick = onNavigateToFreezer,
-            onSuspendedClick = onNavigateToFreezer // For now just go to freezer
-        )
-
-        Spacer(Modifier.height(12.dp))
-
-        // --- ACTIONS ---
-
-        // B. Reinstall All (Warning style card)
-        AnimatedVisibility(state.activePrivilegeMode != null && state.unknownInstallerCount > 0 && state.showReinstallCard) {
-            Column {
-                ActionCard(
-                    title = stringResource(R.string.reinstall_all),
-                    subtitle = stringResource(
-                        R.string.reinstall_all_subtitle,
-                        state.unknownInstallerCount,
-                        state.selectedType.name.lowercase()
-                    ),
-                    icon = R.drawable.apk_install,
-                    isWarning = true,
-                    onClick = onReinstallAll,
-                    onClose = { viewModel.dismissReinstallCard() }
-                )
-                Spacer(Modifier.height(12.dp))
-            }
-
-        }
-
-        // C. Portable Installer (Primary style card)
-        ActionCard(
-            title = stringResource(R.string.install_from_file),
-            subtitle = stringResource(R.string.install_from_file_subtitle),
-            icon = R.drawable.apk_install,
-            isPrimary = true,
-            onClick = {
-                filePickerLauncher.launch(arrayOf("*/*"))
-            }
-        )
-
-        AnimatedVisibility(state.activePrivilegeMode == PrivilegeMode.ROOT) {
-            Column {
-                Spacer(Modifier.height(12.dp))
-                ActionCard(
-                    title = stringResource(R.string.clear_all_cache),
-                    subtitle = stringResource(R.string.clear_all_cache_subtitle),
-                    icon = R.drawable.clear_all,
-                    onClick = { showCacheDialog = true }
-                )
-            }
-        }
-
-        Spacer(Modifier.height(24.dp))
-
-        // 3. Distribution Chart
-        AnimatedVisibility(state.distributionData.isNotEmpty() && !state.isLoading) {
-            Column(
+        if (isWideScreen) {
+            Row(
                 modifier = Modifier
-                    .padding(horizontal = 24.dp)
-                    .clip(RoundedCornerShape(48.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                    .padding(24.dp)
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                horizontalArrangement = Arrangement.spacedBy(24.dp)
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.Bottom
-                ) {
-                    Text(
-                        text = stringResource(R.string.app_distribution),
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
+                // Left Column: Stats & Actions
+                Column(modifier = Modifier.weight(1.2f)) {
+                    SummaryStatRow(
+                        activeCount = state.activeAppCount,
+                        frozenCount = state.frozenAppCount,
+                        suspendedCount = state.suspendedAppCount,
+                        onActiveClick = onNavigateToApps,
+                        onFrozenClick = onNavigateToFreezer,
+                        onSuspendedClick = onNavigateToFreezer,
+                        modifier = Modifier.padding(horizontal = 0.dp)
                     )
-                    Text(
-                        text = stringResource(
-                            R.string.total_apps,
-                            state.activeAppCount + state.frozenAppCount
+
+                    Spacer(Modifier.height(16.dp))
+
+                    AnimatedVisibility(state.activePrivilegeMode != null && state.unknownInstallerCount > 0 && state.showReinstallCard) {
+                        Column {
+                            ActionCard(
+                                title = stringResource(R.string.reinstall_all),
+                                subtitle = stringResource(
+                                    R.string.reinstall_all_subtitle,
+                                    state.unknownInstallerCount,
+                                    state.selectedType.name.lowercase()
+                                ),
+                                icon = R.drawable.apk_install,
+                                isWarning = true,
+                                onClick = onReinstallAll,
+                                onClose = { viewModel.dismissReinstallCard() }
+                            )
+                            Spacer(Modifier.height(12.dp))
+                        }
+                    }
+
+                    ActionCard(
+                        title = stringResource(R.string.install_from_file),
+                        subtitle = stringResource(R.string.install_from_file_subtitle),
+                        icon = R.drawable.apk_install,
+                        isPrimary = true,
+                        onClick = {
+                            filePickerLauncher.launch(arrayOf("*/*"))
+                        }
+                    )
+
+                    AnimatedVisibility(state.activePrivilegeMode == PrivilegeMode.ROOT) {
+                        Column {
+                            Spacer(Modifier.height(12.dp))
+                            ActionCard(
+                                title = stringResource(R.string.clear_all_cache),
+                                subtitle = stringResource(R.string.clear_all_cache_subtitle),
+                                icon = R.drawable.clear_all,
+                                onClick = { showCacheDialog = true }
+                            )
+                        }
+                    }
+                }
+
+                // Right Column: Distribution & Support
+                Column(modifier = Modifier.weight(1f)) {
+                    AnimatedVisibility(state.distributionData.isNotEmpty() && !state.isLoading) {
+                        Column(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(48.dp))
+                                .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                                .padding(24.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.Bottom
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.app_distribution),
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                Text(
+                                    text = stringResource(
+                                        R.string.total_apps,
+                                        state.activeAppCount + state.frozenAppCount
+                                    ),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1
+                                )
+                            }
+                            Spacer(Modifier.height(24.dp))
+                            AppDistributionChart(
+                                data = state.distributionData,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(16.dp))
+                    SupportCommunitySection(onSupportClick = { showSupportSheet = true })
+                }
+            }
+        } else {
+            // 2. Summary Cards
+            SummaryStatRow(
+                activeCount = state.activeAppCount,
+                frozenCount = state.frozenAppCount,
+                suspendedCount = state.suspendedAppCount,
+                onActiveClick = onNavigateToApps,
+                onFrozenClick = onNavigateToFreezer,
+                onSuspendedClick = onNavigateToFreezer
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // --- ACTIONS ---
+            AnimatedVisibility(state.activePrivilegeMode != null && state.unknownInstallerCount > 0 && state.showReinstallCard) {
+                Column {
+                    ActionCard(
+                        title = stringResource(R.string.reinstall_all),
+                        subtitle = stringResource(
+                            R.string.reinstall_all_subtitle,
+                            state.unknownInstallerCount,
+                            state.selectedType.name.lowercase()
                         ),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1
+                        icon = R.drawable.apk_install,
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                        isWarning = true,
+                        onClick = onReinstallAll,
+                        onClose = { viewModel.dismissReinstallCard() }
+                    )
+                    Spacer(Modifier.height(12.dp))
+                }
+            }
+
+            ActionCard(
+                title = stringResource(R.string.install_from_file),
+                subtitle = stringResource(R.string.install_from_file_subtitle),
+                icon = R.drawable.apk_install,
+                modifier = Modifier.padding(horizontal = 24.dp),
+                isPrimary = true,
+                onClick = {
+                    filePickerLauncher.launch(arrayOf("*/*"))
+                }
+            )
+
+            AnimatedVisibility(state.activePrivilegeMode == PrivilegeMode.ROOT) {
+                Column {
+                    Spacer(Modifier.height(12.dp))
+                    ActionCard(
+                        title = stringResource(R.string.clear_all_cache),
+                        subtitle = stringResource(R.string.clear_all_cache_subtitle),
+                        icon = R.drawable.clear_all,
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                        onClick = { showCacheDialog = true }
                     )
                 }
-                Spacer(Modifier.height(24.dp))
-                AppDistributionChart(
-                    data = state.distributionData,
-                    modifier = Modifier.fillMaxWidth()
-                )
             }
-        }
 
-        // 4. Social Links
-        Spacer(Modifier.height(8.dp))
-        SupportCommunitySection(onSupportClick = { showSupportSheet = true })
+            Spacer(Modifier.height(24.dp))
+
+            // 3. Distribution Chart
+            AnimatedVisibility(state.distributionData.isNotEmpty() && !state.isLoading) {
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = 24.dp)
+                        .clip(RoundedCornerShape(48.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                        .padding(24.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.Bottom
+                    ) {
+                        Text(
+                            text = stringResource(R.string.app_distribution),
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.total_apps,
+                                state.activeAppCount + state.frozenAppCount
+                            ),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1
+                        )
+                    }
+                    Spacer(Modifier.height(24.dp))
+                    AppDistributionChart(
+                        data = state.distributionData,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+
+            // 4. Social Links
+            Spacer(Modifier.height(8.dp))
+            SupportCommunitySection(onSupportClick = { showSupportSheet = true })
+        }
         Spacer(Modifier.height(32.dp))
     }
 
@@ -289,6 +403,7 @@ private fun ActionCard(
     title: String,
     subtitle: String,
     icon: Int,
+    modifier: Modifier = Modifier,
     isPrimary: Boolean = false,
     isWarning: Boolean = false,
     onClick: () -> Unit,
@@ -307,9 +422,8 @@ private fun ActionCard(
     }
 
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp)
             .clip(RoundedCornerShape(32.dp))
             .background(containerColor)
             .then(

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/SummaryStatRow.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/SummaryStatRow.kt
@@ -27,12 +27,11 @@ fun SummaryStatRow(
     suspendedCount: Int,
     onActiveClick: () -> Unit,
     onFrozenClick: () -> Unit,
-    onSuspendedClick: () -> Unit
+    onSuspendedClick: () -> Unit,
+    modifier: Modifier = Modifier.padding(horizontal = 24.dp)
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 24.dp),
+        modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         StatCard(

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -18,6 +18,15 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.snap
 import com.valhalla.thor.domain.model.AnimationIntensity
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.ui.res.painterResource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -27,16 +36,26 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import android.content.res.Configuration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.net.toUri
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfoV2
+import androidx.window.core.layout.WindowSizeClass
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
+import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import com.valhalla.thor.R
@@ -62,6 +81,7 @@ import com.valhalla.thor.presentation.widgets.ThankYouDialog
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun MainScreen(
     mainViewModel: MainViewModel = koinViewModel(),
@@ -79,40 +99,65 @@ fun MainScreen(
     var pendingSingleAction by remember { mutableStateOf<AppClickAction?>(null) }
     var showExitConfirmation by remember { mutableStateOf(false) }
 
-    // --- Navigation 3 Setup ---
-    val backStack = rememberNavBackStack(ThorRoute.Home)
+    // --- Navigation 3 Setup (Multiple Backstacks) ---
+    var activeDestination by rememberSaveable { mutableStateOf(AppDestinations.HOME) }
 
-    val activeTab = when (val root = backStack.firstOrNull()) {
-        is ThorRoute.Home -> ThorRoute.Home
-        is ThorRoute.Apps -> ThorRoute.Apps
-        is ThorRoute.Freezer -> ThorRoute.Freezer
-        is ThorRoute.Settings -> ThorRoute.Settings
-        else -> ThorRoute.Home
+    val activeTab = when (activeDestination) {
+        AppDestinations.HOME -> ThorRoute.Home
+        AppDestinations.APPS -> ThorRoute.Apps
+        AppDestinations.FREEZER -> ThorRoute.Freezer
+        AppDestinations.SETTINGS -> ThorRoute.Settings
     }
 
-    val selectedDestination = when (activeTab) {
-        ThorRoute.Home -> AppDestinations.HOME
-        ThorRoute.Apps -> AppDestinations.APPS
-        ThorRoute.Freezer -> AppDestinations.FREEZER
-        ThorRoute.Settings -> AppDestinations.SETTINGS
-        else -> AppDestinations.HOME
+    val homeBackStack = rememberNavBackStack(ThorRoute.Home)
+    val appsBackStack = rememberNavBackStack(ThorRoute.Apps)
+    val freezerBackStack = rememberNavBackStack(ThorRoute.Freezer)
+    val settingsBackStack = rememberNavBackStack(ThorRoute.Settings)
+
+    val backStacks = remember {
+        mapOf(
+            ThorRoute.Home to homeBackStack,
+            ThorRoute.Apps to appsBackStack,
+            ThorRoute.Freezer to freezerBackStack,
+            ThorRoute.Settings to settingsBackStack
+        )
     }
 
-    val showBottomBar = backStack.lastOrNull()?.let {
+    val currentBackStack = backStacks[activeTab] ?: homeBackStack
+
+    val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>()
+
+    val adaptiveInfo = currentWindowAdaptiveInfoV2()
+    val isWideScreen = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+    val showNavRailLabel = adaptiveInfo.windowSizeClass.isHeightAtLeastBreakpoint(600)
+    
+    val configuration = LocalConfiguration.current
+    val isLandscapePhone = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE &&
+            configuration.smallestScreenWidthDp < 600
+
+    val selectedDestination = activeDestination
+
+    val showBottomBar = currentBackStack.lastOrNull()?.let {
         it == ThorRoute.Home || it == ThorRoute.Apps || it == ThorRoute.Freezer || it == ThorRoute.Settings
     } ?: true
 
-    // Handle Back Press to Show Exit Confirmation when at the root of Home stack
-    val isAtRoot = backStack.size == 1 && activeTab == ThorRoute.Home
-    BackHandler(enabled = isAtRoot) {
-        showExitConfirmation = true
+    // System Back Press Handler: 
+    // 1. Pop from the active stack if there are sub-screens (size > 1)
+    val canGoBackInActiveTab = (backStacks[activeTab]?.size ?: 0) > 1
+    BackHandler(enabled = canGoBackInActiveTab) {
+        backStacks[activeTab]?.removeLastOrNull()
     }
 
-    // Handle Back Press to return to Home stack when at the root of another tab
-    val isNonStartRoot = backStack.size == 1 && activeTab != ThorRoute.Home
+    // 2. Switch to Home tab if at the root of a non-Home tab
+    val isNonStartRoot = activeDestination != AppDestinations.HOME && (backStacks[activeTab]?.size ?: 0) == 1
     BackHandler(enabled = isNonStartRoot) {
-        backStack.clear()
-        backStack.add(ThorRoute.Home)
+        activeDestination = AppDestinations.HOME
+    }
+
+    // 3. Show exit confirmation dialog if at the root of the Home tab
+    val isAtRoot = activeDestination == AppDestinations.HOME && (backStacks[ThorRoute.Home]?.size ?: 0) == 1
+    BackHandler(enabled = isAtRoot) {
+        showExitConfirmation = true
     }
 
     val canNotLaunchApp = stringResource(R.string.cannot_launch_app)
@@ -171,14 +216,14 @@ fun MainScreen(
         }
     }
 
-    Scaffold(
-        bottomBar = {
+    Row(modifier = Modifier.fillMaxSize()) {
+        if (isWideScreen) {
             AnimatedVisibility(
                 visible = showBottomBar,
-                enter = slideInVertically(initialOffsetY = { it }),
-                exit = slideOutVertically(targetOffsetY = { it })
+                enter = slideInHorizontally(initialOffsetX = { -it }),
+                exit = slideOutHorizontally(targetOffsetX = { -it })
             ) {
-                ThorNavigationBar(
+                ThorNavigationRail(
                     destinations = AppDestinations.entries,
                     selectedDestination = selectedDestination,
                     onDestinationSelected = { dest ->
@@ -188,13 +233,53 @@ fun MainScreen(
                             AppDestinations.FREEZER -> ThorRoute.Freezer
                             AppDestinations.SETTINGS -> ThorRoute.Settings
                         }
-                        backStack.clear()
-                        backStack.add(route)
-                    }
+                        if (activeDestination == dest) {
+                            val stack = backStacks[route]
+                            while ((stack?.size ?: 0) > 1) {
+                                stack?.removeLastOrNull()
+                            }
+                        } else {
+                            activeDestination = dest
+                        }
+                    },
+                    showLabel = showNavRailLabel
                 )
             }
         }
-    ) { innerPadding ->
+
+        Scaffold(
+            modifier = Modifier.weight(1f),
+            bottomBar = {
+                if (!isWideScreen) {
+                    AnimatedVisibility(
+                        visible = showBottomBar,
+                        enter = slideInVertically(initialOffsetY = { it }),
+                        exit = slideOutVertically(targetOffsetY = { it })
+                    ) {
+                        ThorNavigationBar(
+                            destinations = AppDestinations.entries,
+                            selectedDestination = selectedDestination,
+                            onDestinationSelected = { dest ->
+                                val route = when (dest) {
+                                    AppDestinations.HOME -> ThorRoute.Home
+                                    AppDestinations.APPS -> ThorRoute.Apps
+                                    AppDestinations.FREEZER -> ThorRoute.Freezer
+                                    AppDestinations.SETTINGS -> ThorRoute.Settings
+                                }
+                                if (activeDestination == dest) {
+                                    val stack = backStacks[route]
+                                    while ((stack?.size ?: 0) > 1) {
+                                        stack?.removeLastOrNull()
+                                    }
+                                } else {
+                                    activeDestination = dest
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        ) { innerPadding ->
         val spatialSpec = when (state.prefs.animationIntensity) {
             AnimationIntensity.LOW -> snap<IntOffset>()
             AnimationIntensity.MEDIUM,
@@ -214,12 +299,10 @@ fun MainScreen(
                     HomeScreen(
                         viewModel = homeViewModel,
                         onNavigateToApps = {
-                            backStack.clear()
-                            backStack.add(ThorRoute.Apps)
+                            activeDestination = AppDestinations.APPS
                         },
                         onNavigateToFreezer = {
-                            backStack.clear()
-                            backStack.add(ThorRoute.Freezer)
+                            activeDestination = AppDestinations.FREEZER
                         },
                         onReinstallAll = {
                             checkAndProcessAction(
@@ -232,95 +315,193 @@ fun MainScreen(
                     )
                 }
 
-                entry<ThorRoute.Apps> {
-                    AppListScreen(
-                        viewModel = appListViewModel,
-                        sharedTransitionScope = sharedScope,
-                        onNavigateToAppInfo = { pkg, name ->
-                            backStack.add(ThorRoute.AppInfoDetails(pkg, name))
-                        },
-                        onAppAction = { action ->
-                            if (action is AppClickAction.ManagePermissions) {
-                                backStack.add(
-                                    ThorRoute.PermissionManager(
-                                        action.appInfo.packageName,
-                                        action.appInfo.appName ?: ""
-                                    )
-                                )
-                            } else if (action is AppClickAction.OpenDetails) {
-                                backStack.add(
-                                    ThorRoute.AppInfoDetails(
-                                        action.appInfo.packageName,
-                                        action.appInfo.appName ?: ""
-                                    )
-                                )
-                            } else {
+                entry<ThorRoute.Apps>(
+                    metadata = ListDetailSceneStrategy.listPane(detailPlaceholder = { AppDetailPlaceholder() })
+                ) {
+                    val activeDetailRoute = appsBackStack.lastOrNull() as? ThorRoute.AppInfoDetails
+                    if (isLandscapePhone && activeDetailRoute != null) {
+                        AppInfoDetailsScreen(
+                            packageName = activeDetailRoute.packageName,
+                            appName = activeDetailRoute.appName,
+                            sharedTransitionScope = sharedScope,
+                            onBack = { appsBackStack.removeLastOrNull() },
+                            onNavigateToPermissionManager = { pkg, name ->
+                                appsBackStack.add(ThorRoute.PermissionManager(pkg, name))
+                            },
+                            onAppAction = { action ->
                                 checkAndProcessAction(action, { pendingSingleAction = it }) {
                                     mainViewModel.onAppAction(it)
                                 }
-                            }
-                        },
-                        onMultiAppAction = { pendingMultiAction = it }
-                    )
+                            },
+                            showOnlyHeaderAndActions = true
+                        )
+                    } else {
+                        AppListScreen(
+                            viewModel = appListViewModel,
+                            sharedTransitionScope = sharedScope,
+                            onNavigateToAppInfo = { pkg, name ->
+                                appsBackStack.add(ThorRoute.AppInfoDetails(pkg, name))
+                            },
+                            onAppAction = { action ->
+                                if (action is AppClickAction.ManagePermissions) {
+                                    appsBackStack.add(
+                                        ThorRoute.PermissionManager(
+                                            action.appInfo.packageName,
+                                            action.appInfo.appName ?: ""
+                                        )
+                                    )
+                                } else if (action is AppClickAction.OpenDetails) {
+                                    appsBackStack.add(
+                                        ThorRoute.AppInfoDetails(
+                                            action.appInfo.packageName,
+                                            action.appInfo.appName ?: ""
+                                        )
+                                    )
+                                } else {
+                                    checkAndProcessAction(action, { pendingSingleAction = it }) {
+                                        mainViewModel.onAppAction(it)
+                                    }
+                                }
+                            },
+                            onMultiAppAction = { pendingMultiAction = it }
+                        )
+                    }
                 }
 
-                entry<ThorRoute.Freezer> {
-                    FreezerScreen(
-                        viewModel = freezerViewModel,
-                        sharedTransitionScope = sharedScope,
-                        onAppAction = { action ->
-                            if (action is AppClickAction.ManagePermissions) {
-                                backStack.add(
-                                    ThorRoute.PermissionManager(
-                                        action.appInfo.packageName,
-                                        action.appInfo.appName ?: ""
-                                    )
-                                )
-                            } else if (action is AppClickAction.OpenDetails) {
-                                backStack.add(
-                                    ThorRoute.AppInfoDetails(
-                                        action.appInfo.packageName,
-                                        action.appInfo.appName ?: ""
-                                    )
-                                )
-                            } else {
+                entry<ThorRoute.Freezer>(
+                    metadata = ListDetailSceneStrategy.listPane(detailPlaceholder = { AppDetailPlaceholder() })
+                ) {
+                    val activeDetailRoute = freezerBackStack.lastOrNull() as? ThorRoute.AppInfoDetails
+                    if (isLandscapePhone && activeDetailRoute != null) {
+                        AppInfoDetailsScreen(
+                            packageName = activeDetailRoute.packageName,
+                            appName = activeDetailRoute.appName,
+                            sharedTransitionScope = sharedScope,
+                            onBack = { freezerBackStack.removeLastOrNull() },
+                            onNavigateToPermissionManager = { pkg, name ->
+                                freezerBackStack.add(ThorRoute.PermissionManager(pkg, name))
+                            },
+                            onAppAction = { action ->
                                 checkAndProcessAction(action, { pendingSingleAction = it }) {
                                     mainViewModel.onAppAction(it)
                                 }
-                            }
-                        },
-                        onMultiAppAction = { pendingMultiAction = it }
-                    )
+                            },
+                            showOnlyHeaderAndActions = true
+                        )
+                    } else {
+                        FreezerScreen(
+                            viewModel = freezerViewModel,
+                            sharedTransitionScope = sharedScope,
+                            onAppAction = { action ->
+                                if (action is AppClickAction.ManagePermissions) {
+                                    freezerBackStack.add(
+                                        ThorRoute.PermissionManager(
+                                            action.appInfo.packageName,
+                                            action.appInfo.appName ?: ""
+                                        )
+                                    )
+                                } else if (action is AppClickAction.OpenDetails) {
+                                    freezerBackStack.add(
+                                        ThorRoute.AppInfoDetails(
+                                            action.appInfo.packageName,
+                                            action.appInfo.appName ?: ""
+                                        )
+                                    )
+                                } else {
+                                    checkAndProcessAction(action, { pendingSingleAction = it }) {
+                                        mainViewModel.onAppAction(it)
+                                    }
+                                }
+                            },
+                            onMultiAppAction = { pendingMultiAction = it }
+                        )
+                    }
                 }
 
                 entry<ThorRoute.Settings> {
                     SettingsScreen()
                 }
 
-                entry<ThorRoute.PermissionManager> { route ->
+                entry<ThorRoute.PermissionManager>(
+                    metadata = ListDetailSceneStrategy.detailPane()
+                ) { route ->
                     PermissionManagerScreen(
                         packageName = route.packageName,
                         appName = route.appName,
                         sharedTransitionScope = sharedScope,
-                        onBack = { backStack.removeLastOrNull() }
+                        onBack = { currentBackStack.removeLastOrNull() }
                     )
                 }
 
-                entry<ThorRoute.AppInfoDetails> { route ->
+                entry<ThorRoute.AppInfoDetails>(
+                    metadata = ListDetailSceneStrategy.detailPane()
+                ) { route ->
                     AppInfoDetailsScreen(
                         packageName = route.packageName,
                         appName = route.appName,
                         sharedTransitionScope = sharedScope,
-                        onBack = { backStack.removeLastOrNull() },
+                        onBack = { currentBackStack.removeLastOrNull() },
                         onNavigateToPermissionManager = { pkg, name ->
-                            backStack.add(ThorRoute.PermissionManager(pkg, name))
+                            currentBackStack.add(ThorRoute.PermissionManager(pkg, name))
                         },
                         onAppAction = { action ->
                             checkAndProcessAction(action, { pendingSingleAction = it }) {
                                 mainViewModel.onAppAction(it)
                             }
-                        }
+                        },
+                        showOnlyTabs = isLandscapePhone
                     )
+                }
+            }
+
+            // Decorate entries for each back stack
+            val homeDecorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                rememberViewModelStoreNavEntryDecorator()
+            )
+            val homeEntries = rememberDecoratedNavEntries(
+                backStack = homeBackStack,
+                entryDecorators = homeDecorators,
+                entryProvider = entryProvider
+            )
+
+            val appsDecorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                rememberViewModelStoreNavEntryDecorator()
+            )
+            val appsEntries = rememberDecoratedNavEntries(
+                backStack = appsBackStack,
+                entryDecorators = appsDecorators,
+                entryProvider = entryProvider
+            )
+
+            val freezerDecorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                rememberViewModelStoreNavEntryDecorator()
+            )
+            val freezerEntries = rememberDecoratedNavEntries(
+                backStack = freezerBackStack,
+                entryDecorators = freezerDecorators,
+                entryProvider = entryProvider
+            )
+
+            val settingsDecorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                rememberViewModelStoreNavEntryDecorator()
+            )
+            val settingsEntries = rememberDecoratedNavEntries(
+                backStack = settingsBackStack,
+                entryDecorators = settingsDecorators,
+                entryProvider = entryProvider
+            )
+
+            val entries = remember(activeTab, homeEntries, appsEntries, freezerEntries, settingsEntries) {
+                when (activeTab) {
+                    ThorRoute.Home -> homeEntries
+                    ThorRoute.Apps -> appsEntries
+                    ThorRoute.Freezer -> freezerEntries
+                    ThorRoute.Settings -> settingsEntries
+                    else -> homeEntries
                 }
             }
 
@@ -330,13 +511,9 @@ fun MainScreen(
                     .fillMaxSize()
             ) {
                 NavDisplay(
-                    backStack = backStack,
-                    onBack = { backStack.removeLastOrNull() },
-                    entryDecorators = listOf(
-                        rememberSaveableStateHolderNavEntryDecorator(),
-                        rememberViewModelStoreNavEntryDecorator()
-                    ),
-                    entryProvider = entryProvider,
+                    entries = entries,
+                    onBack = { currentBackStack.removeLastOrNull() },
+                    sceneStrategies = listOf(listDetailStrategy),
                     transitionSpec = {
                         (fadeIn(animationSpec = effectsSpec) + slideInHorizontally(
                             initialOffsetX = { it },
@@ -449,6 +626,7 @@ fun MainScreen(
             }
         }
     }
+    }
 }
 
 private fun checkAndProcessAction(
@@ -461,5 +639,30 @@ private fun checkAndProcessAction(
         AppClickAction.ReinstallAll -> onRequireConfirmation(action)
 
         else -> onExecute(action)
+    }
+}
+
+@Composable
+private fun AppDetailPlaceholder() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.thor_mono),
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.select_app_details),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/main/ThorNavigationRail.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/ThorNavigationRail.kt
@@ -1,23 +1,19 @@
 package com.valhalla.thor.presentation.main
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
-import com.valhalla.thor.presentation.theme.animateExpressiveResize
-import androidx.compose.animation.expandHorizontally
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -36,35 +32,38 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.valhalla.thor.presentation.home.AppDestinations
+import com.valhalla.thor.presentation.theme.animateExpressiveResize
 import com.valhalla.thor.presentation.theme.expressivePress
 
 @Composable
-fun ThorNavigationBar(
+fun ThorNavigationRail(
     destinations: List<AppDestinations>,
     selectedDestination: AppDestinations,
     onDestinationSelected: (AppDestinations) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showLabel: Boolean = true
 ) {
     Surface(
         modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)),
+            .fillMaxHeight()
+            .animateContentSize()
+            .clip(RoundedCornerShape(topEnd = 32.dp, bottomEnd = 32.dp)),
         color = MaterialTheme.colorScheme.surfaceContainer,
     ) {
-        Row(
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .navigationBarsPadding()
-                .padding(horizontal = 12.dp, vertical = 12.dp)
-                .height(64.dp),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalAlignment = Alignment.CenterVertically
+                .fillMaxHeight()
+                .safeDrawingPadding()
+                .padding(vertical = 24.dp, horizontal = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             destinations.forEach { destination ->
-                ThorNavigationBarItem(
+                ThorNavigationRailItem(
                     destination = destination,
                     selected = destination == selectedDestination,
-                    onClick = { onDestinationSelected(destination) }
+                    onClick = { onDestinationSelected(destination) },
+                    showLabel = showLabel
                 )
             }
         }
@@ -72,7 +71,7 @@ fun ThorNavigationBar(
 }
 
 @Composable
-internal fun ThorNavigationBarItem(
+private fun ThorNavigationRailItem(
     destination: AppDestinations,
     selected: Boolean,
     onClick: () -> Unit,
@@ -84,7 +83,6 @@ internal fun ThorNavigationBarItem(
     val containerColorSpec = MaterialTheme.motionScheme.defaultEffectsSpec<Color>()
     val contentColorSpec = MaterialTheme.motionScheme.defaultEffectsSpec<Color>()
     val alphaEffectsSpec = MaterialTheme.motionScheme.fastEffectsSpec<Float>()
-    val spatialSpec = MaterialTheme.motionScheme.fastSpatialSpec<androidx.compose.ui.unit.IntSize>()
 
     val containerColor by animateColorAsState(
         targetValue = if (selected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
@@ -106,7 +104,7 @@ internal fun ThorNavigationBarItem(
 
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(32.dp))
+            .clip(RoundedCornerShape(20.dp))
             .background(containerColor)
             .expressivePress(interactionSource)
             .clickable(
@@ -115,13 +113,13 @@ internal fun ThorNavigationBarItem(
                 onClick = onClick
             )
             .animateExpressiveResize()
-            .padding(horizontal = if (selected) 20.dp else 16.dp, vertical = 10.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp),
         contentAlignment = Alignment.Center
     ) {
-        Row(
+        Column(
             modifier = Modifier.graphicsLayer { alpha = contentAlpha },
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
             Icon(
                 painter = painterResource(if (selected) destination.selectedIcon else destination.icon),
@@ -129,23 +127,13 @@ internal fun ThorNavigationBarItem(
                 tint = contentColor
             )
 
-            AnimatedVisibility(
-                visible = selected && showLabel,
-                enter = fadeIn(animationSpec = alphaEffectsSpec) +
-                        expandHorizontally(
-                            animationSpec = spatialSpec
-                        ),
-                exit = fadeOut(animationSpec = alphaEffectsSpec) +
-                        shrinkHorizontally(
-                            animationSpec = spatialSpec
-                        )
-            ) {
+            if (showLabel) {
+                Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = stringResource(destination.label),
                     color = contentColor,
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(start = 8.dp),
+                    style = if (selected) MaterialTheme.typography.labelMedium else MaterialTheme.typography.labelSmall,
+                    fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
                     maxLines = 1
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="cd_search">Search</string>
     <string name="cd_clear">Clear</string>
     <string name="cd_settings">Settings</string>
+    <string name="select_app_details">Select an app to view details</string>
 
     <!-- Permission Manager -->
     <string name="action_permissions">Permissions</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ koin-plugin = "1.0.1"
 coil3 = "3.5.0"
 navigation3 = "1.1.3"
 play-billing = "9.1.0"
+androidx-adaptive = "1.3.0-rc01"
 
 [libraries]
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
@@ -78,6 +79,12 @@ koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil3" }
 play-billing = { module = "com.android.billingclient:billing", version.ref = "play-billing" }
 play-billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = "play-billing" }
+
+# Adaptive Layouts
+androidx-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidx-adaptive" }
+androidx-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "androidx-adaptive" }
+androidx-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "androidx-adaptive" }
+androidx-adaptive-navigation3 = { module = "androidx.compose.material3.adaptive:adaptive-navigation3", version.ref = "androidx-adaptive" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Add Compose adaptive dependencies to version catalog and app build.
- Implement independent multi-backstack navigation for each top-level tab (Home, Apps, Freezer, Settings) with correct state preservation and custom back press handlers.
- Add vertically oriented custom side navigation rail (ThorNavigationRail) with responsive labels shown below icons (larger/bold for selected, smaller for unselected).
- Hide the bottom navigation bar and navigation rail when navigating to detailed sub-screens.
- Implement a split details layout strictly for landscape phones (details header/actions in the list pane, and details tabs in the details pane).
- Fix action card double-padding on the dashboard screen in landscape/wide-screen viewports.
- Refine the previously disabled apps import logic in Freezer screen to completely skip all system apps.