### PR TITLE
chore(github): issue-form templates + PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: 🐛 Bug report
+description: Report something that isn't working correctly
+title: "[Bug]: "
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! The **privilege mode** and **version** fields are the most
+        important for reproducing the issue — please don't skip them.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I'm on the latest version of Thor and the bug still happens.
+          required: true
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I ..., Thor ...; I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Tap ...
+        3. See ...
+    validations:
+      required: true
+  - type: dropdown
+    id: privilege-mode
+    attributes:
+      label: Privilege mode
+      description: Which mode was active when the bug occurred?
+      options:
+        - Root
+        - Shizuku
+        - Dhizuku
+        - None
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Installer (APK / XAPK / APKS)
+        - Freezer (freeze / unfreeze / suspend)
+        - App management (force-stop, clear cache/data, uninstall)
+        - UI / theming
+        - Permissions
+        - Extensions
+        - Localization / translation
+        - Performance (jank / memory / ANR)
+        - Support the developer / billing
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: Thor version
+      description: See Settings → About (e.g. 1.90.1)
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Install source
+      placeholder: IzzyOnDroid / GitHub / Play Store / Obtainium / other
+  - type: input
+    id: device
+    attributes:
+      label: Device & Android version
+      placeholder: e.g. Pixel 8, Android 15 (One UI 6, etc.)
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste any logs (Thor has an in-app terminal log view) or attach screenshots. Text pasted here is auto-formatted.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -87,6 +87,11 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Logs / screenshots
-      description: Paste any logs (Thor has an in-app terminal log view) or attach screenshots. Text pasted here is auto-formatted.
+      label: Logs
+      description: Paste any logs (Thor has an in-app terminal log view). Text pasted here is auto-formatted as code.
       render: shell
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / additional context
+      description: Drag & drop screenshots here, or add any other relevant context. (Don't paste images into the Logs field above — the code formatting stops them rendering.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & discussion
+    url: https://github.com/trinadhthatakula/Thor/discussions
+    about: Ask questions, share setups, or discuss ideas here instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: ✨ Feature request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please describe the **problem** you're trying to solve, not just
+        the solution — it helps us find the best approach.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and discussions and didn't find a duplicate.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what's missing or hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like Thor to do?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Installer
+        - Freezer
+        - App management
+        - UI / theming
+        - Permissions
+        - Extensions
+        - Localization
+        - Performance
+        - Support the developer / billing
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or other approaches you've thought about.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Thanks for contributing to Thor! -->
+
+## What & why
+<!-- What does this PR change, and why? Link related issues, e.g. "Closes #123". -->
+
+## Changes
+-
+
+## Testing
+<!-- How did you verify this works? -->
+- [ ] Builds locally on JDK 21 (`./gradlew assembleFossDebug`)
+- [ ] Tested under privilege mode(s): <!-- Root / Shizuku / Dhizuku / None -->
+
+## Checklist
+- [ ] Changes are scoped to the stated purpose (no unrelated edits)
+- [ ] Bumped `versionCode` in `gradle.properties` **if** this PR is release-bound (otherwise skip)
+- [ ] Updated docs / release notes if user-facing


### PR DESCRIPTION
Improves issue intake so reports arrive categorized and reproducible.

**Adds** (`.github/`):
- `ISSUE_TEMPLATE/bug_report.yml` — structured form: **privilege mode** (Root/Shizuku/Dhizuku/None), **affected area**, Thor version, install source, device/Android version, and a `render: shell` logs field. Auto-applies `bug` + `needs triage`.
- `ISSUE_TEMPLATE/feature_request.yml` — problem/solution/area form. Auto-applies `enhancement` + `needs triage`.
- `ISSUE_TEMPLATE/config.yml` — disables blank issues; links **Discussions** for questions.
- `pull_request_template.md` — what/why, testing (JDK 21 build + privilege mode), checklist.

**Also done (repo-wide, already live via API):** a label taxonomy — `mode: root/shizuku/dhizuku`, `area: installer/freezer/app-management/ui-ux/permissions/extensions/localization/performance/billing`, `priority: high/medium/low`, and triage states (`needs triage`, `needs info`, `confirmed`, `cannot reproduce`).

> Note: issue templates render from the **default branch (`master`)**, so they go live once this reaches `master` (via the dev→main release PR). Labels are repo-wide and already active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)