### PR TITLE
build: bump Asgard 1.0.0 → 1.0.1 (ships #197 ButtonGroup crash fix)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ navigation3 = "1.1.3"
 play-billing = "9.1.0"
 androidx-adaptive = "1.3.0-rc01"
 thorExtensionApi = "2.0.0"
-asgardUi = "1.0.0"
+asgardUi = "1.0.1"
 
 [libraries]
 thor-extension-api = { module = "com.trinadhthatakula:thor-extension-api", version.ref = "thorExtensionApi" }


### PR DESCRIPTION
Bumps `asgardUi` to **1.0.1** (now on Maven Central). This pulls the published `ConnectedButtonGroup` rewrite (weighted `Row` instead of the expressive `ButtonGroup`) that fixes the **Settings crash at Font=Maximum + Display=Larger** (#197), plus the selected-button zIndex refinement.

Verified: `:app:assembleFossDebug` resolves `com.trinadhthatakula:asgard:1.0.1` and BUILD SUCCESSFUL (JBR-21, `--refresh-dependencies`). Public API unchanged → no call-site changes.

Completes the Thor side of remediation branch B1 (Asgard fix was published from the Asgard repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)