### PR TITLE
chore(github): PR auto-labeler, SECURITY.md, CODEOWNERS, stale bot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners for Thor. Listed owners are auto-requested for review on matching paths.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repository
+*                       @trinadhthatakula
+
+# Release-gating / CI config — always flag for maintainer review
+/.github/                @trinadhthatakula
+/gradle.properties       @trinadhthatakula
+/release-notes/          @trinadhthatakula

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of Thor receives security fixes. Please update to the newest version
+(GitHub Releases / IzzyOnDroid / Play Store) before reporting.
+
+| Version          | Supported |
+|------------------|-----------|
+| Latest (1.90.x)  | ✅        |
+| Older            | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately through GitHub's **Report a vulnerability** button on the
+[Security → Advisories page](https://github.com/trinadhthatakula/Thor/security/advisories/new).
+This opens a private advisory visible only to you and the maintainer.
+
+Because Thor performs privileged operations (Root / Shizuku / Dhizuku, and shell commands such as
+`pm` and `am`), a good report includes:
+
+- The **privilege mode** and **Thor version**.
+- Steps to reproduce and the **impact** — e.g. privilege escalation, unauthorized package/data
+  access, or arbitrary command execution.
+- Any proof-of-concept, logs, or affected code paths.
+
+## What to expect
+
+- Acknowledgement of your report as soon as reasonably possible.
+- An assessment and, if valid, a fix in a subsequent release — with credit, unless you prefer to
+  remain anonymous.
+
+Please give us reasonable time to ship a fix before any public disclosure. Thank you for helping
+keep Thor and its users safe.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -7,8 +7,8 @@ Only the latest release of Thor receives security fixes. Please update to the ne
 
 | Version          | Supported |
 |------------------|-----------|
-| Latest (1.90.x)  | ✅        |
-| Older            | ❌        |
+| Latest release   | ✅        |
+| Older versions   | ❌        |
 
 ## Reporting a vulnerability
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,7 +35,8 @@
 "area: localization":
   - changed-files:
       - any-glob-to-any-file:
-          - "app/src/**/res/values*/**"
+          # values-* only — the base values/ dir holds non-translatable colors/dimens/themes.
+          - "app/src/**/res/values-*/**"
           - "**/strings.xml"
 
 "area: billing":
@@ -51,6 +52,8 @@
           - "app/src/**/widgets/**"
           - "app/src/**/components/**"
           - "app/src/**/*Screen.kt"
+          - "app/src/**/res/drawable*/**"
+          - "app/src/**/res/layout*/**"
 
 "dependencies":
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,66 @@
+# Path-based auto-labeling for PRs (actions/labeler v5).
+# Applies `area:` + dependency/docs labels based on changed files.
+# `mode:` labels are intentionally left for issue triage (they describe repro, not code area).
+
+"area: installer":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/installer/**"
+          - "app/src/**/AppAnalyzer*"
+          - "app/src/**/InstallerRepository*"
+          - "app/src/**/BundleAnalysis*"
+          - "app/src/**/ApksMetadataGenerator*"
+          - "app/src/**/PackageVerifier*"
+
+"area: freezer":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/freezer/**"
+          - "app/src/**/tile/**"
+          - "app/src/**/AutoFreezeManager*"
+          - "app/src/**/Freezer*"
+
+"area: permissions":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/permission/**"
+          - "app/src/**/PermissionRepository*"
+
+"area: extensions":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/extension/**"
+          - "app/src/**/Extension*"
+
+"area: localization":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/res/values*/**"
+          - "**/strings.xml"
+
+"area: billing":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/*Billing*"
+          - "app/src/**/SupportDeveloper*"
+
+"area: ui/ux":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/theme/**"
+          - "app/src/**/widgets/**"
+          - "app/src/**/components/**"
+          - "app/src/**/*Screen.kt"
+
+"dependencies":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "gradle/libs.versions.toml"
+          - "**/build.gradle.kts"
+          - "gradle/wrapper/**"
+
+"documentation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "release-notes/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          # Don't remove labels a maintainer added manually when files change.
+          sync-labels: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: Close stale needs-info issues
+
+# Conservative: ONLY touches issues labelled "needs info" (waiting on the reporter).
+# Feature requests, confirmed bugs, and PRs are never auto-closed by this workflow.
+
+on:
+  schedule:
+    - cron: "30 3 * * *"   # daily, 03:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: "needs info"
+          days-before-stale: 21
+          days-before-close: 7
+          stale-issue-label: "stale"
+          exempt-issue-labels: "confirmed,priority: high"
+          stale-issue-message: >
+            This issue has been waiting on additional information for 21 days, so it's been marked
+            stale. If it's still relevant, please add the requested details — otherwise it will be
+            closed in 7 days. Thanks!
+          close-issue-message: >
+            Closing due to inactivity (no response to the info request). Comment with the details
+            any time and we'll be happy to reopen and take another look.
+          # Never touch pull requests with this workflow.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
Implements suggestions 1–4 from the GitHub housekeeping pass (file-based, no settings changes).

1. **PR auto-labeler** — `.github/labeler.yml` + `.github/workflows/labeler.yml` (actions/labeler v5). Applies `area:*` / `dependencies` / `documentation` labels to PRs based on changed paths. Injection-safe: no `run:` steps and it never checks out or runs PR code (labels via the API from the base branch). `mode:*` labels are left for issue triage by design.
2. **`SECURITY.md`** — private-reporting policy via GitHub Security Advisories, tailored to Thor's privileged operations (Root/Shizuku/Dhizuku, `pm`/`am`).
3. **`CODEOWNERS`** — maintainer as default owner; explicitly flags `.github/`, `gradle.properties`, and `release-notes/`.
4. **Stale bot** — `.github/workflows/stale.yml`. Conservative: only issues labelled `needs info` go stale (21 days) then close (7 days); PRs, `confirmed`, and `priority: high` are never touched. (Created the `stale` label.)

> **Activation:** workflows and (from the templates PR) issue templates render from the **default branch (`master`)**, so these go live once merged to `master`. Labels are repo-wide and already active.

### Still needs your toggle (repo settings)
- Enable **private vulnerability reporting** (Settings → Security) so the `SECURITY.md` "Report a vulnerability" link works.
- Branch protection on `master`/`dev`; optional native Issue Types & milestones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)