### PR TITLE
perf(compose): cut per-recomposition work + fix effect-lifecycle & biometric-signal leaks (A#2,#9-#13,#15-#17)

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -810,8 +810,8 @@ private fun ActionItem(
 private fun GeneralTabScreen(details: DetailedAppInfo) {
     val appInfo = details.appInfo
     val context = LocalContext.current
-    val installTime = remember(appInfo.firstInstallTime) { formatTime(appInfo.firstInstallTime, context) }
-    val lastUpdateTime = remember(appInfo.lastUpdateTime) { formatTime(appInfo.lastUpdateTime, context) }
+    val installTime = remember(appInfo.firstInstallTime, context) { formatTime(appInfo.firstInstallTime, context) }
+    val lastUpdateTime = remember(appInfo.lastUpdateTime, context) { formatTime(appInfo.lastUpdateTime, context) }
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -810,6 +810,8 @@ private fun ActionItem(
 private fun GeneralTabScreen(details: DetailedAppInfo) {
     val appInfo = details.appInfo
     val context = LocalContext.current
+    val installTime = remember(appInfo.firstInstallTime) { formatTime(appInfo.firstInstallTime, context) }
+    val lastUpdateTime = remember(appInfo.lastUpdateTime) { formatTime(appInfo.lastUpdateTime, context) }
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
@@ -850,13 +852,13 @@ private fun GeneralTabScreen(details: DetailedAppInfo) {
         item {
             InfoCard(
                 title = stringResource(R.string.info_install_time),
-                value = formatTime(appInfo.firstInstallTime, context)
+                value = installTime
             )
         }
         item {
             InfoCard(
                 title = stringResource(R.string.info_last_update_time),
-                value = formatTime(appInfo.lastUpdateTime, context)
+                value = lastUpdateTime
             )
         }
         item {
@@ -895,9 +897,11 @@ private fun GeneralTabScreen(details: DetailedAppInfo) {
 @Composable
 private fun PermissionsTabScreen(permissions: List<PermissionDetail>) {
     var searchQuery by remember { mutableStateOf("") }
-    val filteredPermissions = permissions.filter {
-        it.name.contains(searchQuery, ignoreCase = true) ||
-                (it.label?.contains(searchQuery, ignoreCase = true) ?: false)
+    val filteredPermissions = remember(searchQuery, permissions) {
+        permissions.filter {
+            it.name.contains(searchQuery, ignoreCase = true) ||
+                    (it.label?.contains(searchQuery, ignoreCase = true) ?: false)
+        }
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
@@ -1005,10 +1009,6 @@ private fun PermissionsTabScreen(permissions: List<PermissionDetail>) {
 @Composable
 private fun ComponentsTabScreen(details: DetailedAppInfo) {
     var searchQuery by remember { mutableStateOf("") }
-    val filter = { items: List<String> ->
-        if (searchQuery.isEmpty()) items
-        else items.filter { it.contains(searchQuery, ignoreCase = true) }
-    }
 
     Column(modifier = Modifier.fillMaxSize()) {
         OutlinedTextField(
@@ -1033,10 +1033,19 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
             )
         )
 
-        val filteredActivities = filter(details.activities)
-        val filteredServices = filter(details.services)
-        val filteredReceivers = filter(details.receivers)
-        val filteredProviders = filter(details.providers)
+        val (filteredActivities, filteredServices, filteredReceivers, filteredProviders) =
+            remember(searchQuery, details) {
+                val filter = { items: List<String> ->
+                    if (searchQuery.isEmpty()) items
+                    else items.filter { it.contains(searchQuery, ignoreCase = true) }
+                }
+                ComponentLists(
+                    activities = filter(details.activities),
+                    services = filter(details.services),
+                    receivers = filter(details.receivers),
+                    providers = filter(details.providers)
+                )
+            }
 
         LazyColumn(
             modifier = Modifier
@@ -1277,6 +1286,13 @@ private fun InfoCard(title: String, value: String) {
         )
     }
 }
+
+private data class ComponentLists(
+    val activities: List<String>,
+    val services: List<String>,
+    val receivers: List<String>,
+    val providers: List<String>
+)
 
 private fun formatTime(timestamp: Long, context: Context): String {
     if (timestamp == 0L) return context.getString(R.string.not_available)

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -107,12 +107,16 @@ fun FreezerScreen(
     val displayedApps = remember(state.freezerApps, state.searchQuery, state.appListType) {
         val filteredByType =
             state.freezerApps.filter { it.isSystem == (state.appListType == AppListType.SYSTEM) }
-        if (state.searchQuery.isBlank()) filteredByType
+        val filtered = if (state.searchQuery.isBlank()) filteredByType
         else filteredByType.filter {
             it.appName?.contains(state.searchQuery, ignoreCase = true) == true ||
                     it.packageName.contains(state.searchQuery, ignoreCase = true)
         }
+        filtered.sortedBy { it.appName }
     }
+
+    val hasEnabled = remember(state.freezerApps) { state.freezerApps.any { it.enabled } }
+    val hasDisabled = remember(state.freezerApps) { state.freezerApps.any { !it.enabled } }
 
 
     LaunchedEffect(state.actionMessage) {
@@ -258,7 +262,7 @@ fun FreezerScreen(
                         modifier = Modifier.weight(1f)
                     ) {
                         items(
-                            displayedApps.sortedBy { it.appName },
+                            displayedApps,
                             key = { it.packageName }) { app ->
                             AppItemGrid(
                                 app = app,
@@ -281,7 +285,7 @@ fun FreezerScreen(
                         modifier = Modifier.weight(1f)
                     ) {
                         items(
-                            displayedApps.sortedBy { it.appName },
+                            displayedApps,
                             key = { it.packageName }) { app ->
                             AppItemList(
                                 app = app,
@@ -316,8 +320,9 @@ fun FreezerScreen(
 
             // Floating multi-select toolbar
             if (state.multiSelection.isNotEmpty()) {
-                val selectedApps =
+                val selectedApps = remember(state.freezerApps, state.multiSelection) {
                     state.freezerApps.filter { it.packageName in state.multiSelection }
+                }
                 FreezerSelectToolBox(
                     selected = selectedApps,
                     isRoot = state.isRoot,
@@ -355,7 +360,7 @@ fun FreezerScreen(
                         )
                         IconButton(
                             onClick = { viewModel.freezeAll() },
-                            enabled = state.freezerApps.any { it.enabled } && hasPrivilege,
+                            enabled = hasEnabled && hasPrivilege,
                             colors = iconButtonColors
                         ) {
                             Icon(
@@ -374,7 +379,7 @@ fun FreezerScreen(
                         }
                         IconButton(
                             onClick = { viewModel.unfreezeAll() },
-                            enabled = state.freezerApps.any { !it.enabled } && hasPrivilege,
+                            enabled = hasDisabled && hasPrivilege,
                             colors = iconButtonColors
                         ) {
                             Icon(

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -53,7 +53,10 @@ import androidx.window.core.layout.WindowSizeClass
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
@@ -203,46 +206,49 @@ fun MainScreen(
     val shareApp = stringResource(R.string.share_app)
 
     // 4. Handle Side Effects
-    LaunchedEffect(Unit) {
-        mainViewModel.effect.collect { effect ->
-            when (effect) {
-                is MainSideEffect.LaunchApp -> {
-                    val intent =
-                        context.packageManager.getLaunchIntentForPackage(effect.packageName)
-                    if (intent != null) context.startActivity(intent)
-                    else Toast.makeText(context, canNotLaunchApp, Toast.LENGTH_SHORT).show()
-                }
-
-                is MainSideEffect.OpenAppSettings -> {
-                    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                        data = "package:${effect.packageName}".toUri()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            mainViewModel.effect.collect { effect ->
+                when (effect) {
+                    is MainSideEffect.LaunchApp -> {
+                        val intent =
+                            context.packageManager.getLaunchIntentForPackage(effect.packageName)
+                        if (intent != null) context.startActivity(intent)
+                        else Toast.makeText(context, canNotLaunchApp, Toast.LENGTH_SHORT).show()
                     }
-                    context.startActivity(intent)
-                }
 
-                is MainSideEffect.ShareApp -> {
-                    val intent = Intent(Intent.ACTION_SEND).apply {
-                        type = "application/vnd.android.package-archive"
-                        putExtra(Intent.EXTRA_STREAM, effect.uri)
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    is MainSideEffect.OpenAppSettings -> {
+                        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                            data = "package:${effect.packageName}".toUri()
+                        }
+                        context.startActivity(intent)
                     }
-                    context.startActivity(Intent.createChooser(intent, shareApp))
-                }
 
-                is MainSideEffect.ShareApps -> {
-                    val intent = Intent(Intent.ACTION_SEND_MULTIPLE).apply {
-                        type = "*/*"
-                        putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(effect.uris))
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    is MainSideEffect.ShareApp -> {
+                        val intent = Intent(Intent.ACTION_SEND).apply {
+                            type = "application/vnd.android.package-archive"
+                            putExtra(Intent.EXTRA_STREAM, effect.uri)
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        context.startActivity(Intent.createChooser(intent, shareApp))
                     }
-                    context.startActivity(Intent.createChooser(intent, shareApp))
-                }
 
-                is MainSideEffect.NormalUninstall -> {
-                    val intent = Intent(Intent.ACTION_DELETE).apply {
-                        data = "package:${effect.packageName}".toUri()
+                    is MainSideEffect.ShareApps -> {
+                        val intent = Intent(Intent.ACTION_SEND_MULTIPLE).apply {
+                            type = "*/*"
+                            putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(effect.uris))
+                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        context.startActivity(Intent.createChooser(intent, shareApp))
                     }
-                    context.startActivity(intent)
+
+                    is MainSideEffect.NormalUninstall -> {
+                        val intent = Intent(Intent.ACTION_DELETE).apply {
+                            data = "package:${effect.packageName}".toUri()
+                        }
+                        context.startActivity(intent)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/permission/PermissionManagerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/permission/PermissionManagerScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.produceState
@@ -52,6 +51,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.SharedTransitionScope
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
@@ -72,7 +72,7 @@ fun PermissionManagerScreen(
     onBack: () -> Unit,
     viewModel: PermissionManagerViewModel = koinViewModel()
 ) {
-    val state by viewModel.uiState.collectAsState()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     LaunchedEffect(packageName) {
@@ -141,33 +141,39 @@ fun PermissionManagerScreen(
                     androidx.compose.material3.CircularProgressIndicator()
                 }
             } else {
-                // Filter the permissions
-                val filteredList = state.permissions.filter {
-                    it.name.contains(state.searchQuery, ignoreCase = true) ||
-                            it.label.contains(state.searchQuery, ignoreCase = true)
+                // Filter + classify the permissions once; recompute only when inputs change.
+                val classified = remember(state.permissions, state.searchQuery) {
+                    val filteredList = state.permissions.filter {
+                        it.name.contains(state.searchQuery, ignoreCase = true) ||
+                                it.label.contains(state.searchQuery, ignoreCase = true)
+                    }
+
+                    val runtimePermissions = filteredList.filter { it.isRuntime }
+
+                    @Suppress("DEPRECATION")
+                    val normalPermissions = filteredList.filter {
+                        if (it.isRuntime) return@filter false
+                        val base =
+                            it.protectionLevel and android.content.pm.PermissionInfo.PROTECTION_MASK_BASE
+                        base == android.content.pm.PermissionInfo.PROTECTION_NORMAL ||
+                                base == android.content.pm.PermissionInfo.PROTECTION_DANGEROUS
+                    }
+
+                    @Suppress("DEPRECATION")
+                    val signaturePermissions = filteredList.filter {
+                        if (it.isRuntime) return@filter false
+                        val base =
+                            it.protectionLevel and android.content.pm.PermissionInfo.PROTECTION_MASK_BASE
+                        base == android.content.pm.PermissionInfo.PROTECTION_SIGNATURE ||
+                                base == android.content.pm.PermissionInfo.PROTECTION_SIGNATURE_OR_SYSTEM ||
+                                base == android.content.pm.PermissionInfo.PROTECTION_INTERNAL
+                    }
+                    Triple(runtimePermissions, normalPermissions, signaturePermissions)
                 }
 
-                // Split into categories
-                val runtimePermissions = filteredList.filter { it.isRuntime }
-
-                @Suppress("DEPRECATION")
-                val normalPermissions = filteredList.filter {
-                    if (it.isRuntime) return@filter false
-                    val base =
-                        it.protectionLevel and android.content.pm.PermissionInfo.PROTECTION_MASK_BASE
-                    base == android.content.pm.PermissionInfo.PROTECTION_NORMAL ||
-                            base == android.content.pm.PermissionInfo.PROTECTION_DANGEROUS
-                }
-
-                @Suppress("DEPRECATION")
-                val signaturePermissions = filteredList.filter {
-                    if (it.isRuntime) return@filter false
-                    val base =
-                        it.protectionLevel and android.content.pm.PermissionInfo.PROTECTION_MASK_BASE
-                    base == android.content.pm.PermissionInfo.PROTECTION_SIGNATURE ||
-                            base == android.content.pm.PermissionInfo.PROTECTION_SIGNATURE_OR_SYSTEM ||
-                            base == android.content.pm.PermissionInfo.PROTECTION_INTERNAL
-                }
+                val (runtimePermissions, normalPermissions, signaturePermissions) = classified
+                val filteredIsEmpty =
+                    runtimePermissions.isEmpty() && normalPermissions.isEmpty() && signaturePermissions.isEmpty()
                 val displayedLists = when (selectedTab) {
                     0 -> Triple(runtimePermissions, normalPermissions, signaturePermissions)
                     1 -> Triple(runtimePermissions, emptyList(), emptyList())
@@ -175,7 +181,7 @@ fun PermissionManagerScreen(
                     else -> Triple(emptyList(), emptyList(), signaturePermissions)
                 }
 
-                if (filteredList.isEmpty() || (displayedLists.first.isEmpty() && displayedLists.second.isEmpty() && displayedLists.third.isEmpty())) {
+                if (filteredIsEmpty || (displayedLists.first.isEmpty() && displayedLists.second.isEmpty() && displayedLists.third.isEmpty())) {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()

--- a/app/src/main/java/com/valhalla/thor/presentation/security/BiometricPromptHandler.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/BiometricPromptHandler.kt
@@ -22,16 +22,22 @@ internal class BiometricPromptHandler(private val context: Context) {
         onAuthenticated: () -> Unit,
         onError: (String) -> Unit
     ) {
+        // Cancel any in-flight prompt before starting a new one so the previous
+        // CancellationSignal (and its captured callbacks) isn't orphaned.
+        cancellationSignal?.cancel()
+
         val executor = ContextCompat.getMainExecutor(context)
 
         val callback = object : BiometricPrompt.AuthenticationCallback() {
             override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult?) {
                 super.onAuthenticationSucceeded(result)
+                cancellationSignal = null
                 onAuthenticated()
             }
 
             override fun onAuthenticationError(errorCode: Int, errString: CharSequence?) {
                 super.onAuthenticationError(errorCode, errString)
+                cancellationSignal = null
                 // Error code 5 is developer-initiated cancellation, ignore it.
                 if (errorCode != 5) {
                     onError(errString?.toString() ?: "Authentication error")


### PR DESCRIPTION
## What
Jetpack Compose smoothness fixes from the audit — remove redundant per-recomposition work and two lifecycle leaks. Behavior/visuals unchanged.

- **A#2 `MainScreen`** — the one-shot side-effect `Channel` was collected in a plain `LaunchedEffect(Unit)`, so `startActivity`/toast could fire while backgrounded. Now collected inside `repeatOnLifecycle(STARTED)`; the rendezvous `Channel` suspends `send` while STOPPED, so effects are delivered exactly once on resume.
- **A#9/#10/#13 `AppInfoDetailsScreen`** — component/permission list filters and `formatTime` (which built a fresh `DateFormat` per item) ran on every recomposition/keystroke; now memoized with complete `remember(keys)`.
- **A#11/#12 `FreezerScreen`** — the app list was re-sorted (`O(N log N)`) on every recomposition via an inline `items(...) .sortedBy`; sort folded into the `displayedApps` memo. `selectedApps` filter and enabled/disabled scans memoized.
- **A#15/#16 `PermissionManagerScreen`** — `collectAsState()` → `collectAsStateWithLifecycle()`; permission filtering + protection-level classification memoized on `(permissions, searchQuery)` (tab switch no longer reclassifies).
- **A#17 `BiometricPromptHandler`** — `authenticate()` now cancels the prior `CancellationSignal` before reassigning and nulls it in the success/error callbacks, so an auto-trigger + button tap can't orphan a signal/callback.

## Verification
`:app:assembleFossDebug` BUILD SUCCESSFUL (JBR-21). Every added `remember` keys on all inputs its lambda reads (reviewed for stale-UI). No state hoisted into ViewModels; no versionCode bump.

Part of the remediation plan (`remediation_plan.md`, branch B5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)