### PR TITLE
feat: sort apps by total install size (#57)

### DIFF
--- a/app/schemas/com.valhalla.thor.data.source.local.room.AppDatabase/5.json
+++ b/app/schemas/com.valhalla.thor.data.source.local.room.AppDatabase/5.json
@@ -1,0 +1,201 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "20e4df41d4d04b8b7c74ab54244fc704",
+    "entities": [
+      {
+        "tableName": "apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `appName` TEXT, `versionName` TEXT, `versionCode` INTEGER NOT NULL, `minSdk` INTEGER NOT NULL, `targetSdk` INTEGER NOT NULL, `isSystem` INTEGER NOT NULL, `installerPackageName` TEXT, `publicSourceDir` TEXT, `splitPublicSourceDirs` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `dataDir` TEXT, `nativeLibraryDir` TEXT, `deviceProtectedDataDir` TEXT, `sharedLibraryFiles` TEXT, `obbFilePath` TEXT, `sourceDir` TEXT, `sharedDataDir` TEXT NOT NULL, `lastUpdateTime` INTEGER NOT NULL, `firstInstallTime` INTEGER NOT NULL, `isDebuggable` INTEGER NOT NULL, `isSuspended` INTEGER NOT NULL, `installSize` INTEGER, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "appName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "versionCode",
+            "columnName": "versionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minSdk",
+            "columnName": "minSdk",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetSdk",
+            "columnName": "targetSdk",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "isSystem",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installerPackageName",
+            "columnName": "installerPackageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publicSourceDir",
+            "columnName": "publicSourceDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "splitPublicSourceDirs",
+            "columnName": "splitPublicSourceDirs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataDir",
+            "columnName": "dataDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nativeLibraryDir",
+            "columnName": "nativeLibraryDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deviceProtectedDataDir",
+            "columnName": "deviceProtectedDataDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sharedLibraryFiles",
+            "columnName": "sharedLibraryFiles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "obbFilePath",
+            "columnName": "obbFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceDir",
+            "columnName": "sourceDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sharedDataDir",
+            "columnName": "sharedDataDir",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstInstallTime",
+            "columnName": "firstInstallTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDebuggable",
+            "columnName": "isDebuggable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuspended",
+            "columnName": "isSuspended",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installSize",
+            "columnName": "installSize",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "freezer_apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "extension_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`extensionPackageName` TEXT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`extensionPackageName`, `key`))",
+        "fields": [
+          {
+            "fieldPath": "extensionPackageName",
+            "columnName": "extensionPackageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "extensionPackageName",
+            "key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '20e4df41d4d04b8b7c74ab54244fc704')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,9 @@
     <uses-permission android:name="shizuku.permission.API_V23" />
     <uses-permission android:name="com.rosan.dhizuku.permission.API" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission
+        android:name="android.permission.PACKAGE_USAGE_STATS"
+        tools:ignore="ProtectedPermissions" />
 
     <permission
         android:name="com.valhalla.thor.permission.TRIGGER_EXTENSION"

--- a/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
@@ -1,0 +1,35 @@
+package com.valhalla.thor.data.manager
+
+import android.app.usage.StorageStatsManager
+import android.content.Context
+import android.os.Process
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
+
+/**
+ * Computes total install size (app + data + cache) per package via
+ * StorageStatsManager. Requires the GET_USAGE_STATS app-op for other packages
+ * (see UsageAccessManager) — a per-package failure is skipped, never thrown.
+ */
+@Single
+class StorageStatsHelper(private val context: Context) {
+
+    private val statsManager = context.getSystemService(StorageStatsManager::class.java)
+    private val pm = context.packageManager
+    private val user = Process.myUserHandle()
+
+    suspend fun installSizes(packages: List<String>): Map<String, Long> =
+        withContext(Dispatchers.IO) {
+            val out = HashMap<String, Long>(packages.size)
+            for (pkg in packages) {
+                val size = runCatching {
+                    val ai = pm.getApplicationInfo(pkg, 0)
+                    val stats = statsManager.queryStatsForPackage(ai.storageUuid, pkg, user)
+                    stats.appBytes + stats.dataBytes + stats.cacheBytes
+                }.getOrNull()
+                if (size != null) out[pkg] = size
+            }
+            out
+        }
+}

--- a/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
@@ -21,11 +21,12 @@ class StorageStatsHelper(private val context: Context) {
 
     suspend fun installSizes(packages: List<String>): Map<String, Long> =
         withContext(Dispatchers.IO) {
+            val manager = statsManager ?: return@withContext emptyMap()
             val out = HashMap<String, Long>(packages.size)
             for (pkg in packages) {
                 val size = runCatching {
                     val ai = pm.getApplicationInfo(pkg, 0)
-                    val stats = statsManager.queryStatsForPackage(ai.storageUuid, pkg, user)
+                    val stats = manager.queryStatsForPackage(ai.storageUuid, pkg, user)
                     stats.appBytes + stats.dataBytes + stats.cacheBytes
                 }.getOrNull()
                 if (size != null) out[pkg] = size

--- a/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
@@ -1,0 +1,61 @@
+package com.valhalla.thor.data.manager
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Process
+import android.provider.Settings
+import com.valhalla.thor.domain.repository.SystemRepository
+import org.koin.core.annotation.Single
+
+/**
+ * Manages the GET_USAGE_STATS (Usage Access) app-op needed by
+ * StorageStatsManager. Tries a silent grant through the active privilege
+ * gateway; always re-verifies; exposes the Settings deep-link for the fallback.
+ */
+@Single
+class UsageAccessManager(
+    private val context: Context,
+    private val systemRepository: SystemRepository
+) {
+    private val appOps = context.getSystemService(AppOpsManager::class.java)
+    private val pkg = context.packageName
+
+    @Volatile
+    private var autoGrantAttempted = false
+
+    fun isGranted(): Boolean {
+        val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            appOps.unsafeCheckOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
+        } else {
+            @Suppress("DEPRECATION")
+            appOps.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
+        }
+        return mode == AppOpsManager.MODE_ALLOWED
+    }
+
+    /** Best-effort silent grant via a privileged gateway; returns the verified result. */
+    suspend fun tryGrantViaPrivilege(): Boolean {
+        if (isGranted()) return true
+        // Harmless if no privilege is active (command just fails); may also be
+        // blocked on newer Android — hence we re-verify rather than assume success.
+        systemRepository.executeShellCommand("appops set $pkg GET_USAGE_STATS allow")
+        return isGranted()
+    }
+
+    /** One-shot per-process auto-grant, meant to run once a privilege is available. */
+    suspend fun maybeAutoGrant() {
+        if (autoGrantAttempted || isGranted()) return
+        autoGrantAttempted = true
+        tryGrantViaPrivilege()
+    }
+
+    /** Settings deep-link (best-effort per-app; OEMs may land on the list). */
+    fun usageAccessIntent(): Intent =
+        Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
+            data = Uri.fromParts("package", pkg, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+}

--- a/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
@@ -27,11 +27,12 @@ class UsageAccessManager(
     private var autoGrantAttempted = false
 
     fun isGranted(): Boolean {
+        val ops = appOps ?: return false
         val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            appOps.unsafeCheckOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
+            ops.unsafeCheckOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
         } else {
             @Suppress("DEPRECATION")
-            appOps.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
+            ops.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
         }
         return mode == AppOpsManager.MODE_ALLOWED
     }

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -228,7 +228,10 @@ class AppRepositoryImpl(
     override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? =
         withContext(Dispatchers.IO) {
             try {
-                val appInfo = getAppDetails(packageName) ?: return@withContext null
+                val appInfo = (getAppDetails(packageName) ?: return@withContext null)
+                    // Carry the persisted total install size (computed lazily on Size
+                    // sort) so the App Info sheet can show it; null until first computed.
+                    .copy(installSize = appDao.getApp(packageName)?.installSize)
 
                 val flags = (PackageManager.GET_ACTIVITIES or
                         PackageManager.GET_SERVICES or

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -366,4 +366,8 @@ class AppRepositoryImpl(
             appName = pm.getApplicationLabel(appInfo).toString()
         )
     }
+
+    override suspend fun updateInstallSizes(sizes: Map<String, Long>) {
+        appDao.updateInstallSizes(sizes)
+    }
 }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt
@@ -30,6 +30,14 @@ interface AppDao {
         toDelete.forEach { deleteApp(it) }
     }
 
+    @Query("UPDATE apps SET installSize = :size WHERE packageName = :packageName")
+    suspend fun updateInstallSize(packageName: String, size: Long?)
+
+    @Transaction
+    suspend fun updateInstallSizes(sizes: Map<String, Long>) {
+        sizes.forEach { (pkg, size) -> updateInstallSize(pkg, size) }
+    }
+
     @Query("DELETE FROM apps")
     suspend fun clearAll()
 }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt
@@ -7,6 +7,8 @@ import androidx.room.Query
 import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 
+data class PackageInstallSize(val packageName: String, val installSize: Long?)
+
 @Dao
 interface AppDao {
     @Query("SELECT * FROM apps")
@@ -24,9 +26,22 @@ interface AppDao {
     @Query("DELETE FROM apps WHERE packageName = :packageName")
     suspend fun deleteApp(packageName: String)
 
+    @Query("SELECT packageName, installSize FROM apps WHERE packageName IN (:packages)")
+    suspend fun getInstallSizes(packages: List<String>): List<PackageInstallSize>
+
     @Transaction
     suspend fun syncCache(toUpdate: List<AppEntity>, toDelete: List<String>) {
-        if (toUpdate.isNotEmpty()) insertApps(toUpdate)
+        if (toUpdate.isNotEmpty()) {
+            // Scanned entities carry installSize = null (StorageStats is computed
+            // lazily). Preserve any already-persisted size across the REPLACE so the
+            // size cache survives re-syncs.
+            val existing = getInstallSizes(toUpdate.map { it.packageName })
+                .associate { it.packageName to it.installSize }
+            val merged = toUpdate.map {
+                if (it.installSize == null) it.copy(installSize = existing[it.packageName]) else it
+            }
+            insertApps(merged)
+        }
         toDelete.forEach { deleteApp(it) }
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt
@@ -35,8 +35,12 @@ interface AppDao {
             // Scanned entities carry installSize = null (StorageStats is computed
             // lazily). Preserve any already-persisted size across the REPLACE so the
             // size cache survives re-syncs.
-            val existing = getInstallSizes(toUpdate.map { it.packageName })
-                .associate { it.packageName to it.installSize }
+            // Chunk to stay under SQLite's IN(...) variable limit (999) on
+            // devices with very large app counts.
+            val existing = HashMap<String, Long?>(toUpdate.size)
+            for (chunk in toUpdate.map { it.packageName }.chunked(999)) {
+                for (item in getInstallSizes(chunk)) existing[item.packageName] = item.installSize
+            }
             val merged = toUpdate.map {
                 if (it.installSize == null) it.copy(installSize = existing[it.packageName]) else it
             }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDatabase.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDatabase.kt
@@ -9,10 +9,11 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [AppEntity::class, FreezerEntity::class, ExtensionDataEntity::class],
-    version = 4,
+    version = 5,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
-        AutoMigration(from = 3, to = 4)
+        AutoMigration(from = 3, to = 4),
+        AutoMigration(from = 4, to = 5)
     ],
     exportSchema = true
 )

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppEntity.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppEntity.kt
@@ -27,7 +27,8 @@ data class AppEntity(
     val lastUpdateTime: Long,
     val firstInstallTime: Long,
     val isDebuggable: Boolean,
-    val isSuspended: Boolean
+    val isSuspended: Boolean,
+    val installSize: Long? = null
 ) {
     fun toDomain(): AppInfo {
         return AppInfo(
@@ -52,7 +53,8 @@ data class AppEntity(
             lastUpdateTime = lastUpdateTime,
             firstInstallTime = firstInstallTime,
             isDebuggable = isDebuggable,
-            isSuspended = isSuspended
+            isSuspended = isSuspended,
+            installSize = installSize
         )
     }
 
@@ -80,7 +82,8 @@ data class AppEntity(
                 lastUpdateTime = appInfo.lastUpdateTime,
                 firstInstallTime = appInfo.firstInstallTime,
                 isDebuggable = appInfo.isDebuggable,
-                isSuspended = appInfo.isSuspended
+                isSuspended = appInfo.isSuspended,
+                installSize = appInfo.installSize
             )
         }
     }

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppInfo.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppInfo.kt
@@ -40,6 +40,8 @@ data class AppInfo(
     val bloatDescription: String? = null,
     val isInstalled: Boolean = true,
     val isUadLoadFailed: Boolean = false,
+    /** Total install size in bytes (app + data + cache). null = not yet computed. */
+    val installSize: Long? = null,
 ) {
     companion object {
 

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppSorting.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppSorting.kt
@@ -1,0 +1,20 @@
+package com.valhalla.thor.domain.model
+
+/**
+ * Pure, side-effect-free app sorter (unit-tested). Unknown install sizes
+ * (`null`) sort as smallest, so DESCENDING puts the biggest apps first.
+ */
+fun sortApps(apps: List<AppInfo>, sortBy: SortBy, order: SortOrder): List<AppInfo> {
+    val comparator = when (sortBy) {
+        SortBy.NAME -> compareBy<AppInfo> { it.appName?.lowercase() }
+        SortBy.SIZE -> compareBy(nullsFirst<Long>()) { it.installSize }
+        SortBy.INSTALL_DATE -> compareBy { it.firstInstallTime }
+        SortBy.LAST_UPDATED -> compareBy { it.lastUpdateTime }
+        SortBy.VERSION_CODE -> compareBy { it.versionCode }
+        SortBy.VERSION_NAME -> compareBy { it.versionName }
+        SortBy.TARGET_SDK_VERSION -> compareBy { it.targetSdk }
+        SortBy.MIN_SDK_VERSION -> compareBy { it.minSdk }
+    }
+    return if (order == SortOrder.ASCENDING) apps.sortedWith(comparator)
+    else apps.sortedWith(comparator).reversed()
+}

--- a/app/src/main/java/com/valhalla/thor/domain/model/SortBy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/SortBy.kt
@@ -6,8 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class SortBy {
     NAME,
-
-    //SIZE,
+    SIZE,
     INSTALL_DATE,
     LAST_UPDATED,
     VERSION_CODE,
@@ -17,7 +16,7 @@ enum class SortBy {
 
     fun asGeneralName(): String = when (this) {
         NAME -> "Name"
-        //SIZE -> "Size"
+        SIZE -> "Size"
         INSTALL_DATE -> "Install Date"
         LAST_UPDATED -> "Last Updated"
         VERSION_CODE -> "Version Code"

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppRepository.kt
@@ -26,4 +26,7 @@ interface AppRepository {
 
     // Parser for XAPK/APK installation features
     suspend fun getApkDetails(apkPath: String): AppInfo?
+
+    /** Persist freshly-computed total install sizes into the app cache. */
+    suspend fun updateInstallSizes(sizes: Map<String, Long>)
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -843,6 +843,14 @@ private fun GeneralTabScreen(details: DetailedAppInfo) {
                 )
             )
         }
+        appInfo.installSize?.let { bytes ->
+            item {
+                InfoCard(
+                    title = stringResource(R.string.info_app_size),
+                    value = android.text.format.Formatter.formatShortFileSize(context, bytes)
+                )
+            }
+        }
         item {
             InfoCard(
                 title = stringResource(R.string.info_installer_source),

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
@@ -13,10 +13,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
@@ -48,8 +50,10 @@ import com.valhalla.asgard.components.ConnectedButtonGroup
 import com.valhalla.asgard.components.ConnectedButtonGroupItem
 import com.valhalla.thor.presentation.widgets.AppList
 import com.valhalla.thor.presentation.widgets.FreezerPromptSnackbar
+import com.valhalla.thor.data.manager.UsageAccessManager
 import com.valhalla.thor.presentation.widgets.AppInfoDialog
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -142,7 +146,9 @@ fun AppListScreen(
             val refreshState = rememberPullToRefreshState()
 
             PullToRefreshBox(
-                isRefreshing = state.isLoading,
+                // isComputingSizes runs on a populated list, so surface it via the
+                // pull-refresh spinner (the empty-state loader wouldn't show).
+                isRefreshing = state.isLoading || state.isComputingSizes,
                 onRefresh = { viewModel.loadApps() },
                 state = refreshState,
                 modifier = Modifier.weight(1f) // Fill remaining space
@@ -157,7 +163,7 @@ fun AppListScreen(
                     sortBy = state.sortBy,
                     sortOrder = state.sortOrder,
                     searchQuery = state.searchQuery,
-                    isLoading = state.isLoading,
+                    isLoading = state.isLoading || state.isComputingSizes,
                     appList = state.displayedApps,
                     isRoot = state.isRoot,
                     isShizuku = state.isShizuku,
@@ -221,6 +227,24 @@ fun AppListScreen(
                         onAppAction(action)
                     }
                     selectedAppForDialog = null
+                }
+            )
+        }
+
+        val usageAccessManager = koinInject<UsageAccessManager>()
+        if (state.needsUsageAccessPrompt) {
+            AlertDialog(
+                onDismissRequest = { viewModel.dismissUsageAccessPrompt() },
+                title = { Text("Usage Access needed") },
+                text = { Text("Thor needs Usage Access to read app sizes. Enable it for Thor, then pick \"Size\" again. You can also manage this under Settings → Permissions.") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        runCatching { context.startActivity(usageAccessManager.usageAccessIntent()) }
+                        viewModel.dismissUsageAccessPrompt()
+                    }) { Text("Open settings") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { viewModel.dismissUsageAccessPrompt() }) { Text("Cancel") }
                 }
             )
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
@@ -235,16 +235,16 @@ fun AppListScreen(
         if (state.needsUsageAccessPrompt) {
             AlertDialog(
                 onDismissRequest = { viewModel.dismissUsageAccessPrompt() },
-                title = { Text("Usage Access needed") },
-                text = { Text("Thor needs Usage Access to read app sizes. Enable it for Thor, then pick \"Size\" again. You can also manage this under Settings → Permissions.") },
+                title = { Text(stringResource(R.string.usage_access_needed_title)) },
+                text = { Text(stringResource(R.string.usage_access_prompt_body)) },
                 confirmButton = {
                     TextButton(onClick = {
                         runCatching { context.startActivity(usageAccessManager.usageAccessIntent()) }
                         viewModel.dismissUsageAccessPrompt()
-                    }) { Text("Open settings") }
+                    }) { Text(stringResource(R.string.open_settings)) }
                 },
                 dismissButton = {
-                    TextButton(onClick = { viewModel.dismissUsageAccessPrompt() }) { Text("Cancel") }
+                    TextButton(onClick = { viewModel.dismissUsageAccessPrompt() }) { Text(stringResource(R.string.cancel)) }
                 }
             )
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
 import com.valhalla.thor.data.manager.PrivilegeManager
+import com.valhalla.thor.data.manager.StorageStatsHelper
+import com.valhalla.thor.data.manager.UsageAccessManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.FilterType
@@ -11,6 +13,7 @@ import com.valhalla.thor.domain.model.MultiAppAction
 import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
 import com.valhalla.thor.domain.model.sortApps
+import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.usecase.GetAppDetailsUseCase
@@ -24,7 +27,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -61,7 +66,9 @@ data class AppListUiState(
     val actionMessage: UiText? = null,
     val freezerPrompt: FreezerPrompt? = null,
     val useDetailedView: Boolean = true,
-    val isGrid: Boolean = true
+    val isGrid: Boolean = true,
+    val isComputingSizes: Boolean = false,
+    val needsUsageAccessPrompt: Boolean = false
 )
 
 @KoinViewModel
@@ -72,10 +79,14 @@ class AppListViewModel(
     private val privilegeManager: PrivilegeManager,
     private val manageAppUseCase: ManageAppUseCase,
     private val preferenceRepository: PreferenceRepository,
-    private val freezerRepository: FreezerRepository
+    private val freezerRepository: FreezerRepository,
+    private val appRepository: AppRepository,
+    private val storageStatsHelper: StorageStatsHelper,
+    private val usageAccessManager: UsageAccessManager
 ) : ViewModel() {
 
     private var appsJob: Job? = null
+    private var sizeJob: Job? = null
     private val _rawState = MutableStateFlow(AppListUiState())
 
     // Combine raw app data with user preferences from DataStore
@@ -100,6 +111,7 @@ class AppListViewModel(
 
     init {
         loadApps()
+        observeSizeSort()
     }
 
     fun loadApps() {
@@ -136,8 +148,57 @@ class AppListViewModel(
                         allSystemApps = system
                     )
                 }
+                if (priv.hasAnyPrivilege) {
+                    launch { usageAccessManager.maybeAutoGrant() }
+                }
             }
         }
+    }
+
+    // Recompute total install sizes when Size is the active sort AND apps are loaded
+    // (fires both when the user picks Size and when the list finishes loading with
+    // Size already selected). distinctUntilChanged prevents a self-trigger loop.
+    private fun observeSizeSort() {
+        viewModelScope.launch {
+            combine(
+                preferenceRepository.userPreferences.map { it.appSortBy }.distinctUntilChanged(),
+                _rawState.map { it.allUserApps.size + it.allSystemApps.size }.distinctUntilChanged()
+            ) { sortBy, appCount -> sortBy to appCount }
+                .collect { (sortBy, appCount) ->
+                    if (sortBy == SortBy.SIZE && appCount > 0) ensureInstallSizes()
+                }
+        }
+    }
+
+    private fun ensureInstallSizes() {
+        sizeJob?.cancel()
+        sizeJob = viewModelScope.launch {
+            if (!usageAccessManager.isGranted() && !usageAccessManager.tryGrantViaPrivilege()) {
+                _rawState.update { it.copy(needsUsageAccessPrompt = true) }
+                return@launch
+            }
+            _rawState.update { it.copy(isComputingSizes = true) }
+            val packages = (_rawState.value.allUserApps + _rawState.value.allSystemApps)
+                .map { it.packageName }
+            val sizes = storageStatsHelper.installSizes(packages)
+            _rawState.update { state ->
+                state.copy(
+                    isComputingSizes = false,
+                    needsUsageAccessPrompt = false, // clear any stale prompt once sizes resolve
+                    allUserApps = state.allUserApps.map {
+                        it.copy(installSize = sizes[it.packageName] ?: it.installSize)
+                    },
+                    allSystemApps = state.allSystemApps.map {
+                        it.copy(installSize = sizes[it.packageName] ?: it.installSize)
+                    }
+                )
+            }
+            appRepository.updateInstallSizes(sizes)
+        }
+    }
+
+    fun dismissUsageAccessPrompt() {
+        _rawState.update { it.copy(needsUsageAccessPrompt = false) }
     }
 
     fun freezeApp(packageName: String, appName: String?, freeze: Boolean) {

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -178,22 +178,25 @@ class AppListViewModel(
                 return@launch
             }
             _rawState.update { it.copy(isComputingSizes = true) }
-            val packages = (_rawState.value.allUserApps + _rawState.value.allSystemApps)
-                .map { it.packageName }
-            val sizes = storageStatsHelper.installSizes(packages)
-            _rawState.update { state ->
-                state.copy(
-                    isComputingSizes = false,
-                    needsUsageAccessPrompt = false, // clear any stale prompt once sizes resolve
-                    allUserApps = state.allUserApps.map {
-                        it.copy(installSize = sizes[it.packageName] ?: it.installSize)
-                    },
-                    allSystemApps = state.allSystemApps.map {
-                        it.copy(installSize = sizes[it.packageName] ?: it.installSize)
-                    }
-                )
+            try {
+                val packages = (_rawState.value.allUserApps + _rawState.value.allSystemApps)
+                    .map { it.packageName }
+                val sizes = storageStatsHelper.installSizes(packages)
+                _rawState.update { state ->
+                    state.copy(
+                        needsUsageAccessPrompt = false,
+                        allUserApps = state.allUserApps.map {
+                            it.copy(installSize = sizes[it.packageName] ?: it.installSize)
+                        },
+                        allSystemApps = state.allSystemApps.map {
+                            it.copy(installSize = sizes[it.packageName] ?: it.installSize)
+                        }
+                    )
+                }
+                appRepository.updateInstallSizes(sizes)
+            } finally {
+                _rawState.update { it.copy(isComputingSizes = false) }
             }
-            appRepository.updateInstallSizes(sizes)
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -10,6 +10,7 @@ import com.valhalla.thor.domain.model.FilterType
 import com.valhalla.thor.domain.model.MultiAppAction
 import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
+import com.valhalla.thor.domain.model.sortApps
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.usecase.GetAppDetailsUseCase
@@ -431,17 +432,5 @@ class AppListViewModel(
         list: List<AppInfo>,
         sortBy: SortBy,
         order: SortOrder
-    ): List<AppInfo> {
-        val comparator = when (sortBy) {
-            SortBy.NAME -> compareBy<AppInfo> { it.appName?.lowercase() }
-            SortBy.INSTALL_DATE -> compareBy { it.firstInstallTime }
-            SortBy.LAST_UPDATED -> compareBy { it.lastUpdateTime }
-            SortBy.VERSION_CODE -> compareBy { it.versionCode }
-            SortBy.VERSION_NAME -> compareBy { it.versionName }
-            SortBy.TARGET_SDK_VERSION -> compareBy { it.targetSdk }
-            SortBy.MIN_SDK_VERSION -> compareBy { it.minSdk }
-        }
-        return if (order == SortOrder.ASCENDING) list.sortedWith(comparator)
-        else list.sortedWith(comparator).reversed()
-    }
+    ): List<AppInfo> = sortApps(list, sortBy, order)
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -332,7 +332,7 @@ fun SettingsScreen(
         Spacer(Modifier.height(32.dp))
 
         // ── PERMISSIONS ─────────────────────────────────────────────────────
-        SettingsSectionLabel("PERMISSIONS")
+        SettingsSectionLabel(stringResource(R.string.permissions))
 
         val usageAccessManager = koinInject<UsageAccessManager>()
         val lifecycleOwner = LocalLifecycleOwner.current
@@ -356,11 +356,11 @@ fun SettingsScreen(
         ) {
             SettingsSwitchRow(
                 icon = R.drawable.shield,
-                title = "Usage Access",
+                title = stringResource(R.string.usage_access),
                 subtitle = if (usageGranted) {
-                    "Granted — enables app-size sorting"
+                    stringResource(R.string.usage_access_granted_subtitle)
                 } else {
-                    "Needed to read app sizes for the Size sort"
+                    stringResource(R.string.usage_access_needed_subtitle)
                 },
                 checked = usageGranted,
                 onCheckedChange = {

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,14 +50,19 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.valhalla.thor.R
+import com.valhalla.thor.data.manager.UsageAccessManager
 import com.valhalla.thor.domain.model.AnimationIntensity
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.ThemeMode
 import com.valhalla.asgard.components.ConnectedButtonGroup
 import com.valhalla.asgard.components.ConnectedButtonGroupItem
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -320,6 +326,49 @@ fun SettingsScreen(
                 checked = prefs.biometricLockEnabled,
                 enabled = state.canUseBiometric,
                 onCheckedChange = { viewModel.setBiometricLock(it) }
+            )
+        }
+
+        Spacer(Modifier.height(32.dp))
+
+        // ── PERMISSIONS ─────────────────────────────────────────────────────
+        SettingsSectionLabel("PERMISSIONS")
+
+        val usageAccessManager = koinInject<UsageAccessManager>()
+        val lifecycleOwner = LocalLifecycleOwner.current
+        var usageGranted by remember { mutableStateOf(usageAccessManager.isGranted()) }
+        DisposableEffect(lifecycleOwner) {
+            val observer = LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    usageGranted = usageAccessManager.isGranted()
+                }
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(32.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                .padding(8.dp)
+        ) {
+            SettingsSwitchRow(
+                icon = R.drawable.shield,
+                title = "Usage Access",
+                subtitle = if (usageGranted) {
+                    "Granted — enables app-size sorting"
+                } else {
+                    "Needed to read app sizes for the Size sort"
+                },
+                checked = usageGranted,
+                onCheckedChange = {
+                    // This op can't be toggled in-app; deep-link to system settings.
+                    if (!usageGranted) {
+                        runCatching { context.startActivity(usageAccessManager.usageAccessIntent()) }
+                    }
+                }
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,6 +271,7 @@
     <string name="info_app_version">App version</string>
     <string name="info_sdk_details">SDK details</string>
     <string name="info_sdk_details_format">Target SDK: %1$d   |   Min SDK: %2$d</string>
+    <string name="info_app_size">Size</string>
     <string name="info_installer_source">Installer source</string>
     <string name="info_install_time">Install time</string>
     <string name="info_last_update_time">Last update time</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,15 @@
     <string name="permission_state_granted">Granted</string>
     <string name="permission_state_denied">Denied</string>
 
+    <!-- Usage Access / Size sort -->
+    <string name="permissions">PERMISSIONS</string>
+    <string name="usage_access">Usage Access</string>
+    <string name="usage_access_granted_subtitle">Granted — enables app-size sorting</string>
+    <string name="usage_access_needed_subtitle">Needed to read app sizes for the Size sort</string>
+    <string name="usage_access_needed_title">Usage Access needed</string>
+    <string name="usage_access_prompt_body">Thor needs Usage Access to read app sizes. Enable it for Thor, then pick \"Size\" again. You can also manage this under Settings → Permissions.</string>
+    <string name="open_settings">Open settings</string>
+
     <!-- Quick Settings Tile -->
     <string name="tile_no_privilege">No privilege granted</string>
     <string name="tile_no_apps">No apps</string>

--- a/app/src/test/java/com/valhalla/thor/domain/model/AppSortingTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/AppSortingTest.kt
@@ -1,0 +1,33 @@
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppSortingTest {
+
+    private fun app(pkg: String, size: Long?) = AppInfo(packageName = pkg, installSize = size)
+
+    @Test
+    fun size_ascending_putsNullsFirstThenSmallestToLargest() {
+        val apps = listOf(app("b", 200), app("a", null), app("c", 100))
+        val sorted = sortApps(apps, SortBy.SIZE, SortOrder.ASCENDING).map { it.packageName }
+        assertEquals(listOf("a", "c", "b"), sorted)
+    }
+
+    @Test
+    fun size_descending_putsLargestFirstNullsLast() {
+        val apps = listOf(app("b", 200), app("a", null), app("c", 100))
+        val sorted = sortApps(apps, SortBy.SIZE, SortOrder.DESCENDING).map { it.packageName }
+        assertEquals(listOf("b", "c", "a"), sorted)
+    }
+
+    @Test
+    fun name_ascending_stillWorks() {
+        val apps = listOf(
+            AppInfo(packageName = "p2", appName = "Beta"),
+            AppInfo(packageName = "p1", appName = "alpha")
+        )
+        val sorted = sortApps(apps, SortBy.NAME, SortOrder.ASCENDING).map { it.packageName }
+        assertEquals(listOf("p1", "p2"), sorted)
+    }
+}

--- a/docs/superpowers/plans/2026-07-02-sort-by-size.md
+++ b/docs/superpowers/plans/2026-07-02-sort-by-size.md
@@ -1,0 +1,775 @@
+# Sort Apps by Size (#57) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Size" sort option to the app list, ordering by **total install size** (app + data + cache), with a persisted stale-while-revalidate cache and a Usage-Access permission flow.
+
+**Architecture:** A pure `sortApps()` function (unit-tested) gains a `SIZE` branch. `StorageStatsManager` computes sizes lazily when the user picks "Size"; results update the in-memory list and persist to Room (reused instantly next launch). The `GET_USAGE_STATS` app-op is silently granted via the active privilege gateway when available, always re-verified, with a Settings/dialog fallback.
+
+**Tech Stack:** Kotlin, Coroutines/Flow, Room (KSP, schema export on, currently v4), Koin Annotations (`@Single`/`@KoinViewModel`), Jetpack Compose, `StorageStatsManager`, `AppOpsManager`, JUnit4.
+
+## Global Constraints
+- Build/verify the `fossDebug` variant: `./gradlew :app:testFossDebugUnitTest` (compiles + runs unit tests).
+- Koin is annotation-based, scanned via `@ComponentScan("com.valhalla.thor")` — any `@Single`/`@KoinViewModel` under that package is auto-registered; no `di/Modules.kt` edit needed. `Context` is injectable (existing `@Single` classes take it).
+- minSdk 28: `unsafeCheckOpNoThrow` is API 29+ — guard with a `checkOpNoThrow` fallback for API 28.
+- Privileged shell runs via `SystemRepository.executeShellCommand(cmd): Result<Pair<Int, String?>>`.
+- Never compute sizes in the sort comparator — compute on the scan-triggered path and store on `AppInfo`.
+
+---
+
+### Task 1: Pure `sortApps()` with a SIZE branch (TDD)
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/domain/model/SortBy.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/domain/model/AppInfo.kt`
+- Create: `app/src/main/java/com/valhalla/thor/domain/model/AppSorting.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt` (delegate `getSortedList` to `sortApps`)
+- Test: `app/src/test/java/com/valhalla/thor/domain/model/AppSortingTest.kt`
+
+**Interfaces:**
+- Produces: `fun sortApps(apps: List<AppInfo>, sortBy: SortBy, order: SortOrder): List<AppInfo>`; `AppInfo.installSize: Long?`; `SortBy.SIZE`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/valhalla/thor/domain/model/AppSortingTest.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppSortingTest {
+
+    private fun app(pkg: String, size: Long?) = AppInfo(packageName = pkg, installSize = size)
+
+    @Test
+    fun size_ascending_putsNullsFirstThenSmallestToLargest() {
+        val apps = listOf(app("b", 200), app("a", null), app("c", 100))
+        val sorted = sortApps(apps, SortBy.SIZE, SortOrder.ASCENDING).map { it.packageName }
+        assertEquals(listOf("a", "c", "b"), sorted)
+    }
+
+    @Test
+    fun size_descending_putsLargestFirstNullsLast() {
+        val apps = listOf(app("b", 200), app("a", null), app("c", 100))
+        val sorted = sortApps(apps, SortBy.SIZE, SortOrder.DESCENDING).map { it.packageName }
+        assertEquals(listOf("b", "c", "a"), sorted)
+    }
+
+    @Test
+    fun name_ascending_stillWorks() {
+        val apps = listOf(
+            AppInfo(packageName = "p2", appName = "Beta"),
+            AppInfo(packageName = "p1", appName = "alpha")
+        )
+        val sorted = sortApps(apps, SortBy.NAME, SortOrder.ASCENDING).map { it.packageName }
+        assertEquals(listOf("p1", "p2"), sorted)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — verify it fails to compile**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.AppSortingTest"`
+Expected: FAIL — `sortApps` unresolved, `SortBy.SIZE` unresolved, `installSize` unresolved.
+
+- [ ] **Step 3: Add `installSize` to `AppInfo`**
+
+In `AppInfo.kt`, add a field as the last constructor property (after `isUadLoadFailed: Boolean = false,` on line 42):
+
+```kotlin
+    val isUadLoadFailed: Boolean = false,
+    /** Total install size in bytes (app + data + cache). null = not yet computed. */
+    val installSize: Long? = null,
+```
+
+- [ ] **Step 4: Uncomment `SIZE` in `SortBy`**
+
+In `SortBy.kt`, change `//SIZE,` → `SIZE,` in the enum, and `//SIZE -> "Size"` → `SIZE -> "Size"` in `asGeneralName()`:
+
+```kotlin
+enum class SortBy {
+    NAME,
+    SIZE,
+    INSTALL_DATE,
+    LAST_UPDATED,
+    VERSION_CODE,
+    VERSION_NAME,
+    TARGET_SDK_VERSION,
+    MIN_SDK_VERSION;
+
+    fun asGeneralName(): String = when (this) {
+        NAME -> "Name"
+        SIZE -> "Size"
+        INSTALL_DATE -> "Install Date"
+        LAST_UPDATED -> "Last Updated"
+        VERSION_CODE -> "Version Code"
+        VERSION_NAME -> "Version Name"
+        TARGET_SDK_VERSION -> "Target SDK Version"
+        MIN_SDK_VERSION -> "Min SDK Version"
+    }
+}
+```
+
+- [ ] **Step 5: Create the pure `sortApps()`**
+
+Create `app/src/main/java/com/valhalla/thor/domain/model/AppSorting.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+/**
+ * Pure, side-effect-free app sorter (unit-tested). Unknown install sizes
+ * (`null`) sort as smallest, so DESCENDING puts the biggest apps first.
+ */
+fun sortApps(apps: List<AppInfo>, sortBy: SortBy, order: SortOrder): List<AppInfo> {
+    val comparator = when (sortBy) {
+        SortBy.NAME -> compareBy<AppInfo> { it.appName?.lowercase() }
+        SortBy.SIZE -> compareBy(nullsFirst<Long>()) { it.installSize }
+        SortBy.INSTALL_DATE -> compareBy { it.firstInstallTime }
+        SortBy.LAST_UPDATED -> compareBy { it.lastUpdateTime }
+        SortBy.VERSION_CODE -> compareBy { it.versionCode }
+        SortBy.VERSION_NAME -> compareBy { it.versionName }
+        SortBy.TARGET_SDK_VERSION -> compareBy { it.targetSdk }
+        SortBy.MIN_SDK_VERSION -> compareBy { it.minSdk }
+    }
+    return if (order == SortOrder.ASCENDING) apps.sortedWith(comparator)
+    else apps.sortedWith(comparator).reversed()
+}
+```
+
+- [ ] **Step 6: Run the test — verify it passes**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.AppSortingTest"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Delegate the VM's private `getSortedList` to `sortApps`**
+
+In `AppListViewModel.kt`, replace the entire body of `private fun getSortedList(list, sortBy, order)` (the `when` comparator + the ascending/descending return) with:
+
+```kotlin
+    private fun getSortedList(
+        list: List<AppInfo>,
+        sortBy: SortBy,
+        order: SortOrder
+    ): List<AppInfo> = sortApps(list, sortBy, order)
+```
+
+Add the import `import com.valhalla.thor.domain.model.sortApps` if the IDE doesn't infer it (same package prefix, likely already visible).
+
+- [ ] **Step 8: Compile the app + rerun the test**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.AppSortingTest"`
+Expected: BUILD SUCCESSFUL, 3 tests pass, app compiles.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/SortBy.kt \
+        app/src/main/java/com/valhalla/thor/domain/model/AppInfo.kt \
+        app/src/main/java/com/valhalla/thor/domain/model/AppSorting.kt \
+        app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt \
+        app/src/test/java/com/valhalla/thor/domain/model/AppSortingTest.kt
+git commit -m "feat(applist): add Size sort option + pure sortApps() (#57)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Persist install size in Room (cache)
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/data/source/local/room/AppEntity.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/data/source/local/room/AppDatabase.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/domain/repository/AppRepository.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt`
+
+**Interfaces:**
+- Consumes: `AppInfo.installSize` (Task 1).
+- Produces: `AppRepository.updateInstallSizes(sizes: Map<String, Long>)`; `AppDao.updateInstallSizes(...)`; persisted `apps.installSize` column.
+
+- [ ] **Step 1: Add the column + mappers to `AppEntity`**
+
+In `AppEntity.kt`: add `val installSize: Long? = null` as the last constructor property (after `isSuspended: Boolean`); in `toDomain()` add `installSize = installSize`; in `fromDomain()` add `installSize = appInfo.installSize`:
+
+```kotlin
+    val isSuspended: Boolean,
+    val installSize: Long? = null
+) {
+    fun toDomain(): AppInfo {
+        return AppInfo(
+            // ...existing fields unchanged...
+            isSuspended = isSuspended,
+            installSize = installSize
+        )
+    }
+
+    companion object {
+        fun fromDomain(appInfo: AppInfo): AppEntity {
+            return AppEntity(
+                // ...existing fields unchanged...
+                isSuspended = appInfo.isSuspended,
+                installSize = appInfo.installSize
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Bump the DB version + add the auto-migration**
+
+In `AppDatabase.kt`, change `version = 4` → `version = 5` and add `AutoMigration(from = 4, to = 5)` to the `autoMigrations` list:
+
+```kotlin
+    version = 5,
+    autoMigrations = [
+        AutoMigration(from = 2, to = 3),
+        AutoMigration(from = 3, to = 4),
+        AutoMigration(from = 4, to = 5)
+    ],
+```
+
+(Adding a **nullable** column is a valid Room auto-migration — no `defaultValue` needed.)
+
+- [ ] **Step 3: Add the DAO update methods**
+
+In `AppDao.kt`, add before `@Query("DELETE FROM apps") suspend fun clearAll()`:
+
+```kotlin
+    @Query("UPDATE apps SET installSize = :size WHERE packageName = :packageName")
+    suspend fun updateInstallSize(packageName: String, size: Long?)
+
+    @Transaction
+    suspend fun updateInstallSizes(sizes: Map<String, Long>) {
+        sizes.forEach { (pkg, size) -> updateInstallSize(pkg, size) }
+    }
+```
+
+- [ ] **Step 4: Expose it on `AppRepository`**
+
+In `AppRepository.kt` add to the interface:
+
+```kotlin
+    /** Persist freshly-computed total install sizes into the app cache. */
+    suspend fun updateInstallSizes(sizes: Map<String, Long>)
+```
+
+In `AppRepositoryImpl.kt` add the override (the class already holds `private val appDao: AppDao`):
+
+```kotlin
+    override suspend fun updateInstallSizes(sizes: Map<String, Long>) {
+        appDao.updateInstallSizes(sizes)
+    }
+```
+
+- [ ] **Step 5: Compile (this also regenerates the Room schema `5.json`)**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL. A new `app/schemas/.../5.json` is generated (Room schema export).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/data/source/local/room/AppEntity.kt \
+        app/src/main/java/com/valhalla/thor/data/source/local/room/AppDatabase.kt \
+        app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt \
+        app/src/main/java/com/valhalla/thor/domain/repository/AppRepository.kt \
+        app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt \
+        app/schemas
+git commit -m "feat(data): persist installSize in Room (v5 auto-migration) (#57)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `StorageStatsHelper` — compute total install sizes
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt`
+
+**Interfaces:**
+- Produces: `@Single class StorageStatsHelper(Context)` with `suspend fun installSizes(packages: List<String>): Map<String, Long>`.
+
+- [ ] **Step 1: Create the helper**
+
+Create `app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt`:
+
+```kotlin
+package com.valhalla.thor.data.manager
+
+import android.app.usage.StorageStatsManager
+import android.content.Context
+import android.os.Process
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
+
+/**
+ * Computes total install size (app + data + cache) per package via
+ * StorageStatsManager. Requires the GET_USAGE_STATS app-op for other packages
+ * (see UsageAccessManager) — a per-package failure is skipped, never thrown.
+ */
+@Single
+class StorageStatsHelper(private val context: Context) {
+
+    private val statsManager = context.getSystemService(StorageStatsManager::class.java)
+    private val pm = context.packageManager
+    private val user = Process.myUserHandle()
+
+    suspend fun installSizes(packages: List<String>): Map<String, Long> =
+        withContext(Dispatchers.IO) {
+            val out = HashMap<String, Long>(packages.size)
+            for (pkg in packages) {
+                val size = runCatching {
+                    val ai = pm.getApplicationInfo(pkg, 0)
+                    val stats = statsManager.queryStatsForPackage(ai.storageUuid, pkg, user)
+                    stats.appBytes + stats.dataBytes + stats.cacheBytes
+                }.getOrNull()
+                if (size != null) out[pkg] = size
+            }
+            out
+        }
+}
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
+git commit -m "feat(data): StorageStatsHelper for total install size (#57)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Usage-access permission + silent grant
+
+**Files:**
+- Modify: `app/src/main/AndroidManifest.xml`
+- Create: `app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt`
+
+**Interfaces:**
+- Consumes: `SystemRepository.executeShellCommand`.
+- Produces: `@Single class UsageAccessManager(Context, SystemRepository)` with `fun isGranted(): Boolean`, `suspend fun tryGrantViaPrivilege(): Boolean`, `suspend fun maybeAutoGrant()`, `fun usageAccessIntent(): Intent`.
+
+- [ ] **Step 1: Declare the permission**
+
+In `AndroidManifest.xml`, add after the `RECEIVE_BOOT_COMPLETED` line:
+
+```xml
+    <uses-permission
+        android:name="android.permission.PACKAGE_USAGE_STATS"
+        tools:ignore="ProtectedPermissions" />
+```
+
+- [ ] **Step 2: Create `UsageAccessManager`**
+
+Create `app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt`:
+
+```kotlin
+package com.valhalla.thor.data.manager
+
+import android.app.AppOpsManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Process
+import android.provider.Settings
+import com.valhalla.thor.domain.repository.SystemRepository
+import org.koin.core.annotation.Single
+
+/**
+ * Manages the GET_USAGE_STATS (Usage Access) app-op needed by
+ * StorageStatsManager. Tries a silent grant through the active privilege
+ * gateway; always re-verifies; exposes the Settings deep-link for the fallback.
+ */
+@Single
+class UsageAccessManager(
+    private val context: Context,
+    private val systemRepository: SystemRepository
+) {
+    private val appOps = context.getSystemService(AppOpsManager::class.java)
+    private val pkg = context.packageName
+
+    @Volatile
+    private var autoGrantAttempted = false
+
+    fun isGranted(): Boolean {
+        val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            appOps.unsafeCheckOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
+        } else {
+            @Suppress("DEPRECATION")
+            appOps.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
+        }
+        return mode == AppOpsManager.MODE_ALLOWED
+    }
+
+    /** Best-effort silent grant via a privileged gateway; returns the verified result. */
+    suspend fun tryGrantViaPrivilege(): Boolean {
+        if (isGranted()) return true
+        // Harmless if no privilege is active (command just fails); may also be
+        // blocked on newer Android — hence we re-verify rather than assume success.
+        systemRepository.executeShellCommand("appops set $pkg GET_USAGE_STATS allow")
+        return isGranted()
+    }
+
+    /** One-shot per-process auto-grant, meant to run once a privilege is available. */
+    suspend fun maybeAutoGrant() {
+        if (autoGrantAttempted || isGranted()) return
+        autoGrantAttempted = true
+        tryGrantViaPrivilege()
+    }
+
+    /** Settings deep-link (best-effort per-app; OEMs may land on the list). */
+    fun usageAccessIntent(): Intent =
+        Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).apply {
+            data = Uri.fromParts("package", pkg, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+}
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/AndroidManifest.xml \
+        app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
+git commit -m "feat(perm): UsageAccessManager + PACKAGE_USAGE_STATS (silent grant + fallback) (#57)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Wire the size-sort trigger into `AppListViewModel`
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt`
+
+**Interfaces:**
+- Consumes: `StorageStatsHelper.installSizes`, `UsageAccessManager` (Task 3/4), `AppRepository.updateInstallSizes` (Task 2), `PrivilegeState.hasAnyPrivilege`.
+- Produces: `AppListUiState.isComputingSizes`, `AppListUiState.needsUsageAccessPrompt`; `fun dismissUsageAccessPrompt()`.
+
+- [ ] **Step 1: Add the two UI-state fields**
+
+In `AppListUiState` (top of the file), add after `val isGrid: Boolean = true`:
+
+```kotlin
+    val isGrid: Boolean = true,
+    val isComputingSizes: Boolean = false,
+    val needsUsageAccessPrompt: Boolean = false
+```
+
+- [ ] **Step 2: Inject the new collaborators**
+
+Add to the constructor (after `freezerRepository`) and the matching imports:
+
+```kotlin
+    private val freezerRepository: FreezerRepository,
+    private val appRepository: AppRepository,
+    private val storageStatsHelper: StorageStatsHelper,
+    private val usageAccessManager: UsageAccessManager
+) : ViewModel() {
+```
+
+Imports:
+```kotlin
+import com.valhalla.thor.domain.repository.AppRepository
+import com.valhalla.thor.data.manager.StorageStatsHelper
+import com.valhalla.thor.data.manager.UsageAccessManager
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+```
+
+- [ ] **Step 3: Observe the size-sort trigger + attempt silent grant**
+
+Add a `sizeJob` field next to `appsJob`, call `observeSizeSort()` from `init`, and add the functions. In `init`:
+
+```kotlin
+    init {
+        loadApps()
+        observeSizeSort()
+    }
+```
+
+Add the field near `appsJob`:
+```kotlin
+    private var sizeJob: Job? = null
+```
+
+Add these functions (anywhere in the class body):
+
+```kotlin
+    // Recompute total install sizes when Size is the active sort AND apps are loaded
+    // (fires both when the user picks Size and when the list finishes loading with
+    // Size already selected). distinctUntilChanged prevents a self-trigger loop.
+    private fun observeSizeSort() {
+        viewModelScope.launch {
+            combine(
+                preferenceRepository.userPreferences.map { it.appSortBy }.distinctUntilChanged(),
+                _rawState.map { it.allUserApps.size + it.allSystemApps.size }.distinctUntilChanged()
+            ) { sortBy, appCount -> sortBy to appCount }
+                .collect { (sortBy, appCount) ->
+                    if (sortBy == SortBy.SIZE && appCount > 0) ensureInstallSizes()
+                }
+        }
+    }
+
+    private fun ensureInstallSizes() {
+        sizeJob?.cancel()
+        sizeJob = viewModelScope.launch {
+            if (!usageAccessManager.isGranted() && !usageAccessManager.tryGrantViaPrivilege()) {
+                _rawState.update { it.copy(needsUsageAccessPrompt = true) }
+                return@launch
+            }
+            _rawState.update { it.copy(isComputingSizes = true) }
+            val packages = (_rawState.value.allUserApps + _rawState.value.allSystemApps)
+                .map { it.packageName }
+            val sizes = storageStatsHelper.installSizes(packages)
+            _rawState.update { state ->
+                state.copy(
+                    isComputingSizes = false,
+                    allUserApps = state.allUserApps.map {
+                        it.copy(installSize = sizes[it.packageName] ?: it.installSize)
+                    },
+                    allSystemApps = state.allSystemApps.map {
+                        it.copy(installSize = sizes[it.packageName] ?: it.installSize)
+                    }
+                )
+            }
+            appRepository.updateInstallSizes(sizes)
+        }
+    }
+
+    fun dismissUsageAccessPrompt() {
+        _rawState.update { it.copy(needsUsageAccessPrompt = false) }
+    }
+```
+
+- [ ] **Step 4: Silent-grant on first privilege**
+
+In `loadApps()`, inside the `.collect { (user, system, priv) -> ... }` block, after the `_rawState.update { ... }`, add:
+
+```kotlin
+                if (priv.hasAnyPrivilege) {
+                    launch { usageAccessManager.maybeAutoGrant() }
+                }
+```
+
+(`maybeAutoGrant()` is idempotent — the `autoGrantAttempted` guard makes repeated emissions cheap.)
+
+- [ ] **Step 5: Compile + rerun Task 1's test**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.AppSortingTest"`
+Expected: BUILD SUCCESSFUL; app compiles; 3 tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+git commit -m "feat(applist): compute/persist install sizes on Size sort (#57)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: App-list UI — loading + Usage-Access dialog
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt`
+
+**Interfaces:**
+- Consumes: `AppListUiState.isComputingSizes`, `AppListUiState.needsUsageAccessPrompt`, `AppListViewModel.dismissUsageAccessPrompt()`, `UsageAccessManager.usageAccessIntent()` (via `koinInject`).
+
+- [ ] **Step 1: Show the "computing sizes" affordance**
+
+In `AppListScreen.kt`, where the loader is gated on `state.isLoading` (the top-of-list loading branch), also trigger it while sizes compute — change the condition to include `|| state.isComputingSizes` (only affects the first, uncached computation). Locate the existing `state.isLoading` usage in the list header and OR-in `state.isComputingSizes`.
+
+- [ ] **Step 2: Show the Usage-Access dialog**
+
+Add near the other dialogs in the screen (using `androidx.compose.material3.AlertDialog`), pulling the intent from Koin:
+
+```kotlin
+val ctx = LocalContext.current
+val usageAccessManager = org.koin.compose.koinInject<com.valhalla.thor.data.manager.UsageAccessManager>()
+if (state.needsUsageAccessPrompt) {
+    AlertDialog(
+        onDismissRequest = { viewModel.dismissUsageAccessPrompt() },
+        title = { Text("Usage Access needed") },
+        text = { Text("Thor needs Usage Access to read app sizes. Enable it for Thor, then pick \"Size\" again. You can also manage this under Settings → Permissions.") },
+        confirmButton = {
+            TextButton(onClick = {
+                runCatching { ctx.startActivity(usageAccessManager.usageAccessIntent()) }
+                viewModel.dismissUsageAccessPrompt()
+            }) { Text("Open settings") }
+        },
+        dismissButton = {
+            TextButton(onClick = { viewModel.dismissUsageAccessPrompt() }) { Text("Cancel") }
+        }
+    )
+}
+```
+
+Add imports as needed: `androidx.compose.material3.AlertDialog`, `TextButton`, `Text`, `androidx.compose.ui.platform.LocalContext`.
+
+- [ ] **Step 3: Compile**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+git commit -m "feat(applist): size-computing loader + Usage-Access dialog (#57)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Settings → new "Permissions" section
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt`
+- Modify (if it exists / drives the screen): `app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt`
+
+**Interfaces:**
+- Consumes: `UsageAccessManager.isGranted()` / `usageAccessIntent()` (via `koinInject`).
+
+- [ ] **Step 1: Add a PERMISSIONS section that reflects live grant state**
+
+In `SettingsScreen.kt`, after the SECURITY section (before ABOUT), add a new section using the existing `SettingsSectionLabel` and a status/switch row. Re-check the grant on `ON_RESUME` so returning from settings updates it. Concretely:
+
+```kotlin
+// ── PERMISSIONS ─────────────────────────────────────────────────────
+SettingsSectionLabel("PERMISSIONS")
+
+val context = LocalContext.current
+val usageAccessManager = org.koin.compose.koinInject<com.valhalla.thor.data.manager.UsageAccessManager>()
+val lifecycleOwner = LocalLifecycleOwner.current
+var usageGranted by remember { mutableStateOf(usageAccessManager.isGranted()) }
+DisposableEffect(lifecycleOwner) {
+    val obs = LifecycleEventObserver { _, event ->
+        if (event == Lifecycle.Event.ON_RESUME) usageGranted = usageAccessManager.isGranted()
+    }
+    lifecycleOwner.lifecycle.addObserver(obs)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(obs) }
+}
+
+SettingsSwitchRow(
+    icon = R.drawable.<pick_an_existing_stats_or_info_icon>,   // e.g. an existing chart/info drawable
+    title = "Usage Access",
+    subtitle = if (usageGranted) "Granted — enables app-size sorting"
+               else "Needed to read app sizes for the Size sort",
+    checked = usageGranted,
+    onCheckedChange = { desired ->
+        // The app can't toggle this op directly; deep-link to system settings.
+        if (!usageGranted) runCatching { context.startActivity(usageAccessManager.usageAccessIntent()) }
+    }
+)
+```
+
+Match the exact `SettingsSwitchRow(...)` parameter names to the existing definition in this file (it is used by the AMOLED / Dynamic Colors / Biometric rows — mirror one of those). Pick an existing drawable for the icon (grep `R.drawable.` usages in this file for a suitable one). Add imports: `LocalContext`, `LocalLifecycleOwner`, `DisposableEffect`, `remember`, `mutableStateOf`, `getValue`, `setValue`, `androidx.lifecycle.Lifecycle`, `androidx.lifecycle.LifecycleEventObserver`.
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+git commit -m "feat(settings): Permissions section with Usage Access status (#57)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: (Optional) Show size in the App Info details sheet
+
+**Files:**
+- Modify: the App Info details composable (`app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt` or the sheet that renders `AppInfo` metadata).
+
+**Interfaces:**
+- Consumes: `AppInfo.installSize`.
+
+- [ ] **Step 1: Add a metadata row for size (only when known)**
+
+Where the sheet renders metadata rows (version / SDK / installer), add, guarded by non-null:
+
+```kotlin
+appInfo.installSize?.let { bytes ->
+    // Match the existing metadata-row composable used for Version / Installer etc.
+    MetadataRow(label = "Size", value = android.text.format.Formatter.formatShortFileSize(context, bytes))
+}
+```
+
+Match the existing metadata-row composable + `context` source in that file.
+
+- [ ] **Step 2: Compile + commit**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+git commit -m "feat(applist): show total install size in App Info sheet (#57)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Full verification, manual test, push & PR
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full unit tests + assemble**
+
+Run: `./gradlew :app:testFossDebugUnitTest && ./gradlew assembleFossDebug`
+Expected: BUILD SUCCESSFUL; `AppSortingTest` (3) + existing tests pass; APK assembles (confirms Koin resolves `StorageStatsHelper`/`UsageAccessManager` into the VM).
+
+- [ ] **Step 2: Manual verification (device)**
+
+- Root/Shizuku device: launch → open Apps → Sort → **Size**. First time: brief compute, list orders by total size; the App Info sheet size matches. On silent-grant-capable OS, no prompt appeared.
+- Relaunch the app → Size sort shows the **cached** order instantly, then refreshes.
+- Android 16+ / Dhizuku / no privilege where silent grant fails: picking Size shows the **Usage Access** dialog → Open settings → toggle Thor → return → pick Size again → works.
+- Settings → **Permissions** → Usage Access shows "Granted" (or opens settings); state updates on resume.
+- Toggle asc/desc; confirm largest-first on descending; confirm no jank on a large list.
+
+- [ ] **Step 3: Push + open PR into `dev`**
+
+```bash
+git push -u origin feat/sort-by-size
+gh pr create --base dev --head feat/sort-by-size \
+  --title "feat: sort apps by total install size (#57)" \
+  --body "Implements #57. See docs/superpowers/specs/2026-07-02-sort-by-size-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Notes for the implementer
+- The `build-and-test` PR check (from `pr-ci.yml`) runs on the PR into `dev` — it should pass once the unit tests + assemble are green locally.
+- Sizes refresh on Size-sort selection and on app-load-with-Size-active; a mid-session pull-to-refresh does **not** force a size recompute (acceptable for v1 — sizes update on next Size selection / relaunch).
+- Do NOT compute sizes in `sortApps()` / `processList()` — only in `ensureInstallSizes()`.

--- a/docs/superpowers/specs/2026-07-02-sort-by-size-design.md
+++ b/docs/superpowers/specs/2026-07-02-sort-by-size-design.md
@@ -1,0 +1,138 @@
+# Sort Apps by Size — Design
+
+**Date:** 2026-07-02
+**Issue:** #57 — "Sort by Size Option for Installed Apps"
+**Branch:** `feat/sort-by-size`
+
+## Goal
+
+Add a **"Size"** option to the installed-apps sort menu, ordering apps by their
+**total install size** — app code + user data + cache — with a persisted,
+stale-while-revalidate cache and a first-class Usage Access permission flow.
+
+## Decisions
+
+1. **Metric = total install size** (`appBytes + dataBytes + cacheBytes`) via
+   `StorageStatsManager.queryStatsForPackage()`.
+2. **Persisted + stale-while-revalidate.** Sizes are cached in Room and reused on
+   the next launch (shown instantly), then recomputed in the background.
+3. **Permission (`GET_USAGE_STATS`) = best-effort silent grant, always verified,
+   dialog fallback.**
+   - When Thor **first gains a privilege**, it silently attempts to grant itself
+     the app-op via the active gateway (**shell first**: `appops set … GET_USAGE_STATS allow`).
+   - The silent path may be impossible (e.g. Android 16+ tightening) — so we
+     **never assume it worked**: `isGranted()` is re-verified at point of use, and
+     if false we show a dialog that deep-links to Usage Access settings.
+4. **Settings → new "Permissions" section** exposes the Usage Access state
+   persistently (Granted, or a control that opens settings).
+
+## Design
+
+### 1. Domain
+- **`SortBy`** (`domain/model/SortBy.kt`): uncomment `SIZE` (enum +
+  `asGeneralName()` → `"Size"`). The sort menu already renders `SortBy.entries`.
+- **`AppInfo`** (`domain/model/AppInfo.kt`): add `val installSize: Long? = null`
+  (bytes; `null` = unknown / not yet computed).
+
+### 2. Persistence — Room cache (stale-while-revalidate)
+- **`AppEntity`**: add `val installSize: Long? = null` column; map it in
+  `fromDomain` / `toAppInfo`.
+- **`AppDatabase`**: bump `version` 4 → 5 and add `AutoMigration(from = 4, to = 5)`
+  (adding a nullable column is a valid auto-migration; schema export is on).
+- **`AppDao`**: add `suspend fun updateInstallSizes(sizes: Map<String, Long>)` (or
+  a batch update) to write freshly-computed sizes back into the `apps` table.
+- Behavior: the cached `installSize` is served immediately on next launch; a
+  background recompute (below) refreshes it. New apps with no cached size sort as
+  unknown until the background pass fills them.
+
+### 3. Storage-stats source (new)
+- **`StorageStatsHelper`** (`data/…`):
+  `suspend fun installSizes(packages: List<String>): Map<String, Long>` using
+  `getSystemService(StorageStatsManager::class.java).queryStatsForPackage(app.storageUuid, pkg, Process.myUserHandle())`
+  and summing `appBytes + dataBytes + cacheBytes`. On `Dispatchers.IO`; a
+  per-package failure is skipped (stays unknown), never throws.
+
+### 4. Usage-access permission (new)
+- **Manifest:** add `<uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" tools:ignore="ProtectedPermissions"/>`.
+- **`UsageAccessManager`** (new; or `SystemRepository` methods):
+  - `fun isGranted(): Boolean` — `AppOpsManager` `unsafeCheckOpNoThrow(OPSTR_GET_USAGE_STATS, myUid, packageName) == MODE_ALLOWED` (API 28 fallback: `checkOpNoThrow`).
+  - `suspend fun tryGrantViaPrivilege(): Boolean` — if a privileged gateway is
+    active, `executeShellCommand("appops set com.valhalla.thor GET_USAGE_STATS allow")`
+    (shell first), then re-check `isGranted()`. Returns the verified result.
+  - `fun usageAccessIntent(): Intent` — `ACTION_USAGE_ACCESS_SETTINGS` with
+    `data = Uri.fromParts("package", packageName, null)` (best-effort per-app
+    deep-link), falling back to the plain action on failure.
+- **Proactive silent grant (PrivilegeManager hook):** observe
+  `PrivilegeManager.state`; the first time `hasAnyPrivilege` becomes true and
+  Usage Access is not granted, call `tryGrantViaPrivilege()` **once** (guarded by a
+  DataStore flag so we don't retry every launch). Best-effort — failure is fine.
+
+### 5. Settings → "Permissions" section (new UI)
+- New section in `SettingsScreen` (alongside Appearance / Security / About) with a
+  **Usage Access** row:
+  - **Granted:** static "Granted ✓" (the app can't revoke it).
+  - **Not granted:** a `Switch`/action that opens `usageAccessIntent()`.
+  - The row reflects the **real system state**, re-checked on `ON_RESUME` (so
+    returning from settings updates it live).
+- **Caveat (documented in-code):** the per-app deep-link is best-effort and
+  OEM-dependent — some devices land on the Usage Access list instead of Thor's row.
+
+### 6. Sort trigger flow (`presentation/appList/AppListViewModel`)
+When the sort is `SortBy.SIZE` (on selection, or a refresh while size-sort is active):
+1. Sort **immediately** using whatever cached `installSize` values exist (from Room).
+2. If `!isGranted()` → `tryGrantViaPrivilege()`. Still not granted → emit a one-shot
+   `NeedsUsageAccess` UI event; stop (order stays on the cached/unknown result).
+3. Granted → set `isComputingSizes`, call `StorageStatsHelper.installSizes(currentPackages)`
+   off-main, update `_rawState` (`AppInfo.installSize`) **and** persist via
+   `AppDao.updateInstallSizes(...)`, clear the flag → `processList()` re-sorts.
+
+### 7. Sort comparator
+- `getSortedList()`: add `SortBy.SIZE -> compareBy(nullsFirst()) { it.installSize }`
+  (unknown sizes sort smallest; the existing DESC toggle → largest first).
+
+### 8. App-list UI
+- Sort menu: no change (auto-populates).
+- `isComputingSizes` → existing loading affordance (only noticeable on the first,
+  uncached computation).
+- `NeedsUsageAccess` event → dialog: "Thor needs Usage Access to read app sizes",
+  with a button to `usageAccessIntent()` (and a pointer to Settings → Permissions).
+- **Optional (recommended):** show `Formatter.formatShortFileSize(context, installSize)`
+  in the App Info details sheet. Compact list rows unchanged (density).
+
+## Out of scope
+- Per-app breakdown (code vs data vs cache) — one total suffices for sorting.
+- A "size computed at" timestamp (can be added later if we want to surface freshness).
+- Total-vs-APK-size toggle (install size is the chosen metric).
+
+## Error handling / edge cases
+- `StorageStatsManager` failure for a package → `installSize` stays whatever was
+  cached (or `null`); sorts as smallest, no crash.
+- Silent grant fails (Android 16+, Dhizuku, no privilege) → verified `isGranted()`
+  is false → dialog / Settings path; the rest of the app is unaffected.
+- Permission revoked externally → next `isGranted()` check re-triggers the flow;
+  cached sizes remain until a successful recompute.
+- Cold cache / new install → size unknown until first successful compute.
+
+## Testing
+- **Unit test** the comparator: `getSortedList` orders a fixed `List<AppInfo>` by
+  `installSize` ascending/descending with `null` first. (StorageStats query,
+  app-op grant, and the Settings deep-link are device/permission-dependent →
+  manual verification.)
+- **Manual:** root & Shizuku → first launch after privilege → confirm silent grant
+  (where OS allows) → "Size" sorts correctly, sizes match the App Info sheet, and
+  values persist across a relaunch (instant on next open). Android 16+/Dhizuku/no
+  privilege → confirm the dialog + Settings → Permissions flow and live re-check
+  on resume. Toggle asc/desc; verify a clean loading state on the first (uncached)
+  compute of a large list.
+
+## Files touched
+- `domain/model/SortBy.kt`, `domain/model/AppInfo.kt`
+- `data/source/local/room/AppEntity.kt`, `AppDatabase.kt` (v5 + AutoMigration), `AppDao.kt`
+- `data/…/StorageStatsHelper.kt` (new)
+- usage-access check/grant (new `UsageAccessManager` and/or `SystemRepository`/gateway) + the PrivilegeManager hook
+- `AndroidManifest.xml` (+`PACKAGE_USAGE_STATS`)
+- `presentation/appList/AppListViewModel.kt` (trigger flow, loading, event, comparator)
+- `presentation/appList/AppListScreen.kt` / widgets (loading + `NeedsUsageAccess` dialog)
+- `presentation/settings/SettingsScreen.kt` (+ ViewModel) — new **Permissions** section
+- *(optional)* App Info details sheet (formatted size)
+- test: comparator unit test


### PR DESCRIPTION
## Summary

Implements **#57 — sort installed apps by size**, where "size" is the **total install size** (app + user data + cache), not just the APK.

Design + plan: `docs/superpowers/specs/2026-07-02-sort-by-size-design.md`, `docs/superpowers/plans/2026-07-02-sort-by-size.md`.

## What it does

- **New "Size" sort** in the app list — `SortBy.SIZE` via a pure, unit-tested `sortApps()` (unknown sizes sort smallest, so descending shows the biggest apps first).
- **Total install size** computed via `StorageStatsManager`, **lazily** — only when you pick "Size" — off the main thread.
- **Persisted stale-while-revalidate cache** in Room (`installSize` column, v4→v5 auto-migration): sizes show instantly on next launch, then refresh. `syncCache` preserves the persisted size across re-syncs.
- **Usage Access (`GET_USAGE_STATS`) permission flow:** silently granted via the active root/Shizuku gateway (`appops set … allow`, scoped to Thor, always re-verified), with a one-time in-list dialog + a new **Settings → Permissions** section (live grant state, re-checked on resume) as the Android-16-safe fallback.
- Total size also shown in the **App Info** details sheet.

## Testing

- ✅ `./gradlew :app:testFossDebugUnitTest` — `AppSortingTest` (3) + existing tests pass.
- ✅ `./gradlew assembleFossDebug` — Koin resolves the new `@Single` collaborators into the ViewModel; APK packages.
- Manual (per plan Task 9): root/Shizuku silent grant → Size sorts correctly + sizes persist across relaunch; Dhizuku/no-privilege → Usage-Access dialog + Settings flow; asc/desc; size visible in App Info.

## How it was built

Subagent-driven: 10 task commits, each implementer-then-reviewer gated, plus a whole-branch review (verdict: ready to merge). Two review-caught defects were fixed mid-flight — `syncCache` wiping the persisted size, and the App Info "Size" row being dead because the details fetch didn't carry the cached size.

**Known follow-ups (review-accepted, non-blocking):** ON_RESUME auto-populate after granting; `AtomicBoolean` for the one-shot grant guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
