### PR TITLE
Freezer bug fix

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -45,6 +45,9 @@ class DhizukuSystemGateway(
                 if (reflector.uninstallApp(packageName)) Result.success(Unit)
                 else Result.failure(Exception("Dhizuku: Failed to uninstall system app $packageName"))
             } else {
+                if (reflector.isAppDisabled(packageName) && reflector.isAppInstalled(packageName)) {
+                    reflector.setAppEnabled(packageName, true)
+                }
                 if (reflector.reinstallExistingApp(packageName)) Result.success(Unit)
                 else Result.failure(Exception("Dhizuku: Failed to reinstall system app $packageName"))
             }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -45,7 +45,10 @@ class DhizukuSystemGateway(
                 if (reflector.uninstallApp(packageName)) Result.success(Unit)
                 else Result.failure(Exception("Dhizuku: Failed to uninstall system app $packageName"))
             } else {
-                if (reflector.isAppDisabled(packageName) && reflector.isAppInstalled(packageName)) {
+                val appInfo = reflector.getApplicationInfoOrNull(packageName)
+                val isInstalled = appInfo?.let { (it.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0 } ?: false
+                val isAppDisabled = appInfo?.enabled == false
+                if (isAppDisabled && isInstalled) {
                     reflector.setAppEnabled(packageName, true)
                 }
                 if (reflector.reinstallExistingApp(packageName)) Result.success(Unit)

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -96,10 +96,13 @@ class RootSystemGateway(
             if (isDisabled) {
                 runCommand("pm uninstall --user $currentUser $escapedPackage")
             } else {
-                val currentInstalled = (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0
-                val currentEnabled = appInfo.enabled && currentInstalled
-                if (currentInstalled && !currentEnabled) {
-                    runCommand("pm enable $escapedPackage")
+                @Suppress("SENSELESS_COMPARISON")
+                if (appInfo != null) {
+                    val currentInstalled = (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0
+                    val currentEnabled = appInfo.enabled && currentInstalled
+                    if (currentInstalled && !currentEnabled) {
+                        runCommand("pm enable $escapedPackage")
+                    }
                 }
                 runCommand("pm install-existing --user $currentUser $escapedPackage")
             }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -96,6 +96,11 @@ class RootSystemGateway(
             if (isDisabled) {
                 runCommand("pm uninstall --user $currentUser $escapedPackage")
             } else {
+                val currentInstalled = (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0
+                val currentEnabled = appInfo.enabled && currentInstalled
+                if (currentInstalled && !currentEnabled) {
+                    runCommand("pm enable $escapedPackage")
+                }
                 runCommand("pm install-existing --user $currentUser $escapedPackage")
             }
         } else {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -48,6 +48,9 @@ class ShizukuSystemGateway(
             if (isDisabled) {
                 runAction { reflector.uninstallApp(packageName) }
             } else {
+                if (reflector.isAppDisabled(packageName) && !reflector.isAppUninstalled(packageName)) {
+                    reflector.setAppEnabled(packageName, true)
+                }
                 runAction { reflector.reinstallExistingApp(packageName) }
             }
         } else {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -48,7 +48,10 @@ class ShizukuSystemGateway(
             if (isDisabled) {
                 runAction { reflector.uninstallApp(packageName) }
             } else {
-                if (reflector.isAppDisabled(packageName) && !reflector.isAppUninstalled(packageName)) {
+                val appInfo = reflector.getApplicationInfoOrNull(packageName)
+                val isInstalled = appInfo?.let { (it.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0 } ?: false
+                val isAppDisabled = appInfo?.enabled == false
+                if (isAppDisabled && isInstalled) {
                     reflector.setAppEnabled(packageName, true)
                 }
                 runAction { reflector.reinstallExistingApp(packageName) }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuReflector.kt
@@ -65,7 +65,7 @@ class DhizukuReflector(
         }
     }
 
-    private fun getApplicationInfoOrNull(packageName: String): ApplicationInfo? {
+    fun getApplicationInfoOrNull(packageName: String): ApplicationInfo? {
         return try {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
                 context.packageManager.getApplicationInfo(

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuReflector.kt
@@ -65,9 +65,9 @@ class DhizukuReflector(
         }
     }
 
-    fun isSystemApp(packageName: String): Boolean {
+    private fun getApplicationInfoOrNull(packageName: String): ApplicationInfo? {
         return try {
-            val appInfo = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
                 context.packageManager.getApplicationInfo(
                     packageName,
                     PackageManager.ApplicationInfoFlags.of(PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong())
@@ -78,10 +78,24 @@ class DhizukuReflector(
                     PackageManager.MATCH_UNINSTALLED_PACKAGES
                 )
             }
-            (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0
         } catch (_: Exception) {
-            false
+            null
         }
+    }
+
+    fun isAppDisabled(packageName: String): Boolean {
+        val appInfo = getApplicationInfoOrNull(packageName) ?: return false
+        return !appInfo.enabled
+    }
+
+    fun isAppInstalled(packageName: String): Boolean {
+        val appInfo = getApplicationInfoOrNull(packageName) ?: return false
+        return (appInfo.flags and ApplicationInfo.FLAG_INSTALLED) != 0
+    }
+
+    fun isSystemApp(packageName: String): Boolean {
+        val appInfo = getApplicationInfoOrNull(packageName) ?: return false
+        return (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0
     }
 
     fun setAppSuspended(packageName: String, suspended: Boolean): Boolean {

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,9 +46,9 @@ org.gradle.welcome=never
 # APPLICATION VERSIONING (REPRODUCIBLE BUILD SETUP)
 # -----------------------------------------------------------------------------
 # Kept as fallback for clean builds
-initialVersionCode=1822
+initialVersionCode=1823
 # REQUIRED: The active source of truth for our release manager
 # Logic: 1822 -> 1.82.2 (based on math: code/1000 . code%1000/10 . code%10)
-versionCode=1822
-versionName=1.82.2
+versionCode=1823
+versionName=1.82.3
 

--- a/release-notes/v1.82.3/github.md
+++ b/release-notes/v1.82.3/github.md
@@ -1,0 +1,8 @@
+# Thor v1.82.3 Release Notes
+
+This minor patch release resolves a backward-compatibility regression where system apps frozen/disabled by older versions of Thor could not be unfrozen.
+
+## What's Changed
+
+### 🐛 Bug Fixes & Stability Improvements
+*   **System App Unfreezing Compat**: Fixes an issue where system apps disabled by older versions of Thor remained disabled when using the new unfreeze method (`pm install-existing`). The unfreezing logic now checks if the system app is in a disabled state (installed but not enabled) and enables it first (`pm enable` / `setAppEnabled`) before running the reinstall/unfreeze action. This fix is implemented across all privilege engines (Root, Shizuku, and Dhizuku).

--- a/release-notes/v1.82.3/playstore.txt
+++ b/release-notes/v1.82.3/playstore.txt
@@ -1,0 +1,1 @@
+- Fixed an issue where system apps frozen (disabled) by older versions of the app could not be unfrozen. System apps that are only disabled are now properly enabled first before unfreezing.

--- a/release-notes/v1.82.3/telegram.md
+++ b/release-notes/v1.82.3/telegram.md
@@ -1,0 +1,6 @@
+⚡️ **Thor v1.82.3 is out!**
+
+This minor patch release fixes a compatibility issue with system app unfreezing.
+
+**What's New:**
+• **System App Unfreezing Fix**: Fixes a regression where system apps disabled by older versions of the app could not be unfrozen. System apps that are only disabled are now properly enabled first before executing the restoration/unfreeze action (applied to Root, Shizuku, and Dhizuku).


### PR DESCRIPTION
- Fixed an issue where system apps frozen (disabled) by older versions of the app could not be unfrozen. System apps that are only disabled are now properly enabled first before unfreezing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where some previously disabled system apps (that were only disabled, not removed) could fail to be restored/unfrozen.
  * Improved recovery by enabling disabled-but-installed system apps first, then proceeding with the restore/reinstall flow.
* **Chores**
  * Updated version information for the new release (v1.82.3).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->