### PR TITLE
fix(installer): correct bundle detection — stop misidentifying monolithic APKs & harden .xapk parsing (#207, #159)

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -69,17 +69,24 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
 
             // Phase 2: Monolithic-APK gate (GH#207). A file that carries its own
             // top-level AndroidManifest.xml is a single installable APK — parse the
-            // whole file and never scan inner .apk assets.
+            // whole file and NEVER scan inner .apk assets. If the authoritative
+            // whole-file parse fails, we return failure here rather than falling
+            // through to the base-candidate scan: falling through could extract a
+            // nested assets/*.apk (App Manager style) and return the WRONG package
+            // identity, re-triggering the GH#207 false-downgrade bug on the rare
+            // failed-parse path. (The parse itself needs framework
+            // getPackageArchiveInfo, so this exact branch is covered by compile +
+            // manual path; the "monolithic is never routed to candidate selection"
+            // invariant is unit-tested at the helper level in BundleAnalysisTest.)
             if (isMonolithicApk(entryNames)) {
                 contentResolver.openInputStream(uri)?.use { input ->
                     FileOutputStream(tempFile).use { output -> input.copyTo(output) }
                 }
                 val archiveInfo = parseArchive(tempFile)
-                if (archiveInfo != null) {
-                    return@withContext Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
-                }
-                // Fall through to bundle/base handling only if the whole-file parse
-                // unexpectedly failed.
+                    ?: return@withContext Result.failure(
+                        Exception("Failed to parse APK manifest. The file might be corrupted or encrypted.")
+                    )
+                return@withContext Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
             }
 
             // Phase 3: XAPK manifest path — build metadata from the authoritative

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -1,6 +1,7 @@
 package com.valhalla.thor.data.repository
 
 import android.content.Context
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -14,9 +15,6 @@ import com.valhalla.thor.domain.model.AppMetadata
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Single
 import java.io.File
 import java.io.FileOutputStream
@@ -25,32 +23,17 @@ import java.util.zip.ZipInputStream
 @Single(binds = [AppAnalyzer::class])
 class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
 
-    @Serializable
-    private data class XapkManifest(
-        @SerialName("package_name") val packageName: String,
-        @SerialName("name") val name: String,
-        @SerialName("version_code") val versionCode: String,
-        @SerialName("version_name") val versionName: String,
-        @SerialName("permissions") val permissions: List<String> = emptyList(),
-        @SerialName("icon") val iconFile: String? = null,
-        @SerialName("split_apks") val splitApks: List<XapkSplitApk> = emptyList()
-    )
-
-    @Serializable
-    private data class XapkSplitApk(
-        @SerialName("file") val file: String,
-        @SerialName("id") val id: String
-    )
-
-    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
-
     override suspend fun analyze(uri: Uri): Result<AppMetadata> = withContext(Dispatchers.IO) {
         val tempFile = File(context.cacheDir, "analysis_${System.currentTimeMillis()}.apk")
 
         try {
             val contentResolver = context.contentResolver
 
-            // Phase 1: Single pass — collect manifest.json and icon bytes from XAPK zip
+            // Phase 1: Single pass — collect the zip's entry names plus the XAPK
+            // manifest.json and icon bytes (if any). The entry names let us decide
+            // monolithic-vs-bundle without trusting the mere presence of a .apk
+            // entry (every APK is itself a zip that may embed nested .apk assets).
+            val entryNames = mutableListOf<String>()
             var manifestBytes: ByteArray? = null
             var iconBytes: ByteArray? = null
 
@@ -59,6 +42,7 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
                     ZipInputStream(inputStream).use { zipStream ->
                         var entry = zipStream.nextEntry
                         while (entry != null) {
+                            if (!entry.isDirectory) entryNames += entry.name
                             when {
                                 entry.name.equals("manifest.json", ignoreCase = true) -> {
                                     manifestBytes = zipStream.readBytes()
@@ -74,177 +58,70 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
 
                                 else -> zipStream.closeEntry()
                             }
-                            if (manifestBytes != null && iconBytes != null) break
                             entry = zipStream.nextEntry
                         }
                     }
                 }
             } catch (_: Exception) {
+                // Not a readable zip (or truncated). We'll still try the monolithic
+                // whole-file parse below.
             }
 
-            // Phase 2: If we have manifest.json, build metadata directly from it
-            val manifest = manifestBytes?.let { bytes ->
-                try {
-                    json.decodeFromString<XapkManifest>(String(bytes))
-                } catch (_: Exception) {
-                    null
-                }
-            }
-
-            if (manifest != null) {
-                val baseApkFile = manifest.splitApks.firstOrNull { it.id == "base" }?.file
-                if (baseApkFile != null) {
-                    // Authority check: Extract base APK and parse it to avoid trusting manifest.json
-                    try {
-                        contentResolver.openInputStream(uri)?.use { inputStream ->
-                            ZipInputStream(inputStream).use { zipStream ->
-                                var entry = zipStream.nextEntry
-                                while (entry != null) {
-                                    if (entry.name.equals(baseApkFile, ignoreCase = true)) {
-                                        FileOutputStream(tempFile).use { fos -> zipStream.copyTo(fos) }
-                                        break
-                                    }
-                                    zipStream.closeEntry()
-                                    entry = zipStream.nextEntry
-                                }
-                            }
-                        }
-
-                        if (tempFile.exists()) {
-                            val pm = context.packageManager
-                            val flags =
-                                PackageManager.GET_META_DATA or PackageManager.GET_PERMISSIONS
-                            val archiveInfo =
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                                    pm.getPackageArchiveInfo(
-                                        tempFile.absolutePath,
-                                        PackageManager.PackageInfoFlags.of(flags.toLong())
-                                    )
-                                } else {
-                                    @Suppress("DEPRECATION")
-                                    pm.getPackageArchiveInfo(tempFile.absolutePath, flags)
-                                }
-
-                            if (archiveInfo != null) {
-                                archiveInfo.applicationInfo?.sourceDir = tempFile.absolutePath
-                                archiveInfo.applicationInfo?.publicSourceDir = tempFile.absolutePath
-
-                                val currentIconBytes = iconBytes
-                                val iconBitmap: Bitmap? = when {
-                                    currentIconBytes != null -> BitmapFactory.decodeByteArray(
-                                        currentIconBytes,
-                                        0,
-                                        currentIconBytes.size
-                                    )
-
-                                    else -> archiveInfo.applicationInfo?.loadIcon(pm)?.toBitmap()
-                                }
-
-                                return@withContext Result.success(
-                                    AppMetadata(
-                                        label = archiveInfo.applicationInfo?.loadLabel(pm)
-                                            ?.toString() ?: "Unknown",
-                                        packageName = archiveInfo.packageName,
-                                        version = archiveInfo.versionName ?: "Unknown",
-                                        versionCode = archiveInfo.longVersionCode,
-                                        icon = iconBitmap,
-                                        permissions = archiveInfo.requestedPermissions?.toList()
-                                            ?: emptyList()
-                                    )
-                                )
-                            }
-                        }
-                    } catch (_: Exception) {
-                        // Fall through to Phase 3 if authoritative extraction fails
-                    }
-                }
-            }
-
-            // Phase 3: No XAPK manifest — fall back to APK extraction from zip
-            // First scan: look specifically for base.apk; second scan: first .apk found
-            var isNestedBundle = false
-            try {
-                var foundBase = false
-
-                contentResolver.openInputStream(uri)?.use { inputStream ->
-                    ZipInputStream(inputStream).use { zipStream ->
-                        var entry = zipStream.nextEntry
-                        while (entry != null) {
-                            val name = entry.name
-                            if (name.equals("base.apk", ignoreCase = true) ||
-                                name.endsWith("/base.apk", ignoreCase = true)
-                            ) {
-                                FileOutputStream(tempFile).use { fos -> zipStream.copyTo(fos) }
-                                isNestedBundle = true
-                                foundBase = true
-                                break
-                            }
-                            zipStream.closeEntry()
-                            entry = zipStream.nextEntry
-                        }
-                    }
-                }
-
-                if (!foundBase) {
-                    contentResolver.openInputStream(uri)?.use { inputStream ->
-                        ZipInputStream(inputStream).use { zipStream ->
-                            var entry = zipStream.nextEntry
-                            while (entry != null) {
-                                if (entry.name.endsWith(".apk", ignoreCase = true)) {
-                                    FileOutputStream(tempFile).use { fos -> zipStream.copyTo(fos) }
-                                    isNestedBundle = true
-                                    break
-                                }
-                                zipStream.closeEntry()
-                                entry = zipStream.nextEntry
-                            }
-                        }
-                    }
-                }
-            } catch (_: Exception) {
-                isNestedBundle = false
-            }
-
-            // Phase 4: Treat as monolithic APK if nothing was extracted from a zip
-            if (!isNestedBundle) {
+            // Phase 2: Monolithic-APK gate (GH#207). A file that carries its own
+            // top-level AndroidManifest.xml is a single installable APK — parse the
+            // whole file and never scan inner .apk assets.
+            if (isMonolithicApk(entryNames)) {
                 contentResolver.openInputStream(uri)?.use { input ->
                     FileOutputStream(tempFile).use { output -> input.copyTo(output) }
                 }
+                val archiveInfo = parseArchive(tempFile)
+                if (archiveInfo != null) {
+                    return@withContext Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
+                }
+                // Fall through to bundle/base handling only if the whole-file parse
+                // unexpectedly failed.
             }
 
-            // Phase 5: Parse extracted/monolithic APK
-            val pm = context.packageManager
-            val flags = PackageManager.GET_META_DATA or PackageManager.GET_PERMISSIONS
+            // Phase 3: XAPK manifest path — build metadata from the authoritative
+            // base APK. Tolerant deserialization (GH#159) so numeric version_code /
+            // missing name don't nuke this path.
+            val manifest = manifestBytes?.let { bytes -> parseXapkManifest(String(bytes)) }
 
-            val archiveInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                pm.getPackageArchiveInfo(
-                    tempFile.absolutePath,
-                    PackageManager.PackageInfoFlags.of(flags.toLong())
-                )
-            } else {
-                @Suppress("DEPRECATION")
-                pm.getPackageArchiveInfo(tempFile.absolutePath, flags)
+            val manifestBaseFile = manifest?.baseApkFile()
+            if (manifestBaseFile != null) {
+                val archiveInfo = extractAndParse(uri, manifestBaseFile, tempFile)
+                if (archiveInfo != null) {
+                    return@withContext Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
+                }
+                // else fall through to candidate scan below
             }
 
-            if (archiveInfo == null) {
-                return@withContext Result.failure(
+            // Phase 4: Generic bundle base selection (GH#159). Order candidates so
+            // splits/config APKs are tried last, and pick the first that parses as a
+            // non-split base.
+            val candidates = selectBaseApkCandidates(entryNames, manifest?.packageName)
+            for (candidate in candidates) {
+                val archiveInfo = extractAndParse(uri, candidate, tempFile)
+                if (archiveInfo != null && archiveInfo.applicationInfo != null) {
+                    return@withContext Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
+                }
+            }
+
+            // TODO(#159): richer .apks (bundletool/SAI toc.pb, splits/…) and .apkm
+            // (APKMirror info.json) base-layout detection + OBB extraction — tracked
+            // as a separate follow-up.
+
+            // Phase 5: Last resort — treat the whole file as a monolithic APK even
+            // without a detectable top-level manifest (e.g. an entry-listing failure).
+            contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(tempFile).use { output -> input.copyTo(output) }
+            }
+            val archiveInfo = parseArchive(tempFile)
+                ?: return@withContext Result.failure(
                     Exception("Failed to parse APK manifest. The file might be corrupted or encrypted.")
                 )
-            }
 
-            archiveInfo.applicationInfo?.sourceDir = tempFile.absolutePath
-            archiveInfo.applicationInfo?.publicSourceDir = tempFile.absolutePath
-
-            Result.success(
-                AppMetadata(
-                    label = archiveInfo.applicationInfo?.loadLabel(pm).toString(),
-                    packageName = archiveInfo.packageName,
-                    version = archiveInfo.versionName ?: "Unknown",
-                    versionCode = archiveInfo.longVersionCode,
-                    icon = archiveInfo.applicationInfo?.loadIcon(pm)?.toBitmap(),
-                    permissions = archiveInfo.requestedPermissions?.toList() ?: emptyList()
-                )
-            )
+            Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
         } catch (e: Exception) {
             Result.failure(e)
         } finally {
@@ -252,14 +129,17 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
         }
     }
 
-    private fun extractBaseApkIcon(uri: Uri, baseApkFile: String, tempFile: File): Bitmap? {
+    /** Extract a single zip entry into [tempFile] and parse it via PackageManager. */
+    private fun extractAndParse(uri: Uri, entryName: String, tempFile: File): PackageInfo? {
         return try {
+            var extracted = false
             context.contentResolver.openInputStream(uri)?.use { inputStream ->
                 ZipInputStream(inputStream).use { zipStream ->
                     var entry = zipStream.nextEntry
                     while (entry != null) {
-                        if (entry.name.equals(baseApkFile, ignoreCase = true)) {
+                        if (entry.name.equals(entryName, ignoreCase = true)) {
                             FileOutputStream(tempFile).use { fos -> zipStream.copyTo(fos) }
+                            extracted = true
                             break
                         }
                         zipStream.closeEntry()
@@ -267,28 +147,50 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
                     }
                 }
             }
-
-            if (!tempFile.exists()) return null
-
-            val pm = context.packageManager
-            val archiveInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                pm.getPackageArchiveInfo(
-                    tempFile.absolutePath,
-                    PackageManager.PackageInfoFlags.of(PackageManager.GET_META_DATA.toLong())
-                )
-            } else {
-                @Suppress("DEPRECATION")
-                pm.getPackageArchiveInfo(tempFile.absolutePath, PackageManager.GET_META_DATA)
-            }
-
-            archiveInfo?.applicationInfo?.let { appInfo ->
-                appInfo.sourceDir = tempFile.absolutePath
-                appInfo.publicSourceDir = tempFile.absolutePath
-                appInfo.loadIcon(pm)?.toBitmap()
-            }
+            if (!extracted || !tempFile.exists()) null else parseArchive(tempFile)
         } catch (_: Exception) {
             null
         }
+    }
+
+    /** Parse an on-disk APK via getPackageArchiveInfo across API levels. */
+    private fun parseArchive(tempFile: File): PackageInfo? {
+        val pm = context.packageManager
+        val flags = PackageManager.GET_META_DATA or PackageManager.GET_PERMISSIONS
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pm.getPackageArchiveInfo(
+                tempFile.absolutePath,
+                PackageManager.PackageInfoFlags.of(flags.toLong())
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            pm.getPackageArchiveInfo(tempFile.absolutePath, flags)
+        }
+    }
+
+    /** Build [AppMetadata] from a parsed [PackageInfo], preferring the XAPK icon. */
+    private fun metadataFrom(
+        archiveInfo: PackageInfo,
+        tempFile: File,
+        iconBytes: ByteArray?
+    ): AppMetadata {
+        val pm = context.packageManager
+        archiveInfo.applicationInfo?.sourceDir = tempFile.absolutePath
+        archiveInfo.applicationInfo?.publicSourceDir = tempFile.absolutePath
+
+        val iconBitmap: Bitmap? = when {
+            iconBytes != null -> BitmapFactory.decodeByteArray(iconBytes, 0, iconBytes.size)
+            else -> archiveInfo.applicationInfo?.loadIcon(pm)?.toBitmap()
+        }
+
+        return AppMetadata(
+            label = archiveInfo.applicationInfo?.loadLabel(pm)?.toString() ?: "Unknown",
+            packageName = archiveInfo.packageName,
+            version = archiveInfo.versionName ?: "Unknown",
+            versionCode = archiveInfo.longVersionCode,
+            icon = iconBitmap,
+            permissions = archiveInfo.requestedPermissions?.toList() ?: emptyList()
+        )
     }
 
     private fun Drawable.toBitmap(): Bitmap {

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -181,6 +181,17 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
         tempFile: File,
         iconBytes: ByteArray?
     ): AppMetadata {
+        // Defensive validation (hardens GH#207): never build metadata with a
+        // null/blank package identity or a null applicationInfo — a garbage identity
+        // would drive the wrong installed-package lookup and false downgrade. Throwing
+        // here routes to the caller's catch -> Result.failure -> error_parse_package.
+        require(archiveInfo.applicationInfo != null) {
+            "Parsed archive has no applicationInfo; not an installable APK."
+        }
+        require(!archiveInfo.packageName.isNullOrBlank()) {
+            "Parsed archive has a null/blank package name; not an installable APK."
+        }
+
         val pm = context.packageManager
         archiveInfo.applicationInfo?.sourceDir = tempFile.absolutePath
         archiveInfo.applicationInfo?.publicSourceDir = tempFile.absolutePath

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
@@ -1,0 +1,150 @@
+package com.valhalla.thor.data.repository
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Pure, framework-independent helpers for classifying an installer input as a
+ * monolithic APK vs. a genuine bundle (XAPK/.apks/.apkm), and for selecting the
+ * correct base APK inside a bundle.
+ *
+ * Kept free of any Android dependency so they are unit-testable without a device
+ * PackageManager. The authoritative metadata parse still runs through
+ * `getPackageArchiveInfo` in the callers; these helpers only decide *which* entry
+ * to hand to it.
+ *
+ * Related: GH#207 (monolithic APK mis-parsed as bundle), GH#159 (XAPK parse
+ * failure / wrong base pick).
+ */
+
+/** Tolerant, framework-independent JSON reader for XAPK manifests. */
+private val bundleJson = Json {
+    ignoreUnknownKeys = true
+    coerceInputValues = true
+    isLenient = true
+}
+
+/**
+ * Tolerant representation of an XAPK `manifest.json`.
+ *
+ * Real-world manifests vary a lot: `version_code` is often numeric, `name` is
+ * sometimes absent. Everything is therefore nullable with defaults so a single
+ * missing/oddly-typed field never fails the whole deserialization (which used to
+ * silently skip the correct base-APK extraction path — GH#159).
+ */
+@Serializable
+data class XapkManifestInfo(
+    @SerialName("package_name") val packageName: String? = null,
+    @SerialName("name") val name: String? = null,
+    @SerialName("version_code") val versionCode: String? = null,
+    @SerialName("version_name") val versionName: String? = null,
+    @SerialName("permissions") val permissions: List<String> = emptyList(),
+    @SerialName("icon") val iconFile: String? = null,
+    @SerialName("split_apks") val splitApks: List<XapkSplitApkInfo> = emptyList()
+) {
+    /** File name of the entry flagged as `id == "base"`, if any. */
+    fun baseApkFile(): String? = splitApks.firstOrNull { it.id.equals("base", ignoreCase = true) }?.file
+
+    /** All split-apk file names declared in the manifest, in declaration order. */
+    fun splitApkFiles(): List<String> = splitApks.map { it.file }
+}
+
+@Serializable
+data class XapkSplitApkInfo(
+    @SerialName("file") val file: String,
+    @SerialName("id") val id: String = ""
+)
+
+/**
+ * Parse an XAPK `manifest.json` tolerantly. Returns null only when the input is
+ * not valid JSON at all; missing or oddly-typed fields are tolerated.
+ */
+fun parseXapkManifest(jsonText: String): XapkManifestInfo? = try {
+    bundleJson.decodeFromString<XapkManifestInfo>(jsonText)
+} catch (_: Exception) {
+    null
+}
+
+/**
+ * True if the archive has a top-level (root) `AndroidManifest.xml` entry. Every
+ * real APK has exactly this; bundles (XAPK/.apks/.apkm) do not have one at the
+ * archive root (their manifests live inside the nested APKs).
+ */
+fun hasTopLevelAndroidManifest(entryNames: List<String>): Boolean =
+    entryNames.any { it.equals("AndroidManifest.xml", ignoreCase = true) }
+
+/** True if the archive contains a top-level XAPK `manifest.json`. */
+fun hasXapkManifest(entryNames: List<String>): Boolean =
+    entryNames.any { it.equals("manifest.json", ignoreCase = true) }
+
+/**
+ * A file is a monolithic APK (single, installable APK) when it carries its own
+ * top-level `AndroidManifest.xml`. This is the primary signal used to avoid the
+ * old "it's a zip containing a .apk, therefore a bundle" mistake (GH#207).
+ */
+fun isMonolithicApk(entryNames: List<String>): Boolean =
+    hasTopLevelAndroidManifest(entryNames)
+
+/**
+ * A file looks like a genuine bundle when it does NOT have a top-level
+ * `AndroidManifest.xml`. An explicit top-level `manifest.json` (XAPK) is a
+ * positive bundle signal too, but the absence of the manifest is the decisive
+ * one — a monolithic APK always wins.
+ */
+fun looksLikeBundle(entryNames: List<String>): Boolean =
+    !isMonolithicApk(entryNames) && (hasXapkManifest(entryNames) || entryNames.any {
+        it.endsWith(".apk", ignoreCase = true)
+    })
+
+/**
+ * True for obvious split/config APK entries that are never a valid base:
+ * names whose file part starts with `split_` or `config.`, or contain
+ * `.config.` (e.g. `com.example.app.config.xhdpi.apk`).
+ */
+fun isSplitApkName(name: String): Boolean {
+    val fileName = name.substringAfterLast('/').lowercase()
+    if (!fileName.endsWith(".apk")) return false
+    return fileName.startsWith("split_") ||
+        fileName.startsWith("config.") ||
+        fileName.contains(".config.")
+}
+
+/**
+ * Order the `.apk` entries of a bundle into base-APK candidates, best first:
+ *  1. `base.apk` / `base-master.apk`
+ *  2. `{package_name}.apk` (when the package name is known)
+ *  3. any other non-split `.apk` (in archive order)
+ *  4. split/config `.apk` entries, as a last resort
+ *
+ * The caller then picks the first candidate that actually parses via
+ * `getPackageArchiveInfo` as a non-split. This fixes the "first .apk in zip
+ * order (often a config split) wins" bug (GH#159).
+ */
+fun selectBaseApkCandidates(entryNames: List<String>, packageName: String?): List<String> {
+    val apks = entryNames.filter { it.endsWith(".apk", ignoreCase = true) }
+    if (apks.isEmpty()) return emptyList()
+
+    fun fileNameOf(name: String) = name.substringAfterLast('/').lowercase()
+
+    val (splits, nonSplits) = apks.partition { isSplitApkName(it) }
+
+    val preferredNames = buildList {
+        add("base.apk")
+        add("base-master.apk")
+        packageName?.takeIf { it.isNotBlank() }?.let { add("$it.apk".lowercase()) }
+    }
+
+    val ordered = LinkedHashSet<String>()
+
+    // 1 + 2: explicit preferred names, in preference order.
+    for (preferred in preferredNames) {
+        nonSplits.firstOrNull { fileNameOf(it) == preferred }?.let { ordered.add(it) }
+    }
+    // 3: remaining non-splits in archive order.
+    ordered.addAll(nonSplits)
+    // 4: splits/config as last resort.
+    ordered.addAll(splits)
+
+    return ordered.toList()
+}

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
@@ -101,10 +101,17 @@ fun looksLikeBundle(entryNames: List<String>): Boolean =
  * True for obvious split/config APK entries that are never a valid base:
  * names whose file part starts with `split_` or `config.`, or contain
  * `.config.` (e.g. `com.example.app.config.xhdpi.apk`).
+ *
+ * [packageName], when known, guards against a false positive where the package
+ * name itself contains `.config.` (e.g. `com.example.config.foo`, base entry
+ * `com.example.config.foo.apk`): an entry whose basename is exactly
+ * `{packageName}.apk` is ALWAYS the base and is never classified as a split.
  */
-fun isSplitApkName(name: String): Boolean {
+fun isSplitApkName(name: String, packageName: String? = null): Boolean {
     val fileName = name.substringAfterLast('/').lowercase()
     if (!fileName.endsWith(".apk")) return false
+    // Exact `{packageName}.apk` is the base, never a split.
+    if (!packageName.isNullOrBlank() && fileName == "$packageName.apk".lowercase()) return false
     return fileName.startsWith("split_") ||
         fileName.startsWith("config.") ||
         fileName.contains(".config.")
@@ -127,7 +134,9 @@ fun selectBaseApkCandidates(entryNames: List<String>, packageName: String?): Lis
 
     fun fileNameOf(name: String) = name.substringAfterLast('/').lowercase()
 
-    val (splits, nonSplits) = apks.partition { isSplitApkName(it) }
+    // Pass the package name so an exact `{packageName}.apk` base is never
+    // mis-classified as a split, even when the package name contains `.config.`.
+    val (splits, nonSplits) = apks.partition { isSplitApkName(it, packageName) }
 
     val preferredNames = buildList {
         add("base.apk")

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -87,10 +87,9 @@ class InstallerRepositoryImpl(
             if (manifestFiles != null) return manifestFiles
 
             // No usable manifest: order the .apk entries base-first, splits last so
-            // install-multiple gets a valid base (GH#159).
-            val apks = entryNames.filter { it.endsWith(".apk", ignoreCase = true) }
-            if (apks.isEmpty()) return null
-            selectBaseApkCandidates(entryNames, manifest?.packageName).ifEmpty { apks }
+            // install-multiple gets a valid base (GH#159). selectBaseApkCandidates is
+            // empty only when there are no .apk entries at all → treat as monolithic.
+            selectBaseApkCandidates(entryNames, manifest?.packageName).ifEmpty { null }
         } catch (_: Exception) {
             null
         }

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -29,9 +29,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Single
 import java.io.File
 import java.io.FileOutputStream
@@ -46,58 +43,54 @@ class InstallerRepositoryImpl(
     private val shizukuReflector: ShizukuReflector
 ) : InstallerRepository {
 
-    @Serializable
-    private data class XapkManifest(
-        @SerialName("split_apks") val splitApks: List<XapkSplitApk> = emptyList()
-    )
-
-    @Serializable
-    private data class XapkSplitApk(
-        @SerialName("file") val file: String,
-        @SerialName("id") val id: String
-    )
-
-    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
-
     private val defaultInstaller = context.packageManager.packageInstaller
 
     /**
-     * Returns the ordered list of APK filenames to install from an XAPK bundle.
-     * Uses manifest.json split_apks if present; falls back to all .apk entries.
+     * Returns the ordered list of APK filenames to install from a genuine bundle
+     * (XAPK/.apks/.apkm), or null when the file is a monolithic APK that must be
+     * streamed whole.
+     *
+     * A monolithic APK carries its own top-level AndroidManifest.xml (GH#207); it
+     * must never be split by its inner .apk assets. For real bundles we prefer the
+     * manifest.json split list, and otherwise order the .apk entries so the base
+     * comes first and config splits last (GH#159).
      */
     private fun resolveXapkApkFiles(uri: Uri): List<String>? {
         if (!isZipBundle(uri)) return null
         return try {
             var manifestBytes: ByteArray? = null
-            val allApkNames = mutableListOf<String>()
+            val entryNames = mutableListOf<String>()
 
             context.contentResolver.openInputStream(uri)?.use { inputStream ->
                 ZipInputStream(inputStream).use { zipStream ->
                     var entry = zipStream.nextEntry
                     while (entry != null) {
-                        when {
-                            entry.name.equals("manifest.json", ignoreCase = true) ->
-                                manifestBytes = zipStream.readBytes()
-
-                            !entry.isDirectory && entry.name.endsWith(".apk", ignoreCase = true) ->
-                                allApkNames += entry.name
-
-                            else -> zipStream.closeEntry()
+                        if (!entry.isDirectory) entryNames += entry.name
+                        if (entry.name.equals("manifest.json", ignoreCase = true)) {
+                            manifestBytes = zipStream.readBytes()
+                            zipStream.closeEntry()
+                        } else {
+                            zipStream.closeEntry()
                         }
-                        zipStream.nextEntry.also { entry = it }
+                        entry = zipStream.nextEntry
                     }
                 }
             }
 
-            manifestBytes?.let { bytes ->
-                try {
-                    val files =
-                        json.decodeFromString<XapkManifest>(String(bytes)).splitApks.map { it.file }
-                    if (files.isEmpty()) null else files
-                } catch (_: Exception) {
-                    null
-                }
-            } ?: allApkNames.ifEmpty { null }
+            // Monolithic-APK gate (GH#207): a file with a top-level AndroidManifest.xml
+            // is a single APK — stream it whole via the monolithic path (null).
+            if (isMonolithicApk(entryNames)) return null
+
+            // Prefer the manifest.json split_apks list for a genuine XAPK.
+            val manifest = manifestBytes?.let { parseXapkManifest(String(it)) }
+            val manifestFiles = manifest?.splitApkFiles()?.takeIf { it.isNotEmpty() }
+            if (manifestFiles != null) return manifestFiles
+
+            // No usable manifest: order the .apk entries base-first, splits last so
+            // install-multiple gets a valid base (GH#159).
+            val apks = entryNames.filter { it.endsWith(".apk", ignoreCase = true) }
+            if (apks.isEmpty()) return null
+            selectBaseApkCandidates(entryNames, manifest?.packageName).ifEmpty { apks }
         } catch (_: Exception) {
             null
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -63,7 +63,11 @@ class InstallerViewModel(
                     // checkPrivilegeAndModes() (isShizukuAvailable()/isDhizukuAvailable()
                     // are synchronous binder IPC) must not run on the main thread.
                     val existing = withContext(Dispatchers.IO) {
-                        checkPrivilegeAndModes(meta.packageName)
+                        // Privilege detection is best-effort: an unexpected repository/
+                        // binder IPC exception must not crash package parsing. On failure
+                        // the available modes simply stay at their defaults (NORMAL) and
+                        // parsing still proceeds to getPackageInfo so the user can install.
+                        runCatching { checkPrivilegeAndModes(meta.packageName) }
                         runCatching {
                             packageManager.getPackageInfo(meta.packageName, 0)
                         }.getOrNull()

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -13,10 +13,12 @@ import com.valhalla.thor.domain.repository.InstallerRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.R
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
 
 @KoinViewModel
@@ -56,11 +58,16 @@ class InstallerViewModel(
             result.fold(
                 onSuccess = { meta ->
                     currentPackageName = meta.packageName
-                    checkPrivilegeAndModes(meta.packageName)
-                    
-                    val existing = runCatching {
-                        packageManager.getPackageInfo(meta.packageName, 0)
-                    }.getOrNull()
+
+                    // A#8: getPackageInfo() and the privilege checks in
+                    // checkPrivilegeAndModes() (isShizukuAvailable()/isDhizukuAvailable()
+                    // are synchronous binder IPC) must not run on the main thread.
+                    val existing = withContext(Dispatchers.IO) {
+                        checkPrivilegeAndModes(meta.packageName)
+                        runCatching {
+                            packageManager.getPackageInfo(meta.packageName, 0)
+                        }.getOrNull()
+                    }
 
                     isUpdateOperation = existing != null
                     isDowngrade = if (existing != null) {

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
@@ -85,6 +85,34 @@ class BundleAnalysisTest {
         assertFalse(isSplitApkName("com.example.app.apk"))
     }
 
+    @Test
+    fun packageNamedApk_containingDotConfig_isNeverClassifiedAsSplit() {
+        // A package name may itself contain `.config.` (e.g. com.example.config.foo).
+        // Its base entry `com.example.config.foo.apk` must NOT trip the `.config.`
+        // split heuristic when the package name is known.
+        val pkg = "com.example.config.foo"
+        assertTrue(isSplitApkName("com.example.config.foo.apk"))            // no hint -> split
+        assertFalse(isSplitApkName("com.example.config.foo.apk", pkg))      // hinted -> base
+        // A genuine config split of that same package is still a split.
+        assertTrue(isSplitApkName("com.example.config.foo.config.xhdpi.apk", pkg))
+    }
+
+    @Test
+    fun baseSelection_picksPackageNamedBaseWhenPackageContainsDotConfig() {
+        val pkg = "com.example.config.foo"
+        val entries = listOf(
+            "com.example.config.foo.config.xhdpi.apk",
+            "com.example.config.foo.apk"
+        )
+        val candidates = selectBaseApkCandidates(entries, packageName = pkg)
+        // The exact {packageName}.apk is chosen as the base, not the config split.
+        assertEquals("com.example.config.foo.apk", candidates.first())
+        assertTrue(
+            candidates.indexOf("com.example.config.foo.apk") <
+                candidates.indexOf("com.example.config.foo.config.xhdpi.apk")
+        )
+    }
+
     // --- GH#159: base selection ordering ---
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
@@ -1,0 +1,141 @@
+package com.valhalla.thor.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure, framework-independent tests for bundle/base detection helpers.
+ *
+ * These cover the two install regressions without needing a real device
+ * PackageManager:
+ *  - GH#207: a monolithic APK that happens to bundle a nested `assets/child.apk`
+ *    must be detected as monolithic (top-level AndroidManifest.xml present),
+ *    NOT treated as a bundle.
+ *  - GH#159: an XAPK whose `config.*.apk` splits precede the base, and whose
+ *    manifest.json has a numeric `version_code`, must (a) still deserialize
+ *    tolerantly and (b) resolve the correct base APK entry, not a config split.
+ */
+class BundleAnalysisTest {
+
+    // --- GH#207: monolithic vs bundle detection ---
+
+    @Test
+    fun monolithicApk_withNestedApkAsset_isDetectedAsMonolithic() {
+        // A normal APK is a zip with a top-level AndroidManifest.xml. Apps like
+        // App Manager also bundle nested `.apk` assets, which previously tripped
+        // the "first .apk entry wins" scan.
+        val entries = listOf(
+            "AndroidManifest.xml",
+            "classes.dex",
+            "resources.arsc",
+            "assets/child.apk",
+            "META-INF/CERT.RSA"
+        )
+        assertTrue(hasTopLevelAndroidManifest(entries))
+        assertTrue(isMonolithicApk(entries))
+        // A monolithic APK is not a bundle even though it contains an inner .apk.
+        assertFalse(looksLikeBundle(entries))
+    }
+
+    @Test
+    fun xapkBundle_withoutTopLevelManifest_isNotMonolithic() {
+        val entries = listOf(
+            "manifest.json",
+            "icon.png",
+            "config.arm64_v8a.apk",
+            "base.apk"
+        )
+        assertFalse(hasTopLevelAndroidManifest(entries))
+        assertFalse(isMonolithicApk(entries))
+        assertTrue(looksLikeBundle(entries))
+    }
+
+    // --- split detection ---
+
+    @Test
+    fun splitNamesAreRecognized() {
+        assertTrue(isSplitApkName("config.arm64_v8a.apk"))
+        assertTrue(isSplitApkName("split_config.en.apk"))
+        assertTrue(isSplitApkName("com.example.app.config.xhdpi.apk"))
+        assertFalse(isSplitApkName("base.apk"))
+        assertFalse(isSplitApkName("base-master.apk"))
+        assertFalse(isSplitApkName("com.example.app.apk"))
+    }
+
+    // --- GH#159: base selection ordering ---
+
+    @Test
+    fun baseSelection_skipsConfigSplitsThatPrecedeBase() {
+        // config splits come FIRST in zip order; the old code grabbed the first
+        // .apk which was a config split (getPackageArchiveInfo -> null -> failure).
+        val entries = listOf(
+            "config.arm64_v8a.apk",
+            "config.en.apk",
+            "split_config.xhdpi.apk",
+            "base.apk"
+        )
+        val candidates = selectBaseApkCandidates(entries, packageName = null)
+        assertNotNull(candidates.firstOrNull())
+        assertEquals("base.apk", candidates.first())
+        // Config splits are only tried last (fallback).
+        assertTrue(candidates.indexOf("base.apk") < candidates.indexOf("config.arm64_v8a.apk"))
+    }
+
+    @Test
+    fun baseSelection_prefersBaseMasterThenPackageNamedApk() {
+        val entries = listOf(
+            "splits/config.xhdpi.apk",
+            "com.example.app.apk",
+            "base-master.apk"
+        )
+        val candidates = selectBaseApkCandidates(entries, packageName = "com.example.app")
+        assertEquals("base-master.apk", candidates.first())
+        // The package-named apk should be preferred over config splits too.
+        assertTrue(
+            candidates.indexOf("com.example.app.apk") <
+                candidates.indexOf("splits/config.xhdpi.apk")
+        )
+    }
+
+    @Test
+    fun baseSelection_fallsBackToConfigSplitWhenNothingElse() {
+        val entries = listOf("config.arm64_v8a.apk", "config.en.apk")
+        val candidates = selectBaseApkCandidates(entries, packageName = null)
+        // Nothing non-split exists, so the config splits are still returned as
+        // last-resort candidates rather than an empty list.
+        assertEquals(entries.toSet(), candidates.toSet())
+    }
+
+    // --- GH#159: tolerant manifest parsing ---
+
+    @Test
+    fun parseXapkManifest_toleratesNumericVersionCodeAndMissingName() {
+        // Real .xapk manifests use a numeric version_code and may omit `name`.
+        val jsonStr = """
+            {
+              "package_name": "com.example.app",
+              "version_code": 12345,
+              "version_name": "1.2.3",
+              "split_apks": [
+                { "file": "config.arm64_v8a.apk", "id": "config.arm64_v8a" },
+                { "file": "base.apk", "id": "base" }
+              ]
+            }
+        """.trimIndent()
+
+        val manifest = parseXapkManifest(jsonStr)
+        assertNotNull(manifest)
+        assertEquals("com.example.app", manifest!!.packageName)
+        assertEquals("1.2.3", manifest.versionName)
+        assertEquals("base.apk", manifest.baseApkFile())
+    }
+
+    @Test
+    fun parseXapkManifest_returnsNullForGarbage() {
+        assertNull(parseXapkManifest("not json at all"))
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
@@ -42,6 +42,25 @@ class BundleAnalysisTest {
     }
 
     @Test
+    fun monolithicClassification_gatesOutBaseCandidateSelection() {
+        // Invariant behind the I-1 fix: a monolithic APK (top-level
+        // AndroidManifest.xml) must NEVER be routed to inner-.apk base-candidate
+        // selection, even though selectBaseApkCandidates() would otherwise happily
+        // surface its nested assets/child.apk. The analyzer guards this with
+        // isMonolithicApk(); here we assert the two signals disagree exactly so a
+        // caller that gates on isMonolithicApk() cannot leak into candidate scan.
+        val entries = listOf(
+            "AndroidManifest.xml",
+            "classes.dex",
+            "assets/child.apk"
+        )
+        assertTrue(isMonolithicApk(entries))
+        // If a buggy caller ignored the gate, this is the wrong (nested) identity
+        // it would extract — documenting exactly what the gate prevents.
+        assertEquals("assets/child.apk", selectBaseApkCandidates(entries, null).first())
+    }
+
+    @Test
     fun xapkBundle_withoutTopLevelManifest_isNotMonolithic() {
         val entries = listOf(
             "manifest.json",
@@ -131,6 +150,9 @@ class BundleAnalysisTest {
         assertNotNull(manifest)
         assertEquals("com.example.app", manifest!!.packageName)
         assertEquals("1.2.3", manifest.versionName)
+        // Lock the GH#159 string-from-number contract: a numeric version_code is
+        // coerced into the String field rather than throwing.
+        assertEquals("12345", manifest.versionCode)
         assertEquals("base.apk", manifest.baseApkFile())
     }
 


### PR DESCRIPTION
## What
Fixes the installer/analyzer bundle-detection heuristic that caused two user-facing install failures, plus one main-thread IPC jank finding.

### #207 — normal APK mis-parsed → false "downgrade" block
`AppAnalyzerImpl` treated any ZIP containing a `.apk` entry as a bundle — but every APK is a ZIP. Apps that bundle nested `.apk` assets (Muntashirakon App Manager, MT File Manager) had a **nested** APK's identity read instead of their own, producing the wrong package/version and a false downgrade block. Now a file with a top-level `AndroidManifest.xml` (or that parses whole-file) is treated as monolithic and never routed to the inner-`.apk` scan; the same gate is applied on the install path (`InstallerRepositoryImpl`). If the whole-file parse fails, we fail cleanly rather than falling back to a nested asset.

### #159 — `.xapk` install → "failed to parse package"
- `XapkManifest` deserialization is now tolerant (lenient JSON; numeric `version_code`, missing `name` no longer throw).
- Base selection skips `split_`/`config.` splits, prefers `base.apk`/`base-master.apk`/`{package}.apk`, and picks the first entry that parses as a non-split (config split only as last resort).
- `.apks`/`.apkm` full base-layout support and OBB extraction are out of scope (`// TODO(#159)`).

### A#8 (smoothness audit) — main-thread binder/PM IPC
`InstallerViewModel.parsePackage` now runs `getPackageInfo` + availability checks off the main thread via `withContext(Dispatchers.IO)`. `SystemRepository` signatures unchanged (deferred to a later branch).

## Tests
New `BundleAnalysisTest` (9/9) covers monolithic-with-nested-asset detection and config-splits-before-base + numeric `version_code`. `:app:testFossDebugUnitTest` and `:app:assembleFossDebug` pass under JBR-21.

Part of the remediation plan (`remediation_plan.md`, branch B2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)