### PR TITLE
feat(privilege): reactive privilege flow (single StateFlow source of truth)

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
@@ -1,0 +1,94 @@
+package com.valhalla.thor.data.manager
+
+import com.valhalla.thor.domain.model.PrivilegeState
+import com.valhalla.thor.domain.model.resolvePrivilegeMode
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
+import rikka.shizuku.Shizuku
+
+/**
+ * Single reactive source of truth for privilege availability + the active mode.
+ *
+ * Re-probes root/Shizuku/Dhizuku off the main thread on init, on [refresh], on
+ * Shizuku binder/permission events (it owns those listeners), and whenever the
+ * preferred mode changes. As a process-lifetime @Single it never unregisters its
+ * Shizuku listeners (they live for the app), so consumers created before a
+ * first-launch grant still see it once granted.
+ */
+@Single
+class PrivilegeManager(
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _state = MutableStateFlow(PrivilegeState())
+    val state: StateFlow<PrivilegeState> = _state.asStateFlow()
+
+    // Bumped to force a re-probe; StateFlow<Int> emits on every distinct value.
+    private val refreshTrigger = MutableStateFlow(0)
+
+    private val binderReceivedListener = Shizuku.OnBinderReceivedListener { refresh() }
+    private val permissionResultListener =
+        Shizuku.OnRequestPermissionResultListener { _, _ -> refresh() }
+
+    init {
+        Shizuku.addBinderReceivedListener(binderReceivedListener)
+        Shizuku.addRequestPermissionResultListener(permissionResultListener)
+
+        scope.launch {
+            combine(availabilityFlow(), preferenceRepository.userPreferences) { avail, prefs ->
+                PrivilegeState(
+                    root = avail.root,
+                    shizuku = avail.shizuku,
+                    dhizuku = avail.dhizuku,
+                    active = resolvePrivilegeMode(
+                        prefs.preferredPrivilegeMode,
+                        avail.root,
+                        avail.shizuku,
+                        avail.dhizuku
+                    ),
+                    isReady = true
+                )
+            }.collect { _state.value = it }
+        }
+    }
+
+    /** Force a re-probe (e.g. after the user enables root outside the app). */
+    fun refresh() {
+        refreshTrigger.value += 1
+    }
+
+    private data class Availability(val root: Boolean, val shizuku: Boolean, val dhizuku: Boolean)
+
+    private fun availabilityFlow(): Flow<Availability> =
+        refreshTrigger
+            .map {
+                Availability(
+                    root = safeProbe { systemRepository.isRootAvailable() },
+                    shizuku = safeProbe { systemRepository.isShizukuAvailable() },
+                    dhizuku = safeProbe { systemRepository.isDhizukuAvailable() }
+                )
+            }
+            .flowOn(Dispatchers.IO)
+
+    private suspend fun safeProbe(block: suspend () -> Boolean): Boolean = try {
+        block()
+    } catch (e: Exception) {
+        Logger.e("PrivilegeManager", "privilege probe failed", e)
+        false
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
@@ -5,9 +5,12 @@ import com.valhalla.thor.domain.model.resolvePrivilegeMode
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,6 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.Single
 import rikka.shizuku.Shizuku
@@ -69,7 +73,10 @@ class PrivilegeManager(
 
     /** Force a re-probe (e.g. after the user enables root outside the app). */
     fun refresh() {
-        refreshTrigger.value += 1
+        // Called from Shizuku's binder/permission listeners on arbitrary threads, so the
+        // bump must be atomic — `value +=` is a non-atomic read-modify-write that can drop
+        // a concurrent trigger.
+        refreshTrigger.update { it + 1 }
     }
 
     private data class Availability(val root: Boolean, val shizuku: Boolean, val dhizuku: Boolean)
@@ -77,16 +84,22 @@ class PrivilegeManager(
     private fun availabilityFlow(): Flow<Availability> =
         refreshTrigger
             .map {
-                Availability(
-                    root = safeProbe { systemRepository.isRootAvailable() },
-                    shizuku = safeProbe { systemRepository.isShizukuAvailable() },
-                    dhizuku = safeProbe { systemRepository.isDhizukuAvailable() }
-                )
+                // Probe the three sources concurrently: the root probe can spawn a shell
+                // (100-500ms), so running them in parallel keeps cold-start latency at
+                // max(probe) instead of the sum.
+                coroutineScope {
+                    val root = async { safeProbe { systemRepository.isRootAvailable() } }
+                    val shizuku = async { safeProbe { systemRepository.isShizukuAvailable() } }
+                    val dhizuku = async { safeProbe { systemRepository.isDhizukuAvailable() } }
+                    Availability(root.await(), shizuku.await(), dhizuku.await())
+                }
             }
             .flowOn(Dispatchers.IO)
 
     private suspend fun safeProbe(block: suspend () -> Boolean): Boolean = try {
         block()
+    } catch (e: CancellationException) {
+        throw e // never swallow cancellation — it breaks cooperative coroutine cancellation
     } catch (e: Exception) {
         Logger.e("PrivilegeManager", "privilege probe failed", e)
         false

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -44,6 +44,7 @@ class SystemRepositoryImpl(
                 PrivilegeMode.ROOT -> if (isRootAvail) return Result.success(rootGateway)
                 PrivilegeMode.SHIZUKU -> if (isShizukuAvail) return Result.success(shizukuGateway)
                 PrivilegeMode.DHIZUKU -> if (isDhizukuAvail) return Result.success(dhizukuGateway)
+                PrivilegeMode.NONE -> Unit // never persisted as a preference; fall through to auto-detection
             }
         }
 

--- a/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt
@@ -1,6 +1,8 @@
 package com.valhalla.thor.domain.model
 
 enum class PrivilegeMode {
+    /** No privilege available (reactive/active value only — never persisted as a preference). */
+    NONE,
     ROOT,
     SHIZUKU,
     DHIZUKU

--- a/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt
@@ -1,0 +1,43 @@
+package com.valhalla.thor.domain.model
+
+/**
+ * Snapshot of privilege availability + the resolved active mode.
+ *
+ * [isReady] is false until the first probe completes, so consumers can tell
+ * "not probed yet" apart from "probed, nothing available" (avoids a flash of the
+ * no-privilege UI on cold start).
+ */
+data class PrivilegeState(
+    val root: Boolean = false,
+    val shizuku: Boolean = false,
+    val dhizuku: Boolean = false,
+    val active: PrivilegeMode = PrivilegeMode.NONE,
+    val isReady: Boolean = false
+) {
+    val hasAnyPrivilege: Boolean get() = active != PrivilegeMode.NONE
+}
+
+/**
+ * Resolve the effective privilege mode: the user's [preferred] mode when it is
+ * actually available, otherwise the first available in Root -> Shizuku -> Dhizuku
+ * order, otherwise [PrivilegeMode.NONE]. A null or NONE [preferred] means "auto".
+ */
+fun resolvePrivilegeMode(
+    preferred: PrivilegeMode?,
+    root: Boolean,
+    shizuku: Boolean,
+    dhizuku: Boolean
+): PrivilegeMode {
+    when (preferred) {
+        PrivilegeMode.ROOT -> if (root) return PrivilegeMode.ROOT
+        PrivilegeMode.SHIZUKU -> if (shizuku) return PrivilegeMode.SHIZUKU
+        PrivilegeMode.DHIZUKU -> if (dhizuku) return PrivilegeMode.DHIZUKU
+        PrivilegeMode.NONE, null -> Unit // fall through to auto
+    }
+    return when {
+        root -> PrivilegeMode.ROOT
+        shizuku -> PrivilegeMode.SHIZUKU
+        dhizuku -> PrivilegeMode.DHIZUKU
+        else -> PrivilegeMode.NONE
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -122,7 +122,12 @@ class AppListViewModel(
             }.collect { (user, system, priv) ->
                 _rawState.update {
                     it.copy(
-                        isLoading = false,
+                        // Hold the loader until the first privilege probe lands
+                        // (isReady) so privilege-gated controls never flash their
+                        // disabled state on cold start. This restores the old
+                        // await-probe-before-reveal behavior; later Shizuku grants
+                        // still update reactively once isReady is true.
+                        isLoading = !priv.isReady,
                         isRoot = priv.root,
                         isShizuku = priv.shizuku,
                         isDhizuku = priv.dhizuku,

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -3,6 +3,7 @@ package com.valhalla.thor.presentation.appList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
+import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.FilterType
@@ -11,7 +12,6 @@ import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
-import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.GetAppDetailsUseCase
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
@@ -68,7 +68,7 @@ class AppListViewModel(
     private val context: Context,
     private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
     private val getAppDetailsUseCase: GetAppDetailsUseCase,
-    private val systemRepository: SystemRepository,
+    private val privilegeManager: PrivilegeManager,
     private val manageAppUseCase: ManageAppUseCase,
     private val preferenceRepository: PreferenceRepository,
     private val freezerRepository: FreezerRepository
@@ -112,22 +112,20 @@ class AppListViewModel(
             // Allow navigation/bottom bar animations to finish fluidly
             delay(800.milliseconds)
 
-            // Availability probes include non-suspend binder IPC (Shizuku / Dhizuku);
-            // keep them off the Main thread so app-list load never janks.
-            val (hasRoot, hasShizuku, hasDhizuku) = withContext(Dispatchers.IO) {
-                Triple(
-                    systemRepository.isRootAvailable(),
-                    systemRepository.isShizukuAvailable(),
-                    systemRepository.isDhizukuAvailable()
-                )
-            }
-            getInstalledAppsUseCase().collect { (user, system) ->
+            // Privilege availability now comes from the shared reactive PrivilegeManager,
+            // so a Shizuku grant reflects here without reloading the list.
+            combine(
+                getInstalledAppsUseCase(),
+                privilegeManager.state
+            ) { (user, system), priv ->
+                Triple(user, system, priv)
+            }.collect { (user, system, priv) ->
                 _rawState.update {
                     it.copy(
                         isLoading = false,
-                        isRoot = hasRoot,
-                        isShizuku = hasShizuku,
-                        isDhizuku = hasDhizuku,
+                        isRoot = priv.root,
+                        isShizuku = priv.shizuku,
+                        isDhizuku = priv.dhizuku,
                         allUserApps = user,
                         allSystemApps = system
                     )

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -59,7 +59,6 @@ class FreezerViewModel(
     init {
         observeApps()
         observePreferences()
-        observePrivileges()
     }
 
     private fun observeApps() {
@@ -67,20 +66,28 @@ class FreezerViewModel(
             try {
                 combine(
                     freezerRepository.getAll(),
-                    getInstalledAppsUseCase()
-                ) { freezerPkgs, (userApps, systemApps) ->
+                    getInstalledAppsUseCase(),
+                    privilegeManager.state
+                ) { freezerPkgs, (userApps, systemApps), priv ->
                     val pkgSet = freezerPkgs.toSet()
                     val allApps = userApps + systemApps
-                    Triple(pkgSet, allApps.filter { it.packageName in pkgSet }, allApps)
+                    Triple(pkgSet, allApps.filter { it.packageName in pkgSet }, allApps) to priv
                 }
                     .flowOn(Dispatchers.Default)
-                    .collect { (pkgSet, freezerApps, allApps) ->
+                    .collect { (appsData, priv) ->
+                        val (pkgSet, freezerApps, allApps) = appsData
                         _uiState.update {
                             it.copy(
-                                isLoading = false,
+                                // Hold the loader until the first privilege probe lands so
+                                // freeze/unfreeze controls never flash disabled on cold start;
+                                // privilege flags now update atomically with the app list.
+                                isLoading = !priv.isReady,
                                 freezerPackageNames = pkgSet,
                                 freezerApps = freezerApps,
-                                allInstalledApps = allApps
+                                allInstalledApps = allApps,
+                                isRoot = priv.root,
+                                isShizuku = priv.shizuku,
+                                isDhizuku = priv.dhizuku
                             )
                         }
                     }
@@ -91,16 +98,6 @@ class FreezerViewModel(
                         isLoading = false,
                         actionMessage = UiText.StringResource(R.string.failed_to_load_apps)
                     )
-                }
-            }
-        }
-    }
-
-    private fun observePrivileges() {
-        viewModelScope.launch {
-            privilegeManager.state.collect { p ->
-                _uiState.update {
-                    it.copy(isRoot = p.root, isShizuku = p.shizuku, isDhizuku = p.dhizuku)
                 }
             }
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -3,14 +3,13 @@ package com.valhalla.thor.presentation.freezer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
+import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
-import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
-import com.valhalla.thor.presentation.common.ShizukuPermissionHandler
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import kotlinx.coroutines.Dispatchers
@@ -50,30 +49,17 @@ class FreezerViewModel(
     private val freezerRepository: FreezerRepository,
     private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
     private val manageAppUseCase: ManageAppUseCase,
-    private val systemRepository: SystemRepository,
+    private val privilegeManager: PrivilegeManager,
     private val preferenceRepository: PreferenceRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FreezerUiState())
     val uiState: StateFlow<FreezerUiState> = _uiState.asStateFlow()
 
-    // Re-check privileges when Shizuku's binder connects or the user grants permission.
-    // This ViewModel is created at app start (before the first-launch Shizuku grant), so
-    // its init-time loadPrivileges() would otherwise stay stale until an app restart.
-    private val shizukuHandler = ShizukuPermissionHandler(
-        onPermissionGranted = { loadPrivileges() }
-    )
-
     init {
         observeApps()
         observePreferences()
-        loadPrivileges()
-        shizukuHandler.register()
-    }
-
-    override fun onCleared() {
-        shizukuHandler.unregister()
-        super.onCleared()
+        observePrivileges()
     }
 
     private fun observeApps() {
@@ -110,17 +96,12 @@ class FreezerViewModel(
         }
     }
 
-    private fun loadPrivileges() {
-        viewModelScope.launch(Dispatchers.IO) {
-            val hasRoot = systemRepository.isRootAvailable()
-            val hasShizuku = systemRepository.isShizukuAvailable()
-            val hasDhizuku = systemRepository.isDhizukuAvailable()
-            _uiState.update {
-                it.copy(
-                    isRoot = hasRoot,
-                    isShizuku = hasShizuku,
-                    isDhizuku = hasDhizuku
-                )
+    private fun observePrivileges() {
+        viewModelScope.launch {
+            privilegeManager.state.collect { p ->
+                _uiState.update {
+                    it.copy(isRoot = p.root, isShizuku = p.shizuku, isDhizuku = p.dhizuku)
+                }
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -108,6 +108,7 @@ fun HomeScreen(
             isShizuku = state.isShizukuAvailable,
             isDhizuku = state.isDhizukuAvailable,
             activeMode = state.activePrivilegeMode,
+            isPrivilegeReady = state.isPrivilegeReady,
             selectedType = state.selectedType,
             onTypeChanged = { viewModel.onTypeChanged(it) },
             onPrivilegeChanged = { viewModel.onPrivilegeModeChanged(it) },

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -32,6 +32,9 @@ data class HomeUiState(
     val isShizukuAvailable: Boolean = false,
     val isDhizukuAvailable: Boolean = false,
     val activePrivilegeMode: PrivilegeMode? = null,
+    // False until the first privilege probe completes — lets the status icon show a
+    // neutral "detecting" state instead of flashing the red "no privilege" icon on cold start.
+    val isPrivilegeReady: Boolean = false,
 
     // Preferences
     val showReinstallCard: Boolean = true, // <--- Controlled by DataStore
@@ -63,6 +66,7 @@ class HomeViewModel(
             isRootAvailable = priv.root,
             isShizukuAvailable = priv.shizuku,
             isDhizukuAvailable = priv.dhizuku,
+            isPrivilegeReady = priv.isReady,
             // Keep the existing "null = no privilege" contract for the UI. Until the
             // first probe completes (isReady == false), optimistically fall back to the
             // persisted preference so a configured user never sees a "no privilege"

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -63,8 +63,16 @@ class HomeViewModel(
             isRootAvailable = priv.root,
             isShizukuAvailable = priv.shizuku,
             isDhizukuAvailable = priv.dhizuku,
-            // Keep the existing "null = no privilege" contract for the UI.
-            activePrivilegeMode = priv.active.takeIf { it != PrivilegeMode.NONE },
+            // Keep the existing "null = no privilege" contract for the UI. Until the
+            // first probe completes (isReady == false), optimistically fall back to the
+            // persisted preference so a configured user never sees a "no privilege"
+            // flash on cold start (this restores the old one-shot behavior, which read
+            // the preference straight from DataStore before any hardware probe).
+            activePrivilegeMode = if (priv.isReady) {
+                priv.active.takeIf { it != PrivilegeMode.NONE }
+            } else {
+                prefs.preferredPrivilegeMode
+            },
             extensionsUnlocked = prefs.extensionsUnlocked
         )
     }.stateIn(

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -2,11 +2,11 @@ package com.valhalla.thor.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.repository.PreferenceRepository
-import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -41,7 +41,7 @@ data class HomeUiState(
 @KoinViewModel
 class HomeViewModel(
     private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
-    private val systemRepository: SystemRepository,
+    private val privilegeManager: PrivilegeManager,
     private val preferenceRepository: PreferenceRepository // Injected
 ) : ViewModel() {
 
@@ -53,16 +53,18 @@ class HomeViewModel(
     private var lastSystemApps: List<AppInfo> = emptyList()
 
     // Combine internal data processing with user preferences
-    val state = combine(_internalState, preferenceRepository.userPreferences) { internal, prefs ->
-        val activeMode = prefs.preferredPrivilegeMode ?: when {
-            internal.isRootAvailable -> PrivilegeMode.ROOT
-            internal.isShizukuAvailable -> PrivilegeMode.SHIZUKU
-            internal.isDhizukuAvailable -> PrivilegeMode.DHIZUKU
-            else -> null
-        }
+    val state = combine(
+        _internalState,
+        preferenceRepository.userPreferences,
+        privilegeManager.state
+    ) { internal, prefs, priv ->
         internal.copy(
             showReinstallCard = prefs.showReinstallAllCard,
-            activePrivilegeMode = activeMode,
+            isRootAvailable = priv.root,
+            isShizukuAvailable = priv.shizuku,
+            isDhizukuAvailable = priv.dhizuku,
+            // Keep the existing "null = no privilege" contract for the UI.
+            activePrivilegeMode = priv.active.takeIf { it != PrivilegeMode.NONE },
             extensionsUnlocked = prefs.extensionsUnlocked
         )
     }.stateIn(
@@ -81,21 +83,10 @@ class HomeViewModel(
 
         dashboardJob = viewModelScope.launch(Dispatchers.IO) {
             _internalState.update { it.copy(isLoading = true) }
-            val hasRoot = systemRepository.isRootAvailable()
-            val hasShizuku = systemRepository.isShizukuAvailable()
-            val hasDhizuku = systemRepository.isDhizukuAvailable()
-
             getInstalledAppsUseCase().collect { (userApps, systemApps) ->
                 lastUserApps = userApps
                 lastSystemApps = systemApps
-                processData(
-                    userApps,
-                    systemApps,
-                    _internalState.value.selectedType,
-                    hasRoot,
-                    hasShizuku,
-                    hasDhizuku
-                )
+                processData(userApps, systemApps, _internalState.value.selectedType)
             }
         }
     }
@@ -104,22 +95,15 @@ class HomeViewModel(
         _internalState.update { it.copy(selectedType = type) }
         typeChangeJob?.cancel()
         typeChangeJob = viewModelScope.launch(Dispatchers.IO) {
-            val s = _internalState.value
-            processData(
-                lastUserApps,
-                lastSystemApps,
-                type,
-                s.isRootAvailable,
-                s.isShizukuAvailable,
-                s.isDhizukuAvailable
-            )
+            processData(lastUserApps, lastSystemApps, type)
         }
     }
 
     fun onPrivilegeModeChanged(mode: PrivilegeMode) {
+        // PrivilegeManager observes the preference and recomputes `active` reactively;
+        // no dashboard reload needed (app stats don't depend on the privilege mode).
         viewModelScope.launch {
             preferenceRepository.setPrivilegeMode(mode)
-            loadDashboardData() // Refresh everything
         }
     }
 
@@ -139,10 +123,7 @@ class HomeViewModel(
     private fun processData(
         userApps: List<AppInfo>,
         systemApps: List<AppInfo>,
-        selectedType: AppListType,
-        hasRoot: Boolean,
-        hasShizuku: Boolean,
-        hasDhizuku: Boolean
+        selectedType: AppListType
     ) {
         val filteredApps = if (selectedType == AppListType.USER) userApps else systemApps
 
@@ -197,10 +178,8 @@ class HomeViewModel(
                 frozenAppCount = frozenCount,
                 suspendedAppCount = suspendedCount,
                 unknownInstallerCount = unknownCount,
-                distributionData = distribution,
-                isRootAvailable = hasRoot,
-                isShizukuAvailable = hasShizuku,
-                isDhizukuAvailable = hasDhizuku
+                distributionData = distribution
+                // Privilege fields are populated by the state combine from PrivilegeManager.
             )
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/DashboardHeader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/DashboardHeader.kt
@@ -51,6 +51,7 @@ fun DashboardHeader(
     isShizuku: Boolean,
     isDhizuku: Boolean,
     activeMode: PrivilegeMode?,
+    isPrivilegeReady: Boolean,
     selectedType: AppListType,
     onTypeChanged: (AppListType) -> Unit,
     onPrivilegeChanged: (PrivilegeMode) -> Unit,
@@ -86,6 +87,7 @@ fun DashboardHeader(
                 isShizuku = isShizuku,
                 isDhizuku = isDhizuku,
                 activeMode = activeMode,
+                isReady = isPrivilegeReady,
                 onModeSelected = onPrivilegeChanged,
                 onClick = onRestrictedStatusClick
             )
@@ -238,6 +240,7 @@ private fun StatusIcon(
     isShizuku: Boolean,
     isDhizuku: Boolean,
     activeMode: PrivilegeMode?,
+    isReady: Boolean,
     onModeSelected: (PrivilegeMode) -> Unit,
     onClick: () -> Unit
 ) {
@@ -251,7 +254,13 @@ private fun StatusIcon(
         PrivilegeMode.ROOT -> R.drawable.magisk_icon to MaterialTheme.colorScheme.primary
         PrivilegeMode.SHIZUKU -> R.drawable.shizuku to MaterialTheme.colorScheme.primary
         PrivilegeMode.DHIZUKU -> R.drawable.dhizuku to MaterialTheme.colorScheme.primary
-        else -> R.drawable.round_close to MaterialTheme.colorScheme.error
+        // Before the first probe completes, show the placeholder in a neutral tint instead of
+        // the alarming error red, so cold start doesn't flash "no privilege".
+        else -> if (isReady) {
+            R.drawable.round_close to MaterialTheme.colorScheme.error
+        } else {
+            R.drawable.round_close to MaterialTheme.colorScheme.onSurfaceVariant
+        }
     }
 
     Box(

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -405,6 +405,8 @@ fun SettingsScreen(
                         PrivilegeMode.ROOT -> R.drawable.magisk_icon
                         PrivilegeMode.SHIZUKU -> R.drawable.shizuku
                         PrivilegeMode.DHIZUKU -> R.drawable.dhizuku
+                        // Unreachable here: WORK MODE only renders when a real privilege mode is available.
+                        PrivilegeMode.NONE -> R.drawable.shield
                     }
                     IconBox(icon)
                     Spacer(Modifier.width(16.dp))

--- a/app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt
@@ -1,0 +1,56 @@
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PrivilegeResolverTest {
+
+    @Test
+    fun preferred_isUsed_whenAvailable() {
+        assertEquals(
+            PrivilegeMode.SHIZUKU,
+            resolvePrivilegeMode(PrivilegeMode.SHIZUKU, root = true, shizuku = true, dhizuku = false)
+        )
+    }
+
+    @Test
+    fun preferred_fallsBack_whenUnavailable() {
+        // Preferred SHIZUKU not available -> auto fallback picks ROOT (highest available).
+        assertEquals(
+            PrivilegeMode.ROOT,
+            resolvePrivilegeMode(PrivilegeMode.SHIZUKU, root = true, shizuku = false, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noPreference_usesFallbackChain_rootFirst() {
+        assertEquals(
+            PrivilegeMode.ROOT,
+            resolvePrivilegeMode(null, root = true, shizuku = true, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noPreference_shizukuBeforeDhizuku() {
+        assertEquals(
+            PrivilegeMode.SHIZUKU,
+            resolvePrivilegeMode(null, root = false, shizuku = true, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noneAvailable_isNone() {
+        assertEquals(
+            PrivilegeMode.NONE,
+            resolvePrivilegeMode(PrivilegeMode.ROOT, root = false, shizuku = false, dhizuku = false)
+        )
+    }
+
+    @Test
+    fun preferredNone_isTreatedAsAuto() {
+        assertEquals(
+            PrivilegeMode.DHIZUKU,
+            resolvePrivilegeMode(PrivilegeMode.NONE, root = false, shizuku = false, dhizuku = true)
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-07-02-reactive-privilege-flow.md
+++ b/docs/superpowers/plans/2026-07-02-reactive-privilege-flow.md
@@ -1,0 +1,837 @@
+# Reactive Privilege Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-ViewModel one-shot privilege probes with a single reactive source of truth that updates automatically on Shizuku grant and preference changes.
+
+**Architecture:** A `@Single PrivilegeManager` (data layer) exposes `StateFlow<PrivilegeState>` — root/shizuku/dhizuku availability + a resolved `active: PrivilegeMode` — re-probing off the main thread on init, on Shizuku binder/permission events (it owns those listeners), and whenever `preferredPrivilegeMode` changes. Home/AppList/Freezer ViewModels observe it instead of probing.
+
+**Tech Stack:** Kotlin, Coroutines/Flow (`StateFlow`, `combine`), Koin Annotations (`@Single`, `@KoinViewModel`, KSP), Shizuku (`rikka.shizuku.Shizuku`), JUnit4.
+
+## Global Constraints
+
+- Koin DI is annotation-based, scanned via `@ComponentScan("com.valhalla.thor")` in `di/Modules.kt` — a `@Single`-annotated class anywhere under `com.valhalla.thor` is auto-registered. No manual module edits needed.
+- Privilege probes (`isRootAvailable` runs a root shell; Shizuku/Dhizuku do binder IPC) MUST run off the main thread (`Dispatchers.IO`).
+- `preferredPrivilegeMode: PrivilegeMode?` in prefs stays nullable (`null` = auto). `PrivilegeMode.NONE` is used only by the reactive `active` value and is NEVER persisted as a preference.
+- `SystemRepositoryImpl.getActiveGateway()` (the imperative operation path) is OUT OF SCOPE — do not modify it.
+- Build/verify the `fossDebug` variant: `./gradlew :app:compileFossDebugKotlin`.
+
+---
+
+### Task 1: PrivilegeMode + PrivilegeState + pure resolver (with tests)
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt`
+- Create: `app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt`
+- Test: `app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `enum class PrivilegeMode { NONE, ROOT, SHIZUKU, DHIZUKU }`
+  - `data class PrivilegeState(root: Boolean, shizuku: Boolean, dhizuku: Boolean, active: PrivilegeMode, isReady: Boolean)` with `val hasAnyPrivilege: Boolean`
+  - `fun resolvePrivilegeMode(preferred: PrivilegeMode?, root: Boolean, shizuku: Boolean, dhizuku: Boolean): PrivilegeMode`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PrivilegeResolverTest {
+
+    @Test
+    fun preferred_isUsed_whenAvailable() {
+        assertEquals(
+            PrivilegeMode.SHIZUKU,
+            resolvePrivilegeMode(PrivilegeMode.SHIZUKU, root = true, shizuku = true, dhizuku = false)
+        )
+    }
+
+    @Test
+    fun preferred_fallsBack_whenUnavailable() {
+        // Preferred SHIZUKU not available -> auto fallback picks ROOT (highest available).
+        assertEquals(
+            PrivilegeMode.ROOT,
+            resolvePrivilegeMode(PrivilegeMode.SHIZUKU, root = true, shizuku = false, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noPreference_usesFallbackChain_rootFirst() {
+        assertEquals(
+            PrivilegeMode.ROOT,
+            resolvePrivilegeMode(null, root = true, shizuku = true, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noPreference_shizukuBeforeDhizuku() {
+        assertEquals(
+            PrivilegeMode.SHIZUKU,
+            resolvePrivilegeMode(null, root = false, shizuku = true, dhizuku = true)
+        )
+    }
+
+    @Test
+    fun noneAvailable_isNone() {
+        assertEquals(
+            PrivilegeMode.NONE,
+            resolvePrivilegeMode(PrivilegeMode.ROOT, root = false, shizuku = false, dhizuku = false)
+        )
+    }
+
+    @Test
+    fun preferredNone_isTreatedAsAuto() {
+        assertEquals(
+            PrivilegeMode.DHIZUKU,
+            resolvePrivilegeMode(PrivilegeMode.NONE, root = false, shizuku = false, dhizuku = true)
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.PrivilegeResolverTest"`
+Expected: FAIL — compilation error (`resolvePrivilegeMode` / `PrivilegeMode.NONE` unresolved).
+
+- [ ] **Step 3: Add `NONE` to the enum**
+
+Replace the entire contents of `app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+enum class PrivilegeMode {
+    /** No privilege available (reactive/active value only — never persisted as a preference). */
+    NONE,
+    ROOT,
+    SHIZUKU,
+    DHIZUKU
+}
+```
+
+- [ ] **Step 4: Create `PrivilegeState` + `resolvePrivilegeMode`**
+
+Create `app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+/**
+ * Snapshot of privilege availability + the resolved active mode.
+ *
+ * [isReady] is false until the first probe completes, so consumers can tell
+ * "not probed yet" apart from "probed, nothing available" (avoids a flash of the
+ * no-privilege UI on cold start).
+ */
+data class PrivilegeState(
+    val root: Boolean = false,
+    val shizuku: Boolean = false,
+    val dhizuku: Boolean = false,
+    val active: PrivilegeMode = PrivilegeMode.NONE,
+    val isReady: Boolean = false
+) {
+    val hasAnyPrivilege: Boolean get() = active != PrivilegeMode.NONE
+}
+
+/**
+ * Resolve the effective privilege mode: the user's [preferred] mode when it is
+ * actually available, otherwise the first available in Root -> Shizuku -> Dhizuku
+ * order, otherwise [PrivilegeMode.NONE]. A null or NONE [preferred] means "auto".
+ */
+fun resolvePrivilegeMode(
+    preferred: PrivilegeMode?,
+    root: Boolean,
+    shizuku: Boolean,
+    dhizuku: Boolean
+): PrivilegeMode {
+    when (preferred) {
+        PrivilegeMode.ROOT -> if (root) return PrivilegeMode.ROOT
+        PrivilegeMode.SHIZUKU -> if (shizuku) return PrivilegeMode.SHIZUKU
+        PrivilegeMode.DHIZUKU -> if (dhizuku) return PrivilegeMode.DHIZUKU
+        PrivilegeMode.NONE, null -> Unit // fall through to auto
+    }
+    return when {
+        root -> PrivilegeMode.ROOT
+        shizuku -> PrivilegeMode.SHIZUKU
+        dhizuku -> PrivilegeMode.DHIZUKU
+        else -> PrivilegeMode.NONE
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.PrivilegeResolverTest"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt \
+        app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt \
+        app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt
+git commit -m "feat(privilege): add PrivilegeMode.NONE, PrivilegeState + resolver
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: PrivilegeManager (reactive source of truth)
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt`
+
+**Interfaces:**
+- Consumes: `SystemRepository` (`isRootAvailable`/`isShizukuAvailable`/`isDhizukuAvailable`), `PreferenceRepository.userPreferences` (`preferredPrivilegeMode`), `resolvePrivilegeMode(...)`, `PrivilegeState`.
+- Produces:
+  - `@Single class PrivilegeManager(SystemRepository, PreferenceRepository)`
+  - `val state: StateFlow<PrivilegeState>`
+  - `fun refresh()`
+
+- [ ] **Step 1: Create the manager**
+
+Create `app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt`:
+
+```kotlin
+package com.valhalla.thor.data.manager
+
+import com.valhalla.thor.domain.model.PrivilegeState
+import com.valhalla.thor.domain.model.resolvePrivilegeMode
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
+import rikka.shizuku.Shizuku
+
+/**
+ * Single reactive source of truth for privilege availability + the active mode.
+ *
+ * Re-probes root/Shizuku/Dhizuku off the main thread on init, on [refresh], on
+ * Shizuku binder/permission events (it owns those listeners), and whenever the
+ * preferred mode changes. As a process-lifetime @Single it never unregisters its
+ * Shizuku listeners (they live for the app), so consumers created before a
+ * first-launch grant still see it once granted.
+ */
+@Single
+class PrivilegeManager(
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    private val _state = MutableStateFlow(PrivilegeState())
+    val state: StateFlow<PrivilegeState> = _state.asStateFlow()
+
+    // Bumped to force a re-probe; StateFlow<Int> emits on every distinct value.
+    private val refreshTrigger = MutableStateFlow(0)
+
+    private val binderReceivedListener = Shizuku.OnBinderReceivedListener { refresh() }
+    private val permissionResultListener =
+        Shizuku.OnRequestPermissionResultListener { _, _ -> refresh() }
+
+    init {
+        Shizuku.addBinderReceivedListener(binderReceivedListener)
+        Shizuku.addRequestPermissionResultListener(permissionResultListener)
+
+        scope.launch {
+            combine(availabilityFlow(), preferenceRepository.userPreferences) { avail, prefs ->
+                PrivilegeState(
+                    root = avail.root,
+                    shizuku = avail.shizuku,
+                    dhizuku = avail.dhizuku,
+                    active = resolvePrivilegeMode(
+                        prefs.preferredPrivilegeMode,
+                        avail.root,
+                        avail.shizuku,
+                        avail.dhizuku
+                    ),
+                    isReady = true
+                )
+            }.collect { _state.value = it }
+        }
+    }
+
+    /** Force a re-probe (e.g. after the user enables root outside the app). */
+    fun refresh() {
+        refreshTrigger.value += 1
+    }
+
+    private data class Availability(val root: Boolean, val shizuku: Boolean, val dhizuku: Boolean)
+
+    private fun availabilityFlow(): Flow<Availability> =
+        refreshTrigger
+            .map {
+                Availability(
+                    root = safeProbe { systemRepository.isRootAvailable() },
+                    shizuku = safeProbe { systemRepository.isShizukuAvailable() },
+                    dhizuku = safeProbe { systemRepository.isDhizukuAvailable() }
+                )
+            }
+            .flowOn(Dispatchers.IO)
+
+    private suspend fun safeProbe(block: suspend () -> Boolean): Boolean = try {
+        block()
+    } catch (e: Exception) {
+        Logger.e("PrivilegeManager", "privilege probe failed", e)
+        false
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles and Koin can construct it**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL. (The class is under `com.valhalla.thor`, so `@ComponentScan("com.valhalla.thor")` registers it; no `di/Modules.kt` change is needed.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
+git commit -m "feat(privilege): add PrivilegeManager reactive StateFlow<PrivilegeState>
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Migrate FreezerViewModel to observe PrivilegeManager
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt`
+
+**Interfaces:**
+- Consumes: `PrivilegeManager.state: StateFlow<PrivilegeState>`.
+
+- [ ] **Step 1: Swap the dependency and imports**
+
+In `FreezerViewModel.kt`, replace the import line:
+
+```kotlin
+import com.valhalla.thor.presentation.common.ShizukuPermissionHandler
+```
+
+with:
+
+```kotlin
+import com.valhalla.thor.data.manager.PrivilegeManager
+```
+
+Then remove the now-unused import `import com.valhalla.thor.domain.repository.SystemRepository` (it will be flagged unused after Step 2).
+
+In the constructor, replace:
+
+```kotlin
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository
+) : ViewModel() {
+```
+
+with:
+
+```kotlin
+    private val privilegeManager: PrivilegeManager,
+    private val preferenceRepository: PreferenceRepository
+) : ViewModel() {
+```
+
+- [ ] **Step 2: Replace the shim + one-shot probe with an observer**
+
+Replace this block:
+
+```kotlin
+    // Re-check privileges when Shizuku's binder connects or the user grants permission.
+    // This ViewModel is created at app start (before the first-launch Shizuku grant), so
+    // its init-time loadPrivileges() would otherwise stay stale until an app restart.
+    private val shizukuHandler = ShizukuPermissionHandler(
+        onPermissionGranted = { loadPrivileges() }
+    )
+
+    init {
+        observeApps()
+        observePreferences()
+        loadPrivileges()
+        shizukuHandler.register()
+    }
+
+    override fun onCleared() {
+        shizukuHandler.unregister()
+        super.onCleared()
+    }
+```
+
+with:
+
+```kotlin
+    init {
+        observeApps()
+        observePreferences()
+        observePrivileges()
+    }
+```
+
+Then delete the `loadPrivileges()` function entirely:
+
+```kotlin
+    private fun loadPrivileges() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val hasRoot = systemRepository.isRootAvailable()
+            val hasShizuku = systemRepository.isShizukuAvailable()
+            val hasDhizuku = systemRepository.isDhizukuAvailable()
+            _uiState.update {
+                it.copy(
+                    isRoot = hasRoot,
+                    isShizuku = hasShizuku,
+                    isDhizuku = hasDhizuku
+                )
+            }
+        }
+    }
+```
+
+and add the observer (place it where `loadPrivileges` was):
+
+```kotlin
+    private fun observePrivileges() {
+        viewModelScope.launch {
+            privilegeManager.state.collect { p ->
+                _uiState.update {
+                    it.copy(isRoot = p.root, isShizuku = p.shizuku, isDhizuku = p.dhizuku)
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL, with no "unused import" for `SystemRepository` or `Dispatchers` — if `Dispatchers` is now unused (it was only used by `loadPrivileges`), remove `import kotlinx.coroutines.Dispatchers`. (Note: `observeApps` uses `flowOn(Dispatchers.Default)`, so `Dispatchers` IS still used — keep it.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+git commit -m "refactor(freezer): observe PrivilegeManager instead of one-shot probe + Shizuku shim
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Migrate AppListViewModel to observe PrivilegeManager
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt`
+
+**Interfaces:**
+- Consumes: `PrivilegeManager.state`.
+
+- [ ] **Step 1: Swap the dependency**
+
+In `AppListViewModel.kt`, add the import:
+
+```kotlin
+import com.valhalla.thor.data.manager.PrivilegeManager
+```
+
+In the constructor, replace the parameter:
+
+```kotlin
+    private val systemRepository: SystemRepository,
+```
+
+with:
+
+```kotlin
+    private val privilegeManager: PrivilegeManager,
+```
+
+Remove the now-unused `import com.valhalla.thor.domain.repository.SystemRepository` (verify with a search that `systemRepository` has no other references after Step 2; it does not).
+
+- [ ] **Step 2: Combine privilege state into the app collection**
+
+Replace this block in `loadApps()`:
+
+```kotlin
+            // Availability probes include non-suspend binder IPC (Shizuku / Dhizuku);
+            // keep them off the Main thread so app-list load never janks.
+            val (hasRoot, hasShizuku, hasDhizuku) = withContext(Dispatchers.IO) {
+                Triple(
+                    systemRepository.isRootAvailable(),
+                    systemRepository.isShizukuAvailable(),
+                    systemRepository.isDhizukuAvailable()
+                )
+            }
+            getInstalledAppsUseCase().collect { (user, system) ->
+                _rawState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRoot = hasRoot,
+                        isShizuku = hasShizuku,
+                        isDhizuku = hasDhizuku,
+                        allUserApps = user,
+                        allSystemApps = system
+                    )
+                }
+            }
+```
+
+with:
+
+```kotlin
+            // Privilege availability now comes from the shared reactive PrivilegeManager,
+            // so a Shizuku grant reflects here without reloading the list.
+            combine(
+                getInstalledAppsUseCase(),
+                privilegeManager.state
+            ) { (user, system), priv ->
+                Triple(user, system, priv)
+            }.collect { (user, system, priv) ->
+                _rawState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRoot = priv.root,
+                        isShizuku = priv.shizuku,
+                        isDhizuku = priv.dhizuku,
+                        allUserApps = user,
+                        allSystemApps = system
+                    )
+                }
+            }
+```
+
+Ensure these imports exist (add any missing): `import kotlinx.coroutines.flow.combine`. If `withContext`/`Dispatchers` are now unused elsewhere in the file, remove their imports; otherwise leave them.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+git commit -m "refactor(applist): source privileges from reactive PrivilegeManager
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Migrate HomeViewModel to observe PrivilegeManager
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt`
+
+**Interfaces:**
+- Consumes: `PrivilegeManager.state`, `PrivilegeMode`.
+
+- [ ] **Step 1: Swap the dependency**
+
+Add import:
+
+```kotlin
+import com.valhalla.thor.data.manager.PrivilegeManager
+```
+
+In the constructor, replace:
+
+```kotlin
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository // Injected
+```
+
+with:
+
+```kotlin
+    private val privilegeManager: PrivilegeManager,
+    private val preferenceRepository: PreferenceRepository // Injected
+```
+
+Remove `import com.valhalla.thor.domain.repository.SystemRepository` (unused after this task).
+
+- [ ] **Step 2: Derive privilege fields from the manager in the state combine**
+
+Replace the `state` combine:
+
+```kotlin
+    val state = combine(_internalState, preferenceRepository.userPreferences) { internal, prefs ->
+        val activeMode = prefs.preferredPrivilegeMode ?: when {
+            internal.isRootAvailable -> PrivilegeMode.ROOT
+            internal.isShizukuAvailable -> PrivilegeMode.SHIZUKU
+            internal.isDhizukuAvailable -> PrivilegeMode.DHIZUKU
+            else -> null
+        }
+        internal.copy(
+            showReinstallCard = prefs.showReinstallAllCard,
+            activePrivilegeMode = activeMode,
+            extensionsUnlocked = prefs.extensionsUnlocked
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        HomeUiState()
+    )
+```
+
+with:
+
+```kotlin
+    val state = combine(
+        _internalState,
+        preferenceRepository.userPreferences,
+        privilegeManager.state
+    ) { internal, prefs, priv ->
+        internal.copy(
+            showReinstallCard = prefs.showReinstallAllCard,
+            isRootAvailable = priv.root,
+            isShizukuAvailable = priv.shizuku,
+            isDhizukuAvailable = priv.dhizuku,
+            // Keep the existing "null = no privilege" contract for the UI.
+            activePrivilegeMode = priv.active.takeIf { it != PrivilegeMode.NONE },
+            extensionsUnlocked = prefs.extensionsUnlocked
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        HomeUiState()
+    )
+```
+
+- [ ] **Step 3: Stop probing/threading privileges through dashboard loading**
+
+Replace `loadDashboardData()`:
+
+```kotlin
+    fun loadDashboardData() {
+        // Cancel any existing job to ensure we restart with fresh system status
+        dashboardJob?.cancel()
+
+        dashboardJob = viewModelScope.launch(Dispatchers.IO) {
+            _internalState.update { it.copy(isLoading = true) }
+            val hasRoot = systemRepository.isRootAvailable()
+            val hasShizuku = systemRepository.isShizukuAvailable()
+            val hasDhizuku = systemRepository.isDhizukuAvailable()
+
+            getInstalledAppsUseCase().collect { (userApps, systemApps) ->
+                lastUserApps = userApps
+                lastSystemApps = systemApps
+                processData(
+                    userApps,
+                    systemApps,
+                    _internalState.value.selectedType,
+                    hasRoot,
+                    hasShizuku,
+                    hasDhizuku
+                )
+            }
+        }
+    }
+```
+
+with:
+
+```kotlin
+    fun loadDashboardData() {
+        // Cancel any existing job to ensure we restart with fresh data
+        dashboardJob?.cancel()
+
+        dashboardJob = viewModelScope.launch(Dispatchers.IO) {
+            _internalState.update { it.copy(isLoading = true) }
+            getInstalledAppsUseCase().collect { (userApps, systemApps) ->
+                lastUserApps = userApps
+                lastSystemApps = systemApps
+                processData(userApps, systemApps, _internalState.value.selectedType)
+            }
+        }
+    }
+```
+
+Replace `onTypeChanged()`:
+
+```kotlin
+    fun onTypeChanged(type: AppListType) {
+        _internalState.update { it.copy(selectedType = type) }
+        typeChangeJob?.cancel()
+        typeChangeJob = viewModelScope.launch(Dispatchers.IO) {
+            val s = _internalState.value
+            processData(
+                lastUserApps,
+                lastSystemApps,
+                type,
+                s.isRootAvailable,
+                s.isShizukuAvailable,
+                s.isDhizukuAvailable
+            )
+        }
+    }
+```
+
+with:
+
+```kotlin
+    fun onTypeChanged(type: AppListType) {
+        _internalState.update { it.copy(selectedType = type) }
+        typeChangeJob?.cancel()
+        typeChangeJob = viewModelScope.launch(Dispatchers.IO) {
+            processData(lastUserApps, lastSystemApps, type)
+        }
+    }
+```
+
+Replace `onPrivilegeModeChanged()`:
+
+```kotlin
+    fun onPrivilegeModeChanged(mode: PrivilegeMode) {
+        viewModelScope.launch {
+            preferenceRepository.setPrivilegeMode(mode)
+            loadDashboardData() // Refresh everything
+        }
+    }
+```
+
+with:
+
+```kotlin
+    fun onPrivilegeModeChanged(mode: PrivilegeMode) {
+        // PrivilegeManager observes the preference and recomputes `active` reactively;
+        // no dashboard reload needed (app stats don't depend on the privilege mode).
+        viewModelScope.launch {
+            preferenceRepository.setPrivilegeMode(mode)
+        }
+    }
+```
+
+- [ ] **Step 4: Drop the privilege params from `processData`**
+
+Replace the `processData` signature + its trailing `_internalState.update` block.
+
+Signature — replace:
+
+```kotlin
+    private fun processData(
+        userApps: List<AppInfo>,
+        systemApps: List<AppInfo>,
+        selectedType: AppListType,
+        hasRoot: Boolean,
+        hasShizuku: Boolean,
+        hasDhizuku: Boolean
+    ) {
+```
+
+with:
+
+```kotlin
+    private fun processData(
+        userApps: List<AppInfo>,
+        systemApps: List<AppInfo>,
+        selectedType: AppListType
+    ) {
+```
+
+Final update — replace:
+
+```kotlin
+        _internalState.update {
+            it.copy(
+                isLoading = false,
+                selectedType = selectedType,
+                activeAppCount = activeCount,
+                frozenAppCount = frozenCount,
+                suspendedAppCount = suspendedCount,
+                unknownInstallerCount = unknownCount,
+                distributionData = distribution,
+                isRootAvailable = hasRoot,
+                isShizukuAvailable = hasShizuku,
+                isDhizukuAvailable = hasDhizuku
+            )
+        }
+```
+
+with:
+
+```kotlin
+        _internalState.update {
+            it.copy(
+                isLoading = false,
+                selectedType = selectedType,
+                activeAppCount = activeCount,
+                frozenAppCount = frozenCount,
+                suspendedAppCount = suspendedCount,
+                unknownInstallerCount = unknownCount,
+                distributionData = distribution
+                // Privilege fields are populated by the state combine from PrivilegeManager.
+            )
+        }
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL. `combine` with 3 flows is already imported (`kotlinx.coroutines.flow.combine`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+git commit -m "refactor(home): source privileges from reactive PrivilegeManager
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full build, tests, and manual verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full compile + unit tests**
+
+Run: `./gradlew :app:testFossDebugUnitTest`
+Expected: BUILD SUCCESSFUL; `PrivilegeResolverTest` (6) + existing `BundleAnalysisTest`/`BundleZipTest` all pass.
+
+- [ ] **Step 2: Assemble the debug APK**
+
+Run: `./gradlew assembleFossDebug`
+Expected: BUILD SUCCESSFUL (confirms Koin can resolve `PrivilegeManager` into all three ViewModels at runtime wiring/KSP).
+
+- [ ] **Step 3: Manual verification on device (checklist)**
+
+- Fresh install, do NOT pre-grant Shizuku. Launch app → when prompted, grant Shizuku.
+  - Home: privilege status reflects Shizuku immediately.
+  - Navigate to Freezer WITHOUT restarting: the toolbar/FAB are enabled (privilege recognized) — this is the original bug, now fixed reactively.
+  - App List: privilege-gated actions available.
+- Settings → change preferred privilege mode → Home's active mode updates live (no restart).
+- If root is available, confirm the fallback still selects ROOT when no preference is set.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/reactive-privilege-flow
+```
+
+---
+
+## Notes for the implementer
+
+- Do NOT touch `SystemRepositoryImpl.getActiveGateway()` — the imperative operation path stays as-is.
+- The `HomeActivity` `ShizukuPermissionHandler` is unchanged: it still *requests* permission; `PrivilegeManager` independently observes the *result* via its own listeners.
+- `PrivilegeManager` is created when the first consumer ViewModel is injected (app start), so its Shizuku listeners are registered before a first-launch grant.

--- a/docs/superpowers/specs/2026-07-02-reactive-privilege-flow-design.md
+++ b/docs/superpowers/specs/2026-07-02-reactive-privilege-flow-design.md
@@ -1,0 +1,132 @@
+# Reactive Privilege Flow — Design
+
+**Date:** 2026-07-02
+**Branch:** `feat/reactive-privilege-flow`
+
+## Problem
+
+Privilege availability (root / Shizuku / Dhizuku) is probed **one-shot per ViewModel**
+(`HomeViewModel`, `AppListViewModel`, `FreezerViewModel` each call
+`systemRepository.isRootAvailable()` etc. once), and there is **no reactive source**.
+Consequences:
+
+- A first-launch **Shizuku grant is not observed** by screens created before the grant
+  (Freezer needed an app restart). Only `HomeActivity`'s `ShizukuPermissionHandler`
+  refreshes `HomeViewModel`.
+- The "active mode" resolution (`preferred ?: firstAvailable(Root→Shizuku→Dhizuku)`) is
+  duplicated ad-hoc (`HomeViewModel:57`).
+- A stop-gap `ShizukuPermissionHandler`-in-`FreezerViewModel` shim was added to work
+  around the above; it should be replaced by the shared source.
+
+## Goal
+
+A single reactive source of truth for privilege availability + the active mode,
+observed by Home / AppList / Freezer, updated automatically on Shizuku binder/permission
+events and preference changes.
+
+## Design
+
+### 1. Enum
+
+Extend `PrivilegeMode`:
+
+```kotlin
+enum class PrivilegeMode { NONE, ROOT, SHIZUKU, DHIZUKU }
+```
+
+- `preferredPrivilegeMode: PrivilegeMode?` in prefs is **unchanged** (nullable; `null` =
+  auto). `NONE` is used **only** by the reactive *active* value and is **never persisted**
+  as a preference.
+
+### 2. Emitted state
+
+```kotlin
+data class PrivilegeState(
+    val root: Boolean = false,
+    val shizuku: Boolean = false,
+    val dhizuku: Boolean = false,
+    val active: PrivilegeMode = PrivilegeMode.NONE,
+    val isReady: Boolean = false // false until the first probe completes
+) {
+    val hasAnyPrivilege: Boolean get() = active != PrivilegeMode.NONE
+}
+```
+
+`isReady` lets consumers distinguish "not probed yet" from "probed, none available"
+(avoids a flash of the no-privilege UI on cold start).
+
+### 3. `PrivilegeManager` (`@Single`, data layer)
+
+```kotlin
+@Single
+class PrivilegeManager(
+    private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository
+) {
+    // process-lifetime; not cancelled (this @Single lives for the app)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val state: StateFlow<PrivilegeState>
+    fun refresh() // manual re-probe (e.g. after the user enables root)
+}
+```
+
+Responsibilities:
+
+- **Probe** root/shizuku/dhizuku off the main thread (`Dispatchers.IO`) on init, on
+  `refresh()`, and on Shizuku events.
+- **Own the app-wide Shizuku listeners** (`OnBinderReceivedListener`,
+  `OnRequestPermissionResultListener`) — registered once for the process lifetime;
+  re-probe on binder-received / permission-granted. This replaces the per-VM handlers.
+- **Observe `preferredPrivilegeMode`** (`preferenceRepository.userPreferences`) and
+  recompute `active` when it changes.
+- **Resolve `active`** with a pure function:
+  `resolveActive(preferred, root, shizuku, dhizuku)` = the preferred mode if it is
+  available; else the first available in Root→Shizuku→Dhizuku order; else `NONE`.
+- Publish via `MutableStateFlow` updated with `update { }`.
+
+Lifecycle: as a Koin `@Single` it is created when first injected (a consumer VM at app
+start) and lives for the process; Shizuku listeners are never unregistered (process
+lifetime), so no leak concern beyond app teardown.
+
+### 4. Consumer migration (full)
+
+- **HomeViewModel** — collect `privilegeManager.state`; drop its one-shot probes;
+  `activePrivilegeMode` = `state.active`; keep dashboard-specific data loading.
+- **AppListViewModel** — replace the one-shot probe (`AppListViewModel.kt:117-123`) by
+  combining `privilegeManager.state` with the app-list flow.
+- **FreezerViewModel** — collect `privilegeManager.state` for `isRoot/isShizuku/isDhizuku`;
+  **remove** `loadPrivileges()` and the `ShizukuPermissionHandler` shim + `onCleared`
+  override added earlier.
+- **HomeActivity** — keeps `ShizukuPermissionHandler` only to **request** permission
+  (`checkAndRequestPermission`); its `onPermissionGranted` may call
+  `privilegeManager.refresh()` (belt-and-suspenders), but the manager's own listeners
+  already handle the grant.
+
+### 5. DI
+
+Koin **annotation** style, matching the codebase (`@Single` / `@KoinViewModel` scanned via
+KSP): annotate `PrivilegeManager` with `@Single`. It owns its own process-lifetime
+`CoroutineScope` internally (no raw `CoroutineScope` injected). Consumer VMs receive it via
+constructor injection like their other dependencies.
+
+## Out of scope (this branch)
+
+- `SystemRepositoryImpl.getActiveGateway()` — the **imperative** gateway resolution used
+  by privileged operations stays as-is (reads prefs + validates). It is not on the
+  reactive path; converging it onto `PrivilegeManager` is a possible follow-up. This keeps
+  the privileged-operation path stable.
+- The permission-**request** UX (unchanged).
+
+## Testing
+
+- Unit-test the pure `resolveActive(preferred, root, shizuku, dhizuku)` resolver across
+  the matrix (preferred available / preferred unavailable / none available / each fallback).
+- Manager wiring (Shizuku listeners, probes) is device/permission-dependent → manual
+  verification: fresh install → grant Shizuku when prompted → Freezer recognizes it with
+  no restart; toggle preferred mode in Settings → `active` updates live.
+
+## Risks
+
+- Root probe runs a shell command; keep strictly off the main thread (already the case).
+- Ensure `PrivilegeManager` is actually instantiated at startup (it is, via VM injection)
+  so its listeners are registered before the first grant.


### PR DESCRIPTION
## Summary

Replaces per-ViewModel one-shot privilege probes (root / Shizuku / Dhizuku) with a single
reactive source of truth — a `@Single PrivilegeManager` exposing `StateFlow<PrivilegeState>`.
Home, App List, and Freezer now **observe** privilege state instead of probing it once, so a
first-launch Shizuku grant (or a preferred-mode change) updates every screen live, with no app
restart.

Fixes the long-standing bug where granting Shizuku on first launch wasn't recognized by the
Freezer until the app was restarted.

## Problem

- Privilege availability was probed one-shot per ViewModel; there was no reactive source.
- A first-launch Shizuku grant was not observed by screens created before the grant (Freezer
  needed a restart). A stop-gap `ShizukuPermissionHandler` shim had been bolted into
  `FreezerViewModel` to work around this.
- The "active mode" resolution (`preferred ?: firstAvailable(Root → Shizuku → Dhizuku)`) was
  duplicated ad-hoc.

## Changes

- **`PrivilegeMode.NONE`** + **`PrivilegeState`** (`root` / `shizuku` / `dhizuku` / `active` /
  `isReady`) + a pure, unit-tested `resolvePrivilegeMode(...)` resolver.
- **`PrivilegeManager`** (`@Single`, data layer): owns the app-wide Shizuku listeners, re-probes
  off `Dispatchers.IO` on init / `refresh()` / Shizuku binder + permission events / preferred-mode
  change, and publishes `StateFlow<PrivilegeState>`.
- **FreezerViewModel / AppListViewModel / HomeViewModel**: observe `PrivilegeManager.state`;
  removed the one-shot probes, the Freezer Shizuku shim + `onCleared` override, and the duplicated
  active-mode logic.
- **`isReady` gating** (added after adversarial review): consumers hold their pre-probe UI (Home
  falls back to the persisted preference; App List holds its loader) so there is no cold-start
  "no-privilege" flash.

## Out of scope

`SystemRepositoryImpl.getActiveGateway()` — the imperative privileged-operation path — is
intentionally left unchanged.

## Verification

- `./gradlew :app:testFossDebugUnitTest` — ✅ (`PrivilegeResolverTest` + existing bundle tests)
- `./gradlew assembleFossDebug` — ✅ (Koin resolves `PrivilegeManager` into all three ViewModels)
- Adversarial multi-agent review across flow-semantics / threading / lifecycle-leaks /
  behavior-regression / Koin-DI: threading, leaks, and DI came back clean; the confirmed
  cold-start-flash findings are fixed in the `isReady` commit.
- Manual on-device: fresh install → grant Shizuku → Freezer recognized it with **no restart**;
  Settings preferred-mode change updates Home live.

## Design docs

- `docs/superpowers/specs/2026-07-02-reactive-privilege-flow-design.md`
- `docs/superpowers/plans/2026-07-02-reactive-privilege-flow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
