### PR TITLE
fix(perf/leak): decode app icons at target size; billing close() hook; fix UadHelper cache race (A#3/#14/#21)

### DIFF
--- a/app/src/foss/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
+++ b/app/src/foss/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
@@ -24,4 +24,8 @@ class BillingProcessorImpl : BillingProcessor {
     override fun dismissThankYouDialog() {
         // No-op in FOSS flavor
     }
+
+    override fun close() {
+        // No-op in FOSS flavor: no billing client or scope to tear down.
+    }
 }

--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -10,6 +10,7 @@ import com.valhalla.bypass.Bypass
 import com.valhalla.thor.core.ThorShellConfig
 import com.valhalla.thor.data.service.AutoFreezeManager
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.presentation.settings.BillingProcessor
 import com.valhalla.thor.presentation.utils.AppIconFetcher
 import com.valhalla.thor.presentation.utils.AppIconKeyer
 import com.valhalla.thor.util.LocaleManager
@@ -42,6 +43,7 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
     private val preferenceRepository: PreferenceRepository by inject()
     private val localeManager: LocaleManager by inject()
     private val autoFreezeManager: AutoFreezeManager by inject()
+    private val billingProcessor: BillingProcessor by inject()
 
     override fun onCreate() {
         super.onCreate()
@@ -72,5 +74,13 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
                 localeManager.applyLocale(prefs.language)
             }
         }
+    }
+
+    override fun onTerminate() {
+        // Tear down the app-lifetime billing client + coroutine scope so the Play billing
+        // service binding and scope don't outlive the process. onTerminate is only guaranteed
+        // on emulators, but it is the correct application-lifetime teardown hook.
+        billingProcessor.close()
+        super.onTerminate()
     }
 }

--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -43,7 +43,12 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
     private val preferenceRepository: PreferenceRepository by inject()
     private val localeManager: LocaleManager by inject()
     private val autoFreezeManager: AutoFreezeManager by inject()
-    private val billingProcessor: BillingProcessor by inject()
+
+    // Keep the Lazy handle so we can tear the billing client down only if it was actually
+    // created this run — resolving the delegate would otherwise spin up a billing connection at
+    // shutdown, the opposite of what we want.
+    private val billingProcessorLazy = inject<BillingProcessor>()
+    private val billingProcessor by billingProcessorLazy
 
     override fun onCreate() {
         super.onCreate()
@@ -80,7 +85,11 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
         // Tear down the app-lifetime billing client + coroutine scope so the Play billing
         // service binding and scope don't outlive the process. onTerminate is only guaranteed
         // on emulators, but it is the correct application-lifetime teardown hook.
-        billingProcessor.close()
+        // Only close if the singleton was already created this run; touching the delegate
+        // otherwise would initialize billing at shutdown.
+        if (billingProcessorLazy.isInitialized()) {
+            billingProcessor.close()
+        }
         super.onTerminate()
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/UadHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/UadHelper.kt
@@ -17,23 +17,27 @@ class UadHelper(
     private val extensionManager: ExtensionManager
 ) {
 
+    @Volatile
     var didLoadFail = false
         private set
 
+    private val lock = Any()
+
+    @Volatile
     private var cachedMap: Map<String, UadEntry>? = null
 
     val uadMap: Map<String, UadEntry>
         get() {
-            var map = cachedMap
-            if (map == null) {
-                map = buildUadMap()
-                cachedMap = map
+            cachedMap?.let { return it }
+            return synchronized(lock) {
+                cachedMap ?: buildUadMap().also { cachedMap = it }
             }
-            return map
         }
 
     fun invalidateCache() {
-        cachedMap = null
+        synchronized(lock) {
+            cachedMap = null
+        }
     }
 
     private fun buildUadMap(): Map<String, UadEntry> {

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/BillingProcessor.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/BillingProcessor.kt
@@ -3,7 +3,7 @@ package com.valhalla.thor.presentation.settings
 import android.app.Activity
 import kotlinx.coroutines.flow.StateFlow
 
-interface BillingProcessor {
+interface BillingProcessor : AutoCloseable {
     val isBillingAvailable: StateFlow<Boolean>
     val products: StateFlow<List<BillingProduct>>
     val activeSubscription: StateFlow<ActiveSubscription?>
@@ -16,6 +16,12 @@ interface BillingProcessor {
         oldProductId: String? = null
     )
     fun dismissThankYouDialog()
+
+    /**
+     * Tears down any long-lived resources (Play billing connection, coroutine scope).
+     * Invoked from the application lifecycle. No-op for flavors without a real billing client.
+     */
+    override fun close()
 }
 
 data class BillingProduct(

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/AppIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/AppIconLoader.kt
@@ -16,6 +16,7 @@ import coil3.fetch.Fetcher
 import coil3.fetch.ImageFetchResult
 import coil3.key.Keyer
 import coil3.request.Options
+import coil3.size.pxOrElse
 import java.io.File
 import java.io.FileOutputStream
 import com.valhalla.thor.extension.api.AppIconModel
@@ -26,7 +27,8 @@ import com.valhalla.thor.extension.api.AppIconModel
  */
 class AppIconFetcher(
     private val model: AppIconModel,
-    private val context: Context
+    private val context: Context,
+    private val options: Options
 ) : Fetcher {
 
     override suspend fun fetch(): FetchResult? {
@@ -47,12 +49,19 @@ class AppIconFetcher(
             } catch (_: Exception) {}
 
             if (iconFile.exists() && iconFile.lastModified() >= lastUpdateTime) {
-                val bitmap = BitmapFactory.decodeFile(iconFile.absolutePath)
+                // Two-pass decode: read the bounds first, then compute an inSampleSize from the
+                // Coil target size so adaptive/high-res icons don't bloat the memory cache.
+                val boundsOptions = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                BitmapFactory.decodeFile(iconFile.absolutePath, boundsOptions)
+
+                val sampleSize = computeInSampleSize(boundsOptions.outWidth, boundsOptions.outHeight)
+                val decodeOptions = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+                val bitmap = BitmapFactory.decodeFile(iconFile.absolutePath, decodeOptions)
                 if (bitmap != null) {
                     val drawable = BitmapDrawable(context.resources, bitmap)
                     return ImageFetchResult(
                         image = drawable.asImage(),
-                        isSampled = false,
+                        isSampled = sampleSize > 1,
                         dataSource = DataSource.DISK
                     )
                 }
@@ -71,22 +80,28 @@ class AppIconFetcher(
                 appInfo.loadIcon(pm)
             }
 
-            // Save to cache on IO thread
+            // Persist the full-resolution icon so later requests at larger sizes (details
+            // screens render up to ~120dp) stay crisp via the disk two-pass decode. The memory
+            // cache is fed the downscaled bitmap below instead.
             try {
                 if (!iconDir.exists()) {
                     iconDir.mkdirs()
                 }
-                val bitmap = drawable.toBitmap()
+                val fullBitmap = drawable.toFullBitmap()
                 FileOutputStream(iconFile).use { out ->
-                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                    fullBitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
             }
 
+            // Return a bitmap sized to the Coil target (coerced to the intrinsic size) rather
+            // than the full adaptive-icon resolution, keeping the memory cache small.
+            val bitmap = drawable.toBitmap()
+
             ImageFetchResult(
-                image = drawable.asImage(),
-                isSampled = false,
+                image = BitmapDrawable(context.resources, bitmap).asImage(),
+                isSampled = true,
                 dataSource = DataSource.DISK
             )
         } catch (e: Exception) {
@@ -94,7 +109,8 @@ class AppIconFetcher(
         }
     }
 
-    private fun Drawable.toBitmap(): Bitmap {
+    /** Renders the drawable at its full intrinsic size, for persisting to the disk cache. */
+    private fun Drawable.toFullBitmap(): Bitmap {
         if (this is BitmapDrawable) return this.bitmap
         val bitmap = Bitmap.createBitmap(
             intrinsicWidth.coerceAtLeast(1),
@@ -109,13 +125,59 @@ class AppIconFetcher(
         return bitmap
     }
 
+    private fun Drawable.toBitmap(): Bitmap {
+        val intrinsicWidth = intrinsicWidth.coerceAtLeast(1)
+        val intrinsicHeight = intrinsicHeight.coerceAtLeast(1)
+
+        // Target the Coil-requested px, never upscaling past the drawable's intrinsic size.
+        val targetWidth = options.size.width
+            .pxOrElse { intrinsicWidth }
+            .coerceIn(1, intrinsicWidth)
+        val targetHeight = options.size.height
+            .pxOrElse { intrinsicHeight }
+            .coerceIn(1, intrinsicHeight)
+
+        if (this is BitmapDrawable && targetWidth >= intrinsicWidth && targetHeight >= intrinsicHeight) {
+            return this.bitmap
+        }
+
+        val bitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        val oldBounds = bounds
+        setBounds(0, 0, canvas.width, canvas.height)
+        draw(canvas)
+        bounds = oldBounds
+        return bitmap
+    }
+
+    /**
+     * Computes a power-of-two [BitmapFactory.Options.inSampleSize] that downsamples a source of
+     * [sourceWidth] x [sourceHeight] to at least the Coil target size. Falls back to no
+     * downsampling (`1`) for [Size.ORIGINAL] or when the bounds could not be read.
+     */
+    private fun computeInSampleSize(sourceWidth: Int, sourceHeight: Int): Int {
+        if (sourceWidth <= 0 || sourceHeight <= 0) return 1
+
+        val reqWidth = options.size.width.pxOrElse { return 1 }
+        val reqHeight = options.size.height.pxOrElse { return 1 }
+        if (reqWidth <= 0 || reqHeight <= 0) return 1
+
+        var inSampleSize = 1
+        while (sourceWidth / (inSampleSize * 2) >= reqWidth &&
+            sourceHeight / (inSampleSize * 2) >= reqHeight
+        ) {
+            inSampleSize *= 2
+        }
+        return inSampleSize
+    }
+
     class Factory(private val context: Context) : Fetcher.Factory<AppIconModel> {
         override fun create(
             data: AppIconModel,
             options: Options,
             imageLoader: ImageLoader
         ): Fetcher {
-            return AppIconFetcher(data, context)
+            return AppIconFetcher(data, context, options)
         }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/AppIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/AppIconLoader.kt
@@ -16,6 +16,7 @@ import coil3.fetch.Fetcher
 import coil3.fetch.ImageFetchResult
 import coil3.key.Keyer
 import coil3.request.Options
+import coil3.request.bitmapConfig
 import coil3.size.pxOrElse
 import java.io.File
 import java.io.FileOutputStream
@@ -55,13 +56,20 @@ class AppIconFetcher(
                 BitmapFactory.decodeFile(iconFile.absolutePath, boundsOptions)
 
                 val sampleSize = computeInSampleSize(boundsOptions.outWidth, boundsOptions.outHeight)
-                val decodeOptions = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+                val decodeOptions = BitmapFactory.Options().apply {
+                    inSampleSize = sampleSize
+                    inPreferredConfig = options.bitmapConfig
+                }
                 val bitmap = BitmapFactory.decodeFile(iconFile.absolutePath, decodeOptions)
                 if (bitmap != null) {
                     val drawable = BitmapDrawable(context.resources, bitmap)
+                    // Report sampled only when actually smaller than the source, so a full-size
+                    // decode stays reusable for larger targets.
+                    val sampled = bitmap.width < boundsOptions.outWidth ||
+                        bitmap.height < boundsOptions.outHeight
                     return ImageFetchResult(
                         image = drawable.asImage(),
-                        isSampled = sampleSize > 1,
+                        isSampled = sampled,
                         dataSource = DataSource.DISK
                     )
                 }
@@ -99,9 +107,13 @@ class AppIconFetcher(
             // than the full adaptive-icon resolution, keeping the memory cache small.
             val bitmap = drawable.toBitmap()
 
+            // Report sampled only when the rendered bitmap is smaller than the drawable's
+            // intrinsic size, so a full-size render can be reused for larger targets.
+            val sampled = bitmap.width < drawable.intrinsicWidth ||
+                bitmap.height < drawable.intrinsicHeight
             ImageFetchResult(
                 image = BitmapDrawable(context.resources, bitmap).asImage(),
-                isSampled = true,
+                isSampled = sampled,
                 dataSource = DataSource.DISK
             )
         } catch (e: Exception) {
@@ -141,7 +153,13 @@ class AppIconFetcher(
             return this.bitmap
         }
 
-        val bitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
+        // Honor Coil's requested config, but a created (mutable) bitmap can't be HARDWARE.
+        val config = if (options.bitmapConfig == Bitmap.Config.HARDWARE) {
+            Bitmap.Config.ARGB_8888
+        } else {
+            options.bitmapConfig
+        }
+        val bitmap = Bitmap.createBitmap(targetWidth, targetHeight, config)
         val canvas = Canvas(bitmap)
         val oldBounds = bounds
         setBounds(0, 0, canvas.width, canvas.height)

--- a/app/src/store/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
+++ b/app/src/store/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
@@ -21,6 +21,7 @@ import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -248,5 +249,14 @@ class BillingProcessorImpl(
 
     override fun dismissThankYouDialog() {
         _showThankYouDialog.value = false
+    }
+
+    override fun close() {
+        try {
+            billingClient.endConnection()
+        } catch (e: Exception) {
+            Logger.e("BillingProcessor", "Error ending billing connection", e)
+        }
+        scope.cancel()
     }
 }

--- a/app/src/store/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
+++ b/app/src/store/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
@@ -251,6 +251,16 @@ class BillingProcessorImpl(
         _showThankYouDialog.value = false
     }
 
+    /**
+     * TERMINAL teardown — safe ONLY at process shutdown (e.g. [android.app.Application.onTerminate]).
+     *
+     * This is a Koin `@Single`, so the same instance is reused for the whole process. Both the
+     * [billingClient] (via [BillingClient.endConnection]) and [scope] (via cancel) are disposed
+     * permanently and CANNOT be restarted on this instance. Do NOT call this mid-lifecycle
+     * (e.g. on Support-sheet dismissal): a later billing interaction would then use a dead client
+     * and a cancelled scope. A dismissal-driven teardown would first require changing the Koin
+     * binding to factory/scoped, or making the client + scope lazily recreatable.
+     */
     override fun close() {
         try {
             billingClient.endConnection()


### PR DESCRIPTION
## What
Three audit fixes: icon-decode sizing (jank+memory), billing teardown hook (leak), and a cache data race (correctness).

- **A#3 — `AppIconLoader`:** icons were decoded at full adaptive resolution (108-192dp+) and the Coil target `Size` was discarded, bloating the memory cache → scroll jank. Now the fetcher honors `options.size`: a two-pass `inSampleSize` decode on the disk path and a target-sized bitmap on the fresh path. The in-memory bitmap is now ~48-64dp for lists; the disk PNG is kept full-res so the 120dp details icon stays crisp (the disk path re-samples per requested size, so no repeated full-res decode). `Size.ORIGINAL` falls back to intrinsic.
- **A#14 — `BillingProcessor` (store + foss):** the app-lifetime `@Single` bound the Play billing service + a `Default` scope forever. Added a `close()` teardown (`endConnection()` + `scope.cancel()`) to the interface and both flavor impls. Invoked from `Application.onTerminate()` as a best-effort hook (KDoc notes it's not guaranteed on devices). **Fast-follow (recommended):** drive `close()` from the Support-Developer sheet dismissal (lazy-connect on show / close on dismiss) so the binding is released when the support UI closes — deferred to avoid a billing-connection regression on this LOW-severity item.
- **A#21 — `UadHelper`:** `cachedMap`/`didLoadFail` are now `@Volatile` with double-checked locking under a dedicated lock, fixing the cross-thread race between `invalidateCache()` (main thread, from a receiver) and the IO-worker reads (stale reads / duplicate `buildUadMap()`).

## Verification
`:app:assembleFossDebug` AND `:app:assembleStoreDebug` BUILD SUCCESSFUL (JBR-21). Behavior-preserving; only `close()` is new public API; no versionCode bump.

Part of the remediation plan (`remediation_plan.md`, branch B6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)