### PR TITLE
fix: root install fails with exit 255 (session + stdin pipe) (#159)

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -227,6 +227,11 @@ class RootSystemGateway(
         }
         val downgrade = if (canDowngrade) " -d" else ""
         val sb = StringBuilder()
+        // Run the whole thing in a subshell so our `exit` codes exit the SUBSHELL, not
+        // libsu's long-lived root shell. Exiting the parent shell would kill it before
+        // libsu appends its end-marker, leaving it unable to read the real exit code
+        // (it then falls back to code 1) — and would break every later root command.
+        sb.append("(\n")
         // Create the session; pull the numeric id out of "…created install session [<id>]".
         sb.append("SID=\$(pm install-create -r -g").append(downgrade)
             .append(" 2>/dev/null | sed -n 's/.*\\[\\([0-9]*\\)\\].*/\\1/p')\n")
@@ -236,11 +241,11 @@ class RootSystemGateway(
             val size = File(path).length()
             val escPath = ShellUtils.escapedString(path)
             val escName = ShellUtils.escapedString(File(path).name)
-            sb.append("cat ").append(escPath)
+            sb.append("WERR=\$(cat ").append(escPath)
                 .append(" | pm install-write -S ").append(size)
-                .append(" \"\$SID\" ").append(escName).append(" -")
-                .append(" 1>/dev/null 2>&1 || { pm install-abandon \"\$SID\" 2>/dev/null;")
-                .append(" echo 'pm install-write failed' 1>&2; exit 102; }\n")
+                .append(" \"\$SID\" ").append(escName).append(" - 2>&1 1>/dev/null)")
+                .append(" || { pm install-abandon \"\$SID\" 2>/dev/null;")
+                .append(" echo \"pm install-write failed: \$WERR\" 1>&2; exit 102; }\n")
         }
         // Commit; anything but a Success line is a failure — surface pm's reason.
         sb.append("COMMIT=\$(pm install-commit \"\$SID\" 2>&1)\n")
@@ -249,6 +254,7 @@ class RootSystemGateway(
         sb.append("  *) pm install-abandon \"\$SID\" 2>/dev/null;")
             .append(" echo \"pm install-commit failed: \$COMMIT\" 1>&2; exit 103 ;;\n")
         sb.append("esac\n")
+        sb.append(")\n")
         return runCommand(sb.toString())
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import com.valhalla.thor.util.Logger
 import com.valhalla.superuser.ShellUtils
+import java.io.File
 
 private val PACKAGE_NAME_REGEX = Regex("^[a-zA-Z0-9._]+$")
 private val USER_ID_REGEX = Regex("^\\d+$")
@@ -198,21 +199,57 @@ class RootSystemGateway(
     }
 
     override suspend fun installApp(apkPath: String, canDowngrade: Boolean): Result<Unit> {
-        val command = "pm install -r -g${if (canDowngrade) " -d" else ""} ${
-            ShellUtils.escapedString(apkPath)
-        }"
-        return runCommand(command)
+        return installViaSession(listOf(apkPath), canDowngrade)
     }
 
     suspend fun installMultipleApks(apkPaths: List<String>, canDowngrade: Boolean): Result<Unit> {
+        return installViaSession(apkPaths, canDowngrade)
+    }
+
+    /**
+     * Install one or more APKs through a PackageInstaller *session*, streaming each
+     * file's bytes into the session over stdin (`cat <apk> | pm install-write … -`).
+     *
+     * The old `pm install <path>` / `pm install-multiple <paths>` handed the system
+     * installer a path under the app's private cache (`/data/data/…`). On modern
+     * Android the installer can't read another app's private files, so `pm` aborted
+     * with exit 255 (GH#159). Here the root shell's own `cat` reads the app-private
+     * temp file and pipes the bytes in, so neither `pm` nor `installd` ever opens a
+     * `/data/data` path — the install works regardless of where the temp APKs live.
+     * On failure the real `pm` reason is routed to stderr so it surfaces in the error.
+     */
+    private suspend fun installViaSession(
+        apkPaths: List<String>,
+        canDowngrade: Boolean
+    ): Result<Unit> {
         if (apkPaths.isEmpty()) {
-            return Result.failure(Exception("No APK paths provided for multi-install"))
+            return Result.failure(Exception("No APK paths provided for install"))
         }
-        val escapedPaths = apkPaths.joinToString(" ") {
-            ShellUtils.escapedString(it)
+        val downgrade = if (canDowngrade) " -d" else ""
+        val sb = StringBuilder()
+        // Create the session; pull the numeric id out of "…created install session [<id>]".
+        sb.append("SID=\$(pm install-create -r -g").append(downgrade)
+            .append(" 2>/dev/null | sed -n 's/.*\\[\\([0-9]*\\)\\].*/\\1/p')\n")
+        sb.append("if [ -z \"\$SID\" ]; then echo 'pm install-create failed' 1>&2; exit 101; fi\n")
+        // Stream each APK's bytes into the session via stdin.
+        for (path in apkPaths) {
+            val size = File(path).length()
+            val escPath = ShellUtils.escapedString(path)
+            val escName = ShellUtils.escapedString(File(path).name)
+            sb.append("cat ").append(escPath)
+                .append(" | pm install-write -S ").append(size)
+                .append(" \"\$SID\" ").append(escName).append(" -")
+                .append(" 1>/dev/null 2>&1 || { pm install-abandon \"\$SID\" 2>/dev/null;")
+                .append(" echo 'pm install-write failed' 1>&2; exit 102; }\n")
         }
-        val command = "pm install-multiple -r -g${if (canDowngrade) " -d" else ""} $escapedPaths"
-        return runCommand(command)
+        // Commit; anything but a Success line is a failure — surface pm's reason.
+        sb.append("COMMIT=\$(pm install-commit \"\$SID\" 2>&1)\n")
+        sb.append("case \"\$COMMIT\" in\n")
+        sb.append("  *Success*) exit 0 ;;\n")
+        sb.append("  *) pm install-abandon \"\$SID\" 2>/dev/null;")
+            .append(" echo \"pm install-commit failed: \$COMMIT\" 1>&2; exit 103 ;;\n")
+        sb.append("esac\n")
+        return runCommand(sb.toString())
     }
 
     override suspend fun getAppCacheSize(packageName: String): Long {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -232,10 +232,11 @@ class RootSystemGateway(
         // libsu appends its end-marker, leaving it unable to read the real exit code
         // (it then falls back to code 1) — and would break every later root command.
         sb.append("(\n")
-        // Create the session; pull the numeric id out of "…created install session [<id>]".
-        sb.append("SID=\$(pm install-create -r -g").append(downgrade)
-            .append(" 2>/dev/null | sed -n 's/.*\\[\\([0-9]*\\)\\].*/\\1/p')\n")
-        sb.append("if [ -z \"\$SID\" ]; then echo 'pm install-create failed' 1>&2; exit 101; fi\n")
+        // Create the session; capture stdout+stderr so a failure reason isn't lost, then
+        // pull the numeric id out of "…created install session [<id>]".
+        sb.append("CREATE_OUT=\$(pm install-create -r -g").append(downgrade).append(" 2>&1)\n")
+        sb.append("SID=\$(printf '%s\\n' \"\$CREATE_OUT\" | sed -n 's/.*\\[\\([0-9]*\\)\\].*/\\1/p')\n")
+        sb.append("if [ -z \"\$SID\" ]; then echo \"pm install-create failed: \$CREATE_OUT\" 1>&2; exit 101; fi\n")
         // Stream each APK's bytes into the session via stdin.
         for (path in apkPaths) {
             val size = File(path).length()


### PR DESCRIPTION
Fixes the root-mode install failure reported in **#159** (Nothing Phone, Android 16 / SDK 36, KernelSU): both `.xapk` and plain `.apk` installs fail with **`Command failed with code 255`** while parsing succeeds. Shizuku and the system installer work.

## Root cause
`installWithRoot` stages the APKs in the app's **private internal cache** (`/data/data/com.valhalla.thor/cache/…`) and ran `pm install <path>` / `pm install-multiple <paths>` (`RootSystemGateway`). On modern Android the system package installer **can't read another app's private files**, so `pm` aborts → exit **255**.

Corroboration:
- suCore returns the real exit code (255), not `JOB_NOT_EXECUTED = -1` → the shell ran and `pm` itself failed.
- Shizuku/Dhizuku deliberately stage on `externalCacheDir` (system-readable) and work.
- `reinstallAppWithGoogle` installs from `/data/app/…` (system-readable) via the same `pm install` and works.
- The user only ever saw `255` with no reason because `pm` prints its `Failure […]` to **stdout**, which suCore drops on a non-zero exit.

## Fix
`RootSystemGateway.installApp` / `installMultipleApks` now install through a **`PackageInstaller` session, streaming each APK's bytes over stdin**:
```
SID=$(pm install-create -r -g [-d])
cat <apk> | pm install-write -S <size> "$SID" <name> -
pm install-commit "$SID"
```
The root shell's own `cat` reads the app-private temp file and pipes the bytes in, so **neither `pm` nor `installd` ever opens a `/data/data` path** — the install works regardless of where the temp APKs live. On failure, `pm`'s real reason is routed to stderr so it finally surfaces in the app's error message.

Scope: root path only (Shizuku/Dhizuku/system paths already work and are untouched). Both single-APK and split/XAPK go through the same session helper.

## Verification
- `:app:compileFossDebugKotlin` + `assembleFossDebug` → BUILD SUCCESSFUL.
- Shell control-flow (session-id parse, stdin write, commit success/failure → exit codes) verified against a mock `pm`.
- **On-device confirmation pending** — needs a KernelSU/root device (the reporter offered to test a pre-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)