### PR TITLE
feat: export app to folder (Downloads/Thor or SAF) (#164)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -209,6 +209,7 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.splashscreen)
     implementation(libs.androidx.core.ktx)
+    implementation("androidx.documentfile:documentfile:1.0.1")
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.biometric)
     implementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
     <uses-permission android:name="com.rosan.dhizuku.permission.API" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
         android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
 

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -48,6 +48,9 @@ class PreferenceRepositoryImpl(
         // Localization
         val LANGUAGE = stringPreferencesKey("language")
 
+        // Export
+        val EXPORT_DIR_URI = stringPreferencesKey("export_dir_uri")
+
         // Auto Freeze
         val AUTO_FREEZE = booleanPreferencesKey("auto_freeze")
 
@@ -118,7 +121,8 @@ class PreferenceRepositoryImpl(
                 animationIntensity = animationIntensity,
                 appListIsGrid = appListIsGrid,
                 freezerIsGrid = freezerIsGrid,
-                extensionsUnlocked = prefs[Keys.EXTENSIONS_UNLOCKED] ?: false
+                extensionsUnlocked = prefs[Keys.EXTENSIONS_UNLOCKED] ?: false,
+                exportDirUri = prefs[Keys.EXPORT_DIR_URI]
             )
         }
 
@@ -176,6 +180,13 @@ class PreferenceRepositoryImpl(
         context.dataStore.edit {
             if (language == null) it.remove(Keys.LANGUAGE)
             else it[Keys.LANGUAGE] = language
+        }
+    }
+
+    override suspend fun setExportDirUri(uri: String?) {
+        context.dataStore.edit {
+            if (uri == null) it.remove(Keys.EXPORT_DIR_URI)
+            else it[Keys.EXPORT_DIR_URI] = uri
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/domain/model/ExportTarget.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ExportTarget.kt
@@ -1,0 +1,31 @@
+package com.valhalla.thor.domain.model
+
+/** Where an export should be written. */
+sealed interface ExportTargetChoice {
+    /** Public Downloads/Thor (MediaStore / legacy). */
+    data object Downloads : ExportTargetChoice
+    /** A user-picked SAF tree (persisted URI string). */
+    data class Custom(val treeUri: String) : ExportTargetChoice
+}
+
+/**
+ * @param clearSavedDir true when a saved-but-invalid dir should be cleared from prefs.
+ */
+data class ExportTargetResolution(
+    val choice: ExportTargetChoice,
+    val clearSavedDir: Boolean
+)
+
+/**
+ * Pure resolver: use the saved SAF dir only if it is still valid; otherwise fall
+ * back to Downloads (and signal a clear when a stale dir was saved).
+ */
+fun resolveExportTarget(savedUri: String?, isSavedValid: Boolean): ExportTargetResolution =
+    when {
+        savedUri != null && isSavedValid ->
+            ExportTargetResolution(ExportTargetChoice.Custom(savedUri), clearSavedDir = false)
+        savedUri != null ->
+            ExportTargetResolution(ExportTargetChoice.Downloads, clearSavedDir = true)
+        else ->
+            ExportTargetResolution(ExportTargetChoice.Downloads, clearSavedDir = false)
+    }

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -44,7 +44,10 @@ data class UserPreferences(
     val freezerIsGrid: Boolean = true,
 
     // Extensions (hidden until unlocked via the home-screen easter egg — feature not yet stable)
-    val extensionsUnlocked: Boolean = false
+    val extensionsUnlocked: Boolean = false,
+
+    // Export destination (persisted SAF tree URI; null = default Downloads/Thor)
+    val exportDirUri: String? = null
 )
 
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -34,6 +34,9 @@ interface PreferenceRepository {
     // --- Localization ---
     suspend fun setLanguage(language: String?)
 
+    // --- Export ---
+    suspend fun setExportDirUri(uri: String?)
+
     // --- Auto Freeze ---
     suspend fun setAutoFreezeEnabled(enabled: Boolean)
 

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/AppBundleBuilder.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/AppBundleBuilder.kt
@@ -1,0 +1,107 @@
+package com.valhalla.thor.domain.usecase
+
+import com.valhalla.thor.BuildConfig
+import android.content.Context
+import com.valhalla.thor.data.util.ApksMetadataGenerator
+import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.formattedAppName
+import com.valhalla.thor.domain.repository.SystemRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Builds a shareable/exportable app bundle in the cache dir: a single `.apk` for
+ * apps with no splits, an `.apks` (base + splits + metadata.json + manifest.json)
+ * for split apps. Copies with a root fallback for protected/system apps.
+ */
+@Single
+class AppBundleBuilder(
+    private val context: Context,
+    private val systemRepository: SystemRepository,
+    private val apksMetadataGenerator: ApksMetadataGenerator
+) {
+    suspend fun build(appInfo: AppInfo): Result<File> = withContext(Dispatchers.IO) {
+        try {
+            val cacheDir = File(context.cacheDir, "share_temp")
+            if (cacheDir.exists()) cacheDir.deleteRecursively()
+            cacheDir.mkdirs()
+
+            val finalFile: File
+            if (appInfo.splitPublicSourceDirs.isEmpty()) {
+                val sourcePath = appInfo.publicSourceDir ?: appInfo.sourceDir
+                    ?: return@withContext Result.failure(Exception("No source path found"))
+                finalFile = File(cacheDir, "${appInfo.formattedAppName()}_${appInfo.versionName}.apk")
+                if (!copyFileSafely(sourcePath, finalFile)) {
+                    return@withContext Result.failure(Exception("Failed to copy base APK"))
+                }
+            } else {
+                finalFile = File(cacheDir, "${appInfo.formattedAppName()}_${appInfo.versionName}.apks")
+                val tempSplitDir = File(cacheDir, "splits_staging")
+                tempSplitDir.mkdirs()
+
+                val allPaths = mutableListOf<String>()
+                appInfo.sourceDir?.let { allPaths.add(it) }
+                allPaths.addAll(appInfo.splitPublicSourceDirs)
+
+                val filesToZip = allPaths.mapNotNull { path ->
+                    val destFile = File(tempSplitDir, path.substringAfterLast("/"))
+                    if (copyFileSafely(path, destFile)) destFile else null
+                }.toMutableList()
+                if (filesToZip.isEmpty()) {
+                    return@withContext Result.failure(Exception("Failed to copy any APK files"))
+                }
+
+                val metadataFile = File(tempSplitDir, "metadata.json")
+                apksMetadataGenerator.generateJson(appInfo, metadataFile)
+                filesToZip.add(metadataFile)
+
+                val manifestFile = File(tempSplitDir, "manifest.json")
+                apksMetadataGenerator.generateManifestJson(appInfo, manifestFile)
+                filesToZip.add(manifestFile)
+
+                zipFiles(filesToZip, finalFile)
+                tempSplitDir.deleteRecursively()
+            }
+            Result.success(finalFile)
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) e.printStackTrace()
+            Result.failure(e)
+        }
+    }
+
+    private suspend fun copyFileSafely(sourcePath: String, destFile: File): Boolean {
+        return try {
+            File(sourcePath).copyTo(destFile, overwrite = true)
+            true
+        } catch (_: Exception) {
+            systemRepository.copyFileWithRoot(sourcePath, destFile.absolutePath).isSuccess
+        }
+    }
+
+    private fun zipFiles(files: List<File>, zipFile: File) {
+        ZipOutputStream(BufferedOutputStream(FileOutputStream(zipFile))).use { out ->
+            val data = ByteArray(1024)
+            files.forEach { file ->
+                FileInputStream(file).use { fi ->
+                    BufferedInputStream(fi).use { origin ->
+                        val entry = ZipEntry(file.name)
+                        out.putNextEntry(entry)
+                        while (true) {
+                            val readBytes = origin.read(data)
+                            if (readBytes == -1) break
+                            out.write(data, 0, readBytes)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/AppBundleBuilder.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/AppBundleBuilder.kt
@@ -91,7 +91,8 @@ class AppBundleBuilder(
 
     private fun zipFiles(files: List<File>, zipFile: File) {
         ZipOutputStream(BufferedOutputStream(FileOutputStream(zipFile))).use { out ->
-            val data = ByteArray(1024)
+            // 8 KB buffer — 1 KB is needlessly slow when zipping multi-MB APK splits.
+            val data = ByteArray(8192)
             files.forEach { file ->
                 FileInputStream(file).use { fi ->
                     BufferedInputStream(fi).use { origin ->

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/AppBundleBuilder.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/AppBundleBuilder.kt
@@ -6,6 +6,7 @@ import com.valhalla.thor.data.util.ApksMetadataGenerator
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.formattedAppName
 import com.valhalla.thor.domain.repository.SystemRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
@@ -28,9 +29,9 @@ class AppBundleBuilder(
     private val systemRepository: SystemRepository,
     private val apksMetadataGenerator: ApksMetadataGenerator
 ) {
-    suspend fun build(appInfo: AppInfo): Result<File> = withContext(Dispatchers.IO) {
+    suspend fun build(appInfo: AppInfo, cacheSubDir: String = "share_temp"): Result<File> = withContext(Dispatchers.IO) {
         try {
-            val cacheDir = File(context.cacheDir, "share_temp")
+            val cacheDir = File(context.cacheDir, cacheSubDir)
             if (cacheDir.exists()) cacheDir.deleteRecursively()
             cacheDir.mkdirs()
 
@@ -71,6 +72,8 @@ class AppBundleBuilder(
                 tempSplitDir.deleteRecursively()
             }
             Result.success(finalFile)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             if (BuildConfig.DEBUG) e.printStackTrace()
             Result.failure(e)

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
@@ -9,10 +9,12 @@ import android.provider.MediaStore
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.ExportTargetChoice
 import com.valhalla.thor.domain.model.resolveExportTarget
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -29,7 +31,7 @@ class ExportAppUseCase(
     /** Build the bundle and write it to the resolved target. Returns a location label. */
     suspend operator fun invoke(appInfo: AppInfo): Result<String> = withContext(Dispatchers.IO) {
         try {
-            val file = bundleBuilder.build(appInfo).getOrElse { return@withContext Result.failure(it) }
+            val file = bundleBuilder.build(appInfo, cacheSubDir = "export_temp").getOrElse { return@withContext Result.failure(it) }
             val mime = mimeFor(file)
 
             val savedUri = preferenceRepository.userPreferences.first().exportDirUri
@@ -43,6 +45,8 @@ class ExportAppUseCase(
                     else writeToDownloadsLegacy(file)
             }
             Result.success(location)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             if (BuildConfig.DEBUG) e.printStackTrace()
             Result.failure(e)
@@ -54,8 +58,9 @@ class ExportAppUseCase(
         // SAF validity checks hit the content resolver / disk — keep them off the main thread.
         val savedUri = preferenceRepository.userPreferences.first().exportDirUri
         if (savedUri != null && isTreeWritable(savedUri)) {
-            DocumentFile.fromTreeUri(context, savedUri.toUri())?.name ?: "Selected folder"
-        } else "Downloads/Thor"
+            DocumentFile.fromTreeUri(context, savedUri.toUri())?.name
+                ?: context.getString(R.string.export_dest_selected)
+        } else context.getString(R.string.export_dest_downloads)
     }
 
     private fun mimeFor(file: File) =
@@ -90,7 +95,7 @@ class ExportAppUseCase(
             resolver.delete(uri, null, null) // don't leave a dangling pending entry
             throw e
         }
-        return "Downloads/Thor"
+        return context.getString(R.string.export_dest_downloads)
     }
 
     private fun writeToDownloadsLegacy(source: File): String {
@@ -100,7 +105,7 @@ class ExportAppUseCase(
         )
         if (!dir.exists()) dir.mkdirs()
         source.copyTo(File(dir, source.name), overwrite = true)
-        return "Downloads/Thor"
+        return context.getString(R.string.export_dest_downloads)
     }
 
     private fun writeToTree(source: File, treeUri: Uri, mime: String): String {
@@ -110,6 +115,6 @@ class ExportAppUseCase(
         context.contentResolver.openOutputStream(doc.uri)?.use { out ->
             source.inputStream().use { it.copyTo(out) }
         } ?: throw IOException("openOutputStream failed")
-        return tree.name ?: "Selected folder"
+        return tree.name ?: context.getString(R.string.export_dest_selected)
     }
 }

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
@@ -50,9 +50,10 @@ class ExportAppUseCase(
     }
 
     /** The label shown in the export sheet ("Downloads/Thor" or the saved folder name). */
-    suspend fun currentTargetLabel(): String {
+    suspend fun currentTargetLabel(): String = withContext(Dispatchers.IO) {
+        // SAF validity checks hit the content resolver / disk — keep them off the main thread.
         val savedUri = preferenceRepository.userPreferences.first().exportDirUri
-        return if (savedUri != null && isTreeWritable(savedUri)) {
+        if (savedUri != null && isTreeWritable(savedUri)) {
             DocumentFile.fromTreeUri(context, savedUri.toUri())?.name ?: "Selected folder"
         } else "Downloads/Thor"
     }

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
@@ -1,0 +1,114 @@
+package com.valhalla.thor.domain.usecase
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.core.net.toUri
+import androidx.documentfile.provider.DocumentFile
+import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.ExportTargetChoice
+import com.valhalla.thor.domain.model.resolveExportTarget
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Factory
+import java.io.File
+import java.io.IOException
+
+@Factory
+class ExportAppUseCase(
+    private val context: Context,
+    private val bundleBuilder: AppBundleBuilder,
+    private val preferenceRepository: PreferenceRepository
+) {
+    /** Build the bundle and write it to the resolved target. Returns a location label. */
+    suspend operator fun invoke(appInfo: AppInfo): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val file = bundleBuilder.build(appInfo).getOrElse { return@withContext Result.failure(it) }
+            val mime = mimeFor(file)
+
+            val savedUri = preferenceRepository.userPreferences.first().exportDirUri
+            val resolution = resolveExportTarget(savedUri, isTreeWritable(savedUri))
+            if (resolution.clearSavedDir) preferenceRepository.setExportDirUri(null)
+
+            val location = when (val choice = resolution.choice) {
+                is ExportTargetChoice.Custom -> writeToTree(file, choice.treeUri.toUri(), mime)
+                ExportTargetChoice.Downloads ->
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) writeToDownloads(file, mime)
+                    else writeToDownloadsLegacy(file)
+            }
+            Result.success(location)
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) e.printStackTrace()
+            Result.failure(e)
+        }
+    }
+
+    /** The label shown in the export sheet ("Downloads/Thor" or the saved folder name). */
+    suspend fun currentTargetLabel(): String {
+        val savedUri = preferenceRepository.userPreferences.first().exportDirUri
+        return if (savedUri != null && isTreeWritable(savedUri)) {
+            DocumentFile.fromTreeUri(context, savedUri.toUri())?.name ?: "Selected folder"
+        } else "Downloads/Thor"
+    }
+
+    private fun mimeFor(file: File) =
+        if (file.name.endsWith(".apk")) "application/vnd.android.package-archive"
+        else "application/octet-stream"
+
+    private fun isTreeWritable(uriStr: String?): Boolean {
+        if (uriStr == null) return false
+        return try {
+            val doc = DocumentFile.fromTreeUri(context, uriStr.toUri())
+            doc != null && doc.exists() && doc.canWrite()
+        } catch (_: Exception) { false }
+    }
+
+    private fun writeToDownloads(source: File, mime: String): String {
+        val resolver = context.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.Downloads.DISPLAY_NAME, source.name)
+            put(MediaStore.Downloads.MIME_TYPE, mime)
+            put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/Thor")
+            put(MediaStore.Downloads.IS_PENDING, 1)
+        }
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+            ?: throw IOException("MediaStore insert failed")
+        try {
+            resolver.openOutputStream(uri)?.use { out -> source.inputStream().use { it.copyTo(out) } }
+                ?: throw IOException("openOutputStream failed")
+            values.clear()
+            values.put(MediaStore.Downloads.IS_PENDING, 0)
+            resolver.update(uri, values, null, null)
+        } catch (e: Exception) {
+            resolver.delete(uri, null, null) // don't leave a dangling pending entry
+            throw e
+        }
+        return "Downloads/Thor"
+    }
+
+    private fun writeToDownloadsLegacy(source: File): String {
+        @Suppress("DEPRECATION")
+        val dir = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "Thor"
+        )
+        if (!dir.exists()) dir.mkdirs()
+        source.copyTo(File(dir, source.name), overwrite = true)
+        return "Downloads/Thor"
+    }
+
+    private fun writeToTree(source: File, treeUri: Uri, mime: String): String {
+        val tree = DocumentFile.fromTreeUri(context, treeUri) ?: throw IOException("Invalid folder")
+        tree.findFile(source.name)?.delete() // overwrite
+        val doc = tree.createFile(mime, source.name) ?: throw IOException("Could not create file")
+        context.contentResolver.openOutputStream(doc.uri)?.use { out ->
+            source.inputStream().use { it.copyTo(out) }
+        } ?: throw IOException("openOutputStream failed")
+        return tree.name ?: "Selected folder"
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
@@ -77,10 +77,19 @@ class ExportAppUseCase(
 
     private fun writeToDownloads(source: File, mime: String): String {
         val resolver = context.contentResolver
+        val relativePath = Environment.DIRECTORY_DOWNLOADS + "/Thor/"
+        // MediaStore.insert appends " (1)" instead of overwriting, so delete any same-named
+        // entry first. RELATIVE_PATH must match exactly, including the trailing slash.
+        val selection =
+            "${MediaStore.Downloads.DISPLAY_NAME} = ? AND ${MediaStore.Downloads.RELATIVE_PATH} = ?"
+        val selectionArgs = arrayOf(source.name, relativePath)
+        try {
+            resolver.delete(MediaStore.Downloads.EXTERNAL_CONTENT_URI, selection, selectionArgs)
+        } catch (_: Exception) { /* best-effort overwrite; fall through to insert */ }
         val values = ContentValues().apply {
             put(MediaStore.Downloads.DISPLAY_NAME, source.name)
             put(MediaStore.Downloads.MIME_TYPE, mime)
-            put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/Thor")
+            put(MediaStore.Downloads.RELATIVE_PATH, relativePath)
             put(MediaStore.Downloads.IS_PENDING, 1)
         }
         val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
@@ -112,9 +121,14 @@ class ExportAppUseCase(
         val tree = DocumentFile.fromTreeUri(context, treeUri) ?: throw IOException("Invalid folder")
         tree.findFile(source.name)?.delete() // overwrite
         val doc = tree.createFile(mime, source.name) ?: throw IOException("Could not create file")
-        context.contentResolver.openOutputStream(doc.uri)?.use { out ->
-            source.inputStream().use { it.copyTo(out) }
-        } ?: throw IOException("openOutputStream failed")
+        try {
+            context.contentResolver.openOutputStream(doc.uri)?.use { out ->
+                source.inputStream().use { it.copyTo(out) }
+            } ?: throw IOException("openOutputStream failed")
+        } catch (e: Exception) {
+            doc.delete() // don't leave a partial/corrupted file behind
+            throw e
+        }
         return tree.name ?: context.getString(R.string.export_dest_selected)
     }
 }

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
@@ -1,136 +1,19 @@
 package com.valhalla.thor.domain.usecase
 
 import android.content.Context
+import android.net.Uri
 import androidx.core.content.FileProvider
 import com.valhalla.thor.BuildConfig
-import com.valhalla.thor.data.util.ApksMetadataGenerator
 import com.valhalla.thor.domain.model.AppInfo
-import com.valhalla.thor.domain.model.formattedAppName
-import com.valhalla.thor.domain.repository.SystemRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
-import java.io.BufferedInputStream
-import java.io.BufferedOutputStream
-import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
 
 @Factory
 class ShareAppUseCase(
     private val context: Context,
-    private val systemRepository: SystemRepository,
-    private val apksMetadataGenerator: ApksMetadataGenerator
+    private val bundleBuilder: AppBundleBuilder
 ) {
-
-    suspend operator fun invoke(appInfo: AppInfo): Result<android.net.Uri> =
-        withContext(Dispatchers.IO) {
-            try {
-                // 1. Prepare Cache Directory
-                val cacheDir = File(context.cacheDir, "share_temp")
-                if (cacheDir.exists()) cacheDir.deleteRecursively()
-                cacheDir.mkdirs()
-
-                val finalFile: File
-
-                // 2. Check for Splits
-                if (appInfo.splitPublicSourceDirs.isEmpty()) {
-                    // --- Single APK Mode ---
-                    val sourcePath = appInfo.publicSourceDir ?: appInfo.sourceDir
-                    ?: return@withContext Result.failure(Exception("No source path found"))
-
-                    val fileName = "${appInfo.formattedAppName()}_${appInfo.versionName}.apk"
-                    finalFile = File(cacheDir, fileName)
-
-                    if (!copyFileSafely(sourcePath, finalFile)) {
-                        return@withContext Result.failure(Exception("Failed to copy base APK"))
-                    }
-
-                } else {
-                    // --- Split APK Mode (Zip/APKS) ---
-                    val fileName = "${appInfo.formattedAppName()}_${appInfo.versionName}.apks"
-                    finalFile = File(cacheDir, fileName)
-
-                    // Temp staging folder for individual parts
-                    val tempSplitDir = File(cacheDir, "splits_staging")
-                    tempSplitDir.mkdirs()
-
-                    // A. Gather APK Paths
-                    val allPaths = mutableListOf<String>()
-                    appInfo.sourceDir?.let { allPaths.add(it) }
-                    allPaths.addAll(appInfo.splitPublicSourceDirs)
-
-                    // B. Copy APKs to staging
-                    val filesToZip = allPaths.mapNotNull { path ->
-                        val name = path.substringAfterLast("/")
-                        val destFile = File(tempSplitDir, name)
-                        if (copyFileSafely(path, destFile)) destFile else null
-                    }.toMutableList()
-
-                    if (filesToZip.isEmpty()) {
-                        return@withContext Result.failure(Exception("Failed to copy any APK files"))
-                    }
-
-                    // C. GENERATE METADATA & MANIFEST (The Missing Piece)
-                    // We generate "metadata.json" and "manifest.json" so installers know what this bundle is.
-                    val metadataFile = File(tempSplitDir, "metadata.json")
-                    apksMetadataGenerator.generateJson(appInfo, metadataFile)
-                    filesToZip.add(metadataFile)
-
-                    val manifestFile = File(tempSplitDir, "manifest.json")
-                    apksMetadataGenerator.generateManifestJson(appInfo, manifestFile)
-                    filesToZip.add(manifestFile)
-
-                    // D. Zip Everything (APKs + JSON)
-                    zipFiles(filesToZip, finalFile)
-                    tempSplitDir.deleteRecursively()
-                }
-
-                // 3. Generate URI
-                val uri = FileProvider.getUriForFile(
-                    context,
-                    "${BuildConfig.APPLICATION_ID}.provider",
-                    finalFile
-                )
-                Result.success(uri)
-
-            } catch (e: Exception) {
-                if (BuildConfig.DEBUG)
-                    e.printStackTrace()
-                Result.failure(e)
-            }
+    suspend operator fun invoke(appInfo: AppInfo): Result<Uri> =
+        bundleBuilder.build(appInfo).map { file ->
+            FileProvider.getUriForFile(context, "${BuildConfig.APPLICATION_ID}.provider", file)
         }
-
-    /**
-     * Tries standard copy, falls back to Root if permission denied.
-     */
-    private suspend fun copyFileSafely(sourcePath: String, destFile: File): Boolean {
-        return try {
-            File(sourcePath).copyTo(destFile, overwrite = true)
-            true
-        } catch (_: Exception) {
-            systemRepository.copyFileWithRoot(sourcePath, destFile.absolutePath).isSuccess
-        }
-    }
-
-    private fun zipFiles(files: List<File>, zipFile: File) {
-        ZipOutputStream(BufferedOutputStream(FileOutputStream(zipFile))).use { out ->
-            val data = ByteArray(1024)
-            files.forEach { file ->
-                FileInputStream(file).use { fi ->
-                    BufferedInputStream(fi).use { origin ->
-                        val entry = ZipEntry(file.name)
-                        out.putNextEntry(entry)
-                        while (true) {
-                            val readBytes = origin.read(data)
-                            if (readBytes == -1) break
-                            out.write(data, 0, readBytes)
-                        }
-                    }
-                }
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
@@ -13,7 +13,7 @@ class ShareAppUseCase(
     private val bundleBuilder: AppBundleBuilder
 ) {
     suspend operator fun invoke(appInfo: AppInfo): Result<Uri> =
-        bundleBuilder.build(appInfo).map { file ->
+        bundleBuilder.build(appInfo).mapCatching { file ->
             FileProvider.getUriForFile(context, "${BuildConfig.APPLICATION_ID}.provider", file)
         }
 }

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
@@ -5,6 +5,8 @@ import android.net.Uri
 import androidx.core.content.FileProvider
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.domain.model.AppInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -12,8 +14,9 @@ class ShareAppUseCase(
     private val context: Context,
     private val bundleBuilder: AppBundleBuilder
 ) {
-    suspend operator fun invoke(appInfo: AppInfo): Result<Uri> =
+    suspend operator fun invoke(appInfo: AppInfo): Result<Uri> = withContext(Dispatchers.IO) {
         bundleBuilder.build(appInfo).mapCatching { file ->
             FileProvider.getUriForFile(context, "${BuildConfig.APPLICATION_ID}.provider", file)
         }
+    }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -110,6 +110,7 @@ fun AppInfoDetailsScreen(
     var showClearDataConfirmation by remember { mutableStateOf(false) }
     var showUninstallConfirmation by remember { mutableStateOf(false) }
     var showFreezeConfirmation by remember { mutableStateOf(false) }
+    var showExportSheet by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -229,7 +230,8 @@ fun AppInfoDetailsScreen(
                                 onUninstall = { showUninstallConfirmation = true },
                                 onShare = {
                                     onAppAction(AppClickAction.Share(details.appInfo))
-                                }
+                                },
+                                onExport = { showExportSheet = true }
                             )
                         }
 
@@ -496,6 +498,12 @@ fun AppInfoDetailsScreen(
             )
         }
     }
+
+    if (showExportSheet) {
+        state.detailedInfo?.appInfo?.let { appInfo ->
+            ExportBottomSheet(appInfo = appInfo, onDismiss = { showExportSheet = false })
+        }
+    }
 }
 
 @Composable
@@ -666,7 +674,8 @@ private fun AppDetailsActionRow(
     onClearCache: () -> Unit,
     onClearData: () -> Unit,
     onUninstall: () -> Unit,
-    onShare: () -> Unit
+    onShare: () -> Unit,
+    onExport: () -> Unit
 ) {
     val hasPrivilege = isRoot || isShizuku || isDhizuku
     val isFrozen = !appInfo.enabled
@@ -753,6 +762,12 @@ private fun AppDetailsActionRow(
             icon = R.drawable.share,
             label = stringResource(R.string.action_share),
             onClick = onShare
+        )
+
+        ActionItem(
+            icon = R.drawable.storage,
+            label = stringResource(R.string.action_export),
+            onClick = onExport
         )
 
         if (appInfo.packageName != BuildConfig.APPLICATION_ID) {

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
@@ -244,10 +244,11 @@ fun AppInfoDetailsScreen(
                                 stringResource(R.string.action_permissions)
                             )
 
-                            TabRow(
+                            ScrollableTabRow(
                                 selectedTabIndex = selectedTab,
                                 containerColor = Color.Transparent,
                                 contentColor = MaterialTheme.colorScheme.primary,
+                                edgePadding = 0.dp,
                                 indicator = { tabPositions ->
                                     TabRowDefaults.SecondaryIndicator(
                                         modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTab]),

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -7,15 +7,28 @@ import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -23,18 +36,30 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import coil3.compose.AsyncImage
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.usecase.ExportAppUseCase
+import com.valhalla.thor.presentation.utils.AppIconModel
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
+/**
+ * Destination picker + explainer for exporting an installed app's bundle. Self-contained
+ * (hosts its own SAF picker and Koin dependencies); shown from the App Info surfaces.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
@@ -42,6 +67,8 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
     val exportUseCase = koinInject<ExportAppUseCase>()
     val preferenceRepository = koinInject<PreferenceRepository>()
     val scope = rememberCoroutineScope()
+
+    val isSplit = appInfo.splitPublicSourceDirs.isNotEmpty()
 
     var targetLabel by remember { mutableStateOf(context.getString(R.string.export_dest_downloads)) }
     var exporting by remember { mutableStateOf(false) }
@@ -97,41 +124,179 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
         }
     }
 
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shape = RoundedCornerShape(topStart = 48.dp, topEnd = 48.dp),
+        tonalElevation = 0.dp
+    ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            // Section header
             Text(
-                stringResource(
-                    R.string.export_title,
-                    appInfo.appName ?: appInfo.packageName
-                )
+                text = stringResource(R.string.action_export).uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 2.sp
             )
-            Text(stringResource(R.string.export_destination, targetLabel))
-            TextButton(onClick = { picker.launch(null) }) {
-                Text(stringResource(R.string.export_change_folder))
+
+            // App identity card + format badge
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                        .padding(8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    AsyncImage(
+                        model = AppIconModel(appInfo.packageName),
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = appInfo.appName ?: appInfo.packageName,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = appInfo.packageName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Text(
+                    text = if (isSplit) ".apks" else ".apk",
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp)
+                )
             }
-            Button(
-                enabled = !exporting,
-                onClick = {
-                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
-                        ContextCompat.checkSelfPermission(
-                            context,
-                            Manifest.permission.WRITE_EXTERNAL_STORAGE
-                        ) != PackageManager.PERMISSION_GRANTED
-                    ) {
-                        permLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+
+            // Plain-language explanation (adapts to the export format)
+            Text(
+                text = stringResource(
+                    if (isSplit) R.string.export_explain_apks else R.string.export_explain_apk
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            // Destination
+            Text(
+                text = stringResource(R.string.export_save_to).uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 1.sp
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.6f))
+                    .padding(start = 16.dp, top = 10.dp, bottom = 10.dp, end = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.storage),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+                Text(
+                    text = targetLabel,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                FilledTonalButton(
+                    onClick = { picker.launch(null) },
+                    enabled = !exporting
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.open_in),
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(stringResource(R.string.export_change))
+                }
+            }
+
+            // Actions
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    enabled = !exporting,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(stringResource(R.string.cancel))
+                }
+                Button(
+                    enabled = !exporting,
+                    onClick = {
+                        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+                            ContextCompat.checkSelfPermission(
+                                context,
+                                Manifest.permission.WRITE_EXTERNAL_STORAGE
+                            ) != PackageManager.PERMISSION_GRANTED
+                        ) {
+                            permLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        } else {
+                            runExport()
+                        }
+                    },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    if (exporting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.export_in_progress))
                     } else {
-                        runExport()
+                        Text(stringResource(R.string.action_export))
                     }
                 }
-            ) {
-                Text(
-                    stringResource(
-                        if (exporting) R.string.export_in_progress else R.string.action_export
-                    )
-                )
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -1,0 +1,138 @@
+package com.valhalla.thor.presentation.appList
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.valhalla.thor.R
+import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.usecase.ExportAppUseCase
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val exportUseCase = koinInject<ExportAppUseCase>()
+    val preferenceRepository = koinInject<PreferenceRepository>()
+    val scope = rememberCoroutineScope()
+
+    var targetLabel by remember { mutableStateOf("Downloads/Thor") }
+    var exporting by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) { targetLabel = exportUseCase.currentTargetLabel() }
+
+    val runExport = {
+        exporting = true
+        scope.launch {
+            val result = exportUseCase(appInfo)
+            exporting = false
+            result
+                .onSuccess {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.export_saved, it),
+                        Toast.LENGTH_LONG
+                    ).show()
+                    onDismiss()
+                }
+                .onFailure {
+                    Toast.makeText(
+                        context,
+                        context.getString(
+                            R.string.export_failed,
+                            it.message ?: "unknown error"
+                        ),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+        }
+    }
+
+    // On API <= 28, writing to the public Downloads directory needs WRITE_EXTERNAL_STORAGE
+    // granted at runtime. Run the export regardless of the grant result: SAF export still
+    // works when denied, and the export itself surfaces success/failure.
+    val permLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { runExport() }
+
+    val picker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        if (uri != null) {
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+            scope.launch {
+                preferenceRepository.setExportDirUri(uri.toString())
+                targetLabel = exportUseCase.currentTargetLabel()
+            }
+        }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                stringResource(
+                    R.string.export_title,
+                    appInfo.appName ?: appInfo.packageName
+                )
+            )
+            Text(stringResource(R.string.export_destination, targetLabel))
+            TextButton(onClick = { picker.launch(null) }) {
+                Text(stringResource(R.string.export_change_folder))
+            }
+            Button(
+                enabled = !exporting,
+                onClick = {
+                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+                        ContextCompat.checkSelfPermission(
+                            context,
+                            Manifest.permission.WRITE_EXTERNAL_STORAGE
+                        ) != PackageManager.PERMISSION_GRANTED
+                    ) {
+                        permLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    } else {
+                        runExport()
+                    }
+                }
+            ) {
+                Text(
+                    stringResource(
+                        if (exporting) R.string.export_in_progress else R.string.action_export
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -67,7 +67,7 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
                         context,
                         context.getString(
                             R.string.export_failed,
-                            it.message ?: "unknown error"
+                            it.message ?: context.getString(R.string.export_failed_unknown)
                         ),
                         Toast.LENGTH_LONG
                     ).show()

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -43,7 +43,7 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
     val preferenceRepository = koinInject<PreferenceRepository>()
     val scope = rememberCoroutineScope()
 
-    var targetLabel by remember { mutableStateOf("Downloads/Thor") }
+    var targetLabel by remember { mutableStateOf(context.getString(R.string.export_dest_downloads)) }
     var exporting by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) { targetLabel = exportUseCase.currentTargetLabel() }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -272,7 +272,12 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
                 Button(
                     enabled = !exporting,
                     onClick = {
-                        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+                        // A custom SAF folder writes via DocumentFile and needs no
+                        // WRITE_EXTERNAL_STORAGE — only the legacy Downloads path (API <= 28) does.
+                        val usingCustomFolder =
+                            targetLabel != context.getString(R.string.export_dest_downloads)
+                        if (!usingCustomFolder &&
+                            Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
                             ContextCompat.checkSelfPermission(
                                 context,
                                 Manifest.permission.WRITE_EXTERNAL_STORAGE

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
@@ -47,6 +47,7 @@ import coil3.compose.AsyncImage
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.presentation.appList.ExportBottomSheet
 import com.valhalla.thor.presentation.utils.AppIconModel
 import com.valhalla.thor.presentation.utils.getBloatRecommendationColors
 
@@ -73,6 +74,7 @@ fun AppInfoDialog(
     var showReinstallWarning by remember { mutableStateOf(false) }
     var showClearDataConfirmation by remember { mutableStateOf(false) }
     var showFreezeConfirmation by remember { mutableStateOf(false) }
+    var showExportSheet by remember { mutableStateOf(false) }
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -101,6 +103,7 @@ fun AppInfoDialog(
                 isRoot = isRoot,
                 isShizuku = isShizuku,
                 isDhizuku = isDhizuku,
+                onExport = { showExportSheet = true },
                 onAction = { action ->
                     // Intercept dangerous actions for local confirmation
                     when (action) {
@@ -132,7 +135,11 @@ fun AppInfoDialog(
         }
     }
 
-    // --- ALERTS ---
+    // --- OVERLAYS ---
+
+    if (showExportSheet) {
+        ExportBottomSheet(appInfo = appInfo, onDismiss = { showExportSheet = false })
+    }
 
     if (showClearDataConfirmation) {
         AlertDialog(
@@ -501,6 +508,7 @@ private fun AppActionRow(
     isRoot: Boolean,
     isShizuku: Boolean,
     isDhizuku: Boolean,
+    onExport: () -> Unit,
     onAction: (AppClickAction) -> Unit
 ) {
     val hasPrivilege = isRoot || isShizuku || isDhizuku
@@ -584,6 +592,10 @@ private fun AppActionRow(
             onAction(
                 AppClickAction.Share(appInfo)
             )
+        }
+
+        ActionItem(R.drawable.storage, stringResource(R.string.action_export)) {
+            onExport()
         }
 
         ActionItem(R.drawable.shield, stringResource(R.string.action_permissions)) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,15 @@
     <string name="action_uninstall">Uninstall</string>
     <string name="action_reinstall">Reinstall</string>
 
+    <!-- Export -->
+    <string name="action_export">Export</string>
+    <string name="export_title">Export %1$s</string>
+    <string name="export_destination">Destination: %1$s</string>
+    <string name="export_change_folder">Change folder</string>
+    <string name="export_in_progress">Exporting…</string>
+    <string name="export_saved">Saved to %1$s</string>
+    <string name="export_failed">Export failed: %1$s</string>
+
     <!-- Main Screen / Global -->
     <string name="cannot_launch_app">Cannot launch app</string>
     <string name="share_app">Share App</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,8 @@
     <string name="export_saved">Saved to %1$s</string>
     <string name="export_failed">Export failed: %1$s</string>
     <string name="export_failed_unknown">unknown error</string>
+    <string name="export_dest_downloads">Downloads/Thor</string>
+    <string name="export_dest_selected">Selected folder</string>
 
     <!-- Main Screen / Global -->
     <string name="cannot_launch_app">Cannot launch app</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,9 +143,10 @@
 
     <!-- Export -->
     <string name="action_export">Export</string>
-    <string name="export_title">Export %1$s</string>
-    <string name="export_destination">Destination: %1$s</string>
-    <string name="export_change_folder">Change folder</string>
+    <string name="export_explain_apk">Thor saves this app as a single installer file (.apk) to the folder below. Use it to back up the app or reinstall it later.</string>
+    <string name="export_explain_apks">This app ships as several split parts, so Thor packages them into one bundle (.apks) in the folder below. Reinstall it anytime with Thor\'s installer.</string>
+    <string name="export_save_to">Save to</string>
+    <string name="export_change">Change</string>
     <string name="export_in_progress">Exporting…</string>
     <string name="export_saved">Saved to %1$s</string>
     <string name="export_failed">Export failed: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="export_in_progress">Exporting…</string>
     <string name="export_saved">Saved to %1$s</string>
     <string name="export_failed">Export failed: %1$s</string>
+    <string name="export_failed_unknown">unknown error</string>
 
     <!-- Main Screen / Global -->
     <string name="cannot_launch_app">Cannot launch app</string>

--- a/app/src/test/java/com/valhalla/thor/domain/model/ExportTargetTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/ExportTargetTest.kt
@@ -1,0 +1,30 @@
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExportTargetTest {
+
+    @Test
+    fun noSavedDir_usesDownloads_noClear() {
+        val r = resolveExportTarget(savedUri = null, isSavedValid = false)
+        assertEquals(ExportTargetChoice.Downloads, r.choice)
+        assertFalse(r.clearSavedDir)
+    }
+
+    @Test
+    fun savedValid_usesCustom_noClear() {
+        val r = resolveExportTarget(savedUri = "content://tree/abc", isSavedValid = true)
+        assertEquals(ExportTargetChoice.Custom("content://tree/abc"), r.choice)
+        assertFalse(r.clearSavedDir)
+    }
+
+    @Test
+    fun savedInvalid_fallsBackToDownloads_andClears() {
+        val r = resolveExportTarget(savedUri = "content://tree/gone", isSavedValid = false)
+        assertEquals(ExportTargetChoice.Downloads, r.choice)
+        assertTrue(r.clearSavedDir)
+    }
+}

--- a/docs/superpowers/plans/2026-07-02-export-to-folder.md
+++ b/docs/superpowers/plans/2026-07-02-export-to-folder.md
@@ -1,0 +1,691 @@
+# Export App to Folder (#164) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Export an installed app to a user-visible folder (default `Downloads/Thor`, or a remembered SAF folder) via a simple bottom sheet, reusing Share's bundle logic.
+
+**Architecture:** Extract Share's cache-bundle builder into a shared `AppBundleBuilder`. A pure `resolveExportTarget()` decides SAF-vs-Downloads; `ExportAppUseCase` builds the bundle, resolves the target, and writes via MediaStore (Downloads/Thor) or SAF `DocumentFile`. A self-contained `ExportBottomSheet` (target + Change + Export) is hosted locally in the App Info screen.
+
+**Tech Stack:** Kotlin, Coroutines, Koin annotations, Room-free, `MediaStore`, `DocumentFile` (SAF), Jetpack Compose, DataStore, JUnit4.
+
+## Global Constraints
+- Build/verify `fossDebug`: `./gradlew :app:testFossDebugUnitTest` (compiles + unit tests). **In this environment `./gradlew` via the Bash tool is redirected** — run it through the context-mode executor instead.
+- Target SDK 37 / minSdk 28, **scoped storage**: **never** use `MANAGE_EXTERNAL_STORAGE`. Downloads write = `MediaStore.Downloads` (API 29+) / `WRITE_EXTERNAL_STORAGE maxSdkVersion="28"` legacy.
+- Format mirrors Share: no splits → `.apk`; splits → `.apks` (base + splits + `metadata.json` + `manifest.json`).
+- `@Single`/`@Factory`/`@KoinViewModel` auto-register via `@ComponentScan("com.valhalla.thor")` — no `di/Modules.kt` edits.
+- Bundle-building must stay behavior-identical to today's Share output.
+
+---
+
+### Task 1: Extract `AppBundleBuilder` (behaviour-preserving refactor of Share)
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/domain/usecase/AppBundleBuilder.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt`
+
+**Interfaces:**
+- Produces: `@Single class AppBundleBuilder` with `suspend fun build(appInfo: AppInfo): Result<File>` — a cache file (`.apk` no-split, `.apks` split).
+
+- [ ] **Step 1: Create `AppBundleBuilder`** — move the cache-build logic verbatim.
+
+Create `AppBundleBuilder.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.usecase
+
+import com.valhalla.thor.BuildConfig
+import android.content.Context
+import com.valhalla.thor.data.util.ApksMetadataGenerator
+import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.formattedAppName
+import com.valhalla.thor.domain.repository.SystemRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Builds a shareable/exportable app bundle in the cache dir: a single `.apk` for
+ * apps with no splits, an `.apks` (base + splits + metadata.json + manifest.json)
+ * for split apps. Copies with a root fallback for protected/system apps.
+ */
+@Single
+class AppBundleBuilder(
+    private val context: Context,
+    private val systemRepository: SystemRepository,
+    private val apksMetadataGenerator: ApksMetadataGenerator
+) {
+    suspend fun build(appInfo: AppInfo): Result<File> = withContext(Dispatchers.IO) {
+        try {
+            val cacheDir = File(context.cacheDir, "share_temp")
+            if (cacheDir.exists()) cacheDir.deleteRecursively()
+            cacheDir.mkdirs()
+
+            val finalFile: File
+            if (appInfo.splitPublicSourceDirs.isEmpty()) {
+                val sourcePath = appInfo.publicSourceDir ?: appInfo.sourceDir
+                    ?: return@withContext Result.failure(Exception("No source path found"))
+                finalFile = File(cacheDir, "${appInfo.formattedAppName()}_${appInfo.versionName}.apk")
+                if (!copyFileSafely(sourcePath, finalFile)) {
+                    return@withContext Result.failure(Exception("Failed to copy base APK"))
+                }
+            } else {
+                finalFile = File(cacheDir, "${appInfo.formattedAppName()}_${appInfo.versionName}.apks")
+                val tempSplitDir = File(cacheDir, "splits_staging")
+                tempSplitDir.mkdirs()
+
+                val allPaths = mutableListOf<String>()
+                appInfo.sourceDir?.let { allPaths.add(it) }
+                allPaths.addAll(appInfo.splitPublicSourceDirs)
+
+                val filesToZip = allPaths.mapNotNull { path ->
+                    val destFile = File(tempSplitDir, path.substringAfterLast("/"))
+                    if (copyFileSafely(path, destFile)) destFile else null
+                }.toMutableList()
+                if (filesToZip.isEmpty()) {
+                    return@withContext Result.failure(Exception("Failed to copy any APK files"))
+                }
+
+                val metadataFile = File(tempSplitDir, "metadata.json")
+                apksMetadataGenerator.generateJson(appInfo, metadataFile)
+                filesToZip.add(metadataFile)
+
+                val manifestFile = File(tempSplitDir, "manifest.json")
+                apksMetadataGenerator.generateManifestJson(appInfo, manifestFile)
+                filesToZip.add(manifestFile)
+
+                zipFiles(filesToZip, finalFile)
+                tempSplitDir.deleteRecursively()
+            }
+            Result.success(finalFile)
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) e.printStackTrace()
+            Result.failure(e)
+        }
+    }
+
+    private suspend fun copyFileSafely(sourcePath: String, destFile: File): Boolean {
+        return try {
+            File(sourcePath).copyTo(destFile, overwrite = true)
+            true
+        } catch (_: Exception) {
+            systemRepository.copyFileWithRoot(sourcePath, destFile.absolutePath).isSuccess
+        }
+    }
+
+    private fun zipFiles(files: List<File>, zipFile: File) {
+        ZipOutputStream(BufferedOutputStream(FileOutputStream(zipFile))).use { out ->
+            val data = ByteArray(1024)
+            files.forEach { file ->
+                FileInputStream(file).use { fi ->
+                    BufferedInputStream(fi).use { origin ->
+                        val entry = ZipEntry(file.name)
+                        out.putNextEntry(entry)
+                        while (true) {
+                            val readBytes = origin.read(data)
+                            if (readBytes == -1) break
+                            out.write(data, 0, readBytes)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Rewrite `ShareAppUseCase` to delegate to the builder.**
+
+Replace the entire contents of `ShareAppUseCase.kt` with:
+
+```kotlin
+package com.valhalla.thor.domain.usecase
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.domain.model.AppInfo
+import org.koin.core.annotation.Factory
+
+@Factory
+class ShareAppUseCase(
+    private val context: Context,
+    private val bundleBuilder: AppBundleBuilder
+) {
+    suspend operator fun invoke(appInfo: AppInfo): Result<Uri> =
+        bundleBuilder.build(appInfo).map { file ->
+            FileProvider.getUriForFile(context, "${BuildConfig.APPLICATION_ID}.provider", file)
+        }
+}
+```
+
+- [ ] **Step 3: Compile — Share still builds.**
+
+Run (via context-mode ctx_execute): `./gradlew :app:compileFossDebugKotlin 2>&1 | tail -25`
+Expected: BUILD SUCCESSFUL. (`AppBundleBuilder` auto-registers via `@Single`; `ShareAppUseCase` now takes only `Context` + `AppBundleBuilder`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/usecase/AppBundleBuilder.kt \
+        app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
+git commit -m "refactor(share): extract AppBundleBuilder for reuse by export (#164)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: DataStore — `exportDirUri`
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt`
+
+**Interfaces:**
+- Produces: `UserPreferences.exportDirUri: String?`; `PreferenceRepository.setExportDirUri(uri: String?)`.
+
+- [ ] **Step 1: Add the field to `UserPreferences`** — after the last property (before the closing `)`):
+
+```kotlin
+    // Export destination (persisted SAF tree URI; null = default Downloads/Thor)
+    val exportDirUri: String? = null
+```
+
+- [ ] **Step 2: Add the interface method** — in `PreferenceRepository.kt`, next to `setLanguage`:
+
+```kotlin
+    suspend fun setExportDirUri(uri: String?)
+```
+
+- [ ] **Step 3: Implement it** — mirror the existing nullable `language` pref exactly.
+
+In `PreferenceRepositoryImpl.kt`, in the `Keys` object (next to `LANGUAGE`):
+```kotlin
+        val EXPORT_DIR_URI = stringPreferencesKey("export_dir_uri")
+```
+In the `userPreferences` flow's `UserPreferences(...)` construction (next to `language = prefs[Keys.LANGUAGE],`):
+```kotlin
+            exportDirUri = prefs[Keys.EXPORT_DIR_URI],
+```
+And the setter (next to `setLanguage`):
+```kotlin
+    override suspend fun setExportDirUri(uri: String?) {
+        context.dataStore.edit {
+            if (uri == null) it.remove(Keys.EXPORT_DIR_URI)
+            else it[Keys.EXPORT_DIR_URI] = uri
+        }
+    }
+```
+(Match the surrounding `context.dataStore.edit { ... }` form used by `setLanguage`.)
+
+- [ ] **Step 4: Compile**
+
+Run: `./gradlew :app:compileFossDebugKotlin 2>&1 | tail -20`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt \
+        app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt \
+        app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+git commit -m "feat(prefs): persist export destination (exportDirUri) (#164)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `resolveExportTarget()` — pure target resolver (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/domain/model/ExportTarget.kt`
+- Test: `app/src/test/java/com/valhalla/thor/domain/model/ExportTargetTest.kt`
+
+**Interfaces:**
+- Produces: `sealed interface ExportTargetChoice { object Downloads; data class Custom(treeUri: String) }`; `data class ExportTargetResolution(choice, clearSavedDir: Boolean)`; `fun resolveExportTarget(savedUri: String?, isSavedValid: Boolean): ExportTargetResolution`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/valhalla/thor/domain/model/ExportTargetTest.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExportTargetTest {
+
+    @Test
+    fun noSavedDir_usesDownloads_noClear() {
+        val r = resolveExportTarget(savedUri = null, isSavedValid = false)
+        assertEquals(ExportTargetChoice.Downloads, r.choice)
+        assertFalse(r.clearSavedDir)
+    }
+
+    @Test
+    fun savedValid_usesCustom_noClear() {
+        val r = resolveExportTarget(savedUri = "content://tree/abc", isSavedValid = true)
+        assertEquals(ExportTargetChoice.Custom("content://tree/abc"), r.choice)
+        assertFalse(r.clearSavedDir)
+    }
+
+    @Test
+    fun savedInvalid_fallsBackToDownloads_andClears() {
+        val r = resolveExportTarget(savedUri = "content://tree/gone", isSavedValid = false)
+        assertEquals(ExportTargetChoice.Downloads, r.choice)
+        assertTrue(r.clearSavedDir)
+    }
+}
+```
+
+- [ ] **Step 2: Run — verify it fails**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.ExportTargetTest" 2>&1 | tail -20`
+Expected: FAIL — unresolved `resolveExportTarget` / `ExportTargetChoice`.
+
+- [ ] **Step 3: Implement**
+
+Create `app/src/main/java/com/valhalla/thor/domain/model/ExportTarget.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.model
+
+/** Where an export should be written. */
+sealed interface ExportTargetChoice {
+    /** Public Downloads/Thor (MediaStore / legacy). */
+    data object Downloads : ExportTargetChoice
+    /** A user-picked SAF tree (persisted URI string). */
+    data class Custom(val treeUri: String) : ExportTargetChoice
+}
+
+/**
+ * @param clearSavedDir true when a saved-but-invalid dir should be cleared from prefs.
+ */
+data class ExportTargetResolution(
+    val choice: ExportTargetChoice,
+    val clearSavedDir: Boolean
+)
+
+/**
+ * Pure resolver: use the saved SAF dir only if it is still valid; otherwise fall
+ * back to Downloads (and signal a clear when a stale dir was saved).
+ */
+fun resolveExportTarget(savedUri: String?, isSavedValid: Boolean): ExportTargetResolution =
+    when {
+        savedUri != null && isSavedValid ->
+            ExportTargetResolution(ExportTargetChoice.Custom(savedUri), clearSavedDir = false)
+        savedUri != null ->
+            ExportTargetResolution(ExportTargetChoice.Downloads, clearSavedDir = true)
+        else ->
+            ExportTargetResolution(ExportTargetChoice.Downloads, clearSavedDir = false)
+    }
+```
+
+- [ ] **Step 4: Run — verify it passes**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.ExportTargetTest" 2>&1 | tail -20`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/ExportTarget.kt \
+        app/src/test/java/com/valhalla/thor/domain/model/ExportTargetTest.kt
+git commit -m "feat(export): pure resolveExportTarget() + tests (#164)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `ExportAppUseCase` — build, resolve, write
+
+**Files:**
+- Modify: `app/src/main/AndroidManifest.xml`
+- Create: `app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt`
+- Possibly modify: `app/build.gradle.kts` (add `androidx.documentfile` if unresolved)
+
+**Interfaces:**
+- Consumes: `AppBundleBuilder.build` (T1), `PreferenceRepository.exportDirUri`/`setExportDirUri` (T2), `resolveExportTarget`/`ExportTargetChoice` (T3).
+- Produces: `@Factory class ExportAppUseCase` with `suspend operator fun invoke(appInfo): Result<String>` (returns a human location label) and `suspend fun currentTargetLabel(): String`.
+
+- [ ] **Step 1: Declare the legacy permission** — in `AndroidManifest.xml` after the `RECEIVE_BOOT_COMPLETED` line:
+
+```xml
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+```
+
+- [ ] **Step 2: Create `ExportAppUseCase`**
+
+Create `ExportAppUseCase.kt`:
+
+```kotlin
+package com.valhalla.thor.domain.usecase
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.core.net.toUri
+import androidx.documentfile.provider.DocumentFile
+import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.ExportTargetChoice
+import com.valhalla.thor.domain.model.resolveExportTarget
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Factory
+import java.io.File
+import java.io.IOException
+
+@Factory
+class ExportAppUseCase(
+    private val context: Context,
+    private val bundleBuilder: AppBundleBuilder,
+    private val preferenceRepository: PreferenceRepository
+) {
+    /** Build the bundle and write it to the resolved target. Returns a location label. */
+    suspend operator fun invoke(appInfo: AppInfo): Result<String> = withContext(Dispatchers.IO) {
+        try {
+            val file = bundleBuilder.build(appInfo).getOrElse { return@withContext Result.failure(it) }
+            val mime = mimeFor(file)
+
+            val savedUri = preferenceRepository.userPreferences.first().exportDirUri
+            val resolution = resolveExportTarget(savedUri, isTreeWritable(savedUri))
+            if (resolution.clearSavedDir) preferenceRepository.setExportDirUri(null)
+
+            val location = when (val choice = resolution.choice) {
+                is ExportTargetChoice.Custom -> writeToTree(file, choice.treeUri.toUri(), mime)
+                ExportTargetChoice.Downloads ->
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) writeToDownloads(file, mime)
+                    else writeToDownloadsLegacy(file)
+            }
+            Result.success(location)
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) e.printStackTrace()
+            Result.failure(e)
+        }
+    }
+
+    /** The label shown in the export sheet ("Downloads/Thor" or the saved folder name). */
+    suspend fun currentTargetLabel(): String {
+        val savedUri = preferenceRepository.userPreferences.first().exportDirUri
+        return if (savedUri != null && isTreeWritable(savedUri)) {
+            DocumentFile.fromTreeUri(context, savedUri.toUri())?.name ?: "Selected folder"
+        } else "Downloads/Thor"
+    }
+
+    private fun mimeFor(file: File) =
+        if (file.name.endsWith(".apk")) "application/vnd.android.package-archive"
+        else "application/octet-stream"
+
+    private fun isTreeWritable(uriStr: String?): Boolean {
+        if (uriStr == null) return false
+        return try {
+            val doc = DocumentFile.fromTreeUri(context, uriStr.toUri())
+            doc != null && doc.exists() && doc.canWrite()
+        } catch (_: Exception) { false }
+    }
+
+    private fun writeToDownloads(source: File, mime: String): String {
+        val resolver = context.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.Downloads.DISPLAY_NAME, source.name)
+            put(MediaStore.Downloads.MIME_TYPE, mime)
+            put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/Thor")
+            put(MediaStore.Downloads.IS_PENDING, 1)
+        }
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+            ?: throw IOException("MediaStore insert failed")
+        try {
+            resolver.openOutputStream(uri)?.use { out -> source.inputStream().use { it.copyTo(out) } }
+                ?: throw IOException("openOutputStream failed")
+            values.clear()
+            values.put(MediaStore.Downloads.IS_PENDING, 0)
+            resolver.update(uri, values, null, null)
+        } catch (e: Exception) {
+            resolver.delete(uri, null, null) // don't leave a dangling pending entry
+            throw e
+        }
+        return "Downloads/Thor"
+    }
+
+    private fun writeToDownloadsLegacy(source: File): String {
+        @Suppress("DEPRECATION")
+        val dir = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "Thor"
+        )
+        if (!dir.exists()) dir.mkdirs()
+        source.copyTo(File(dir, source.name), overwrite = true)
+        return "Downloads/Thor"
+    }
+
+    private fun writeToTree(source: File, treeUri: Uri, mime: String): String {
+        val tree = DocumentFile.fromTreeUri(context, treeUri) ?: throw IOException("Invalid folder")
+        tree.findFile(source.name)?.delete() // overwrite
+        val doc = tree.createFile(mime, source.name) ?: throw IOException("Could not create file")
+        context.contentResolver.openOutputStream(doc.uri)?.use { out ->
+            source.inputStream().use { it.copyTo(out) }
+        } ?: throw IOException("openOutputStream failed")
+        return tree.name ?: "Selected folder"
+    }
+}
+```
+
+- [ ] **Step 3: Compile (add the DocumentFile dep only if unresolved)**
+
+Run: `./gradlew :app:compileFossDebugKotlin 2>&1 | tail -25`
+- If it fails with `unresolved reference: documentfile` / `DocumentFile`, add to `app/build.gradle.kts` dependencies: `implementation("androidx.documentfile:documentfile:1.0.1")`, then re-run.
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/main/AndroidManifest.xml \
+        app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt \
+        app/build.gradle.kts
+git commit -m "feat(export): ExportAppUseCase — MediaStore/SAF writers + target resolve (#164)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Export bottom sheet + App Info action
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt`
+- Add strings: `app/src/main/res/values/strings.xml`
+
+**Interfaces:**
+- Consumes: `ExportAppUseCase` (T4), `PreferenceRepository.setExportDirUri` (T2).
+
+- [ ] **Step 1: Create the self-contained `ExportBottomSheet`**
+
+Create `ExportBottomSheet.kt`. It shows the current target, a "Change" row that launches the SAF folder picker (persisting the grant + saving to prefs), and an Export button.
+
+```kotlin
+package com.valhalla.thor.presentation.appList
+
+import android.content.Intent
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.usecase.ExportAppUseCase
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val exportUseCase = koinInject<ExportAppUseCase>()
+    val preferenceRepository = koinInject<PreferenceRepository>()
+    val scope = rememberCoroutineScope()
+
+    var targetLabel by remember { mutableStateOf("Downloads/Thor") }
+    var exporting by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) { targetLabel = exportUseCase.currentTargetLabel() }
+
+    val picker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        if (uri != null) {
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+            scope.launch {
+                preferenceRepository.setExportDirUri(uri.toString())
+                targetLabel = exportUseCase.currentTargetLabel()
+            }
+        }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("Export ${appInfo.appName ?: appInfo.packageName}")
+            Text("Destination: $targetLabel")
+            TextButton(onClick = { picker.launch(null) }) { Text("Change folder") }
+            Button(
+                enabled = !exporting,
+                onClick = {
+                    exporting = true
+                    scope.launch {
+                        val result = exportUseCase(appInfo)
+                        exporting = false
+                        result
+                            .onSuccess {
+                                Toast.makeText(context, "Saved to $it", Toast.LENGTH_LONG).show()
+                                onDismiss()
+                            }
+                            .onFailure {
+                                Toast.makeText(
+                                    context,
+                                    "Export failed: ${it.message ?: "unknown error"}",
+                                    Toast.LENGTH_LONG
+                                ).show()
+                            }
+                    }
+                }
+            ) { Text(if (exporting) "Exporting…" else "Export") }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add an "Export" action + host the sheet in `AppInfoDetailsScreen`**
+
+Read `AppInfoDetailsScreen.kt`. The actions row composable (the one with the `onShare: () -> Unit` param around line 669, rendered near line 230 with `onShare = { onAppAction(AppClickAction.Share(details.appInfo)) }`) exposes typed callbacks. Do three things, matching the existing style:
+1. Add an `onExport: () -> Unit` parameter to that actions composable and an action button beside Share — reuse the existing action-button pattern used for `onShare`; pick an existing export/save drawable (`grep -n 'R.drawable' AppInfoDetailsScreen.kt` for a suitable one, e.g. a download/share icon).
+2. At the call site, add a local state near the screen's other state: `var showExportSheet by remember { mutableStateOf(false) }`, and pass `onExport = { showExportSheet = true }` (handled **locally** — do NOT bubble it through `onAppAction`).
+3. Where the screen renders its other overlays, add:
+```kotlin
+if (showExportSheet) {
+    ExportBottomSheet(appInfo = details.appInfo, onDismiss = { showExportSheet = false })
+}
+```
+Add imports: `androidx.compose.runtime.getValue/setValue/mutableStateOf/remember` (if not already present).
+
+- [ ] **Step 3: Add the action label string** — in `strings.xml` near the other action labels:
+```xml
+    <string name="action_export">Export</string>
+```
+Use `stringResource(R.string.action_export)` for the button's label/content-description (match how the Share button labels itself).
+
+- [ ] **Step 4: Compile**
+
+Run: `./gradlew :app:compileFossDebugKotlin 2>&1 | tail -25`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt \
+        app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt \
+        app/src/main/res/values/strings.xml
+git commit -m "feat(export): App Info Export action + destination bottom sheet (#164)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full verification, manual test, push & PR
+
+**Files:** none.
+
+- [ ] **Step 1: Full unit tests + assemble**
+
+Run: `./gradlew :app:testFossDebugUnitTest 2>&1 | tail -12` then `./gradlew assembleFossDebug 2>&1 | tail -12`
+Expected: BUILD SUCCESSFUL; `ExportTargetTest` (3) + existing tests pass; APK assembles (Koin resolves `AppBundleBuilder`/`ExportAppUseCase`).
+
+- [ ] **Step 2: Manual verification (device)**
+
+- App Info → **Export**: a single-APK app writes `<name>.apk`, a split app writes `<name>.apks`, both under **Downloads/Thor** (visible in a file manager) with a "Saved to Downloads/Thor" toast.
+- **Change folder** → pick a folder → export → file lands there; the sheet now shows that folder's name; relaunch and it's remembered.
+- Delete the picked folder → export again → falls back to Downloads/Thor and the label reverts.
+- Rooted device: a system/protected app exports (root copy fallback).
+
+- [ ] **Step 3: Push + open PR into `dev`**
+
+```bash
+git push -u origin feat/export-to-folder
+gh pr create --base dev --head feat/export-to-folder \
+  --title "feat: export app to folder (Downloads/Thor or SAF) (#164)" \
+  --body "Implements #164 (single-app export). See docs/superpowers/specs/2026-07-02-export-to-folder-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Notes for the implementer
+- The pure `resolveExportTarget()` is the only unit-tested piece; MediaStore/SAF/DocumentFile writes are device-dependent (manual).
+- Export is handled **locally** in the App Info screen (self-contained sheet) — no `MainViewModel`/`AppClickAction` global routing, unlike Share.
+- Do not add `MANAGE_EXTERNAL_STORAGE`. The `WRITE_EXTERNAL_STORAGE maxSdkVersion="28"` is only for the API-28 legacy Downloads write.

--- a/docs/superpowers/specs/2026-07-02-export-to-folder-design.md
+++ b/docs/superpowers/specs/2026-07-02-export-to-folder-design.md
@@ -1,0 +1,129 @@
+# Export App to Folder — Design
+
+**Date:** 2026-07-02
+**Issue:** #164 — ".APK, .XAPK, .APKS and Split bundle export?"
+**Branch:** `feat/export-to-folder`
+
+## Goal
+
+Let the user **export an installed app to a user-visible folder** (not just Share
+it), via a simple bottom sheet: a default **`Downloads/Thor`** target with a
+**"Change"** option to pick any folder (Storage Access Framework), remembered
+across exports.
+
+## Constraints (why this design)
+
+- Thor targets **SDK 37** (minSdk 28) → **scoped storage** is fully enforced.
+  Legacy external writes are a no-op on API 30+, and **`MANAGE_EXTERNAL_STORAGE`
+  is Play-policy-restricted** — so it is **not used**.
+- Thor currently declares **no storage permissions** (only a `FileProvider`).
+- The bundle-building already exists in `ShareAppUseCase` and is reused, not
+  duplicated.
+
+## Decisions
+
+1. **Format mirrors Share:** an app with **no splits → `.apk`**; an app **with
+   splits → `.apks`** (base + splits + `metadata.json` + `manifest.json`). No
+   format picker.
+2. **Two write paths, no risky permission:**
+   - Default **`Downloads/Thor`** via `MediaStore.Downloads`
+     (`RELATIVE_PATH = "Download/Thor"`) on API 29+; on **API 28** a legacy write
+     behind `WRITE_EXTERNAL_STORAGE android:maxSdkVersion="28"`.
+   - Custom folder via **SAF** (`DocumentFile`), the tree URI persisted in DataStore.
+3. **Single-app export** for v1 (from the App Info sheet). Batch export
+   (mirroring the existing multi-select `ShareApps`) is a **follow-up**, out of scope.
+
+## Design
+
+### 1. Reuse — extract the bundle builder (DRY)
+`ShareAppUseCase` currently builds the shareable file in cache (gather base +
+splits, `copyFileSafely` with a **root fallback**, generate
+`metadata.json`/`manifest.json` via `ApksMetadataGenerator`, zip splits into
+`.apks`). Extract that into a shared:
+
+- **`AppBundleBuilder`** (`data/…`): `suspend fun build(appInfo: AppInfo): Result<File>`
+  → a cache file (`.apk` for no-split, `.apks` for split). Behavior identical to
+  today's Share output.
+
+Then:
+- `ShareAppUseCase` → `build()` → `FileProvider.getUriForFile(...)` (unchanged behavior).
+- `ExportAppUseCase` (new) → `build()` → write the cache file to the resolved target.
+
+### 2. Target resolution + persistence
+- **DataStore:** add `exportDirUri: String? = null` to `UserPreferences`;
+  `PreferenceRepository.setExportDirUri(uri: String?)` (null clears it).
+- **`ExportTargetResolver`** (new; testable): given the saved `exportDirUri`,
+  returns the write target:
+  - saved URI present **and** valid (`DocumentFile.fromTreeUri(ctx, uri).exists() && canWrite()`)
+    → **SAF target** (the tree `DocumentFile`).
+  - otherwise → **Downloads/Thor default** (and, if the pref was set-but-invalid,
+    signal the caller to clear it so the sheet reverts to the default label).
+- **Display name** for the sheet: `"Downloads/Thor"` for the default; for a saved
+  folder, the tree `DocumentFile.name` (or last path segment).
+
+### 3. Writers
+`ExportAppUseCase` writes the built cache file to the resolved target:
+- **`MediaStoreExporter`** (default): API 29+ inserts into
+  `MediaStore.Downloads.EXTERNAL_CONTENT_URI` with `DISPLAY_NAME`, MIME
+  `application/vnd.android.package-archive` (`.apk`) or `application/octet-stream`
+  (`.apks`), and `RELATIVE_PATH = Environment.DIRECTORY_DOWNLOADS + "/Thor"`, using
+  `IS_PENDING` during the copy. **API 28**: write to
+  `Environment.getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS)/Thor/<name>`
+  (guarded by the `maxSdkVersion="28"` permission).
+- **SAF writer**: `treeDoc.createFile(mime, name)` → `contentResolver.openOutputStream(doc.uri)`
+  → stream the cache file in. If a same-named file exists, overwrite (delete-then-create).
+- Returns a human-readable location string for the confirmation ("Saved to Downloads/Thor" / the folder name).
+
+### 4. UI — the Export bottom sheet
+- New `AppClickAction.Export(appInfo)` (sibling of `ShareApp`), wired from the App
+  Info sheet's actions. Handling it opens the **Export bottom sheet**.
+- Sheet contents (Compose `ModalBottomSheet`):
+  - Title + the app being exported (name/icon).
+  - **Target row:** the effective target label (`Downloads/Thor` or saved folder),
+    with a **"Change"** action → `rememberLauncherForActivityResult(OpenDocumentTree)`
+    → on result `takePersistableUriPermission(READ|WRITE)` + `setExportDirUri(uri)`;
+    the label updates.
+  - **Export** button → runs `ExportAppUseCase` (off-main; a progress state) →
+    on success dismiss + a "Saved to …" snackbar/toast; on failure an error message.
+
+### 5. Manifest
+```xml
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+    android:maxSdkVersion="28" />
+```
+(Only requested on API 28, for the legacy Downloads write; not present on API 29+.)
+
+## Error handling / edge cases
+- **Saved folder deleted / permission lost:** resolver detects invalid tree →
+  clears `exportDirUri` → falls back to `Downloads/Thor`; the sheet shows the
+  default again.
+- **Protected/system apps:** APK copy uses the existing `copyFileSafely` root
+  fallback in the builder; degrades without root (consistent with Share).
+- **Write failure** (no space, revoked SAF grant mid-write): surfaced as an error
+  message; no partial `IS_PENDING`/temp file left dangling (finalize/delete on failure).
+- **Name collisions:** overwrite the same-named export.
+- **API 28 without `WRITE_EXTERNAL_STORAGE` granted:** request it at export time;
+  if denied, surface an error (SAF path still works as an alternative).
+
+## Testing
+- **Unit test `ExportTargetResolver`** with a mockable validity check: saved-valid
+  → SAF target; saved-invalid → default + clear signal; none → default.
+- **Behavior-preserving check:** Share still produces the same `.apk`/`.apks`
+  after the `AppBundleBuilder` extraction (compile + the existing Share flow).
+- **Manual:** export a single-APK app (→ `.apk`) and a split app (→ `.apks`) to
+  Downloads/Thor; pick a custom folder via Change and export there; delete the
+  custom folder and confirm fallback to Downloads/Thor; verify on a rooted device
+  a system/protected app exports via the root copy; API 28 legacy path if available.
+
+## Out of scope (follow-ups)
+- Batch/multi-select export (mirror `ShareApps`).
+- Additional formats (real `.xapk`, raw split folder) — a later format selector.
+- Exporting app **data** (that's #51's root-gated territory).
+
+## Files touched (indicative)
+- Extract: `data/…/AppBundleBuilder.kt` (from `ShareAppUseCase`); modify `ShareAppUseCase` to use it.
+- New: `ExportAppUseCase`, `ExportTargetResolver`, `MediaStoreExporter` (+ SAF write).
+- `domain/model/UserPreferences.kt` (+`exportDirUri`), `PreferenceRepository` (+ setter) + impl.
+- `AndroidManifest.xml` (+`WRITE_EXTERNAL_STORAGE maxSdkVersion=28`).
+- `domain/model/AppClickAction.kt` (+`Export`), the App Info sheet action wiring, and the new Export bottom-sheet composable + its state.
+- test: `ExportTargetResolverTest`.


### PR DESCRIPTION
Implements **#164** — export an installed app's bundle to a user-visible folder, not just Share it. Single-app export for v1 (from the App Info screen).

Spec: `docs/superpowers/specs/2026-07-02-export-to-folder-design.md`
Plan: `docs/superpowers/plans/2026-07-02-export-to-folder.md`

## What it does
- App Info → **Export** opens a small bottom sheet showing the destination (default **`Downloads/Thor`**, or a remembered folder) with a **Change folder** option (SAF `OpenDocumentTree`, persisted). Tap **Export** to write the bundle there.
- **Format mirrors Share:** no splits → `.apk`; splits → `.apks` (base + splits + `metadata.json` + `manifest.json`).
- The chosen SAF folder is remembered across exports; if it's later deleted / the grant is lost, it silently falls back to `Downloads/Thor`.

## How it's built
- **`AppBundleBuilder`** (`@Single`) — extracted verbatim from `ShareAppUseCase` (which now delegates to it); builds the cache `.apk`/`.apks` with a root-fallback copy for protected/system apps. Share output is behavior-identical.
- **`resolveExportTarget()`** — pure, unit-tested (`ExportTargetTest`, 3 tests) target resolver (saved-valid → SAF; saved-invalid → Downloads + clear; none → Downloads).
- **`ExportAppUseCase`** (`@Factory`) — builds, resolves, and writes via **MediaStore.Downloads** (API 29+, `IS_PENDING` with delete-on-failure) / legacy Downloads (API 28) / **SAF `DocumentFile`**.
- **`ExportBottomSheet`** — self-contained Compose sheet, wired locally into `AppInfoDetailsScreen` (no global `AppClickAction` route). Full `stringResource` i18n. On API ≤ 28 it requests the runtime `WRITE_EXTERNAL_STORAGE` grant before exporting (SAF still works if denied).
- `exportDirUri` persisted in DataStore (mirrors the `language` pref).

## Storage policy
No `MANAGE_EXTERNAL_STORAGE` (Play-restricted). Scoped-storage compliant: MediaStore for API 29+, `WRITE_EXTERNAL_STORAGE android:maxSdkVersion="28"` only for the API-28 legacy write. Adds `androidx.documentfile:documentfile:1.0.1`.

## Verification
- `:app:testFossDebugUnitTest` — **BUILD SUCCESSFUL** (incl. `ExportTargetTest` 3/3).
- `assembleFossDebug` — **BUILD SUCCESSFUL** (Koin graph resolves).
- Built via subagent-driven-development: per-task spec+quality review, plus a final whole-branch review (verdict: **READY TO MERGE**). Its Important findings were fixed before this PR (isolated Export's cache subdir from Share's; rethrow `CancellationException` so a mid-export dismiss isn't a false failure/partial file; restored Share's IO threading; localized two labels).

## Still to do (reviewer / author, device-only)
Manual device pass: single-APK app → `.apk` and split app → `.apks` land under Downloads/Thor; Change folder → export lands there and is remembered; delete the folder → falls back; rooted device → a protected app exports via the root copy; API-28 legacy path if a device is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)