### PR TITLE
feat(privilege): reactive privilege flow (single StateFlow source of truth)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners for Thor. Listed owners are auto-requested for review on matching paths.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repository
+*                       @trinadhthatakula
+
+# Release-gating / CI config — always flag for maintainer review
+/.github/                @trinadhthatakula
+/gradle.properties       @trinadhthatakula
+/release-notes/          @trinadhthatakula

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: 🐛 Bug report
+description: Report something that isn't working correctly
+title: "[Bug]: "
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! The **privilege mode** and **version** fields are the most
+        important for reproducing the issue — please don't skip them.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I'm on the latest version of Thor and the bug still happens.
+          required: true
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I ..., Thor ...; I expected ...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open ...
+        2. Tap ...
+        3. See ...
+    validations:
+      required: true
+  - type: dropdown
+    id: privilege-mode
+    attributes:
+      label: Privilege mode
+      description: Which mode was active when the bug occurred?
+      options:
+        - Root
+        - Shizuku
+        - Dhizuku
+        - None
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Installer (APK / XAPK / APKS)
+        - Freezer (freeze / unfreeze / suspend)
+        - App management (force-stop, clear cache/data, uninstall)
+        - UI / theming
+        - Permissions
+        - Extensions
+        - Localization / translation
+        - Performance (jank / memory / ANR)
+        - Support the developer / billing
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: Thor version
+      description: See Settings → About (e.g. 1.90.1)
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Install source
+      placeholder: IzzyOnDroid / GitHub / Play Store / Obtainium / other
+  - type: input
+    id: device
+    attributes:
+      label: Device & Android version
+      placeholder: e.g. Pixel 8, Android 15 (One UI 6, etc.)
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste any logs (Thor has an in-app terminal log view) or attach screenshots. Text pasted here is auto-formatted.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -87,6 +87,11 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Logs / screenshots
-      description: Paste any logs (Thor has an in-app terminal log view) or attach screenshots. Text pasted here is auto-formatted.
+      label: Logs
+      description: Paste any logs (Thor has an in-app terminal log view). Text pasted here is auto-formatted as code.
       render: shell
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / additional context
+      description: Drag & drop screenshots here, or add any other relevant context. (Don't paste images into the Logs field above — the code formatting stops them rendering.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & discussion
+    url: https://github.com/trinadhthatakula/Thor/discussions
+    about: Ask questions, share setups, or discuss ideas here instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: ✨ Feature request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please describe the **problem** you're trying to solve, not just
+        the solution — it helps us find the best approach.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and discussions and didn't find a duplicate.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what's missing or hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like Thor to do?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Installer
+        - Freezer
+        - App management
+        - UI / theming
+        - Permissions
+        - Extensions
+        - Localization
+        - Performance
+        - Support the developer / billing
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or other approaches you've thought about.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of Thor receives security fixes. Please update to the newest version
+(GitHub Releases / IzzyOnDroid / Play Store) before reporting.
+
+| Version          | Supported |
+|------------------|-----------|
+| Latest (1.90.x)  | ✅        |
+| Older            | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately through GitHub's **Report a vulnerability** button on the
+[Security → Advisories page](https://github.com/trinadhthatakula/Thor/security/advisories/new).
+This opens a private advisory visible only to you and the maintainer.
+
+Because Thor performs privileged operations (Root / Shizuku / Dhizuku, and shell commands such as
+`pm` and `am`), a good report includes:
+
+- The **privilege mode** and **Thor version**.
+- Steps to reproduce and the **impact** — e.g. privilege escalation, unauthorized package/data
+  access, or arbitrary command execution.
+- Any proof-of-concept, logs, or affected code paths.
+
+## What to expect
+
+- Acknowledgement of your report as soon as reasonably possible.
+- An assessment and, if valid, a fix in a subsequent release — with credit, unless you prefer to
+  remain anonymous.
+
+Please give us reasonable time to ship a fix before any public disclosure. Thank you for helping
+keep Thor and its users safe.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -7,8 +7,8 @@ Only the latest release of Thor receives security fixes. Please update to the ne
 
 | Version          | Supported |
 |------------------|-----------|
-| Latest (1.90.x)  | ✅        |
-| Older            | ❌        |
+| Latest release   | ✅        |
+| Older versions   | ❌        |
 
 ## Reporting a vulnerability
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,7 +35,8 @@
 "area: localization":
   - changed-files:
       - any-glob-to-any-file:
-          - "app/src/**/res/values*/**"
+          # values-* only — the base values/ dir holds non-translatable colors/dimens/themes.
+          - "app/src/**/res/values-*/**"
           - "**/strings.xml"
 
 "area: billing":
@@ -51,6 +52,8 @@
           - "app/src/**/widgets/**"
           - "app/src/**/components/**"
           - "app/src/**/*Screen.kt"
+          - "app/src/**/res/drawable*/**"
+          - "app/src/**/res/layout*/**"
 
 "dependencies":
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,66 @@
+# Path-based auto-labeling for PRs (actions/labeler v5).
+# Applies `area:` + dependency/docs labels based on changed files.
+# `mode:` labels are intentionally left for issue triage (they describe repro, not code area).
+
+"area: installer":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/installer/**"
+          - "app/src/**/AppAnalyzer*"
+          - "app/src/**/InstallerRepository*"
+          - "app/src/**/BundleAnalysis*"
+          - "app/src/**/ApksMetadataGenerator*"
+          - "app/src/**/PackageVerifier*"
+
+"area: freezer":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/freezer/**"
+          - "app/src/**/tile/**"
+          - "app/src/**/AutoFreezeManager*"
+          - "app/src/**/Freezer*"
+
+"area: permissions":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/permission/**"
+          - "app/src/**/PermissionRepository*"
+
+"area: extensions":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/extension/**"
+          - "app/src/**/Extension*"
+
+"area: localization":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/res/values*/**"
+          - "**/strings.xml"
+
+"area: billing":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/*Billing*"
+          - "app/src/**/SupportDeveloper*"
+
+"area: ui/ux":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/theme/**"
+          - "app/src/**/widgets/**"
+          - "app/src/**/components/**"
+          - "app/src/**/*Screen.kt"
+
+"dependencies":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "gradle/libs.versions.toml"
+          - "**/build.gradle.kts"
+          - "gradle/wrapper/**"
+
+"documentation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "release-notes/**"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Thanks for contributing to Thor! -->
+
+## What & why
+<!-- What does this PR change, and why? Link related issues, e.g. "Closes #123". -->
+
+## Changes
+-
+
+## Testing
+<!-- How did you verify this works? -->
+- [ ] Builds locally on JDK 21 (`./gradlew assembleFossDebug`)
+- [ ] Tested under privilege mode(s): <!-- Root / Shizuku / Dhizuku / None -->
+
+## Checklist
+- [ ] Changes are scoped to the stated purpose (no unrelated edits)
+- [ ] Bumped `versionCode` in `gradle.properties` **if** this PR is release-bound (otherwise skip)
+- [ ] Updated docs / release notes if user-facing

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          # Don't remove labels a maintainer added manually when files change.
+          sync-labels: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: Close stale needs-info issues
+
+# Conservative: ONLY touches issues labelled "needs info" (waiting on the reporter).
+# Feature requests, confirmed bugs, and PRs are never auto-closed by this workflow.
+
+on:
+  schedule:
+    - cron: "30 3 * * *"   # daily, 03:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: "needs info"
+          days-before-stale: 21
+          days-before-close: 7
+          stale-issue-label: "stale"
+          exempt-issue-labels: "confirmed,priority: high"
+          stale-issue-message: >
+            This issue has been waiting on additional information for 21 days, so it's been marked
+            stale. If it's still relevant, please add the requested details — otherwise it will be
+            closed in 7 days. Thanks!
+          close-issue-message: >
+            Closing due to inactivity (no response to the info request). Comment with the details
+            any time and we'll be happy to reopen and take another look.
+          # Never touch pull requests with this workflow.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
@@ -1,0 +1,94 @@
+package com.valhalla.thor.data.manager
+
+import com.valhalla.thor.domain.model.PrivilegeState
+import com.valhalla.thor.domain.model.resolvePrivilegeMode
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
+import rikka.shizuku.Shizuku
+
+/**
+ * Single reactive source of truth for privilege availability + the active mode.
+ *
+ * Re-probes root/Shizuku/Dhizuku off the main thread on init, on [refresh], on
+ * Shizuku binder/permission events (it owns those listeners), and whenever the
+ * preferred mode changes. As a process-lifetime @Single it never unregisters its
+ * Shizuku listeners (they live for the app), so consumers created before a
+ * first-launch grant still see it once granted.
+ */
+@Single
+class PrivilegeManager(
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _state = MutableStateFlow(PrivilegeState())
+    val state: StateFlow<PrivilegeState> = _state.asStateFlow()
+
+    // Bumped to force a re-probe; StateFlow<Int> emits on every distinct value.
+    private val refreshTrigger = MutableStateFlow(0)
+
+    private val binderReceivedListener = Shizuku.OnBinderReceivedListener { refresh() }
+    private val permissionResultListener =
+        Shizuku.OnRequestPermissionResultListener { _, _ -> refresh() }
+
+    init {
+        Shizuku.addBinderReceivedListener(binderReceivedListener)
+        Shizuku.addRequestPermissionResultListener(permissionResultListener)
+
+        scope.launch {
+            combine(availabilityFlow(), preferenceRepository.userPreferences) { avail, prefs ->
+                PrivilegeState(
+                    root = avail.root,
+                    shizuku = avail.shizuku,
+                    dhizuku = avail.dhizuku,
+                    active = resolvePrivilegeMode(
+                        prefs.preferredPrivilegeMode,
+                        avail.root,
+                        avail.shizuku,
+                        avail.dhizuku
+                    ),
+                    isReady = true
+                )
+            }.collect { _state.value = it }
+        }
+    }
+
+    /** Force a re-probe (e.g. after the user enables root outside the app). */
+    fun refresh() {
+        refreshTrigger.value += 1
+    }
+
+    private data class Availability(val root: Boolean, val shizuku: Boolean, val dhizuku: Boolean)
+
+    private fun availabilityFlow(): Flow<Availability> =
+        refreshTrigger
+            .map {
+                Availability(
+                    root = safeProbe { systemRepository.isRootAvailable() },
+                    shizuku = safeProbe { systemRepository.isShizukuAvailable() },
+                    dhizuku = safeProbe { systemRepository.isDhizukuAvailable() }
+                )
+            }
+            .flowOn(Dispatchers.IO)
+
+    private suspend fun safeProbe(block: suspend () -> Boolean): Boolean = try {
+        block()
+    } catch (e: Exception) {
+        Logger.e("PrivilegeManager", "privilege probe failed", e)
+        false
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -48,12 +48,19 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
             var infoBytes: ByteArray? = null
             var iconBytes: ByteArray? = null
             try {
-                entryNames = BundleZip.entryNames(bundleFile)
-                manifestBytes = BundleZip.readEntry(bundleFile, "manifest.json")
-                infoBytes = BundleZip.readEntry(bundleFile, "info.json")
-                iconBytes = BundleZip.readEntry(bundleFile, "icon.png")
-                    ?: BundleZip.readEntry(bundleFile, "icon.jpg")
-                    ?: BundleZip.readEntry(bundleFile, "icon.webp")
+                // Single ZipFile pass for entry names + all sidecar/icon bytes, instead
+                // of re-opening (and re-parsing the central directory of) the archive per
+                // file.
+                val contents = BundleZip.read(
+                    bundleFile,
+                    setOf("manifest.json", "info.json", "icon.png", "icon.jpg", "icon.webp")
+                )
+                entryNames = contents.entryNames
+                manifestBytes = contents.bytes["manifest.json"]
+                infoBytes = contents.bytes["info.json"]
+                iconBytes = contents.bytes["icon.png"]
+                    ?: contents.bytes["icon.jpg"]
+                    ?: contents.bytes["icon.webp"]
             } catch (_: Exception) {
                 // Not a readable zip — fall through to the monolithic whole-file parse.
             }
@@ -153,7 +160,10 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
         val fromProvider = try {
             context.contentResolver.query(
                 uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null
-            )?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+            )?.use { cursor ->
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index != -1 && cursor.moveToFirst()) cursor.getString(index) else null
+            }
         } catch (_: Exception) {
             null
         }

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -10,6 +10,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build
+import android.provider.OpenableColumns
 import androidx.core.graphics.createBitmap
 import com.valhalla.thor.domain.model.AppMetadata
 import com.valhalla.thor.domain.repository.AppAnalyzer
@@ -18,146 +19,114 @@ import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import java.io.File
 import java.io.FileOutputStream
-import java.util.zip.ZipInputStream
 
 @Single(binds = [AppAnalyzer::class])
 class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
 
     override suspend fun analyze(uri: Uri): Result<AppMetadata> = withContext(Dispatchers.IO) {
-        val tempFile = File(context.cacheDir, "analysis_${System.currentTimeMillis()}.apk")
+        val displayName = displayNameOf(uri)
+        val stamp = System.currentTimeMillis()
+        // The whole input is copied to disk once so it can be read with ZipFile
+        // (random access via the central directory). ZipInputStream cannot handle
+        // APKPure's STORED-with-data-descriptor entries (zero-size local headers) and
+        // mis-reads the archive; ZipFile reads the central directory like `unzip`.
+        val bundleFile = File(context.cacheDir, "analysis_bundle_$stamp")
+        val apkFile = File(context.cacheDir, "analysis_$stamp.apk")
 
         try {
-            val contentResolver = context.contentResolver
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(bundleFile).use { output -> input.copyTo(output) }
+            } ?: return@withContext Result.failure(
+                Exception("Could not open the selected file.")
+            )
 
-            // Phase 1: Single pass — collect the zip's entry names plus the XAPK
-            // manifest.json and icon bytes (if any). The entry names let us decide
-            // monolithic-vs-bundle without trusting the mere presence of a .apk
-            // entry (every APK is itself a zip that may embed nested .apk assets).
-            val entryNames = mutableListOf<String>()
+            // Phase 1: Enumerate entries + read sidecar metadata (XAPK manifest.json /
+            // APKMirror info.json) and icon bytes via ZipFile. If the file is not a
+            // readable zip, entryNames stays empty and the monolithic parse below runs.
+            var entryNames: List<String> = emptyList()
             var manifestBytes: ByteArray? = null
+            var infoBytes: ByteArray? = null
             var iconBytes: ByteArray? = null
-
             try {
-                contentResolver.openInputStream(uri)?.use { inputStream ->
-                    ZipInputStream(inputStream).use { zipStream ->
-                        var entry = zipStream.nextEntry
-                        while (entry != null) {
-                            if (!entry.isDirectory) entryNames += entry.name
-                            when {
-                                entry.name.equals("manifest.json", ignoreCase = true) -> {
-                                    manifestBytes = zipStream.readBytes()
-                                    zipStream.closeEntry()
-                                }
-
-                                entry.name.equals("icon.png", ignoreCase = true) ||
-                                        entry.name.equals("icon.jpg", ignoreCase = true) ||
-                                        entry.name.equals("icon.webp", ignoreCase = true) -> {
-                                    iconBytes = zipStream.readBytes()
-                                    zipStream.closeEntry()
-                                }
-
-                                else -> zipStream.closeEntry()
-                            }
-                            entry = zipStream.nextEntry
-                        }
-                    }
-                }
+                entryNames = BundleZip.entryNames(bundleFile)
+                manifestBytes = BundleZip.readEntry(bundleFile, "manifest.json")
+                infoBytes = BundleZip.readEntry(bundleFile, "info.json")
+                iconBytes = BundleZip.readEntry(bundleFile, "icon.png")
+                    ?: BundleZip.readEntry(bundleFile, "icon.jpg")
+                    ?: BundleZip.readEntry(bundleFile, "icon.webp")
             } catch (_: Exception) {
-                // Not a readable zip (or truncated). We'll still try the monolithic
-                // whole-file parse below.
+                // Not a readable zip — fall through to the monolithic whole-file parse.
             }
 
-            // Phase 2: Monolithic-APK gate (GH#207). A file that carries its own
-            // top-level AndroidManifest.xml is a single installable APK — parse the
-            // whole file and NEVER scan inner .apk assets. If the authoritative
-            // whole-file parse fails, we return failure here rather than falling
-            // through to the base-candidate scan: falling through could extract a
-            // nested assets/*.apk (App Manager style) and return the WRONG package
-            // identity, re-triggering the GH#207 false-downgrade bug on the rare
-            // failed-parse path. (The parse itself needs framework
-            // getPackageArchiveInfo, so this exact branch is covered by compile +
-            // manual path; the "monolithic is never routed to candidate selection"
-            // invariant is unit-tested at the helper level in BundleAnalysisTest.)
-            if (isMonolithicApk(entryNames)) {
-                contentResolver.openInputStream(uri)?.use { input ->
-                    FileOutputStream(tempFile).use { output -> input.copyTo(output) }
-                }
-                val archiveInfo = parseArchive(tempFile)
+            // Phase 2: Monolithic-APK gate (GH#207). A single installable APK carries
+            // its own top-level AndroidManifest.xml and shows no bundle signal — parse
+            // the whole file as-is and NEVER scan inner .apk assets.
+            if (isMonolithicApk(entryNames, displayName)) {
+                val archiveInfo = parseArchiveSafely(bundleFile)
                     ?: return@withContext Result.failure(
                         Exception("Failed to parse APK manifest. The file might be corrupted or encrypted.")
                     )
-                return@withContext Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
+                return@withContext Result.success(metadataFrom(archiveInfo, bundleFile, iconBytes))
             }
 
-            // Phase 3: XAPK manifest path — build metadata from the authoritative
-            // base APK. Tolerant deserialization (GH#159) so numeric version_code /
-            // missing name don't nuke this path.
+            // Phase 3: Sidecar-metadata hint. The XAPK manifest.json / APKMirror
+            // info.json declares the package; that hint drives base selection so it no
+            // longer depends on a literal `base.apk` name. Tolerant deserialization
+            // (GH#159) keeps a numeric version_code / missing name from nuking it.
             val manifest = manifestBytes?.let { bytes -> parseXapkManifest(String(bytes)) }
+            val apkmInfo = infoBytes?.let { bytes -> parseApkmInfo(String(bytes)) }
+            val packageHint = manifest?.packageName?.takeIf { it.isNotBlank() }
+                ?: apkmInfo?.packageName?.takeIf { it.isNotBlank() }
 
-            val manifestBaseFile = manifest?.baseApkFile()
-            if (manifestBaseFile != null) {
-                val archiveInfo = extractAndParse(uri, manifestBaseFile, tempFile)
-                if (archiveInfo != null) {
-                    return@withContext Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
-                }
-                // else fall through to candidate scan below
-            }
+            // Phase 4: Base selection (GH#159) — the manifest's declared base first,
+            // then generic candidates (config/splits last). Extract each from the
+            // bundle and return the first that parses as a real, non-split base APK.
+            val baseCandidates = buildList {
+                manifest?.baseApkFile()?.let { add(it) }
+                addAll(selectBaseApkCandidates(entryNames, packageHint))
+            }.distinctBy { it.substringAfterLast('/').lowercase() }
 
-            // Phase 4: Generic bundle base selection (GH#159). Order candidates so
-            // splits/config APKs are tried last, and pick the first that parses as a
-            // non-split base.
-            val candidates = selectBaseApkCandidates(entryNames, manifest?.packageName)
-            for (candidate in candidates) {
-                val archiveInfo = extractAndParse(uri, candidate, tempFile)
+            for (candidate in baseCandidates) {
+                val base = candidate.substringAfterLast('/')
+                if (!BundleZip.extractEntryTo(bundleFile, base, apkFile)) continue
+                val archiveInfo = parseArchiveSafely(apkFile)
                 if (archiveInfo != null && archiveInfo.applicationInfo != null) {
-                    return@withContext Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
+                    return@withContext Result.success(metadataFrom(archiveInfo, apkFile, iconBytes))
                 }
             }
 
-            // TODO(#159): richer .apks (bundletool/SAI toc.pb, splits/…) and .apkm
-            // (APKMirror info.json) base-layout detection + OBB extraction — tracked
-            // as a separate follow-up.
-
-            // Phase 5: Last resort — treat the whole file as a monolithic APK even
-            // without a detectable top-level manifest (e.g. an entry-listing failure).
-            contentResolver.openInputStream(uri)?.use { input ->
-                FileOutputStream(tempFile).use { output -> input.copyTo(output) }
+            // Phase 4.5: Sidecar-only metadata fallback (GH#159). If no bundled APK
+            // parsed but the bundle declares its own identity, surface that — it is the
+            // bundle's own package (never a nested APK's), so it cannot cause the
+            // GH#207 wrong-identity downgrade, and it lets the (independent) installer
+            // path proceed instead of the whole flow reading as "failed to parse".
+            buildMetadataFromSidecar(manifest, apkmInfo, iconBytes)?.let {
+                return@withContext Result.success(it)
             }
-            val archiveInfo = parseArchive(tempFile)
+
+            // Phase 5: Last resort — parse the whole file as a monolithic APK (only
+            // reachable when it wasn't a readable bundle at all).
+            val archiveInfo = parseArchiveSafely(bundleFile)
                 ?: return@withContext Result.failure(
                     Exception("Failed to parse APK manifest. The file might be corrupted or encrypted.")
                 )
-
-            Result.success(metadataFrom(archiveInfo, tempFile, iconBytes))
+            Result.success(metadataFrom(archiveInfo, bundleFile, iconBytes))
         } catch (e: Exception) {
             Result.failure(e)
         } finally {
-            tempFile.delete()
+            bundleFile.delete()
+            apkFile.delete()
         }
     }
 
-    /** Extract a single zip entry into [tempFile] and parse it via PackageManager. */
-    private fun extractAndParse(uri: Uri, entryName: String, tempFile: File): PackageInfo? {
-        return try {
-            var extracted = false
-            context.contentResolver.openInputStream(uri)?.use { inputStream ->
-                ZipInputStream(inputStream).use { zipStream ->
-                    var entry = zipStream.nextEntry
-                    while (entry != null) {
-                        if (entry.name.equals(entryName, ignoreCase = true)) {
-                            FileOutputStream(tempFile).use { fos -> zipStream.copyTo(fos) }
-                            extracted = true
-                            break
-                        }
-                        zipStream.closeEntry()
-                        entry = zipStream.nextEntry
-                    }
-                }
-            }
-            if (!extracted || !tempFile.exists()) null else parseArchive(tempFile)
-        } catch (_: Exception) {
-            null
-        }
+    /**
+     * [parseArchive] that also swallows a thrown getPackageArchiveInfo (it can throw
+     * — not just return null — on some ROMs/APIs) so callers get a clean null.
+     */
+    private fun parseArchiveSafely(file: File): PackageInfo? = try {
+        parseArchive(file)
+    } catch (_: Exception) {
+        null
     }
 
     /** Parse an on-disk APK via getPackageArchiveInfo across API levels. */
@@ -173,6 +142,54 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
             @Suppress("DEPRECATION")
             pm.getPackageArchiveInfo(tempFile.absolutePath, flags)
         }
+    }
+
+    /**
+     * Best-effort display name (hence file extension) for [uri]: the provider's
+     * OpenableColumns.DISPLAY_NAME, falling back to the URI's last path segment.
+     * Used only as a secondary bundle signal, so null is fine.
+     */
+    private fun displayNameOf(uri: Uri): String? {
+        val fromProvider = try {
+            context.contentResolver.query(
+                uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null
+            )?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+        } catch (_: Exception) {
+            null
+        }
+        return fromProvider?.takeIf { it.isNotBlank() } ?: uri.lastPathSegment
+    }
+
+    /**
+     * Build [AppMetadata] purely from bundle sidecar JSON when no bundled APK could
+     * be parsed. Returns null if neither sidecar declares a package name. The icon
+     * comes from the bundle's own icon bytes (there is no APK to load one from).
+     */
+    private fun buildMetadataFromSidecar(
+        manifest: XapkManifestInfo?,
+        apkmInfo: ApkmInfo?,
+        iconBytes: ByteArray?
+    ): AppMetadata? {
+        val pkg = manifest?.packageName?.takeIf { it.isNotBlank() }
+            ?: apkmInfo?.packageName?.takeIf { it.isNotBlank() }
+            ?: return null
+        val label = manifest?.name?.takeIf { it.isNotBlank() }
+            ?: apkmInfo?.appName?.takeIf { it.isNotBlank() }
+            ?: apkmInfo?.title?.takeIf { it.isNotBlank() }
+            ?: pkg
+        val versionName = manifest?.versionName?.takeIf { it.isNotBlank() }
+            ?: apkmInfo?.versionName?.takeIf { it.isNotBlank() }
+            ?: "Unknown"
+        val versionCode = (manifest?.versionCode ?: apkmInfo?.versionCode)?.toLongOrNull() ?: 0L
+        val icon = iconBytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
+        return AppMetadata(
+            label = label,
+            packageName = pkg,
+            version = versionName,
+            versionCode = versionCode,
+            icon = icon,
+            permissions = manifest?.permissions ?: emptyList()
+        )
     }
 
     /** Build [AppMetadata] from a parsed [PackageInfo], preferring the XAPK icon. */

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -89,6 +89,13 @@ class AppRepositoryImpl(
                     val currentList = ArrayList<AppInfo>(installedPackages.size)
                     val toUpdate = mutableListOf<AppEntity>()
 
+                    // Read the (cache-backed) UAD map + load-fail flag ONCE per rescan.
+                    // Reading uadHelper.uadMap per-package rebuilt the ~1.6MB list under
+                    // its lock whenever a bulk freeze/unfreeze invalidated the cache
+                    // mid-loop, stalling the main-thread receiver (ANR) and this rescan.
+                    val uadMap = uadHelper.uadMap
+                    val uadLoadFailed = uadHelper.didLoadFail
+
                     for (packInfo in installedPackages) {
                         val appInfo = packInfo.applicationInfo ?: continue
                         val packageName = packInfo.packageName
@@ -100,7 +107,6 @@ class AppRepositoryImpl(
                         val isInstalled = (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0
                         val isEnabled = appInfo.enabled && isInstalled
 
-                        val uadMap = uadHelper.uadMap
                         if (!forceRefresh &&
                             cachedEntry != null &&
                             cachedEntry.lastUpdateTime == packInfo.lastUpdateTime &&
@@ -113,7 +119,7 @@ class AppRepositoryImpl(
                                 bloatRecommendation = bloat?.removal,
                                 bloatDescription = bloat?.description,
                                 isInstalled = isInstalled,
-                                isUadLoadFailed = uadHelper.didLoadFail
+                                isUadLoadFailed = uadLoadFailed
                             ))
                         } else {
                             val mapped =
@@ -122,7 +128,7 @@ class AppRepositoryImpl(
                             val mappedWithBloat = mapped.copy(
                                 bloatRecommendation = bloat?.removal,
                                 bloatDescription = bloat?.description,
-                                isUadLoadFailed = uadHelper.didLoadFail
+                                isUadLoadFailed = uadLoadFailed
                             )
                             currentList.add(mappedWithBloat)
                             val entity = AppEntity.fromDomain(mapped)

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
@@ -67,6 +67,46 @@ fun parseXapkManifest(jsonText: String): XapkManifestInfo? = try {
 }
 
 /**
+ * Tolerant representation of an APKMirror `.apkm` `info.json` (schema v5). Its
+ * layout differs from an XAPK `manifest.json`: the package is `pname`, the label
+ * `app_name`, the version `release_version`, and the version code `versioncode`.
+ * It does NOT enumerate the split file names — .apkm always ships a literal
+ * `base.apk` plus `split_config.*.apk` entries — so we only mine it for the
+ * package-name hint + display metadata (GH#159 follow-up: base detection must not
+ * depend solely on the literal `base.apk` name).
+ */
+@Serializable
+data class ApkmInfo(
+    @SerialName("pname") val packageName: String? = null,
+    @SerialName("app_name") val appName: String? = null,
+    @SerialName("apk_title") val title: String? = null,
+    @SerialName("release_version") val versionName: String? = null,
+    @SerialName("versioncode") val versionCode: String? = null
+)
+
+/**
+ * Parse an APKMirror `info.json` tolerantly. Returns null only when the input is
+ * not valid JSON at all; missing or oddly-typed fields are tolerated.
+ */
+fun parseApkmInfo(jsonText: String): ApkmInfo? = try {
+    bundleJson.decodeFromString<ApkmInfo>(jsonText)
+} catch (_: Exception) {
+    null
+}
+
+/** File extensions that unambiguously denote a bundle container (never a single APK). */
+private val BUNDLE_EXTENSIONS = setOf("xapk", "apkm", "apks")
+
+/**
+ * True when [fileName] carries a known bundle extension (`.xapk`/`.apkm`/`.apks`).
+ * A cheap, reliable secondary signal so a genuine bundle that also happens to
+ * carry a stray top-level `AndroidManifest.xml` is never mis-parsed as a single
+ * APK (root cause of the APKPure install failure).
+ */
+fun hasBundleExtension(fileName: String?): Boolean =
+    fileName != null && fileName.substringAfterLast('.', "").lowercase() in BUNDLE_EXTENSIONS
+
+/**
  * True if the archive has a top-level (root) `AndroidManifest.xml` entry. Every
  * real APK has exactly this; bundles (XAPK/.apks/.apkm) do not have one at the
  * archive root (their manifests live inside the nested APKs).
@@ -78,24 +118,62 @@ fun hasTopLevelAndroidManifest(entryNames: List<String>): Boolean =
 fun hasXapkManifest(entryNames: List<String>): Boolean =
     entryNames.any { it.equals("manifest.json", ignoreCase = true) }
 
-/**
- * A file is a monolithic APK (single, installable APK) when it carries its own
- * top-level `AndroidManifest.xml`. This is the primary signal used to avoid the
- * old "it's a zip containing a .apk, therefore a bundle" mistake (GH#207).
- */
-fun isMonolithicApk(entryNames: List<String>): Boolean =
-    hasTopLevelAndroidManifest(entryNames)
+/** True if the archive contains a top-level APKMirror `info.json`. */
+fun hasApkmInfoJson(entryNames: List<String>): Boolean =
+    entryNames.any { it.equals("info.json", ignoreCase = true) }
 
 /**
- * A file looks like a genuine bundle when it does NOT have a top-level
- * `AndroidManifest.xml`. An explicit top-level `manifest.json` (XAPK) is a
- * positive bundle signal too, but the absence of the manifest is the decisive
- * one — a monolithic APK always wins.
+ * True if the archive carries bundle sidecar metadata — an XAPK `manifest.json`
+ * or an APKMirror `info.json`. Either is a decisive positive bundle signal.
  */
-fun looksLikeBundle(entryNames: List<String>): Boolean =
-    !isMonolithicApk(entryNames) && (hasXapkManifest(entryNames) || entryNames.any {
-        it.endsWith(".apk", ignoreCase = true)
-    })
+fun hasBundleMetadata(entryNames: List<String>): Boolean =
+    hasXapkManifest(entryNames) || hasApkmInfoJson(entryNames)
+
+/**
+ * True for a *top-level* `.apk` entry (archive root, no `/` in the name). A real
+ * single APK never has a sibling `.apk` at its root — only bundles do — so this
+ * distinguishes a genuine bundle from a monolithic APK that merely embeds a
+ * nested `assets/child.apk` (GH#207), whose name contains a `/`.
+ */
+fun isTopLevelApkEntry(name: String): Boolean =
+    !name.contains('/') && name.endsWith(".apk", ignoreCase = true)
+
+/**
+ * A file is a monolithic APK (single, installable APK) only when it carries its
+ * own top-level `AndroidManifest.xml` AND shows no bundle signal. Requiring the
+ * *absence* of bundle signals — not just the presence of a manifest — is the fix
+ * for genuine bundles (XAPK/.apkm/.apks) that also ship a stray top-level
+ * `AndroidManifest.xml`: the old "AndroidManifest.xml ⇒ monolithic" gate routed
+ * the whole multi-APK zip into `getPackageArchiveInfo`, which failed with
+ * `FileNotFoundException: AndroidManifest.xml`.
+ *
+ * Bundle signals (any ⇒ NOT monolithic):
+ *  - a known bundle [fileName] extension (`.xapk`/`.apkm`/`.apks`), when known;
+ *  - a top-level `manifest.json` / `info.json`;
+ *  - a top-level `.apk` sibling (a real APK never has one).
+ *
+ * The GH#207 case is preserved: a monolithic APK with a nested `assets/child.apk`
+ * has no bundle metadata and no *top-level* `.apk`, so it stays monolithic.
+ */
+fun isMonolithicApk(entryNames: List<String>, fileName: String? = null): Boolean {
+    if (hasBundleExtension(fileName)) return false
+    if (!hasTopLevelAndroidManifest(entryNames)) return false
+    if (hasBundleMetadata(entryNames)) return false
+    if (entryNames.any { isTopLevelApkEntry(it) }) return false
+    return true
+}
+
+/**
+ * A file looks like a genuine bundle when it is not monolithic and shows at least
+ * one positive bundle signal: sidecar metadata, a top-level `.apk`, a nested
+ * split `.apk`, or a known bundle extension.
+ */
+fun looksLikeBundle(entryNames: List<String>, fileName: String? = null): Boolean =
+    !isMonolithicApk(entryNames, fileName) && (
+        hasBundleMetadata(entryNames) ||
+            hasBundleExtension(fileName) ||
+            entryNames.any { it.endsWith(".apk", ignoreCase = true) }
+        )
 
 /**
  * True for obvious split/config APK entries that are never a valid base:
@@ -156,4 +234,41 @@ fun selectBaseApkCandidates(entryNames: List<String>, packageName: String?): Lis
     ordered.addAll(splits)
 
     return ordered.toList()
+}
+
+/**
+ * Resolve the complete, base-first set of APK entry names to hand to
+ * `install-multiple` for a genuine bundle.
+ *
+ * When a `manifest.json` split list is present AND every declared split
+ * physically exists, that list is authoritative for base ordering — but we then
+ * *union* it with any additional top-level `.apk` entries the manifest omitted,
+ * so a stale/subset manifest can never silently drop a physically-present split
+ * (which would yield a base-only/partial install). Otherwise we fall back to
+ * [selectBaseApkCandidates], which orders every `.apk` base-first.
+ *
+ * Returns an empty list only when there are no `.apk` entries at all (caller then
+ * treats the input as monolithic).
+ */
+fun resolveBundleInstallSet(
+    entryNames: List<String>,
+    manifestSplitFiles: List<String>?,
+    packageName: String?
+): List<String> {
+    val ordered = selectBaseApkCandidates(entryNames, packageName)
+    if (manifestSplitFiles.isNullOrEmpty()) return ordered
+
+    val available = entryNames.mapTo(HashSet()) { it.substringAfterLast('/') }
+    // A manifest that references files not present is stale/partial: ignore it and
+    // fall back to the entry scan rather than extracting nothing.
+    if (!manifestSplitFiles.all { it.substringAfterLast('/') in available }) return ordered
+
+    val listed = manifestSplitFiles.mapTo(HashSet()) { it.substringAfterLast('/') }
+    // Only append entries that are genuinely config/splits the manifest omitted —
+    // never a standalone/foreign top-level APK (e.g. a `universal.apk`), which would
+    // add a second base and break install-multiple.
+    val extras = ordered.filter {
+        it.substringAfterLast('/') !in listed && isSplitApkName(it, packageName)
+    }
+    return manifestSplitFiles + extras
 }

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
@@ -20,6 +20,37 @@ import java.util.zip.ZipFile
  */
 object BundleZip {
 
+    /**
+     * Result of a single-pass read: every entry name, plus the bytes of the requested
+     * base names ([bytes] keyed by lowercased base name; only entries that existed).
+     */
+    data class BundleContents(
+        val entryNames: List<String>,
+        val bytes: Map<String, ByteArray>
+    )
+
+    /**
+     * Open [zip] ONCE and return every entry name plus the bytes of any entry whose base
+     * name is in [wantedBaseNames] (case-insensitive). Avoids re-opening (and re-parsing
+     * the central directory of) the archive once per metadata file.
+     */
+    fun read(zip: File, wantedBaseNames: Set<String>): BundleContents {
+        val wanted = wantedBaseNames.mapTo(HashSet()) { it.lowercase() }
+        val names = ArrayList<String>()
+        val bytes = HashMap<String, ByteArray>()
+        ZipFile(zip).use { zf ->
+            for (entry in zf.entries()) {
+                if (entry.isDirectory) continue
+                names.add(entry.name)
+                val key = entry.name.substringAfterLast('/').lowercase()
+                if (key in wanted && key !in bytes) {
+                    bytes[key] = zf.getInputStream(entry).use { it.readBytes() }
+                }
+            }
+        }
+        return BundleContents(names, bytes)
+    }
+
     /** Top-level entry names (files only) of [zip], read from the central directory. */
     fun entryNames(zip: File): List<String> =
         ZipFile(zip).use { zf ->

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
@@ -1,0 +1,88 @@
+package com.valhalla.thor.data.repository
+
+import java.io.File
+import java.util.zip.ZipFile
+
+/**
+ * Random-access ZIP reading for installer bundles (XAPK/.apkm/.apks) and APKs.
+ *
+ * APKPure packages the inner APKs of an `.xapk` as **STORED** (uncompressed)
+ * entries with the **data-descriptor** flag set and a **zero-size local header**
+ * (the real sizes live only in the central directory / trailing descriptor).
+ * `java.util.zip.ZipInputStream` reads *local* headers sequentially and cannot
+ * determine where such a STORED entry ends, so it derails on the very first
+ * entry — which is exactly why `manifest.json` / the base APK could not be found
+ * and a nested `AndroidManifest.xml` was mis-read as a top-level entry.
+ *
+ * `ZipFile` reads the **central directory** (authoritative names + sizes), just
+ * like the `unzip` tool, so it reads these bundles correctly. It requires an
+ * on-disk file, so callers copy the input to a temp file first.
+ */
+object BundleZip {
+
+    /** Top-level entry names (files only) of [zip], read from the central directory. */
+    fun entryNames(zip: File): List<String> =
+        ZipFile(zip).use { zf ->
+            zf.entries().asSequence()
+                .filter { !it.isDirectory }
+                .map { it.name }
+                .toList()
+        }
+
+    /**
+     * Bytes of the first entry whose *base name* equals [baseName] (case-insensitive),
+     * or null if absent. Base-name matching mirrors how installers reference splits.
+     */
+    fun readEntry(zip: File, baseName: String): ByteArray? =
+        ZipFile(zip).use { zf ->
+            val entry = zf.entries().asSequence().firstOrNull {
+                !it.isDirectory &&
+                    it.name.substringAfterLast('/').equals(baseName, ignoreCase = true)
+            } ?: return null
+            zf.getInputStream(entry).use { it.readBytes() }
+        }
+
+    /**
+     * Extract the first entry whose base name equals [baseName] (case-insensitive)
+     * into [dest]. Returns true on success, false if no such entry exists.
+     */
+    fun extractEntryTo(zip: File, baseName: String, dest: File): Boolean =
+        ZipFile(zip).use { zf ->
+            val entry = zf.entries().asSequence().firstOrNull {
+                !it.isDirectory &&
+                    it.name.substringAfterLast('/').equals(baseName, ignoreCase = true)
+            } ?: return false
+            zf.getInputStream(entry).use { input ->
+                dest.outputStream().use { output -> input.copyTo(output) }
+            }
+            true
+        }
+
+    /**
+     * Extract every entry whose base name is in [wantedBaseNames] (compared
+     * case-insensitively) into [outDir], one file per entry named by its base name.
+     * The first match wins if two entries share a base name. Returns the extracted
+     * files (archive order).
+     */
+    fun extractEntries(zip: File, wantedBaseNames: Set<String>, outDir: File): List<File> {
+        outDir.mkdirs()
+        val wanted = wantedBaseNames.mapTo(HashSet()) { it.lowercase() }
+        val seen = HashSet<String>()
+        val out = mutableListOf<File>()
+        ZipFile(zip).use { zf ->
+            for (entry in zf.entries()) {
+                if (entry.isDirectory) continue
+                val base = entry.name.substringAfterLast('/')
+                val key = base.lowercase()
+                if (key in wanted && seen.add(key)) {
+                    val dest = File(outDir, base)
+                    zf.getInputStream(entry).use { input ->
+                        dest.outputStream().use { output -> input.copyTo(output) }
+                    }
+                    out.add(dest)
+                }
+            }
+        }
+        return out
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -33,7 +33,7 @@ import org.koin.core.annotation.Single
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
-import java.util.zip.ZipInputStream
+import java.util.zip.ZipFile
 
 @Single(binds = [InstallerRepository::class])
 class InstallerRepositoryImpl(
@@ -46,61 +46,50 @@ class InstallerRepositoryImpl(
     private val defaultInstaller = context.packageManager.packageInstaller
 
     /**
-     * Returns the ordered list of APK filenames to install from a genuine bundle
-     * (XAPK/.apks/.apkm), or null when the file is a monolithic APK that must be
-     * streamed whole.
+     * Given an on-disk copy of the installer input, return the ordered list of APK
+     * base names to install from a genuine bundle (XAPK/.apks/.apkm), or null when
+     * it is a monolithic APK that must be streamed whole.
      *
-     * A monolithic APK carries its own top-level AndroidManifest.xml (GH#207); it
-     * must never be split by its inner .apk assets. For real bundles we prefer the
-     * manifest.json split list, and otherwise order the .apk entries so the base
-     * comes first and config splits last (GH#159).
+     * Reads the bundle with [BundleZip] (ZipFile / central directory) — NOT
+     * ZipInputStream, which cannot handle APKPure's STORED-with-data-descriptor
+     * entries. A monolithic APK carries its own top-level AndroidManifest.xml and no
+     * bundle signal (GH#207); for real bundles we prefer the manifest.json split
+     * list (unioned with any present-but-unlisted splits so a stale manifest never
+     * drops one) and otherwise order the .apk entries base-first (GH#159).
      */
-    private fun resolveXapkApkFiles(uri: Uri): List<String>? {
-        if (!isZipBundle(uri)) return null
-        return try {
-            var manifestBytes: ByteArray? = null
-            val entryNames = mutableListOf<String>()
+    private fun resolveInstallSetFromFile(bundleFile: File, displayName: String?): List<String>? {
+        val entryNames = try {
+            BundleZip.entryNames(bundleFile)
+        } catch (_: Exception) {
+            return null // not a readable zip → treat as a monolithic APK
+        }
+        if (isMonolithicApk(entryNames, displayName)) return null
 
-            context.contentResolver.openInputStream(uri)?.use { inputStream ->
-                ZipInputStream(inputStream).use { zipStream ->
-                    var entry = zipStream.nextEntry
-                    while (entry != null) {
-                        if (!entry.isDirectory) entryNames += entry.name
-                        if (entry.name.equals("manifest.json", ignoreCase = true)) {
-                            manifestBytes = zipStream.readBytes()
-                            zipStream.closeEntry()
-                        } else {
-                            zipStream.closeEntry()
-                        }
-                        entry = zipStream.nextEntry
-                    }
-                }
-            }
+        val manifest = BundleZip.readEntry(bundleFile, "manifest.json")
+            ?.let { parseXapkManifest(String(it)) }
+        val apkmInfo = BundleZip.readEntry(bundleFile, "info.json")
+            ?.let { parseApkmInfo(String(it)) }
+        val packageHint = manifest?.packageName?.takeIf { it.isNotBlank() }
+            ?: apkmInfo?.packageName?.takeIf { it.isNotBlank() }
 
-            // Monolithic-APK gate (GH#207): a file with a top-level AndroidManifest.xml
-            // is a single APK — stream it whole via the monolithic path (null).
-            if (isMonolithicApk(entryNames)) return null
+        return resolveBundleInstallSet(entryNames, manifest?.splitApkFiles(), packageHint)
+            .ifEmpty { null }
+    }
 
-            // Prefer the manifest.json split_apks list for a genuine XAPK — but only when
-            // every declared split actually exists in the archive. A stale/partial manifest
-            // (splits renamed, removed, or never packaged) must not shadow the entry-scan
-            // recovery path below, or extraction would yield nothing and the install fails.
-            val manifest = manifestBytes?.let { parseXapkManifest(String(it)) }
-            val manifestFiles = manifest?.splitApkFiles()?.takeIf { it.isNotEmpty() }
-            if (manifestFiles != null) {
-                val availableNames = entryNames.mapTo(HashSet()) { it.substringAfterLast('/') }
-                if (manifestFiles.all { it.substringAfterLast('/') in availableNames }) {
-                    return manifestFiles
-                }
-            }
-
-            // No usable manifest: order the .apk entries base-first, splits last so
-            // install-multiple gets a valid base (GH#159). selectBaseApkCandidates is
-            // empty only when there are no .apk entries at all → treat as monolithic.
-            selectBaseApkCandidates(entryNames, manifest?.packageName).ifEmpty { null }
+    /**
+     * Best-effort display name (hence file extension) for [uri]: the provider's
+     * OpenableColumns.DISPLAY_NAME, falling back to the URI's last path segment.
+     * Used only as a secondary bundle signal, so null is acceptable.
+     */
+    private fun displayNameOf(uri: Uri): String? {
+        val fromProvider = try {
+            context.contentResolver.query(
+                uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null
+            )?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
         } catch (_: Exception) {
             null
         }
+        return fromProvider?.takeIf { it.isNotBlank() } ?: uri.lastPathSegment
     }
 
     override suspend fun installPackage(uri: Uri, mode: InstallMode, canDowngrade: Boolean) =
@@ -310,36 +299,31 @@ class InstallerRepositoryImpl(
     }
 
     private fun copyUriToTempFiles(uri: Uri, tempDir: File): List<File>? {
-        val xapkApkFiles = resolveXapkApkFiles(uri)
         return try {
             tempDir.mkdirs()
-            if (xapkApkFiles != null) {
-                val extracted = mutableListOf<File>()
-                val wanted = xapkApkFiles.map { it.substringAfterLast('/') }.toSet()
+            // Copy the input to disk once, then read it with ZipFile (central
+            // directory). ZipInputStream cannot handle APKPure's
+            // STORED-with-data-descriptor entries and derails on the first one.
+            val bundleFile = File(tempDir, "__bundle__")
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(bundleFile).use { output -> input.copyTo(output) }
+            } ?: return null
 
-                context.contentResolver.openInputStream(uri)?.use { input ->
-                    ZipInputStream(input).use { zipStream ->
-                        var entry = zipStream.nextEntry
-                        while (entry != null) {
-                            val entryFileName = entry.name.substringAfterLast('/')
-                            if (!entry.isDirectory && entryFileName in wanted) {
-                                val dest = File(tempDir, entryFileName)
-                                FileOutputStream(dest).use { fos -> zipStream.copyTo(fos) }
-                                extracted.add(dest)
-                            } else {
-                                zipStream.closeEntry()
-                            }
-                            entry = zipStream.nextEntry
-                        }
-                    }
-                }
-                if (extracted.isEmpty()) null else extracted
-            } else {
+            val installSet = resolveInstallSetFromFile(bundleFile, displayNameOf(uri))
+            if (installSet == null) {
+                // Monolithic APK: install the copied file as-is (renamed to base.apk).
                 val tempApk = File(tempDir, "base.apk")
-                context.contentResolver.openInputStream(uri)?.use { input ->
-                    FileOutputStream(tempApk).use { output -> input.copyTo(output) }
-                } ?: return null
+                if (!bundleFile.renameTo(tempApk)) {
+                    bundleFile.copyTo(tempApk, overwrite = true)
+                    bundleFile.delete()
+                }
                 listOf(tempApk)
+            } else {
+                // Genuine bundle: extract exactly the resolved split set via ZipFile.
+                val wanted = installSet.mapTo(HashSet()) { it.substringAfterLast('/') }
+                val extracted = BundleZip.extractEntries(bundleFile, wanted, tempDir)
+                bundleFile.delete()
+                extracted.ifEmpty { null }
             }
         } catch (e: Exception) {
             Logger.e("InstallerRepo", "Failed to copy URI to temp files", e)
@@ -477,18 +461,6 @@ class InstallerRepositoryImpl(
         }
     }
 
-    private fun isZipBundle(uri: Uri): Boolean {
-        return try {
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                val magic = ByteArray(4)
-                input.read(magic) == 4 &&
-                        magic[0] == 0x50.toByte() && magic[1] == 0x4B.toByte() // PK header
-            } ?: false
-        } catch (_: Exception) {
-            false
-        }
-    }
-
     @SuppressLint("RequestInstallPackagesPolicy")
     private suspend fun performPackageInstallerInstall(
         uri: Uri,
@@ -530,7 +502,7 @@ class InstallerRepositoryImpl(
             } else throw e
         }
 
-        var session = try {
+        val session = try {
             packageInstaller.openSession(sessionId)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
@@ -576,85 +548,19 @@ class InstallerRepositoryImpl(
         }
 
         try {
-            // ATTEMPT 1: Try as XAPK/APKS/APKM bundle
-            // Use manifest.json split_apks list if available; otherwise include all .apk entries.
-            val xapkApkFiles = resolveXapkApkFiles(uri)
-
-            if (xapkApkFiles != null) {
-                val wanted = xapkApkFiles.map { it.substringAfterLast('/') }.toSet()
-                try {
-                    context.contentResolver.openInputStream(uri)?.use { bundleStream ->
-                        ZipInputStream(bundleStream).use { zipStream ->
-                            var entry = zipStream.nextEntry
-                            while (entry != null) {
-                                val entryFileName = entry.name.substringAfterLast('/')
-                                if (!entry.isDirectory && entryFileName in wanted) {
-                                    filesWritten = true
-                                    val size = entry.size
-
-                                    if (size == -1L) {
-                                        // Unknown size: buffer to temp file first
-                                        val tempFile = File(
-                                            context.cacheDir,
-                                            "temp_${System.currentTimeMillis()}_$entryFileName"
-                                        )
-                                        FileOutputStream(tempFile).use { fos -> zipStream.copyTo(fos) }
-                                        val actualSize = tempFile.length()
-                                        session.openWrite(entryFileName, 0, actualSize).use { out ->
-                                            tempFile.inputStream().use { fis -> fis.copyTo(out) }
-                                            session.fsync(out)
-                                        }
-                                        tempFile.delete()
-                                    } else {
-                                        // Known size: stream directly
-                                        session.openWrite(entryFileName, 0, size).use { out ->
-                                            val buffer = ByteArray(65536)
-                                            var len: Int
-                                            while (zipStream.read(buffer).also { len = it } > 0) {
-                                                out.write(buffer, 0, len)
-                                            }
-                                            session.fsync(out)
-                                        }
-                                    }
-                                } else {
-                                    zipStream.closeEntry()
-                                }
-                                entry = zipStream.nextEntry
-                            }
-                        }
+            // Copy the input to disk once (tracking progress), then read it with
+            // ZipFile (central directory). ZipInputStream cannot handle APKPure's
+            // STORED-with-data-descriptor entries and derails on the first one.
+            val bundleFile = File(context.cacheDir, "install_bundle_${System.currentTimeMillis()}")
+            try {
+                val copied = context.contentResolver.openInputStream(uri)?.use { input ->
+                    FileOutputStream(bundleFile).use { output ->
+                        getTrackedStream(input).copyTo(output)
                     }
-                } catch (e: Exception) {
-                    Logger.e("thor", "Bundle extraction failed, trying fallback: ${e.message}")
-                    if (filesWritten) {
-                        try {
-                            session.abandon()
-                            session.close()
-                        } catch (_: Exception) {
-                        }
-                        val newSessionId = packageInstaller.createSession(params)
-                        try {
-                            session = packageInstaller.openSession(newSessionId)
-                        } catch (e: Exception) {
-                            try {
-                                packageInstaller.abandonSession(newSessionId)
-                            } catch (_: Exception) {
-                            }
-                            throw e
-                        }
-                    }
-                    filesWritten = false
-                }
-            }
+                    true
+                } ?: false
 
-            // ATTEMPT 2: Fallback to Monolithic APK
-            if (!filesWritten) {
-                Logger.d("thor", "Fallback: Treating stream as monolithic base.apk")
-
-                bytesProcessed = 0
-                lastProgressEmitted = 0
-
-                val rawStream = context.contentResolver.openInputStream(uri)
-                if (rawStream == null) {
+                if (!copied) {
                     session.abandon()
                     Logger.e("thor", "Could not open file stream.")
                     if (emitErrors) {
@@ -663,16 +569,41 @@ class InstallerRepositoryImpl(
                     } else throw Exception("Could not open file stream.")
                 }
 
-                val trackedStream = getTrackedStream(rawStream)
+                // Genuine bundle: write each resolved split into the session, read via
+                // ZipFile so STORED-with-data-descriptor entries stream correctly.
+                val installSet = resolveInstallSetFromFile(bundleFile, displayNameOf(uri))
+                if (installSet != null) {
+                    val wanted = installSet.mapTo(HashSet()) { it.substringAfterLast('/').lowercase() }
+                    val seen = HashSet<String>()
+                    ZipFile(bundleFile).use { zf ->
+                        for (entry in zf.entries()) {
+                            if (entry.isDirectory) continue
+                            val base = entry.name.substringAfterLast('/')
+                            val key = base.lowercase()
+                            if (key !in wanted || !seen.add(key)) continue
+                            val size = if (entry.size >= 0) entry.size else -1L
+                            session.openWrite(base, 0, size).use { out ->
+                                zf.getInputStream(entry).use { inner -> inner.copyTo(out) }
+                                session.fsync(out)
+                            }
+                            filesWritten = true
+                        }
+                    }
+                }
 
-                trackedStream.use { input ->
-                    val size = if (totalBytes > 0) totalBytes else -1L
-                    val outStream = session.openWrite("base.apk", 0, size)
-                    input.copyTo(outStream)
-                    session.fsync(outStream)
-                    outStream.close()
+                // Monolithic APK (or not a readable bundle): stream the copied file
+                // whole as base.apk.
+                if (!filesWritten) {
+                    Logger.d("thor", "Treating stream as monolithic base.apk")
+                    val size = if (bundleFile.length() > 0) bundleFile.length() else -1L
+                    session.openWrite("base.apk", 0, size).use { out ->
+                        bundleFile.inputStream().use { inner -> inner.copyTo(out) }
+                        session.fsync(out)
+                    }
                     filesWritten = true
                 }
+            } finally {
+                bundleFile.delete()
             }
 
             eventBus.emit(InstallState.Installing(1.0f))

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -58,21 +58,20 @@ class InstallerRepositoryImpl(
      * drops one) and otherwise order the .apk entries base-first (GH#159).
      */
     private fun resolveInstallSetFromFile(bundleFile: File, displayName: String?): List<String>? {
-        val entryNames = try {
-            BundleZip.entryNames(bundleFile)
+        // Single ZipFile pass for entry names + both sidecar files.
+        val contents = try {
+            BundleZip.read(bundleFile, setOf("manifest.json", "info.json"))
         } catch (_: Exception) {
             return null // not a readable zip → treat as a monolithic APK
         }
-        if (isMonolithicApk(entryNames, displayName)) return null
+        if (isMonolithicApk(contents.entryNames, displayName)) return null
 
-        val manifest = BundleZip.readEntry(bundleFile, "manifest.json")
-            ?.let { parseXapkManifest(String(it)) }
-        val apkmInfo = BundleZip.readEntry(bundleFile, "info.json")
-            ?.let { parseApkmInfo(String(it)) }
+        val manifest = contents.bytes["manifest.json"]?.let { parseXapkManifest(String(it)) }
+        val apkmInfo = contents.bytes["info.json"]?.let { parseApkmInfo(String(it)) }
         val packageHint = manifest?.packageName?.takeIf { it.isNotBlank() }
             ?: apkmInfo?.packageName?.takeIf { it.isNotBlank() }
 
-        return resolveBundleInstallSet(entryNames, manifest?.splitApkFiles(), packageHint)
+        return resolveBundleInstallSet(contents.entryNames, manifest?.splitApkFiles(), packageHint)
             .ifEmpty { null }
     }
 
@@ -85,7 +84,10 @@ class InstallerRepositoryImpl(
         val fromProvider = try {
             context.contentResolver.query(
                 uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null
-            )?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+            )?.use { cursor ->
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index != -1 && cursor.moveToFirst()) cursor.getString(index) else null
+            }
         } catch (_: Exception) {
             null
         }

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -44,6 +44,7 @@ class SystemRepositoryImpl(
                 PrivilegeMode.ROOT -> if (isRootAvail) return Result.success(rootGateway)
                 PrivilegeMode.SHIZUKU -> if (isShizukuAvail) return Result.success(shizukuGateway)
                 PrivilegeMode.DHIZUKU -> if (isDhizukuAvail) return Result.success(dhizukuGateway)
+                PrivilegeMode.NONE -> Unit // never persisted as a preference; fall through to auto-detection
             }
         }
 

--- a/app/src/main/java/com/valhalla/thor/data/source/local/UadHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/UadHelper.kt
@@ -35,9 +35,15 @@ class UadHelper(
         }
 
     fun invalidateCache() {
-        synchronized(lock) {
-            cachedMap = null
-        }
+        // Lock-free by design: this is called from a main-thread BroadcastReceiver on
+        // every package change. Taking `lock` here would block the main thread behind
+        // an in-progress buildUadMap() (a ~1.6MB JSON parse), which — during a bulk
+        // freeze/unfreeze that floods PACKAGE_CHANGED broadcasts — caused an ANR.
+        // A `null` write to the @Volatile field is atomic and visible; the getter still
+        // holds `lock` to de-duplicate concurrent rebuilds. Worst case, an invalidate
+        // that races a concurrent rebuild is absorbed by that (fresh) rebuild — a
+        // harmless one-generation staleness for a static recommendation list.
+        cachedMap = null
     }
 
     private fun buildUadMap(): Map<String, UadEntry> {

--- a/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt
@@ -1,6 +1,8 @@
 package com.valhalla.thor.domain.model
 
 enum class PrivilegeMode {
+    /** No privilege available (reactive/active value only — never persisted as a preference). */
+    NONE,
     ROOT,
     SHIZUKU,
     DHIZUKU

--- a/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt
@@ -1,0 +1,43 @@
+package com.valhalla.thor.domain.model
+
+/**
+ * Snapshot of privilege availability + the resolved active mode.
+ *
+ * [isReady] is false until the first probe completes, so consumers can tell
+ * "not probed yet" apart from "probed, nothing available" (avoids a flash of the
+ * no-privilege UI on cold start).
+ */
+data class PrivilegeState(
+    val root: Boolean = false,
+    val shizuku: Boolean = false,
+    val dhizuku: Boolean = false,
+    val active: PrivilegeMode = PrivilegeMode.NONE,
+    val isReady: Boolean = false
+) {
+    val hasAnyPrivilege: Boolean get() = active != PrivilegeMode.NONE
+}
+
+/**
+ * Resolve the effective privilege mode: the user's [preferred] mode when it is
+ * actually available, otherwise the first available in Root -> Shizuku -> Dhizuku
+ * order, otherwise [PrivilegeMode.NONE]. A null or NONE [preferred] means "auto".
+ */
+fun resolvePrivilegeMode(
+    preferred: PrivilegeMode?,
+    root: Boolean,
+    shizuku: Boolean,
+    dhizuku: Boolean
+): PrivilegeMode {
+    when (preferred) {
+        PrivilegeMode.ROOT -> if (root) return PrivilegeMode.ROOT
+        PrivilegeMode.SHIZUKU -> if (shizuku) return PrivilegeMode.SHIZUKU
+        PrivilegeMode.DHIZUKU -> if (dhizuku) return PrivilegeMode.DHIZUKU
+        PrivilegeMode.NONE, null -> Unit // fall through to auto
+    }
+    return when {
+        root -> PrivilegeMode.ROOT
+        shizuku -> PrivilegeMode.SHIZUKU
+        dhizuku -> PrivilegeMode.DHIZUKU
+        else -> PrivilegeMode.NONE
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -132,7 +133,8 @@ fun AppListScreen(
                         )
                     },
                     selectedIndex = AppListType.entries.indexOf(state.appListType),
-                    onItemSelected = { viewModel.updateListType(AppListType.entries[it]) }
+                    onItemSelected = { viewModel.updateListType(AppListType.entries[it]) },
+                    modifier = Modifier.width(IntrinsicSize.Max)
                 )
             }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -122,7 +122,12 @@ class AppListViewModel(
             }.collect { (user, system, priv) ->
                 _rawState.update {
                     it.copy(
-                        isLoading = false,
+                        // Hold the loader until the first privilege probe lands
+                        // (isReady) so privilege-gated controls never flash their
+                        // disabled state on cold start. This restores the old
+                        // await-probe-before-reveal behavior; later Shizuku grants
+                        // still update reactively once isReady is true.
+                        isLoading = !priv.isReady,
                         isRoot = priv.root,
                         isShizuku = priv.shizuku,
                         isDhizuku = priv.dhizuku,

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -3,6 +3,7 @@ package com.valhalla.thor.presentation.appList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
+import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.FilterType
@@ -11,7 +12,6 @@ import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
-import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.GetAppDetailsUseCase
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
@@ -68,7 +68,7 @@ class AppListViewModel(
     private val context: Context,
     private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
     private val getAppDetailsUseCase: GetAppDetailsUseCase,
-    private val systemRepository: SystemRepository,
+    private val privilegeManager: PrivilegeManager,
     private val manageAppUseCase: ManageAppUseCase,
     private val preferenceRepository: PreferenceRepository,
     private val freezerRepository: FreezerRepository
@@ -112,22 +112,20 @@ class AppListViewModel(
             // Allow navigation/bottom bar animations to finish fluidly
             delay(800.milliseconds)
 
-            // Availability probes include non-suspend binder IPC (Shizuku / Dhizuku);
-            // keep them off the Main thread so app-list load never janks.
-            val (hasRoot, hasShizuku, hasDhizuku) = withContext(Dispatchers.IO) {
-                Triple(
-                    systemRepository.isRootAvailable(),
-                    systemRepository.isShizukuAvailable(),
-                    systemRepository.isDhizukuAvailable()
-                )
-            }
-            getInstalledAppsUseCase().collect { (user, system) ->
+            // Privilege availability now comes from the shared reactive PrivilegeManager,
+            // so a Shizuku grant reflects here without reloading the list.
+            combine(
+                getInstalledAppsUseCase(),
+                privilegeManager.state
+            ) { (user, system), priv ->
+                Triple(user, system, priv)
+            }.collect { (user, system, priv) ->
                 _rawState.update {
                     it.copy(
                         isLoading = false,
-                        isRoot = hasRoot,
-                        isShizuku = hasShizuku,
-                        isDhizuku = hasDhizuku,
+                        isRoot = priv.root,
+                        isShizuku = priv.shizuku,
+                        isDhizuku = priv.dhizuku,
                         allUserApps = user,
                         allSystemApps = system
                     )

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -120,6 +120,13 @@ fun FreezerScreen(
     val hasEnabled = remember(state.freezerApps) { state.freezerApps.any { it.enabled } }
     val hasDisabled = remember(state.freezerApps) { state.freezerApps.any { !it.enabled } }
 
+    // Apps the "Freeze all" / "Unfreeze all" toolbar acts on. These route through the
+    // shared batch action (MultiAppAction) so progress streams into the TermLoggerDialog
+    // (rendered by MainScreen), identical to multi-select. The unsafe/UAD eligibility
+    // skip is applied once, centrally, by MainViewModel.onMultiAppAction.
+    val appsToFreeze = remember(state.freezerApps) { state.freezerApps.filter { it.enabled } }
+    val appsToUnfreeze = remember(state.freezerApps) { state.freezerApps.filter { !it.enabled } }
+
 
     LaunchedEffect(state.actionMessage) {
         state.actionMessage?.let {
@@ -362,7 +369,7 @@ fun FreezerScreen(
                             disabledContentColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f)
                         )
                         IconButton(
-                            onClick = { viewModel.freezeAll() },
+                            onClick = { onMultiAppAction(MultiAppAction.Freeze(appsToFreeze)) },
                             enabled = hasEnabled && hasPrivilege,
                             colors = iconButtonColors
                         ) {
@@ -381,7 +388,7 @@ fun FreezerScreen(
                             )
                         }
                         IconButton(
-                            onClick = { viewModel.unfreezeAll() },
+                            onClick = { onMultiAppAction(MultiAppAction.UnFreeze(appsToUnfreeze)) },
                             enabled = hasDisabled && hasPrivilege,
                             colors = iconButtonColors
                         ) {
@@ -450,7 +457,7 @@ fun FreezerScreen(
             onToggleView = viewModel::toggleGridMode,
             onToggleAutoFreeze = viewModel::setAutoFreezeEnabled,
             onDismiss = { showSettingsSheet = false },
-            onUnfreezeAll = viewModel::unfreezeAll,
+            onUnfreezeAll = { onMultiAppAction(MultiAppAction.UnFreeze(appsToUnfreeze)) },
             onImportDisabledApps = {
                 showSettingsSheet = false
                 if (disabledAppsNotInFreezer.isNotEmpty()) {

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -213,7 +215,8 @@ fun FreezerScreen(
                                 )
                             },
                             selectedIndex = AppListType.entries.indexOf(state.appListType),
-                            onItemSelected = { viewModel.updateListType(AppListType.entries[it]) }
+                            onItemSelected = { viewModel.updateListType(AppListType.entries[it]) },
+                            modifier = Modifier.width(IntrinsicSize.Max)
                         )
                     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
@@ -2,11 +2,13 @@ package com.valhalla.thor.presentation.freezer
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -120,7 +122,8 @@ fun FreezerSettingsSheet(
                         )
                     },
                     selectedIndex = AppListType.entries.indexOf(appListType),
-                    onItemSelected = { onListTypeChanged(AppListType.entries[it]) }
+                    onItemSelected = { onListTypeChanged(AppListType.entries[it]) },
+                    modifier = Modifier.width(IntrinsicSize.Max)
                 )
             }
 
@@ -148,7 +151,8 @@ fun FreezerSettingsSheet(
                         )
                     ),
                     selectedIndex = if (isGrid) 0 else 1,
-                    onItemSelected = { onToggleView() }
+                    onItemSelected = { onToggleView() },
+                    modifier = Modifier.width(IntrinsicSize.Max)
                 )
             }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -10,11 +10,10 @@ import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.presentation.common.ShizukuPermissionHandler
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -58,10 +57,23 @@ class FreezerViewModel(
     private val _uiState = MutableStateFlow(FreezerUiState())
     val uiState: StateFlow<FreezerUiState> = _uiState.asStateFlow()
 
+    // Re-check privileges when Shizuku's binder connects or the user grants permission.
+    // This ViewModel is created at app start (before the first-launch Shizuku grant), so
+    // its init-time loadPrivileges() would otherwise stay stale until an app restart.
+    private val shizukuHandler = ShizukuPermissionHandler(
+        onPermissionGranted = { loadPrivileges() }
+    )
+
     init {
         observeApps()
         observePreferences()
         loadPrivileges()
+        shizukuHandler.register()
+    }
+
+    override fun onCleared() {
+        shizukuHandler.unregister()
+        super.onCleared()
     }
 
     private fun observeApps() {
@@ -113,56 +125,9 @@ class FreezerViewModel(
         }
     }
 
-    // --- Freeze All / Unfreeze All ---
-
-    fun freezeAll() {
-        viewModelScope.launch(Dispatchers.IO) {
-            val apps = _uiState.value.freezerApps
-            val eligibleApps = apps.filter { appInfo ->
-                val isSystem = appInfo.isSystem
-                val isUadFailed = isSystem && appInfo.isUadLoadFailed
-                val isUnsafe = isSystem && appInfo.bloatRecommendation?.lowercase() == "unsafe"
-                !(isUadFailed || isUnsafe)
-            }
-            val skippedCount = apps.size - eligibleApps.size
-            val results = eligibleApps.map { app ->
-                async { manageAppUseCase.setAppDisabled(app.packageName, true) }
-            }.awaitAll()
-            val failures = results.count { it.isFailure } + skippedCount
-            val uiText = if (failures == 0) {
-                UiText.StringResource(R.string.tile_freeze_success, eligibleApps.size)
-            } else {
-                UiText.StringResource(
-                    R.string.tile_freeze_partial_failure,
-                    eligibleApps.size - results.count { it.isFailure },
-                    apps.size,
-                    failures
-                )
-            }
-            _uiState.update { it.copy(actionMessage = uiText) }
-        }
-    }
-
-    fun unfreezeAll() {
-        viewModelScope.launch(Dispatchers.IO) {
-            val pkgs = _uiState.value.freezerPackageNames.toList()
-            val results = pkgs.map { pkg ->
-                async { manageAppUseCase.setAppDisabled(pkg, false) }
-            }.awaitAll()
-            val failures = results.count { it.isFailure }
-            val uiText = if (failures == 0) {
-                UiText.StringResource(R.string.unfrozen_count_success, pkgs.size)
-            } else {
-                UiText.StringResource(
-                    R.string.tile_unfreeze_partial_failure,
-                    pkgs.size - failures,
-                    pkgs.size,
-                    failures
-                )
-            }
-            _uiState.update { it.copy(actionMessage = uiText) }
-        }
-    }
+    // Freeze-all / Unfreeze-all are handled by the shared batch action
+    // (MultiAppAction.Freeze / UnFreeze) so their progress streams into the
+    // TermLoggerDialog; the toolbar in FreezerScreen dispatches them via onMultiAppAction.
 
     // --- Multi-select removal ---
 

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -3,14 +3,13 @@ package com.valhalla.thor.presentation.freezer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
+import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
-import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
-import com.valhalla.thor.presentation.common.ShizukuPermissionHandler
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import kotlinx.coroutines.Dispatchers
@@ -50,30 +49,17 @@ class FreezerViewModel(
     private val freezerRepository: FreezerRepository,
     private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
     private val manageAppUseCase: ManageAppUseCase,
-    private val systemRepository: SystemRepository,
+    private val privilegeManager: PrivilegeManager,
     private val preferenceRepository: PreferenceRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FreezerUiState())
     val uiState: StateFlow<FreezerUiState> = _uiState.asStateFlow()
 
-    // Re-check privileges when Shizuku's binder connects or the user grants permission.
-    // This ViewModel is created at app start (before the first-launch Shizuku grant), so
-    // its init-time loadPrivileges() would otherwise stay stale until an app restart.
-    private val shizukuHandler = ShizukuPermissionHandler(
-        onPermissionGranted = { loadPrivileges() }
-    )
-
     init {
         observeApps()
         observePreferences()
-        loadPrivileges()
-        shizukuHandler.register()
-    }
-
-    override fun onCleared() {
-        shizukuHandler.unregister()
-        super.onCleared()
+        observePrivileges()
     }
 
     private fun observeApps() {
@@ -110,17 +96,12 @@ class FreezerViewModel(
         }
     }
 
-    private fun loadPrivileges() {
-        viewModelScope.launch(Dispatchers.IO) {
-            val hasRoot = systemRepository.isRootAvailable()
-            val hasShizuku = systemRepository.isShizukuAvailable()
-            val hasDhizuku = systemRepository.isDhizukuAvailable()
-            _uiState.update {
-                it.copy(
-                    isRoot = hasRoot,
-                    isShizuku = hasShizuku,
-                    isDhizuku = hasDhizuku
-                )
+    private fun observePrivileges() {
+        viewModelScope.launch {
+            privilegeManager.state.collect { p ->
+                _uiState.update {
+                    it.copy(isRoot = p.root, isShizuku = p.shizuku, isDhizuku = p.dhizuku)
+                }
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/ManageFreezerSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/ManageFreezerSheet.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -112,7 +114,8 @@ fun ManageFreezerSheet(
                         )
                     },
                     selectedIndex = AppListType.entries.indexOf(selectedType),
-                    onItemSelected = { selectedType = AppListType.entries[it] }
+                    onItemSelected = { selectedType = AppListType.entries[it] },
+                    modifier = Modifier.width(IntrinsicSize.Max)
                 )
             }
             Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -63,8 +63,16 @@ class HomeViewModel(
             isRootAvailable = priv.root,
             isShizukuAvailable = priv.shizuku,
             isDhizukuAvailable = priv.dhizuku,
-            // Keep the existing "null = no privilege" contract for the UI.
-            activePrivilegeMode = priv.active.takeIf { it != PrivilegeMode.NONE },
+            // Keep the existing "null = no privilege" contract for the UI. Until the
+            // first probe completes (isReady == false), optimistically fall back to the
+            // persisted preference so a configured user never sees a "no privilege"
+            // flash on cold start (this restores the old one-shot behavior, which read
+            // the preference straight from DataStore before any hardware probe).
+            activePrivilegeMode = if (priv.isReady) {
+                priv.active.takeIf { it != PrivilegeMode.NONE }
+            } else {
+                prefs.preferredPrivilegeMode
+            },
             extensionsUnlocked = prefs.extensionsUnlocked
         )
     }.stateIn(

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -2,11 +2,11 @@ package com.valhalla.thor.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.repository.PreferenceRepository
-import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -41,7 +41,7 @@ data class HomeUiState(
 @KoinViewModel
 class HomeViewModel(
     private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
-    private val systemRepository: SystemRepository,
+    private val privilegeManager: PrivilegeManager,
     private val preferenceRepository: PreferenceRepository // Injected
 ) : ViewModel() {
 
@@ -53,16 +53,18 @@ class HomeViewModel(
     private var lastSystemApps: List<AppInfo> = emptyList()
 
     // Combine internal data processing with user preferences
-    val state = combine(_internalState, preferenceRepository.userPreferences) { internal, prefs ->
-        val activeMode = prefs.preferredPrivilegeMode ?: when {
-            internal.isRootAvailable -> PrivilegeMode.ROOT
-            internal.isShizukuAvailable -> PrivilegeMode.SHIZUKU
-            internal.isDhizukuAvailable -> PrivilegeMode.DHIZUKU
-            else -> null
-        }
+    val state = combine(
+        _internalState,
+        preferenceRepository.userPreferences,
+        privilegeManager.state
+    ) { internal, prefs, priv ->
         internal.copy(
             showReinstallCard = prefs.showReinstallAllCard,
-            activePrivilegeMode = activeMode,
+            isRootAvailable = priv.root,
+            isShizukuAvailable = priv.shizuku,
+            isDhizukuAvailable = priv.dhizuku,
+            // Keep the existing "null = no privilege" contract for the UI.
+            activePrivilegeMode = priv.active.takeIf { it != PrivilegeMode.NONE },
             extensionsUnlocked = prefs.extensionsUnlocked
         )
     }.stateIn(
@@ -81,21 +83,10 @@ class HomeViewModel(
 
         dashboardJob = viewModelScope.launch(Dispatchers.IO) {
             _internalState.update { it.copy(isLoading = true) }
-            val hasRoot = systemRepository.isRootAvailable()
-            val hasShizuku = systemRepository.isShizukuAvailable()
-            val hasDhizuku = systemRepository.isDhizukuAvailable()
-
             getInstalledAppsUseCase().collect { (userApps, systemApps) ->
                 lastUserApps = userApps
                 lastSystemApps = systemApps
-                processData(
-                    userApps,
-                    systemApps,
-                    _internalState.value.selectedType,
-                    hasRoot,
-                    hasShizuku,
-                    hasDhizuku
-                )
+                processData(userApps, systemApps, _internalState.value.selectedType)
             }
         }
     }
@@ -104,22 +95,15 @@ class HomeViewModel(
         _internalState.update { it.copy(selectedType = type) }
         typeChangeJob?.cancel()
         typeChangeJob = viewModelScope.launch(Dispatchers.IO) {
-            val s = _internalState.value
-            processData(
-                lastUserApps,
-                lastSystemApps,
-                type,
-                s.isRootAvailable,
-                s.isShizukuAvailable,
-                s.isDhizukuAvailable
-            )
+            processData(lastUserApps, lastSystemApps, type)
         }
     }
 
     fun onPrivilegeModeChanged(mode: PrivilegeMode) {
+        // PrivilegeManager observes the preference and recomputes `active` reactively;
+        // no dashboard reload needed (app stats don't depend on the privilege mode).
         viewModelScope.launch {
             preferenceRepository.setPrivilegeMode(mode)
-            loadDashboardData() // Refresh everything
         }
     }
 
@@ -139,10 +123,7 @@ class HomeViewModel(
     private fun processData(
         userApps: List<AppInfo>,
         systemApps: List<AppInfo>,
-        selectedType: AppListType,
-        hasRoot: Boolean,
-        hasShizuku: Boolean,
-        hasDhizuku: Boolean
+        selectedType: AppListType
     ) {
         val filteredApps = if (selectedType == AppListType.USER) userApps else systemApps
 
@@ -197,10 +178,8 @@ class HomeViewModel(
                 frozenAppCount = frozenCount,
                 suspendedAppCount = suspendedCount,
                 unknownInstallerCount = unknownCount,
-                distributionData = distribution,
-                isRootAvailable = hasRoot,
-                isShizukuAvailable = hasShizuku,
-                isDhizukuAvailable = hasDhizuku
+                distributionData = distribution
+                // Privilege fields are populated by the state combine from PrivilegeManager.
             )
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/DashboardHeader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/DashboardHeader.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -99,7 +101,8 @@ fun DashboardHeader(
                     )
                 },
                 selectedIndex = AppListType.entries.indexOf(selectedType),
-                onItemSelected = { onTypeChanged(AppListType.entries[it]) }
+                onItemSelected = { onTypeChanged(AppListType.entries[it]) },
+                modifier = Modifier.width(IntrinsicSize.Max)
             )
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -86,6 +86,7 @@ import com.valhalla.thor.presentation.settings.BillingProcessor
 import com.valhalla.thor.presentation.settings.SupportDeveloperHelper
 import com.valhalla.thor.presentation.widgets.AffirmationDialog
 import com.valhalla.thor.presentation.widgets.MultiAppAffirmationDialog
+import com.valhalla.thor.presentation.widgets.FreezeLoggerDialog
 import com.valhalla.thor.presentation.widgets.TermLoggerDialog
 import com.valhalla.thor.presentation.widgets.ThankYouDialog
 import org.koin.androidx.compose.koinViewModel
@@ -653,6 +654,17 @@ fun MainScreen(
                         logs = state.loggerState.logs,
                         isOperationComplete = state.loggerState.isComplete,
                         onDismiss = { mainViewModel.dismissLogger() }
+                    )
+                }
+
+                if (state.freezeLoggerState.isVisible) {
+                    FreezeLoggerDialog(
+                        isFreeze = state.freezeLoggerState.isFreeze,
+                        total = state.freezeLoggerState.total,
+                        processed = state.freezeLoggerState.processed,
+                        failed = state.freezeLoggerState.failed,
+                        isComplete = state.freezeLoggerState.isComplete,
+                        onDismiss = { mainViewModel.dismissFreezeLogger() }
                     )
                 }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -52,11 +52,26 @@ data class LoggerState(
 )
 
 /**
+ * Compact count-only progress for bulk freeze / unfreeze. Unlike [LoggerState] it
+ * never lists app names — just a live `processed / total` count — and auto-dismisses
+ * shortly after a fully-successful run.
+ */
+data class FreezeLoggerState(
+    val isVisible: Boolean = false,
+    val isFreeze: Boolean = true,
+    val total: Int = 0,
+    val processed: Int = 0,
+    val failed: Int = 0,
+    val isComplete: Boolean = false
+)
+
+/**
  * Main UI State holding global feedback.
  */
 data class MainUiState(
     val actionMessage: UiText? = null, // For transient Toasts
     val loggerState: LoggerState = LoggerState(), // For persistent Logs
+    val freezeLoggerState: FreezeLoggerState = FreezeLoggerState(), // Compact freeze/unfreeze progress
     val selectedDestination: AppDestinations = AppDestinations.HOME, // For Bottom Nav
     val hasShownSupportDeveloperPrompt: Boolean = true,
     val showSupportDeveloperPrompt: Boolean = false,
@@ -373,26 +388,9 @@ class MainViewModel(
                     }
                 }
 
-                is MultiAppAction.Freeze -> performLoggedMultiAction(
-                    UiText.StringResource(R.string.log_freezing_batch),
-                    action.appList
-                ) { appInfo ->
-                    val isSystem = appInfo.isSystem
-                    val isUadFailed = isSystem && appInfo.isUadLoadFailed
-                    val isUnsafe = isSystem && appInfo.bloatRecommendation?.lowercase() == "unsafe"
-                    if (isUadFailed || isUnsafe) {
-                        Result.failure(UiTextException(UiText.StringResource(R.string.error_unsafe_skipped)))
-                    } else {
-                        manageAppUseCase.setAppDisabled(appInfo.packageName, disabled = true)
-                    }
-                }
+                is MultiAppAction.Freeze -> performCountedFreeze(action.appList, isFreeze = true)
 
-                is MultiAppAction.UnFreeze -> performLoggedMultiAction(
-                    UiText.StringResource(R.string.log_unfreezing_batch),
-                    action.appList
-                ) {
-                    manageAppUseCase.setAppDisabled(it.packageName, disabled = false)
-                }
+                is MultiAppAction.UnFreeze -> performCountedFreeze(action.appList, isFreeze = false)
 
                 is MultiAppAction.Kill -> performLoggedMultiAction(
                     UiText.StringResource(R.string.log_killing_batch),
@@ -481,6 +479,59 @@ class MainViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * Bulk freeze / unfreeze with compact count-only progress ([FreezeLoggerState]).
+     * Unsafe / UAD-failed system apps are excluded from the freeze set up-front (so the
+     * total reflects only what we actually attempt), then each app is toggled
+     * sequentially with a live `processed / total` count.
+     */
+    private suspend fun performCountedFreeze(apps: List<AppInfo>, isFreeze: Boolean) {
+        val targets = if (isFreeze) {
+            apps.filter { app ->
+                !(app.isSystem && (app.isUadLoadFailed ||
+                    app.bloatRecommendation?.lowercase() == "unsafe"))
+            }
+        } else {
+            apps
+        }
+
+        _uiState.update {
+            it.copy(
+                freezeLoggerState = FreezeLoggerState(
+                    isVisible = true,
+                    isFreeze = isFreeze,
+                    total = targets.size
+                )
+            )
+        }
+
+        var processed = 0
+        var failed = 0
+        withContext(Dispatchers.IO) {
+            targets.forEach { app ->
+                val result = manageAppUseCase.setAppDisabled(app.packageName, disabled = isFreeze)
+                processed++
+                if (result.isFailure) failed++
+                val p = processed
+                val f = failed
+                _uiState.update {
+                    it.copy(freezeLoggerState = it.freezeLoggerState.copy(processed = p, failed = f))
+                }
+            }
+        }
+
+        _uiState.update {
+            it.copy(freezeLoggerState = it.freezeLoggerState.copy(isComplete = true))
+        }
+        if (processed - failed > 0) {
+            triggerSupportPromptIfNeeded()
+        }
+    }
+
+    fun dismissFreezeLogger() {
+        _uiState.update { it.copy(freezeLoggerState = FreezeLoggerState()) }
     }
 
     private suspend fun performLoggedMultiAction(

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -405,6 +405,8 @@ fun SettingsScreen(
                         PrivilegeMode.ROOT -> R.drawable.magisk_icon
                         PrivilegeMode.SHIZUKU -> R.drawable.shizuku
                         PrivilegeMode.DHIZUKU -> R.drawable.dhizuku
+                        // Unreachable here: WORK MODE only renders when a real privilege mode is available.
+                        PrivilegeMode.NONE -> R.drawable.shield
                     }
                     IconBox(icon)
                     Spacer(Modifier.width(16.dp))

--- a/app/src/main/java/com/valhalla/thor/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/theme/Theme.kt
@@ -10,11 +10,21 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+
+/**
+ * The app's resolved dark-theme flag (from [ThemeMode] + system setting), independent
+ * of the device night mode. Widgets that load night-qualified resources (e.g. Lottie
+ * raw files under res/raw-night) read this so they follow the in-app theme rather than
+ * the device configuration's -night qualifier.
+ */
+val LocalDarkTheme = staticCompositionLocalOf { false }
 
 private val AsgardianLightColorScheme = lightColorScheme(
     primary = LightPrimary,
@@ -141,7 +151,11 @@ fun ThorTheme(
         colorScheme = colorScheme,
         motionScheme = MotionScheme.expressive(),
         typography = AppTypography,
-        content = content
+        content = {
+            CompositionLocalProvider(LocalDarkTheme provides darkTheme) {
+                content()
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AnimateLottieRaw.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AnimateLottieRaw.kt
@@ -1,15 +1,20 @@
 package com.valhalla.thor.presentation.widgets
 
+import android.content.res.Configuration
 import androidx.annotation.RawRes
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
+import com.valhalla.thor.presentation.theme.LocalDarkTheme
 
 @Composable
 fun AnimateLottieRaw(
@@ -19,15 +24,33 @@ fun AnimateLottieRaw(
     repeatCount: Int = LottieConstants.IterateForever,
     contentScale: ContentScale = ContentScale.None
 ) {
-    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(resId))
-    val progress by animateLottieCompositionAsState(
-        composition = composition,
-        iterations = if (shouldLoop) repeatCount else 1
-    )
-    LottieAnimation(
-        composition = composition,
-        progress = { progress },
-        modifier = modifier,
-        contentScale = contentScale
-    )
+    // Resolve the raw resource against a configuration that reflects the IN-APP theme
+    // (LocalDarkTheme), so night-qualified variants (res/raw-night) follow the app's
+    // ThemeMode instead of the device's night mode. Lottie's RawRes spec loads via
+    // LocalContext's resources — which otherwise honor only the device configuration's
+    // -night qualifier — and it also keys its composition cache on the context's night
+    // mode, so overriding the context here yields the correct day/night variant.
+    val darkTheme = LocalDarkTheme.current
+    val baseContext = LocalContext.current
+    val themedContext = remember(darkTheme, baseContext) {
+        val config = Configuration(baseContext.resources.configuration).apply {
+            uiMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                (if (darkTheme) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO)
+        }
+        baseContext.createConfigurationContext(config)
+    }
+
+    CompositionLocalProvider(LocalContext provides themedContext) {
+        val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(resId))
+        val progress by animateLottieCompositionAsState(
+            composition = composition,
+            iterations = if (shouldLoop) repeatCount else 1
+        )
+        LottieAnimation(
+            composition = composition,
+            progress = { progress },
+            modifier = modifier,
+            contentScale = contentScale
+        )
+    }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -874,7 +875,8 @@ private fun AppFilterSheet(
                         )
                     },
                     selectedIndex = AppListType.entries.indexOf(appListType),
-                    onItemSelected = { onListTypeChanged(AppListType.entries[it]) }
+                    onItemSelected = { onListTypeChanged(AppListType.entries[it]) },
+                    modifier = Modifier.width(IntrinsicSize.Max)
                 )
             }
 
@@ -903,7 +905,8 @@ private fun AppFilterSheet(
                         )
                     ),
                     selectedIndex = if (isGrid) 0 else 1,
-                    onItemSelected = { onToggleView() }
+                    onItemSelected = { onToggleView() },
+                    modifier = Modifier.width(IntrinsicSize.Max)
                 )
             }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/FreezeLoggerDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/FreezeLoggerDialog.kt
@@ -1,0 +1,148 @@
+package com.valhalla.thor.presentation.widgets
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.valhalla.thor.R
+import kotlinx.coroutines.delay
+
+/**
+ * Compact, count-only progress for bulk freeze / unfreeze. Shows a live
+ * `processed / total` count while running and a one-line summary when done — it
+ * never lists app names. On a fully-successful run it auto-dismisses after a short
+ * delay; if any app failed it stays open with a Close button so the result is read.
+ */
+@Composable
+fun FreezeLoggerDialog(
+    isFreeze: Boolean,
+    total: Int,
+    processed: Int,
+    failed: Int,
+    isComplete: Boolean,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    autoDismissMillis: Long = 2000L
+) {
+    val succeeded = processed - failed
+    val hasFailures = failed > 0
+
+    // Auto-dismiss shortly after a fully-successful run.
+    LaunchedEffect(isComplete, hasFailures) {
+        if (isComplete && !hasFailures) {
+            delay(autoDismissMillis)
+            onDismiss()
+        }
+    }
+
+    Dialog(
+        onDismissRequest = { if (isComplete) onDismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = isComplete,
+            dismissOnClickOutside = false
+        )
+    ) {
+        Surface(
+            modifier = modifier,
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(min = 220.dp)
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                when {
+                    !isComplete -> AnimateLottieRaw(
+                        resId = R.raw.rearrange,
+                        shouldLoop = true,
+                        modifier = Modifier.size(56.dp),
+                        contentScale = ContentScale.Crop
+                    )
+
+                    hasFailures -> Icon(
+                        imageVector = Icons.Rounded.Warning,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.error
+                    )
+
+                    else -> Icon(
+                        painter = painterResource(R.drawable.check_circle),
+                        contentDescription = stringResource(R.string.cd_selected),
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                if (!isComplete) {
+                    Text(
+                        text = stringResource(
+                            if (isFreeze) R.string.log_freezing_batch else R.string.log_unfreezing_batch
+                        ),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = "$processed / $total",
+                        style = MaterialTheme.typography.headlineSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Text(
+                        text = if (hasFailures) {
+                            stringResource(
+                                if (isFreeze) R.string.tile_freeze_partial_failure
+                                else R.string.tile_unfreeze_partial_failure,
+                                succeeded, total, failed
+                            )
+                        } else {
+                            stringResource(
+                                if (isFreeze) R.string.tile_freeze_success
+                                else R.string.unfrozen_count_success,
+                                succeeded
+                            )
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+
+                    if (hasFailures) {
+                        Button(
+                            onClick = onDismiss,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(stringResource(R.string.close))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/FreezeLoggerDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/FreezeLoggerDialog.kt
@@ -16,6 +16,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -48,11 +50,15 @@ fun FreezeLoggerDialog(
     val succeeded = processed - failed
     val hasFailures = failed > 0
 
+    // Keyed on completion state (NOT onDismiss, which would reset the delay each
+    // recomposition); rememberUpdatedState keeps the latest onDismiss without restarting.
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+
     // Auto-dismiss shortly after a fully-successful run.
     LaunchedEffect(isComplete, hasFailures) {
         if (isComplete && !hasFailures) {
             delay(autoDismissMillis)
-            onDismiss()
+            currentOnDismiss()
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/SupportDeveloperBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/SupportDeveloperBottomSheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -142,7 +143,7 @@ fun SupportDeveloperTabbedBottomSheet(
                     items = tabs.map { ConnectedButtonGroupItem.Label(it.label) },
                     selectedIndex = selectedTab,
                     onItemSelected = { selectedTab = it },
-                    modifier = Modifier.padding(bottom = 16.dp)
+                    modifier = Modifier.width(IntrinsicSize.Max).padding(bottom = 16.dp)
                 )
             }
 

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
@@ -188,4 +188,216 @@ class BundleAnalysisTest {
     fun parseXapkManifest_returnsNullForGarbage() {
         assertNull(parseXapkManifest("not json at all"))
     }
+
+    // --- stray top-level AndroidManifest.xml in a genuine bundle (APKPure crash) ---
+
+    @Test
+    fun bundleWithStrayTopLevelManifest_isNotMonolithic() {
+        // Root cause of the APKPure install failure: a genuine XAPK that ALSO ships
+        // a top-level AndroidManifest.xml. The old gate ("AndroidManifest.xml ⇒
+        // monolithic") routed the whole multi-APK zip into getPackageArchiveInfo,
+        // which threw FileNotFoundException: AndroidManifest.xml. Bundle signals
+        // (manifest.json + top-level {package}.apk/config splits) must win.
+        val entries = listOf(
+            "AndroidManifest.xml",
+            "manifest.json",
+            "com.amazon.mShop.android.shopping.apk",
+            "config.arm64_v8a.apk",
+            "config.xxhdpi.apk",
+            "icon.png"
+        )
+        assertTrue(hasTopLevelAndroidManifest(entries))
+        assertFalse(isMonolithicApk(entries))
+        assertTrue(looksLikeBundle(entries))
+    }
+
+    @Test
+    fun apkmShapedZipWithStrayManifest_isNotMonolithic() {
+        // Same defect for an .apkm-shaped zip: a stray root AndroidManifest.xml plus
+        // a top-level base.apk sibling and info.json must be classified as a bundle.
+        val entries = listOf(
+            "AndroidManifest.xml",
+            "base.apk",
+            "split_config.arm64_v8a.apk",
+            "info.json"
+        )
+        assertFalse(isMonolithicApk(entries))
+        assertTrue(looksLikeBundle(entries))
+    }
+
+    // --- file-extension as a secondary bundle signal ---
+
+    @Test
+    fun fileExtension_forcesBundleButNeverBreaksAPlainApk() {
+        val plainApk = listOf("AndroidManifest.xml", "classes.dex", "resources.arsc")
+        // No bundle signal at all → monolithic.
+        assertTrue(isMonolithicApk(plainApk))
+        // .apk name keeps it monolithic.
+        assertTrue(isMonolithicApk(plainApk, "app.apk"))
+        // A known bundle extension forces the bundle path even with a stray manifest.
+        assertFalse(isMonolithicApk(plainApk, "app.xapk"))
+        assertFalse(isMonolithicApk(plainApk, "App.APKM"))
+        assertFalse(isMonolithicApk(plainApk, "thing.apks"))
+    }
+
+    @Test
+    fun hasBundleExtension_recognizesKnownContainers() {
+        assertTrue(hasBundleExtension("foo.xapk"))
+        assertTrue(hasBundleExtension("Foo.APKM"))
+        assertTrue(hasBundleExtension("bar.apks"))
+        assertFalse(hasBundleExtension("bar.apk"))
+        assertFalse(hasBundleExtension("noextension"))
+        assertFalse(hasBundleExtension(null))
+    }
+
+    // --- APKPure .xapk manifest + APKMirror .apkm info.json ---
+
+    @Test
+    fun amazonXapkManifest_picksPackageNamedBaseAndAllSplits() {
+        // Real APKPure manifest.json: base is named {package}.apk (not base.apk) and
+        // version_code is numeric.
+        val json = """
+            {
+              "xapk_version": 2,
+              "package_name": "com.amazon.mShop.android.shopping",
+              "version_code": 1241319416,
+              "version_name": "32.12.4.100",
+              "split_apks": [
+                { "file": "com.amazon.mShop.android.shopping.apk", "id": "base" },
+                { "file": "config.arm64_v8a.apk", "id": "config.arm64_v8a" },
+                { "file": "config.xxhdpi.apk", "id": "config.xxhdpi" }
+              ]
+            }
+        """.trimIndent()
+        val manifest = parseXapkManifest(json)
+        assertNotNull(manifest)
+        assertEquals("com.amazon.mShop.android.shopping.apk", manifest!!.baseApkFile())
+        assertEquals(
+            listOf(
+                "com.amazon.mShop.android.shopping.apk",
+                "config.arm64_v8a.apk",
+                "config.xxhdpi.apk"
+            ),
+            manifest.splitApkFiles()
+        )
+    }
+
+    @Test
+    fun parseApkmInfo_readsPackageLabelAndVersion() {
+        val json = """
+            {
+              "apkm_version": 5,
+              "app_name": "Google Journal",
+              "apk_title": "Google Journal 2026.02.10.867917178",
+              "release_version": "2026.02.10.867917178",
+              "versioncode": "30271",
+              "pname": "com.google.android.apps.pixel.aurelius",
+              "arches": ["arm64-v8a"]
+            }
+        """.trimIndent()
+        val info = parseApkmInfo(json)
+        assertNotNull(info)
+        assertEquals("com.google.android.apps.pixel.aurelius", info!!.packageName)
+        assertEquals("Google Journal", info.appName)
+        assertEquals("30271", info.versionCode)
+        assertNull(parseApkmInfo("definitely not json"))
+    }
+
+    @Test
+    fun apkmWithoutManifest_infoHintSelectsPackageNamedBase() {
+        // .apkm has no manifest.json; the base is {package}.apk. The info.json
+        // package hint must surface it as the base even though a split precedes it.
+        val entries = listOf(
+            "split_config.arm64_v8a.apk",
+            "com.google.android.apps.pixel.aurelius.apk",
+            "info.json",
+            "icon.png"
+        )
+        val set = resolveBundleInstallSet(
+            entries,
+            manifestSplitFiles = null,
+            packageName = "com.google.android.apps.pixel.aurelius"
+        )
+        assertEquals("com.google.android.apps.pixel.aurelius.apk", set.first())
+    }
+
+    // --- split completeness: a subset/stale manifest must never drop a real split ---
+
+    @Test
+    fun resolveBundleInstallSet_appendsSplitsMissingFromManifest() {
+        val entries = listOf(
+            "base.apk",
+            "config.arm64_v8a.apk",
+            "config.xxhdpi.apk",
+            "manifest.json",
+            "icon.png"
+        )
+        // Manifest omits config.xxhdpi.apk (stale/subset).
+        val manifestSplits = listOf("base.apk", "config.arm64_v8a.apk")
+        val set = resolveBundleInstallSet(entries, manifestSplits, packageName = null)
+        assertEquals("base.apk", set.first())
+        assertEquals(
+            setOf("base.apk", "config.arm64_v8a.apk", "config.xxhdpi.apk"),
+            set.map { it.substringAfterLast('/') }.toSet()
+        )
+    }
+
+    @Test
+    fun resolveBundleInstallSet_ignoresManifestReferencingMissingFiles() {
+        val entries = listOf("base.apk", "split_config.arm64_v8a.apk")
+        // Manifest references a file that isn't in the archive → fall back to scan.
+        val manifestSplits = listOf("base.apk", "config.does_not_exist.apk")
+        val set = resolveBundleInstallSet(entries, manifestSplits, packageName = null)
+        assertEquals("base.apk", set.first())
+        assertFalse(set.any { it.contains("does_not_exist") })
+        assertEquals(
+            setOf("base.apk", "split_config.arm64_v8a.apk"),
+            set.map { it.substringAfterLast('/') }.toSet()
+        )
+    }
+
+    @Test
+    fun resolveBundleInstallSet_keepsManifestOrderWhenComplete() {
+        val entries = listOf(
+            "config.arm64_v8a.apk",
+            "com.amazon.mShop.android.shopping.apk",
+            "config.xxhdpi.apk",
+            "manifest.json"
+        )
+        val manifestSplits = listOf(
+            "com.amazon.mShop.android.shopping.apk",
+            "config.arm64_v8a.apk",
+            "config.xxhdpi.apk"
+        )
+        val set = resolveBundleInstallSet(
+            entries,
+            manifestSplits,
+            packageName = "com.amazon.mShop.android.shopping"
+        )
+        // Base first, exactly the manifest order, no extras.
+        assertEquals(manifestSplits, set)
+    }
+
+    @Test
+    fun resolveBundleInstallSet_returnsEmptyWhenNoApkEntries() {
+        val entries = listOf("manifest.json", "icon.png", "obb/main.obb")
+        assertTrue(resolveBundleInstallSet(entries, null, null).isEmpty())
+    }
+
+    @Test
+    fun resolveBundleInstallSet_doesNotAppendForeignStandaloneApk() {
+        // A complete manifest plus a stray standalone top-level APK (e.g. a
+        // `universal.apk` fallback): the union must NOT add it, or install-multiple
+        // would receive two base APKs and fail. Only real config/splits are appended.
+        val entries = listOf(
+            "base.apk",
+            "config.arm64_v8a.apk",
+            "universal.apk",
+            "manifest.json"
+        )
+        val manifestSplits = listOf("base.apk", "config.arm64_v8a.apk")
+        val set = resolveBundleInstallSet(entries, manifestSplits, packageName = null)
+        assertEquals(manifestSplits, set)
+        assertFalse(set.any { it.contains("universal") })
+    }
 }

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleZipTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleZipTest.kt
@@ -174,6 +174,21 @@ class BundleZipTest {
     }
 
     @Test
+    fun bundleZip_read_returnsEntryNamesAndRequestedBytesInOnePass() {
+        val zip = writeStoredDataDescriptorZip(amazonEntries)
+
+        val contents = BundleZip.read(zip, setOf("manifest.json", "missing.json"))
+
+        assertEquals(amazonEntries.map { it.first }.toSet(), contents.entryNames.toSet())
+        assertArrayEquals(
+            amazonEntries.first { it.first == "manifest.json" }.second,
+            contents.bytes["manifest.json"]
+        )
+        assertNull(contents.bytes["missing.json"])          // absent entry -> not in the map
+        assertNull(contents.bytes["config.arm64_v8a.apk"])  // present but not requested
+    }
+
+    @Test
     fun zipInputStream_cannotReadThisLayout_documentingWhyTheBugExisted() {
         // The whole point of BundleZip: ZipInputStream does NOT recover the real
         // manifest.json bytes from this layout (it throws or mis-reads), whereas

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleZipTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleZipTest.kt
@@ -1,0 +1,221 @@
+package com.valhalla.thor.data.repository
+
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.CRC32
+import java.util.zip.ZipInputStream
+
+/**
+ * Regression tests for the APKPure `.xapk` install failure.
+ *
+ * APKPure stores the inner APKs as STORED entries with the data-descriptor flag
+ * set and ZERO sizes in the local file header (the real sizes live only in the
+ * central directory / trailing descriptor). [ZipInputStream] reads local headers
+ * sequentially and cannot find where such a STORED entry ends, so it derails;
+ * [BundleZip] uses ZipFile (central directory) and reads it correctly — exactly
+ * like the `unzip` tool.
+ *
+ * These tests build a zip in that precise pathological layout by hand.
+ */
+class BundleZipTest {
+
+    private val temp = mutableListOf<File>()
+
+    @After
+    fun cleanup() {
+        temp.forEach { it.deleteRecursively() }
+    }
+
+    private fun tempFile(name: String): File =
+        File.createTempFile("bundlezip_", "_$name").also { temp.add(it) }
+
+    private fun tempDir(): File =
+        File(System.getProperty("java.io.tmpdir"), "bundlezip_out_${temp.size}")
+            .also { it.mkdirs(); temp.add(it) }
+
+    private fun le16(v: Int) =
+        byteArrayOf((v and 0xFF).toByte(), ((v ushr 8) and 0xFF).toByte())
+
+    private fun le32(v: Long) = byteArrayOf(
+        (v and 0xFF).toByte(),
+        ((v ushr 8) and 0xFF).toByte(),
+        ((v ushr 16) and 0xFF).toByte(),
+        ((v ushr 24) and 0xFF).toByte()
+    )
+
+    private fun crc(data: ByteArray): Long = CRC32().apply { update(data) }.value
+
+    /**
+     * Write a zip whose entries are STORED, flag bit-3 (data descriptor) set, with
+     * zero crc/csize/usize in the LOCAL header and the real values only in the data
+     * descriptor + central directory — the APKPure `.xapk` layout.
+     */
+    private fun writeStoredDataDescriptorZip(entries: List<Pair<String, ByteArray>>): File {
+        val file = tempFile("stored.zip")
+        file.outputStream().use { out ->
+            data class Cd(val name: ByteArray, val crc: Long, val size: Int, val offset: Int)
+
+            val cds = mutableListOf<Cd>()
+            var offset = 0
+            fun write(b: ByteArray) { out.write(b); offset += b.size }
+
+            for ((name, data) in entries) {
+                val nameBytes = name.toByteArray(Charsets.US_ASCII)
+                val c = crc(data)
+                val start = offset
+                // Local file header — zero sizes, data-descriptor flag set, STORED.
+                write(le32(0x04034b50))
+                write(le16(20))          // version needed
+                write(le16(0x0008))      // GP flags: bit 3 (data descriptor)
+                write(le16(0))           // method: STORED
+                write(le16(0))           // mod time
+                write(le16(0x21))        // mod date (1980-01-01)
+                write(le32(0))           // crc-32 (zero in local header)
+                write(le32(0))           // compressed size (zero)
+                write(le32(0))           // uncompressed size (zero)
+                write(le16(nameBytes.size))
+                write(le16(0))           // extra len
+                write(nameBytes)
+                write(data)
+                // Data descriptor with the real values.
+                write(le32(0x08074b50))
+                write(le32(c))
+                write(le32(data.size.toLong()))
+                write(le32(data.size.toLong()))
+                cds.add(Cd(nameBytes, c, data.size, start))
+            }
+
+            val cdStart = offset
+            for (cd in cds) {
+                write(le32(0x02014b50))
+                write(le16(20))          // version made by
+                write(le16(20))          // version needed
+                write(le16(0x0008))      // flags
+                write(le16(0))           // method: STORED
+                write(le16(0))           // mod time
+                write(le16(0x21))        // mod date
+                write(le32(cd.crc))      // real crc
+                write(le32(cd.size.toLong())) // real compressed size
+                write(le32(cd.size.toLong())) // real uncompressed size
+                write(le16(cd.name.size))
+                write(le16(0))           // extra len
+                write(le16(0))           // comment len
+                write(le16(0))           // disk number start
+                write(le16(0))           // internal attrs
+                write(le32(0))           // external attrs
+                write(le32(cd.offset.toLong()))
+                write(cd.name)
+            }
+            val cdSize = offset - cdStart
+
+            // End of central directory.
+            write(le32(0x06054b50))
+            write(le16(0))               // disk
+            write(le16(0))               // cd start disk
+            write(le16(cds.size))        // entries this disk
+            write(le16(cds.size))        // entries total
+            write(le32(cdSize.toLong()))
+            write(le32(cdStart.toLong()))
+            write(le16(0))               // comment len
+        }
+        return file
+    }
+
+    private val amazonEntries = listOf(
+        "com.amazon.mShop.android.shopping.apk" to "BASE-APK-BYTES-payload-0123456789".toByteArray(),
+        "config.arm64_v8a.apk" to "ARM64-CONFIG-SPLIT-bytes".toByteArray(),
+        "config.xxhdpi.apk" to "XXHDPI-CONFIG-SPLIT-bytes".toByteArray(),
+        "manifest.json" to """{"package_name":"com.amazon.mShop.android.shopping"}""".toByteArray()
+    )
+
+    @Test
+    fun bundleZip_readsStoredDataDescriptorEntries() {
+        val zip = writeStoredDataDescriptorZip(amazonEntries)
+
+        // Central-directory read (like unzip) finds every entry with correct content.
+        assertEquals(
+            amazonEntries.map { it.first }.toSet(),
+            BundleZip.entryNames(zip).toSet()
+        )
+        assertArrayEquals(
+            amazonEntries.first { it.first == "manifest.json" }.second,
+            BundleZip.readEntry(zip, "manifest.json")
+        )
+        assertArrayEquals(
+            amazonEntries.first { it.first.startsWith("com.amazon") }.second,
+            BundleZip.readEntry(zip, "com.amazon.mShop.android.shopping.apk")
+        )
+        assertNull(BundleZip.readEntry(zip, "does-not-exist.apk"))
+    }
+
+    @Test
+    fun bundleZip_extractsSelectedEntriesWithExactContent() {
+        val zip = writeStoredDataDescriptorZip(amazonEntries)
+        val outDir = tempDir()
+
+        val wanted = setOf(
+            "com.amazon.mShop.android.shopping.apk",
+            "config.arm64_v8a.apk",
+            "config.xxhdpi.apk"
+        )
+        val extracted = BundleZip.extractEntries(zip, wanted, outDir)
+
+        assertEquals(wanted, extracted.map { it.name }.toSet())
+        for ((name, data) in amazonEntries.filter { it.first in wanted }) {
+            assertArrayEquals(data, File(outDir, name).readBytes())
+        }
+    }
+
+    @Test
+    fun zipInputStream_cannotReadThisLayout_documentingWhyTheBugExisted() {
+        // The whole point of BundleZip: ZipInputStream does NOT recover the real
+        // manifest.json bytes from this layout (it throws or mis-reads), whereas
+        // BundleZip does. We assert BundleZip is correct and ZipInputStream is not.
+        val zip = writeStoredDataDescriptorZip(amazonEntries)
+        val expected = amazonEntries.first { it.first == "manifest.json" }.second
+
+        assertArrayEquals(expected, BundleZip.readEntry(zip, "manifest.json"))
+
+        val viaZis: ByteArray? = try {
+            ZipInputStream(ByteArrayInputStream(zip.readBytes())).use { zis ->
+                var found: ByteArray? = null
+                var e = zis.nextEntry
+                while (e != null) {
+                    if (e.name == "manifest.json") { found = zis.readBytes(); break }
+                    e = zis.nextEntry
+                }
+                found
+            }
+        } catch (_: Exception) {
+            null // ZipInputStream threw on the STORED+data-descriptor entry
+        }
+
+        // Either it threw (null) or it read the wrong bytes — never the correct ones.
+        assertTrue(
+            "ZipInputStream unexpectedly read the entry correctly",
+            viaZis == null || !viaZis.contentEquals(expected)
+        )
+    }
+
+    @Test
+    fun bundleZip_handlesNormalDeflatedZipToo() {
+        // A conventional (DEFLATED, sizes-in-local-header) zip must also read fine.
+        val file = tempFile("normal.zip")
+        val payload = "hello-deflated-world".toByteArray()
+        java.util.zip.ZipOutputStream(file.outputStream()).use { zos ->
+            zos.putNextEntry(java.util.zip.ZipEntry("base.apk"))
+            zos.write(payload)
+            zos.closeEntry()
+        }
+        assertEquals(listOf("base.apk"), BundleZip.entryNames(file))
+        assertArrayEquals(payload, BundleZip.readEntry(file, "base.apk"))
+        assertNotEquals(0, BundleZip.readEntry(file, "base.apk")!!.size)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt
@@ -1,0 +1,56 @@
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PrivilegeResolverTest {
+
+    @Test
+    fun preferred_isUsed_whenAvailable() {
+        assertEquals(
+            PrivilegeMode.SHIZUKU,
+            resolvePrivilegeMode(PrivilegeMode.SHIZUKU, root = true, shizuku = true, dhizuku = false)
+        )
+    }
+
+    @Test
+    fun preferred_fallsBack_whenUnavailable() {
+        // Preferred SHIZUKU not available -> auto fallback picks ROOT (highest available).
+        assertEquals(
+            PrivilegeMode.ROOT,
+            resolvePrivilegeMode(PrivilegeMode.SHIZUKU, root = true, shizuku = false, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noPreference_usesFallbackChain_rootFirst() {
+        assertEquals(
+            PrivilegeMode.ROOT,
+            resolvePrivilegeMode(null, root = true, shizuku = true, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noPreference_shizukuBeforeDhizuku() {
+        assertEquals(
+            PrivilegeMode.SHIZUKU,
+            resolvePrivilegeMode(null, root = false, shizuku = true, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noneAvailable_isNone() {
+        assertEquals(
+            PrivilegeMode.NONE,
+            resolvePrivilegeMode(PrivilegeMode.ROOT, root = false, shizuku = false, dhizuku = false)
+        )
+    }
+
+    @Test
+    fun preferredNone_isTreatedAsAuto() {
+        assertEquals(
+            PrivilegeMode.DHIZUKU,
+            resolvePrivilegeMode(PrivilegeMode.NONE, root = false, shizuku = false, dhizuku = true)
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-07-02-reactive-privilege-flow.md
+++ b/docs/superpowers/plans/2026-07-02-reactive-privilege-flow.md
@@ -1,0 +1,837 @@
+# Reactive Privilege Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-ViewModel one-shot privilege probes with a single reactive source of truth that updates automatically on Shizuku grant and preference changes.
+
+**Architecture:** A `@Single PrivilegeManager` (data layer) exposes `StateFlow<PrivilegeState>` — root/shizuku/dhizuku availability + a resolved `active: PrivilegeMode` — re-probing off the main thread on init, on Shizuku binder/permission events (it owns those listeners), and whenever `preferredPrivilegeMode` changes. Home/AppList/Freezer ViewModels observe it instead of probing.
+
+**Tech Stack:** Kotlin, Coroutines/Flow (`StateFlow`, `combine`), Koin Annotations (`@Single`, `@KoinViewModel`, KSP), Shizuku (`rikka.shizuku.Shizuku`), JUnit4.
+
+## Global Constraints
+
+- Koin DI is annotation-based, scanned via `@ComponentScan("com.valhalla.thor")` in `di/Modules.kt` — a `@Single`-annotated class anywhere under `com.valhalla.thor` is auto-registered. No manual module edits needed.
+- Privilege probes (`isRootAvailable` runs a root shell; Shizuku/Dhizuku do binder IPC) MUST run off the main thread (`Dispatchers.IO`).
+- `preferredPrivilegeMode: PrivilegeMode?` in prefs stays nullable (`null` = auto). `PrivilegeMode.NONE` is used only by the reactive `active` value and is NEVER persisted as a preference.
+- `SystemRepositoryImpl.getActiveGateway()` (the imperative operation path) is OUT OF SCOPE — do not modify it.
+- Build/verify the `fossDebug` variant: `./gradlew :app:compileFossDebugKotlin`.
+
+---
+
+### Task 1: PrivilegeMode + PrivilegeState + pure resolver (with tests)
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt`
+- Create: `app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt`
+- Test: `app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `enum class PrivilegeMode { NONE, ROOT, SHIZUKU, DHIZUKU }`
+  - `data class PrivilegeState(root: Boolean, shizuku: Boolean, dhizuku: Boolean, active: PrivilegeMode, isReady: Boolean)` with `val hasAnyPrivilege: Boolean`
+  - `fun resolvePrivilegeMode(preferred: PrivilegeMode?, root: Boolean, shizuku: Boolean, dhizuku: Boolean): PrivilegeMode`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PrivilegeResolverTest {
+
+    @Test
+    fun preferred_isUsed_whenAvailable() {
+        assertEquals(
+            PrivilegeMode.SHIZUKU,
+            resolvePrivilegeMode(PrivilegeMode.SHIZUKU, root = true, shizuku = true, dhizuku = false)
+        )
+    }
+
+    @Test
+    fun preferred_fallsBack_whenUnavailable() {
+        // Preferred SHIZUKU not available -> auto fallback picks ROOT (highest available).
+        assertEquals(
+            PrivilegeMode.ROOT,
+            resolvePrivilegeMode(PrivilegeMode.SHIZUKU, root = true, shizuku = false, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noPreference_usesFallbackChain_rootFirst() {
+        assertEquals(
+            PrivilegeMode.ROOT,
+            resolvePrivilegeMode(null, root = true, shizuku = true, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noPreference_shizukuBeforeDhizuku() {
+        assertEquals(
+            PrivilegeMode.SHIZUKU,
+            resolvePrivilegeMode(null, root = false, shizuku = true, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noneAvailable_isNone() {
+        assertEquals(
+            PrivilegeMode.NONE,
+            resolvePrivilegeMode(PrivilegeMode.ROOT, root = false, shizuku = false, dhizuku = false)
+        )
+    }
+
+    @Test
+    fun preferredNone_isTreatedAsAuto() {
+        assertEquals(
+            PrivilegeMode.DHIZUKU,
+            resolvePrivilegeMode(PrivilegeMode.NONE, root = false, shizuku = false, dhizuku = true)
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.PrivilegeResolverTest"`
+Expected: FAIL — compilation error (`resolvePrivilegeMode` / `PrivilegeMode.NONE` unresolved).
+
+- [ ] **Step 3: Add `NONE` to the enum**
+
+Replace the entire contents of `app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+enum class PrivilegeMode {
+    /** No privilege available (reactive/active value only — never persisted as a preference). */
+    NONE,
+    ROOT,
+    SHIZUKU,
+    DHIZUKU
+}
+```
+
+- [ ] **Step 4: Create `PrivilegeState` + `resolvePrivilegeMode`**
+
+Create `app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+/**
+ * Snapshot of privilege availability + the resolved active mode.
+ *
+ * [isReady] is false until the first probe completes, so consumers can tell
+ * "not probed yet" apart from "probed, nothing available" (avoids a flash of the
+ * no-privilege UI on cold start).
+ */
+data class PrivilegeState(
+    val root: Boolean = false,
+    val shizuku: Boolean = false,
+    val dhizuku: Boolean = false,
+    val active: PrivilegeMode = PrivilegeMode.NONE,
+    val isReady: Boolean = false
+) {
+    val hasAnyPrivilege: Boolean get() = active != PrivilegeMode.NONE
+}
+
+/**
+ * Resolve the effective privilege mode: the user's [preferred] mode when it is
+ * actually available, otherwise the first available in Root -> Shizuku -> Dhizuku
+ * order, otherwise [PrivilegeMode.NONE]. A null or NONE [preferred] means "auto".
+ */
+fun resolvePrivilegeMode(
+    preferred: PrivilegeMode?,
+    root: Boolean,
+    shizuku: Boolean,
+    dhizuku: Boolean
+): PrivilegeMode {
+    when (preferred) {
+        PrivilegeMode.ROOT -> if (root) return PrivilegeMode.ROOT
+        PrivilegeMode.SHIZUKU -> if (shizuku) return PrivilegeMode.SHIZUKU
+        PrivilegeMode.DHIZUKU -> if (dhizuku) return PrivilegeMode.DHIZUKU
+        PrivilegeMode.NONE, null -> Unit // fall through to auto
+    }
+    return when {
+        root -> PrivilegeMode.ROOT
+        shizuku -> PrivilegeMode.SHIZUKU
+        dhizuku -> PrivilegeMode.DHIZUKU
+        else -> PrivilegeMode.NONE
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.PrivilegeResolverTest"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt \
+        app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt \
+        app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt
+git commit -m "feat(privilege): add PrivilegeMode.NONE, PrivilegeState + resolver
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: PrivilegeManager (reactive source of truth)
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt`
+
+**Interfaces:**
+- Consumes: `SystemRepository` (`isRootAvailable`/`isShizukuAvailable`/`isDhizukuAvailable`), `PreferenceRepository.userPreferences` (`preferredPrivilegeMode`), `resolvePrivilegeMode(...)`, `PrivilegeState`.
+- Produces:
+  - `@Single class PrivilegeManager(SystemRepository, PreferenceRepository)`
+  - `val state: StateFlow<PrivilegeState>`
+  - `fun refresh()`
+
+- [ ] **Step 1: Create the manager**
+
+Create `app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt`:
+
+```kotlin
+package com.valhalla.thor.data.manager
+
+import com.valhalla.thor.domain.model.PrivilegeState
+import com.valhalla.thor.domain.model.resolvePrivilegeMode
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
+import rikka.shizuku.Shizuku
+
+/**
+ * Single reactive source of truth for privilege availability + the active mode.
+ *
+ * Re-probes root/Shizuku/Dhizuku off the main thread on init, on [refresh], on
+ * Shizuku binder/permission events (it owns those listeners), and whenever the
+ * preferred mode changes. As a process-lifetime @Single it never unregisters its
+ * Shizuku listeners (they live for the app), so consumers created before a
+ * first-launch grant still see it once granted.
+ */
+@Single
+class PrivilegeManager(
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _state = MutableStateFlow(PrivilegeState())
+    val state: StateFlow<PrivilegeState> = _state.asStateFlow()
+
+    // Bumped to force a re-probe; StateFlow<Int> emits on every distinct value.
+    private val refreshTrigger = MutableStateFlow(0)
+
+    private val binderReceivedListener = Shizuku.OnBinderReceivedListener { refresh() }
+    private val permissionResultListener =
+        Shizuku.OnRequestPermissionResultListener { _, _ -> refresh() }
+
+    init {
+        Shizuku.addBinderReceivedListener(binderReceivedListener)
+        Shizuku.addRequestPermissionResultListener(permissionResultListener)
+
+        scope.launch {
+            combine(availabilityFlow(), preferenceRepository.userPreferences) { avail, prefs ->
+                PrivilegeState(
+                    root = avail.root,
+                    shizuku = avail.shizuku,
+                    dhizuku = avail.dhizuku,
+                    active = resolvePrivilegeMode(
+                        prefs.preferredPrivilegeMode,
+                        avail.root,
+                        avail.shizuku,
+                        avail.dhizuku
+                    ),
+                    isReady = true
+                )
+            }.collect { _state.value = it }
+        }
+    }
+
+    /** Force a re-probe (e.g. after the user enables root outside the app). */
+    fun refresh() {
+        refreshTrigger.value += 1
+    }
+
+    private data class Availability(val root: Boolean, val shizuku: Boolean, val dhizuku: Boolean)
+
+    private fun availabilityFlow(): Flow<Availability> =
+        refreshTrigger
+            .map {
+                Availability(
+                    root = safeProbe { systemRepository.isRootAvailable() },
+                    shizuku = safeProbe { systemRepository.isShizukuAvailable() },
+                    dhizuku = safeProbe { systemRepository.isDhizukuAvailable() }
+                )
+            }
+            .flowOn(Dispatchers.IO)
+
+    private suspend fun safeProbe(block: suspend () -> Boolean): Boolean = try {
+        block()
+    } catch (e: Exception) {
+        Logger.e("PrivilegeManager", "privilege probe failed", e)
+        false
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles and Koin can construct it**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL. (The class is under `com.valhalla.thor`, so `@ComponentScan("com.valhalla.thor")` registers it; no `di/Modules.kt` change is needed.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
+git commit -m "feat(privilege): add PrivilegeManager reactive StateFlow<PrivilegeState>
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Migrate FreezerViewModel to observe PrivilegeManager
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt`
+
+**Interfaces:**
+- Consumes: `PrivilegeManager.state: StateFlow<PrivilegeState>`.
+
+- [ ] **Step 1: Swap the dependency and imports**
+
+In `FreezerViewModel.kt`, replace the import line:
+
+```kotlin
+import com.valhalla.thor.presentation.common.ShizukuPermissionHandler
+```
+
+with:
+
+```kotlin
+import com.valhalla.thor.data.manager.PrivilegeManager
+```
+
+Then remove the now-unused import `import com.valhalla.thor.domain.repository.SystemRepository` (it will be flagged unused after Step 2).
+
+In the constructor, replace:
+
+```kotlin
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository
+) : ViewModel() {
+```
+
+with:
+
+```kotlin
+    private val privilegeManager: PrivilegeManager,
+    private val preferenceRepository: PreferenceRepository
+) : ViewModel() {
+```
+
+- [ ] **Step 2: Replace the shim + one-shot probe with an observer**
+
+Replace this block:
+
+```kotlin
+    // Re-check privileges when Shizuku's binder connects or the user grants permission.
+    // This ViewModel is created at app start (before the first-launch Shizuku grant), so
+    // its init-time loadPrivileges() would otherwise stay stale until an app restart.
+    private val shizukuHandler = ShizukuPermissionHandler(
+        onPermissionGranted = { loadPrivileges() }
+    )
+
+    init {
+        observeApps()
+        observePreferences()
+        loadPrivileges()
+        shizukuHandler.register()
+    }
+
+    override fun onCleared() {
+        shizukuHandler.unregister()
+        super.onCleared()
+    }
+```
+
+with:
+
+```kotlin
+    init {
+        observeApps()
+        observePreferences()
+        observePrivileges()
+    }
+```
+
+Then delete the `loadPrivileges()` function entirely:
+
+```kotlin
+    private fun loadPrivileges() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val hasRoot = systemRepository.isRootAvailable()
+            val hasShizuku = systemRepository.isShizukuAvailable()
+            val hasDhizuku = systemRepository.isDhizukuAvailable()
+            _uiState.update {
+                it.copy(
+                    isRoot = hasRoot,
+                    isShizuku = hasShizuku,
+                    isDhizuku = hasDhizuku
+                )
+            }
+        }
+    }
+```
+
+and add the observer (place it where `loadPrivileges` was):
+
+```kotlin
+    private fun observePrivileges() {
+        viewModelScope.launch {
+            privilegeManager.state.collect { p ->
+                _uiState.update {
+                    it.copy(isRoot = p.root, isShizuku = p.shizuku, isDhizuku = p.dhizuku)
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL, with no "unused import" for `SystemRepository` or `Dispatchers` — if `Dispatchers` is now unused (it was only used by `loadPrivileges`), remove `import kotlinx.coroutines.Dispatchers`. (Note: `observeApps` uses `flowOn(Dispatchers.Default)`, so `Dispatchers` IS still used — keep it.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+git commit -m "refactor(freezer): observe PrivilegeManager instead of one-shot probe + Shizuku shim
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Migrate AppListViewModel to observe PrivilegeManager
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt`
+
+**Interfaces:**
+- Consumes: `PrivilegeManager.state`.
+
+- [ ] **Step 1: Swap the dependency**
+
+In `AppListViewModel.kt`, add the import:
+
+```kotlin
+import com.valhalla.thor.data.manager.PrivilegeManager
+```
+
+In the constructor, replace the parameter:
+
+```kotlin
+    private val systemRepository: SystemRepository,
+```
+
+with:
+
+```kotlin
+    private val privilegeManager: PrivilegeManager,
+```
+
+Remove the now-unused `import com.valhalla.thor.domain.repository.SystemRepository` (verify with a search that `systemRepository` has no other references after Step 2; it does not).
+
+- [ ] **Step 2: Combine privilege state into the app collection**
+
+Replace this block in `loadApps()`:
+
+```kotlin
+            // Availability probes include non-suspend binder IPC (Shizuku / Dhizuku);
+            // keep them off the Main thread so app-list load never janks.
+            val (hasRoot, hasShizuku, hasDhizuku) = withContext(Dispatchers.IO) {
+                Triple(
+                    systemRepository.isRootAvailable(),
+                    systemRepository.isShizukuAvailable(),
+                    systemRepository.isDhizukuAvailable()
+                )
+            }
+            getInstalledAppsUseCase().collect { (user, system) ->
+                _rawState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRoot = hasRoot,
+                        isShizuku = hasShizuku,
+                        isDhizuku = hasDhizuku,
+                        allUserApps = user,
+                        allSystemApps = system
+                    )
+                }
+            }
+```
+
+with:
+
+```kotlin
+            // Privilege availability now comes from the shared reactive PrivilegeManager,
+            // so a Shizuku grant reflects here without reloading the list.
+            combine(
+                getInstalledAppsUseCase(),
+                privilegeManager.state
+            ) { (user, system), priv ->
+                Triple(user, system, priv)
+            }.collect { (user, system, priv) ->
+                _rawState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRoot = priv.root,
+                        isShizuku = priv.shizuku,
+                        isDhizuku = priv.dhizuku,
+                        allUserApps = user,
+                        allSystemApps = system
+                    )
+                }
+            }
+```
+
+Ensure these imports exist (add any missing): `import kotlinx.coroutines.flow.combine`. If `withContext`/`Dispatchers` are now unused elsewhere in the file, remove their imports; otherwise leave them.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+git commit -m "refactor(applist): source privileges from reactive PrivilegeManager
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Migrate HomeViewModel to observe PrivilegeManager
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt`
+
+**Interfaces:**
+- Consumes: `PrivilegeManager.state`, `PrivilegeMode`.
+
+- [ ] **Step 1: Swap the dependency**
+
+Add import:
+
+```kotlin
+import com.valhalla.thor.data.manager.PrivilegeManager
+```
+
+In the constructor, replace:
+
+```kotlin
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository // Injected
+```
+
+with:
+
+```kotlin
+    private val privilegeManager: PrivilegeManager,
+    private val preferenceRepository: PreferenceRepository // Injected
+```
+
+Remove `import com.valhalla.thor.domain.repository.SystemRepository` (unused after this task).
+
+- [ ] **Step 2: Derive privilege fields from the manager in the state combine**
+
+Replace the `state` combine:
+
+```kotlin
+    val state = combine(_internalState, preferenceRepository.userPreferences) { internal, prefs ->
+        val activeMode = prefs.preferredPrivilegeMode ?: when {
+            internal.isRootAvailable -> PrivilegeMode.ROOT
+            internal.isShizukuAvailable -> PrivilegeMode.SHIZUKU
+            internal.isDhizukuAvailable -> PrivilegeMode.DHIZUKU
+            else -> null
+        }
+        internal.copy(
+            showReinstallCard = prefs.showReinstallAllCard,
+            activePrivilegeMode = activeMode,
+            extensionsUnlocked = prefs.extensionsUnlocked
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        HomeUiState()
+    )
+```
+
+with:
+
+```kotlin
+    val state = combine(
+        _internalState,
+        preferenceRepository.userPreferences,
+        privilegeManager.state
+    ) { internal, prefs, priv ->
+        internal.copy(
+            showReinstallCard = prefs.showReinstallAllCard,
+            isRootAvailable = priv.root,
+            isShizukuAvailable = priv.shizuku,
+            isDhizukuAvailable = priv.dhizuku,
+            // Keep the existing "null = no privilege" contract for the UI.
+            activePrivilegeMode = priv.active.takeIf { it != PrivilegeMode.NONE },
+            extensionsUnlocked = prefs.extensionsUnlocked
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        HomeUiState()
+    )
+```
+
+- [ ] **Step 3: Stop probing/threading privileges through dashboard loading**
+
+Replace `loadDashboardData()`:
+
+```kotlin
+    fun loadDashboardData() {
+        // Cancel any existing job to ensure we restart with fresh system status
+        dashboardJob?.cancel()
+
+        dashboardJob = viewModelScope.launch(Dispatchers.IO) {
+            _internalState.update { it.copy(isLoading = true) }
+            val hasRoot = systemRepository.isRootAvailable()
+            val hasShizuku = systemRepository.isShizukuAvailable()
+            val hasDhizuku = systemRepository.isDhizukuAvailable()
+
+            getInstalledAppsUseCase().collect { (userApps, systemApps) ->
+                lastUserApps = userApps
+                lastSystemApps = systemApps
+                processData(
+                    userApps,
+                    systemApps,
+                    _internalState.value.selectedType,
+                    hasRoot,
+                    hasShizuku,
+                    hasDhizuku
+                )
+            }
+        }
+    }
+```
+
+with:
+
+```kotlin
+    fun loadDashboardData() {
+        // Cancel any existing job to ensure we restart with fresh data
+        dashboardJob?.cancel()
+
+        dashboardJob = viewModelScope.launch(Dispatchers.IO) {
+            _internalState.update { it.copy(isLoading = true) }
+            getInstalledAppsUseCase().collect { (userApps, systemApps) ->
+                lastUserApps = userApps
+                lastSystemApps = systemApps
+                processData(userApps, systemApps, _internalState.value.selectedType)
+            }
+        }
+    }
+```
+
+Replace `onTypeChanged()`:
+
+```kotlin
+    fun onTypeChanged(type: AppListType) {
+        _internalState.update { it.copy(selectedType = type) }
+        typeChangeJob?.cancel()
+        typeChangeJob = viewModelScope.launch(Dispatchers.IO) {
+            val s = _internalState.value
+            processData(
+                lastUserApps,
+                lastSystemApps,
+                type,
+                s.isRootAvailable,
+                s.isShizukuAvailable,
+                s.isDhizukuAvailable
+            )
+        }
+    }
+```
+
+with:
+
+```kotlin
+    fun onTypeChanged(type: AppListType) {
+        _internalState.update { it.copy(selectedType = type) }
+        typeChangeJob?.cancel()
+        typeChangeJob = viewModelScope.launch(Dispatchers.IO) {
+            processData(lastUserApps, lastSystemApps, type)
+        }
+    }
+```
+
+Replace `onPrivilegeModeChanged()`:
+
+```kotlin
+    fun onPrivilegeModeChanged(mode: PrivilegeMode) {
+        viewModelScope.launch {
+            preferenceRepository.setPrivilegeMode(mode)
+            loadDashboardData() // Refresh everything
+        }
+    }
+```
+
+with:
+
+```kotlin
+    fun onPrivilegeModeChanged(mode: PrivilegeMode) {
+        // PrivilegeManager observes the preference and recomputes `active` reactively;
+        // no dashboard reload needed (app stats don't depend on the privilege mode).
+        viewModelScope.launch {
+            preferenceRepository.setPrivilegeMode(mode)
+        }
+    }
+```
+
+- [ ] **Step 4: Drop the privilege params from `processData`**
+
+Replace the `processData` signature + its trailing `_internalState.update` block.
+
+Signature — replace:
+
+```kotlin
+    private fun processData(
+        userApps: List<AppInfo>,
+        systemApps: List<AppInfo>,
+        selectedType: AppListType,
+        hasRoot: Boolean,
+        hasShizuku: Boolean,
+        hasDhizuku: Boolean
+    ) {
+```
+
+with:
+
+```kotlin
+    private fun processData(
+        userApps: List<AppInfo>,
+        systemApps: List<AppInfo>,
+        selectedType: AppListType
+    ) {
+```
+
+Final update — replace:
+
+```kotlin
+        _internalState.update {
+            it.copy(
+                isLoading = false,
+                selectedType = selectedType,
+                activeAppCount = activeCount,
+                frozenAppCount = frozenCount,
+                suspendedAppCount = suspendedCount,
+                unknownInstallerCount = unknownCount,
+                distributionData = distribution,
+                isRootAvailable = hasRoot,
+                isShizukuAvailable = hasShizuku,
+                isDhizukuAvailable = hasDhizuku
+            )
+        }
+```
+
+with:
+
+```kotlin
+        _internalState.update {
+            it.copy(
+                isLoading = false,
+                selectedType = selectedType,
+                activeAppCount = activeCount,
+                frozenAppCount = frozenCount,
+                suspendedAppCount = suspendedCount,
+                unknownInstallerCount = unknownCount,
+                distributionData = distribution
+                // Privilege fields are populated by the state combine from PrivilegeManager.
+            )
+        }
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL. `combine` with 3 flows is already imported (`kotlinx.coroutines.flow.combine`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+git commit -m "refactor(home): source privileges from reactive PrivilegeManager
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full build, tests, and manual verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full compile + unit tests**
+
+Run: `./gradlew :app:testFossDebugUnitTest`
+Expected: BUILD SUCCESSFUL; `PrivilegeResolverTest` (6) + existing `BundleAnalysisTest`/`BundleZipTest` all pass.
+
+- [ ] **Step 2: Assemble the debug APK**
+
+Run: `./gradlew assembleFossDebug`
+Expected: BUILD SUCCESSFUL (confirms Koin can resolve `PrivilegeManager` into all three ViewModels at runtime wiring/KSP).
+
+- [ ] **Step 3: Manual verification on device (checklist)**
+
+- Fresh install, do NOT pre-grant Shizuku. Launch app → when prompted, grant Shizuku.
+  - Home: privilege status reflects Shizuku immediately.
+  - Navigate to Freezer WITHOUT restarting: the toolbar/FAB are enabled (privilege recognized) — this is the original bug, now fixed reactively.
+  - App List: privilege-gated actions available.
+- Settings → change preferred privilege mode → Home's active mode updates live (no restart).
+- If root is available, confirm the fallback still selects ROOT when no preference is set.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/reactive-privilege-flow
+```
+
+---
+
+## Notes for the implementer
+
+- Do NOT touch `SystemRepositoryImpl.getActiveGateway()` — the imperative operation path stays as-is.
+- The `HomeActivity` `ShizukuPermissionHandler` is unchanged: it still *requests* permission; `PrivilegeManager` independently observes the *result* via its own listeners.
+- `PrivilegeManager` is created when the first consumer ViewModel is injected (app start), so its Shizuku listeners are registered before a first-launch grant.

--- a/docs/superpowers/specs/2026-07-02-reactive-privilege-flow-design.md
+++ b/docs/superpowers/specs/2026-07-02-reactive-privilege-flow-design.md
@@ -1,0 +1,132 @@
+# Reactive Privilege Flow — Design
+
+**Date:** 2026-07-02
+**Branch:** `feat/reactive-privilege-flow`
+
+## Problem
+
+Privilege availability (root / Shizuku / Dhizuku) is probed **one-shot per ViewModel**
+(`HomeViewModel`, `AppListViewModel`, `FreezerViewModel` each call
+`systemRepository.isRootAvailable()` etc. once), and there is **no reactive source**.
+Consequences:
+
+- A first-launch **Shizuku grant is not observed** by screens created before the grant
+  (Freezer needed an app restart). Only `HomeActivity`'s `ShizukuPermissionHandler`
+  refreshes `HomeViewModel`.
+- The "active mode" resolution (`preferred ?: firstAvailable(Root→Shizuku→Dhizuku)`) is
+  duplicated ad-hoc (`HomeViewModel:57`).
+- A stop-gap `ShizukuPermissionHandler`-in-`FreezerViewModel` shim was added to work
+  around the above; it should be replaced by the shared source.
+
+## Goal
+
+A single reactive source of truth for privilege availability + the active mode,
+observed by Home / AppList / Freezer, updated automatically on Shizuku binder/permission
+events and preference changes.
+
+## Design
+
+### 1. Enum
+
+Extend `PrivilegeMode`:
+
+```kotlin
+enum class PrivilegeMode { NONE, ROOT, SHIZUKU, DHIZUKU }
+```
+
+- `preferredPrivilegeMode: PrivilegeMode?` in prefs is **unchanged** (nullable; `null` =
+  auto). `NONE` is used **only** by the reactive *active* value and is **never persisted**
+  as a preference.
+
+### 2. Emitted state
+
+```kotlin
+data class PrivilegeState(
+    val root: Boolean = false,
+    val shizuku: Boolean = false,
+    val dhizuku: Boolean = false,
+    val active: PrivilegeMode = PrivilegeMode.NONE,
+    val isReady: Boolean = false // false until the first probe completes
+) {
+    val hasAnyPrivilege: Boolean get() = active != PrivilegeMode.NONE
+}
+```
+
+`isReady` lets consumers distinguish "not probed yet" from "probed, none available"
+(avoids a flash of the no-privilege UI on cold start).
+
+### 3. `PrivilegeManager` (`@Single`, data layer)
+
+```kotlin
+@Single
+class PrivilegeManager(
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository
+) {
+    // process-lifetime; not cancelled (this @Single lives for the app)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val state: StateFlow<PrivilegeState>
+    fun refresh() // manual re-probe (e.g. after the user enables root)
+}
+```
+
+Responsibilities:
+
+- **Probe** root/shizuku/dhizuku off the main thread (`Dispatchers.IO`) on init, on
+  `refresh()`, and on Shizuku events.
+- **Own the app-wide Shizuku listeners** (`OnBinderReceivedListener`,
+  `OnRequestPermissionResultListener`) — registered once for the process lifetime;
+  re-probe on binder-received / permission-granted. This replaces the per-VM handlers.
+- **Observe `preferredPrivilegeMode`** (`preferenceRepository.userPreferences`) and
+  recompute `active` when it changes.
+- **Resolve `active`** with a pure function:
+  `resolveActive(preferred, root, shizuku, dhizuku)` = the preferred mode if it is
+  available; else the first available in Root→Shizuku→Dhizuku order; else `NONE`.
+- Publish via `MutableStateFlow` updated with `update { }`.
+
+Lifecycle: as a Koin `@Single` it is created when first injected (a consumer VM at app
+start) and lives for the process; Shizuku listeners are never unregistered (process
+lifetime), so no leak concern beyond app teardown.
+
+### 4. Consumer migration (full)
+
+- **HomeViewModel** — collect `privilegeManager.state`; drop its one-shot probes;
+  `activePrivilegeMode` = `state.active`; keep dashboard-specific data loading.
+- **AppListViewModel** — replace the one-shot probe (`AppListViewModel.kt:117-123`) by
+  combining `privilegeManager.state` with the app-list flow.
+- **FreezerViewModel** — collect `privilegeManager.state` for `isRoot/isShizuku/isDhizuku`;
+  **remove** `loadPrivileges()` and the `ShizukuPermissionHandler` shim + `onCleared`
+  override added earlier.
+- **HomeActivity** — keeps `ShizukuPermissionHandler` only to **request** permission
+  (`checkAndRequestPermission`); its `onPermissionGranted` may call
+  `privilegeManager.refresh()` (belt-and-suspenders), but the manager's own listeners
+  already handle the grant.
+
+### 5. DI
+
+Koin **annotation** style, matching the codebase (`@Single` / `@KoinViewModel` scanned via
+KSP): annotate `PrivilegeManager` with `@Single`. It owns its own process-lifetime
+`CoroutineScope` internally (no raw `CoroutineScope` injected). Consumer VMs receive it via
+constructor injection like their other dependencies.
+
+## Out of scope (this branch)
+
+- `SystemRepositoryImpl.getActiveGateway()` — the **imperative** gateway resolution used
+  by privileged operations stays as-is (reads prefs + validates). It is not on the
+  reactive path; converging it onto `PrivilegeManager` is a possible follow-up. This keeps
+  the privileged-operation path stable.
+- The permission-**request** UX (unchanged).
+
+## Testing
+
+- Unit-test the pure `resolveActive(preferred, root, shizuku, dhizuku)` resolver across
+  the matrix (preferred available / preferred unavailable / none available / each fallback).
+- Manager wiring (Shizuku listeners, probes) is device/permission-dependent → manual
+  verification: fresh install → grant Shizuku when prompted → Freezer recognizes it with
+  no restart; toggle preferred mode in Settings → `active` updates live.
+
+## Risks
+
+- Root probe runs a shell command; keep strictly off the main thread (already the case).
+- Ensure `PrivilegeManager` is actually instantiated at startup (it is, via VM injection)
+  so its listeners are registered before the first grant.

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,6 @@ org.gradle.welcome=never
 initialVersionCode=1900
 # REQUIRED: The active source of truth for our release manager
 # Logic: 1822 -> 1.82.2 (based on math: code/1000 . code%1000/10 . code%10)
-versionCode=1901
-versionName=1.90.1
+versionCode=1902
+versionName=1.90.2
 

--- a/release-notes/v1.90.2/github.md
+++ b/release-notes/v1.90.2/github.md
@@ -1,4 +1,4 @@
-# Thor v1.90.1 Release Notes
+# Thor v1.90.2 Release Notes
 
 A focused **stability & smoothness** release on top of v1.90.0 — hardened APK installation, a fix for the Settings crash on large fonts, and a broad pass to eliminate memory leaks and UI jank across the app.
 

--- a/release-notes/v1.90.2/github.md
+++ b/release-notes/v1.90.2/github.md
@@ -7,6 +7,13 @@ A focused **stability & smoothness** release on top of v1.90.0 — hardened APK 
 ### 📦 Installer
 *   **No more false "downgrade" blocks**: normal apps that bundle helper `.apk` assets (e.g. Muntashirakon **App Manager**, **MT File Manager**) were being misidentified as a system downgrade and blocked. A file is now recognized as a single APK by its top-level manifest instead of by any nested `.apk` entry, so it installs correctly. (#207)
 *   **`.xapk` installs fixed**: bundles that failed with *"Error: failed to parse package"* now install — tolerant manifest parsing (numeric `version_code`, missing fields) and correct base-APK selection that skips config splits. (#159)
+*   **APKPure `.xapk` now installs too**: APKPure stores a bundle's inner APKs uncompressed with streaming data descriptors, which the old sequential zip reader couldn't parse — it failed with *`AndroidManifest.xml` not found*. Bundles are now read via the archive's central directory (like `unzip`), so APKPure `.xapk` — and APKMirror `.apkm` (via its `info.json`) — install reliably.
+
+### ❄️ Freezer
+*   **"Freeze all / Unfreeze all" no longer freezes the app**: a bulk toggle flooded package-change broadcasts that stalled the main thread on the debloat cache, so the app hung and the list wouldn't refresh. The cache is no longer rebuilt under a main-thread lock — bulk actions stay responsive.
+*   **Live progress**: bulk freeze/unfreeze now shows a compact sheet with a running count that auto-dismisses when it finishes.
+*   **Shizuku recognized on first launch**: granting Shizuku is now picked up by the Freezer screen immediately, without an app restart.
+*   **Animations follow the in-app theme**: the progress/terminal Lottie now respects the app's Light/Dark setting instead of the device theme.
 
 ### 🐛 Crash Fix
 *   **Settings no longer crashes** with system Font Size = Maximum and Display Size = Larger. The connected button group was rebuilt (via **Asgard 1.0.1**) so it can no longer produce the internal `ButtonGroup` measurement crash at any font/display scale. (#197)

--- a/release-notes/v1.90.2/playstore.txt
+++ b/release-notes/v1.90.2/playstore.txt
@@ -1,4 +1,4 @@
-What's new in Thor v1.90.1
+What's new in Thor v1.90.2
 
 • Fixed some apps being wrongly blocked as a "downgrade" during install.
 • Fixed .xapk files failing to install.

--- a/release-notes/v1.90.2/playstore.txt
+++ b/release-notes/v1.90.2/playstore.txt
@@ -1,7 +1,9 @@
 What's new in Thor v1.90.2
 
 • Fixed some apps being wrongly blocked as a "downgrade" during install.
-• Fixed .xapk files failing to install.
+• Fixed .xapk installs, including APKPure bundles.
+• Fixed the Freezer "Freeze/Unfreeze all" freeze and added live progress.
+• Shizuku is now recognized right after you grant it — no restart needed.
 • Fixed the Settings screen crash on large font / display sizes.
 • Smoother scrolling and less jank — lighter app icons and more work moved off the main thread.
 • Squashed several memory leaks and hardened stability under the hood.

--- a/release-notes/v1.90.2/telegram.md
+++ b/release-notes/v1.90.2/telegram.md
@@ -1,4 +1,4 @@
-⚡️ **Thor v1.90.1 is here!**
+⚡️ **Thor v1.90.2 is here!**
 
 A focused stability & smoothness update:
 

--- a/release-notes/v1.90.2/telegram.md
+++ b/release-notes/v1.90.2/telegram.md
@@ -3,7 +3,9 @@
 A focused stability & smoothness update:
 
 • 📦 Fixed apps wrongly blocked as a "downgrade" (App Manager, MT Manager & co.)
-• 🧩 `.xapk` installs that failed to parse now work
+• 🧩 `.xapk` installs fixed — including APKPure bundles
+• ❄️ Fixed the Freezer "Freeze/Unfreeze all" freeze + added live progress
+• 🔑 Shizuku recognized right after granting — no restart needed
 • 🐛 Fixed the Settings crash on large font / display sizes
 • 🚀 Smoother scrolling & less jank — lighter icons, more off-main-thread work
 • 🔒 Squashed memory leaks & hardened privileged shell/process handling


### PR DESCRIPTION
## Summary

Replaces per-ViewModel one-shot privilege probes (root / Shizuku / Dhizuku) with a single
reactive source of truth — a `@Single PrivilegeManager` exposing `StateFlow<PrivilegeState>`.
Home, App List, and Freezer now **observe** privilege state instead of probing it once, so a
first-launch Shizuku grant (or a preferred-mode change) updates every screen live, with no app
restart.

Fixes the long-standing bug where granting Shizuku on first launch wasn't recognized by the
Freezer until the app was restarted.

## Problem

- Privilege availability was probed one-shot per ViewModel; there was no reactive source.
- A first-launch Shizuku grant was not observed by screens created before the grant (Freezer
  needed a restart). A stop-gap `ShizukuPermissionHandler` shim had been bolted into
  `FreezerViewModel` to work around this.
- The "active mode" resolution (`preferred ?: firstAvailable(Root → Shizuku → Dhizuku)`) was
  duplicated ad-hoc.

## Changes

- **`PrivilegeMode.NONE`** + **`PrivilegeState`** (`root` / `shizuku` / `dhizuku` / `active` /
  `isReady`) + a pure, unit-tested `resolvePrivilegeMode(...)` resolver.
- **`PrivilegeManager`** (`@Single`, data layer): owns the app-wide Shizuku listeners, re-probes
  off `Dispatchers.IO` on init / `refresh()` / Shizuku binder + permission events / preferred-mode
  change, and publishes `StateFlow<PrivilegeState>`.
- **FreezerViewModel / AppListViewModel / HomeViewModel**: observe `PrivilegeManager.state`;
  removed the one-shot probes, the Freezer Shizuku shim + `onCleared` override, and the duplicated
  active-mode logic.
- **`isReady` gating** (added after adversarial review): consumers hold their pre-probe UI (Home
  falls back to the persisted preference; App List holds its loader) so there is no cold-start
  "no-privilege" flash.

## Out of scope

`SystemRepositoryImpl.getActiveGateway()` — the imperative privileged-operation path — is
intentionally left unchanged.

## Verification

- `./gradlew :app:testFossDebugUnitTest` — ✅ (`PrivilegeResolverTest` + existing bundle tests)
- `./gradlew assembleFossDebug` — ✅ (Koin resolves `PrivilegeManager` into all three ViewModels)
- Adversarial multi-agent review across flow-semantics / threading / lifecycle-leaks /
  behavior-regression / Koin-DI: threading, leaks, and DI came back clean; the confirmed
  cold-start-flash findings are fixed in the `isReady` commit.
- Manual on-device: fresh install → grant Shizuku → Freezer recognized it with **no restart**;
  Settings preferred-mode change updates Home live.

## Design docs

- `docs/superpowers/specs/2026-07-02-reactive-privilege-flow-design.md`
- `docs/superpowers/plans/2026-07-02-reactive-privilege-flow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
