### PR TITLE
release: v1.90.2 — trim Play Store notes under 500 chars (re-deploy)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,11 @@
 /.github/                @trinadhthatakula
 /gradle.properties       @trinadhthatakula
 /release-notes/          @trinadhthatakula
+
+# High-risk privilege / native surface — always flag for maintainer review
+/bypass/                                                          @trinadhthatakula
+/suCore/                                                          @trinadhthatakula
+/vm-runtime/                                                      @trinadhthatakula
+/app/src/main/java/com/valhalla/thor/data/gateway/               @trinadhthatakula
+/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/  @trinadhthatakula
+/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/  @trinadhthatakula

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,11 +72,21 @@ body:
       description: See Settings → About (e.g. 1.90.1)
     validations:
       required: true
-  - type: input
+  - type: dropdown
     id: source
     attributes:
       label: Install source
-      placeholder: IzzyOnDroid / GitHub / Play Store / Obtainium / other
+      description: Where did you install this build from?
+      options:
+        - IzzyOnDroid
+        - GitHub Releases
+        - Play Store
+        - Indus Appstore
+        - Obtainium
+        - APKPure
+        - Other
+    validations:
+      required: true
   - type: input
     id: device
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: 💬 Questions & discussion
     url: https://github.com/trinadhthatakula/Thor/discussions
     about: Ask questions, share setups, or discuss ideas here instead of opening an issue.
+  - name: 📣 Telegram channel & chat
+    url: https://t.me/thorAppDev
+    about: Follow releases and ask quick questions in the community chat.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,15 @@ updates:
       maven:
         patterns:
           - "*"
+
+  # Keep GitHub Actions versions current/patched (esp. actions used in the
+  # keystore-bearing release workflows). Grouped into one weekly PR.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,9 @@
 - [ ] Builds locally on JDK 21 (`./gradlew assembleFossDebug`)
 - [ ] Tested under privilege mode(s): <!-- Root / Shizuku / Dhizuku / None -->
 
+## Screenshots
+<!-- For UI changes, add before/after screenshots or a short screen recording. Delete this section if the PR isn't UI-facing. -->
+
 ## Checklist
 - [ ] Changes are scoped to the stated purpose (no unrelated edits)
 - [ ] Bumped `versionCode` in `gradle.properties` **if** this PR is release-bound (otherwise skip)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "master", "dev" ]
+  pull_request:
+    branches: [ "master", "dev" ]
+  schedule:
+    - cron: '27 3 * * 1' # weekly, Monday 03:27 UTC
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -5,6 +5,11 @@ on:
     branches: [ "master" ]
   workflow_dispatch:
 
+# Don't let overlapping release runs race on the same version tag / Play upload.
+concurrency:
+  group: dev-build-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-release-check:
     runs-on: ubuntu-latest
@@ -14,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags so the release-notes changelog fallback works
 
       - name: Setup JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Added Ruby for Fastlane in Dev
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -152,7 +152,7 @@ jobs:
 
       # --- 5. GITHUB RELEASE (PRE-RELEASE) ---
       - name: Create GitHub Pre-Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           # Unique tag for dev builds: v1.0.0-dev-45
           tag_name: v${{ steps.prep_notes.outputs.version_name }}-dev-${{ github.run_number }}

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,41 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches: [ "master", "dev" ]
+
+# Least-privilege token — this workflow only reads the repo.
+permissions:
+  contents: read
+
+# Cancel superseded runs for the same PR.
+concurrency:
+  group: pr-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Assemble + unit test (foss debug)
+        run: ./gradlew assembleFossDebug testFossDebugUnitTest --stacktrace
+
+      # Advisory for now — surfaces Android Lint without blocking merges on
+      # pre-existing lint debt. Promote to a required step once lint is clean.
+      - name: Android Lint (advisory)
+        continue-on-error: true
+        run: ./gradlew lintFossDebug

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -5,6 +5,11 @@ on:
     branches: [ "production" ]
   workflow_dispatch:
 
+# Don't let overlapping release runs race on the same version tag / Play upload.
+concurrency:
+  group: prod-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-distribute:
     runs-on: ubuntu-latest
@@ -14,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags so the release-notes changelog fallback works
 
       - name: Setup JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -99,7 +99,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ steps.prep_notes.outputs.version_name }}
           name: Release v${{ steps.prep_notes.outputs.version_name }}

--- a/.github/workflows/telegram-release.yml
+++ b/.github/workflows/telegram-release.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,9 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement via the Thor
-community channel at **https://t.me/thorAppDev**, or privately through GitHub's
-[private vulnerability / abuse reporting](https://github.com/trinadhthatakula/Thor/security).
+reported privately to the community leaders responsible for enforcement through
+GitHub's [private vulnerability / abuse reporting](https://github.com/trinadhthatakula/Thor/security).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -128,6 +127,6 @@ For answers to common questions about this code of conduct, see the FAQ at
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
+[Mozilla CoC]: https://github.com/mozilla/inclusion
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via the Thor
+community channel at **https://t.me/thorAppDev**, or privately through GitHub's
+[private vulnerability / abuse reporting](https://github.com/trinadhthatakula/Thor/security).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/release-notes/v1.90.2/playstore.txt
+++ b/release-notes/v1.90.2/playstore.txt
@@ -1,11 +1,10 @@
 What's new in Thor v1.90.2
 
-• Fixed some apps being wrongly blocked as a "downgrade" during install.
 • Fixed .xapk installs, including APKPure bundles.
-• Fixed the Freezer "Freeze/Unfreeze all" freeze and added live progress.
-• Shizuku is now recognized right after you grant it — no restart needed.
+• Fixed apps wrongly blocked as a "downgrade" on install.
+• Fixed the Freezer "Freeze/Unfreeze all" hang; added live progress.
+• Shizuku is recognized right after you grant it — no restart needed.
 • Fixed the Settings screen crash on large font / display sizes.
-• Smoother scrolling and less jank — lighter app icons and more work moved off the main thread.
-• Squashed several memory leaks and hardened stability under the hood.
+• Smoother scrolling, fewer memory leaks, and better stability.
 
 Thanks for using Thor!


### PR DESCRIPTION
Re-deploys **v1.90.2** (versionCode 1902) after the Play upload failed on the release-notes length limit (was 556 chars; en-US max is 500). Trimmed to 429 chars, all key fixes retained. Also promotes the merged repo-hardening (#226) to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)