### PR TITLE
fix(viewmodel): cancel stacked app-list collector; move availability binder IPC off main thread (A#1/#6/#7)

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -47,9 +47,15 @@ class AppInfoDetailsViewModel(
             )
         }
         viewModelScope.launch {
-            val hasRoot = systemRepository.isRootAvailable()
-            val hasShizuku = systemRepository.isShizukuAvailable()
-            val hasDhizuku = systemRepository.isDhizukuAvailable()
+            // Availability probes include non-suspend binder IPC (Shizuku / Dhizuku);
+            // keep them off the Main thread so opening app details never janks.
+            val (hasRoot, hasShizuku, hasDhizuku) = withContext(Dispatchers.IO) {
+                Triple(
+                    systemRepository.isRootAvailable(),
+                    systemRepository.isShizukuAvailable(),
+                    systemRepository.isDhizukuAvailable()
+                )
+            }
             val inFreezer = withContext(Dispatchers.IO) {
                 freezerRepository.contains(packageName)
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -48,17 +48,16 @@ class AppInfoDetailsViewModel(
         }
         viewModelScope.launch {
             // Availability probes include non-suspend binder IPC (Shizuku / Dhizuku);
-            // keep them off the Main thread so opening app details never janks.
-            val (hasRoot, hasShizuku, hasDhizuku) = withContext(Dispatchers.IO) {
+            // compute them and the freezer lookup in a single IO context to keep them
+            // off the Main thread and avoid an extra dispatch switch.
+            val (probes, inFreezer) = withContext(Dispatchers.IO) {
                 Triple(
                     systemRepository.isRootAvailable(),
                     systemRepository.isShizukuAvailable(),
                     systemRepository.isDhizukuAvailable()
-                )
+                ) to freezerRepository.contains(packageName)
             }
-            val inFreezer = withContext(Dispatchers.IO) {
-                freezerRepository.contains(packageName)
-            }
+            val (hasRoot, hasShizuku, hasDhizuku) = probes
 
             val details = appRepository.getDetailedAppInfo(packageName)
             if (details != null) {

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -18,6 +18,7 @@ import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.presentation.freezer.FreezerPrompt
 import com.valhalla.thor.util.UiText
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -73,6 +74,7 @@ class AppListViewModel(
     private val freezerRepository: FreezerRepository
 ) : ViewModel() {
 
+    private var appsJob: Job? = null
     private val _rawState = MutableStateFlow(AppListUiState())
 
     // Combine raw app data with user preferences from DataStore
@@ -100,7 +102,11 @@ class AppListViewModel(
     }
 
     fun loadApps() {
-        viewModelScope.launch {
+        // Cancel any existing collector so the prior (infinite) getInstalledAppsUseCase()
+        // callbackFlow tears down (awaitClose -> unregister receivers) before we relaunch.
+        appsJob?.cancel()
+
+        appsJob = viewModelScope.launch {
             _rawState.update { it.copy(isLoading = true) }
 
             // Allow navigation/bottom bar animations to finish fluidly

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -112,9 +112,15 @@ class AppListViewModel(
             // Allow navigation/bottom bar animations to finish fluidly
             delay(800.milliseconds)
 
-            val hasRoot = systemRepository.isRootAvailable()
-            val hasShizuku = systemRepository.isShizukuAvailable()
-            val hasDhizuku = systemRepository.isDhizukuAvailable()
+            // Availability probes include non-suspend binder IPC (Shizuku / Dhizuku);
+            // keep them off the Main thread so app-list load never janks.
+            val (hasRoot, hasShizuku, hasDhizuku) = withContext(Dispatchers.IO) {
+                Triple(
+                    systemRepository.isRootAvailable(),
+                    systemRepository.isShizukuAvailable(),
+                    systemRepository.isDhizukuAvailable()
+                )
+            }
             getInstalledAppsUseCase().collect { (user, system) ->
                 _rawState.update {
                     it.copy(

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -54,18 +55,16 @@ class SettingsViewModel(
         _actionMessage,
         flow {
             // Availability probes hit binder IPC (Shizuku.pingBinder / DhizukuAPI).
-            // Run them off the Main thread to avoid janking the first subscription /
-            // every WhileSubscribed restart.
+            // flowOn(IO) below keeps them off the Main thread to avoid janking the
+            // first subscription / every WhileSubscribed restart.
             emit(
-                withContext(Dispatchers.IO) {
-                    Triple(
-                        systemRepository.isRootAvailable(),
-                        systemRepository.isShizukuAvailable(),
-                        systemRepository.isDhizukuAvailable()
-                    )
-                }
+                Triple(
+                    systemRepository.isRootAvailable(),
+                    systemRepository.isShizukuAvailable(),
+                    systemRepository.isDhizukuAvailable()
+                )
             )
-        }
+        }.flowOn(Dispatchers.IO)
     ) { prefs, message, status ->
         SettingsUiState(
             prefs = prefs,

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -53,12 +53,17 @@ class SettingsViewModel(
         preferenceRepository.userPreferences,
         _actionMessage,
         flow {
+            // Availability probes hit binder IPC (Shizuku.pingBinder / DhizukuAPI).
+            // Run them off the Main thread to avoid janking the first subscription /
+            // every WhileSubscribed restart.
             emit(
-                Triple(
-                    systemRepository.isRootAvailable(),
-                    systemRepository.isShizukuAvailable(),
-                    systemRepository.isDhizukuAvailable()
-                )
+                withContext(Dispatchers.IO) {
+                    Triple(
+                        systemRepository.isRootAvailable(),
+                        systemRepository.isShizukuAvailable(),
+                        systemRepository.isDhizukuAvailable()
+                    )
+                }
             )
         }
     ) { prefs, message, status ->


### PR DESCRIPTION
## What
ViewModel lifecycle/threading fixes from the smoothness audit.

- **A#1 — `AppListViewModel.loadApps()`:** previously each call (`init`, a `LaunchedEffect`, and pull-to-refresh) launched a fresh collector of the **infinite** package-change `callbackFlow` with no `Job` reference, so refreshes stacked never-completing collectors (each holding 2 `BroadcastReceiver`s + a worker) and re-ran full `getInstalledPackages` enumerations. Now a tracked `appsJob` is cancelled before relaunch (mirrors `HomeViewModel.dashboardJob`), so the prior collector's `awaitClose` unregisters its receivers before a new one starts.
- **A#6 — `SettingsViewModel`:** the availability probes (`isShizukuAvailable`/`isDhizukuAvailable` = synchronous binder IPC) ran on `Dispatchers.Main.immediate` via the `stateIn` flow; now wrapped in `withContext(Dispatchers.IO)`. Single immutable `StateFlow<UiState>` preserved.
- **A#7 — `AppInfoDetailsViewModel.loadAppDetails()`:** same binder probes moved off the main thread.

## Verification
`:app:assembleFossDebug` BUILD SUCCESSFUL (JBR-21). Behavior-preserving; single-StateFlow contract intact; no `SystemRepository` signature changes (that API-level hardening is a later branch); no versionCode bump.

Part of the remediation plan (`remediation_plan.md`, branch B4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)