### PR TITLE
chore(release): bump to v1.90.1 + release notes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,6 @@ org.gradle.welcome=never
 initialVersionCode=1900
 # REQUIRED: The active source of truth for our release manager
 # Logic: 1822 -> 1.82.2 (based on math: code/1000 . code%1000/10 . code%10)
-versionCode=1900
-versionName=1.90.0
+versionCode=1901
+versionName=1.90.1
 

--- a/release-notes/v1.90.1/github.md
+++ b/release-notes/v1.90.1/github.md
@@ -1,0 +1,32 @@
+# Thor v1.90.1 Release Notes
+
+A focused **stability & smoothness** release on top of v1.90.0 — hardened APK installation, a fix for the Settings crash on large fonts, and a broad pass to eliminate memory leaks and UI jank across the app.
+
+## What's Changed
+
+### 📦 Installer
+*   **No more false "downgrade" blocks**: normal apps that bundle helper `.apk` assets (e.g. Muntashirakon **App Manager**, **MT File Manager**) were being misidentified as a system downgrade and blocked. A file is now recognized as a single APK by its top-level manifest instead of by any nested `.apk` entry, so it installs correctly. (#207)
+*   **`.xapk` installs fixed**: bundles that failed with *"Error: failed to parse package"* now install — tolerant manifest parsing (numeric `version_code`, missing fields) and correct base-APK selection that skips config splits. (#159)
+
+### 🐛 Crash Fix
+*   **Settings no longer crashes** with system Font Size = Maximum and Display Size = Larger. The connected button group was rebuilt (via **Asgard 1.0.1**) so it can no longer produce the internal `ButtonGroup` measurement crash at any font/display scale. (#197)
+
+### 🚀 Performance & Smoothness
+*   App-list **pull-to-refresh no longer stacks background collectors** — previously each refresh leaked broadcast receivers and re-ran a full package enumeration.
+*   Privilege availability checks (Shizuku/Dhizuku binder IPC) are now **`suspend` and main-safe**, moved off the main thread across Settings, App Details, App List, and the installer — noticeably less jank.
+*   **Less recomposition work**: list filtering/sorting and date formatting are memoized in App Details, Freezer, and Permission Manager.
+*   **App icons decode at their display size** — lower memory use and smoother scrolling in the app grid.
+*   Lifecycle-aware state collection and one-shot side effects throughout (no more background activity launches).
+
+### 🔒 Stability & Resource Fixes
+*   Privileged **shell/process execution** (Shizuku/Dhizuku) now uses **bounded waits with guaranteed teardown** and daemon reader threads — a hung command can no longer pin a background thread forever or leak file descriptors.
+*   Fixed a **cross-thread data race** in the debloat (UAD) cache.
+*   The **biometric prompt** no longer orphans a cancellation signal when re-triggered (auto-prompt + manual tap).
+*   Billing no longer initializes at app shutdown; added a proper teardown hook.
+*   Removed an unused cache-scanner path that leaked a `su` subprocess and its file descriptors.
+
+### ✅ Issues Resolved
+*   **#197** — Settings crash on large font/display size.
+*   **#207** — installation wrongly blocked as a system downgrade.
+*   **#159** — `.xapk` install failing to parse.
+*   Also closed **#77** (clear cache / force-stop — already fixed) and **#161** (tap-to-install — already shipped).

--- a/release-notes/v1.90.1/playstore.txt
+++ b/release-notes/v1.90.1/playstore.txt
@@ -1,0 +1,9 @@
+What's new in Thor v1.90.1
+
+• Fixed some apps being wrongly blocked as a "downgrade" during install.
+• Fixed .xapk files failing to install.
+• Fixed the Settings screen crash on large font / display sizes.
+• Smoother scrolling and less jank — lighter app icons and more work moved off the main thread.
+• Squashed several memory leaks and hardened stability under the hood.
+
+Thanks for using Thor!

--- a/release-notes/v1.90.1/telegram.md
+++ b/release-notes/v1.90.1/telegram.md
@@ -1,0 +1,11 @@
+⚡️ **Thor v1.90.1 is here!**
+
+A focused stability & smoothness update:
+
+• 📦 Fixed apps wrongly blocked as a "downgrade" (App Manager, MT Manager & co.)
+• 🧩 `.xapk` installs that failed to parse now work
+• 🐛 Fixed the Settings crash on large font / display sizes
+• 🚀 Smoother scrolling & less jank — lighter icons, more off-main-thread work
+• 🔒 Squashed memory leaks & hardened privileged shell/process handling
+
+Fixes #197, #207 & #159. Update and enjoy the smoother Thor! 🚀


### PR DESCRIPTION
Bumps `versionCode` 1900 → **1901** and `versionName` → **1.90.1** (verified: APK resolves `versionCode 1901 / versionName 1.90.1`), and adds `release-notes/v1.90.1/` in all three variants (`github.md`, `playstore.txt` — 409 chars, under the 500 limit, `telegram.md`).

**v1.90.1 is a stability & smoothness point release** covering everything merged since 1.90.0:
- Installer: fixed false "downgrade" blocks for apps bundling nested APKs (#207) and `.xapk` parse failures (#159).
- Settings crash at large font/display fixed via Asgard 1.0.1 (#197).
- Memory-leak / jank remediation: app-list collector leak, off-main binder IPC, memoized recomposition, target-size icon decode, bounded shell/process teardown, UAD cache race, biometric signal, billing teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)