### PR TITLE
feat: Add Freezer to launcher (#210) — v1.90.4

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -248,6 +248,10 @@
 
 
         <receiver
+            android:name=".data.receivers.FreezerShortcutPinnedReceiver"
+            android:exported="false" />
+
+        <receiver
             android:name=".data.receivers.InstallReceiver"
             android:exported="false">
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -309,6 +309,8 @@
             android:exported="false"
             android:excludeFromRecents="true"
             android:noHistory="true"
+            android:launchMode="singleInstance"
+            android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <receiver

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -304,6 +304,13 @@
             android:exported="false"
             android:theme="@android:style/Theme.NoDisplay" />
 
+        <activity
+            android:name=".presentation.launcher.FreezerLaunchActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
         <receiver
             android:name=".data.receivers.ExtensionTriggerReceiver"
             android:permission="com.valhalla.thor.permission.TRIGGER_EXTENSION"

--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -43,6 +43,7 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
     private val preferenceRepository: PreferenceRepository by inject()
     private val localeManager: LocaleManager by inject()
     private val autoFreezeManager: AutoFreezeManager by inject()
+    private val freezerShortcutManager: com.valhalla.thor.data.launcher.FreezerShortcutManager by inject()
 
     // Keep the Lazy handle so we can tear the billing client down only if it was actually
     // created this run — resolving the delegate would otherwise spin up a billing connection at
@@ -75,6 +76,7 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
 
         MainScope().launch {
             val prefs = preferenceRepository.userPreferences.first()
+            freezerShortcutManager.syncDynamicShortcuts(prefs.addFreezerToLauncher)
             withContext(Dispatchers.Main) {
                 localeManager.applyLocale(prefs.language)
             }

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutContract.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutContract.kt
@@ -1,0 +1,24 @@
+package com.valhalla.thor.data.launcher
+
+/** Pure contract shared between the shortcut publisher and the launch trampoline. */
+object FreezerShortcutContract {
+    const val EXTRA_ACTION = "com.valhalla.thor.extra.FREEZER_SHORTCUT_ACTION"
+    const val EXTRA_PACKAGE = "com.valhalla.thor.extra.FREEZER_SHORTCUT_PACKAGE"
+
+    const val ACTION_LAUNCH = "launch"
+    const val ACTION_FREEZE_ALL = "freeze_all"
+    const val ACTION_UNFREEZE_ALL = "unfreeze_all"
+
+    const val SHORTCUT_FREEZE_ALL = "freezer_freeze_all"
+    const val SHORTCUT_UNFREEZE_ALL = "freezer_unfreeze_all"
+    private const val APP_SHORTCUT_PREFIX = "freezer_app_"
+
+    /** Stable, package-scoped id for a per-app frozen-app shortcut. */
+    fun appShortcutId(packageName: String): String = "$APP_SHORTCUT_PREFIX$packageName"
+
+    /** Normalize a raw intent extra to a known action, or null if unrecognized. */
+    fun parseAction(raw: String?): String? = when (raw) {
+        ACTION_LAUNCH, ACTION_FREEZE_ALL, ACTION_UNFREEZE_ALL -> raw
+        else -> null
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutContract.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutContract.kt
@@ -13,6 +13,11 @@ object FreezerShortcutContract {
     const val SHORTCUT_UNFREEZE_ALL = "freezer_unfreeze_all"
     private const val APP_SHORTCUT_PREFIX = "freezer_app_"
 
+    // Launcher-tile ARGB colours for the bulk shortcuts — shared by the pinned adaptive icon and the
+    // in-app "Shortcuts" preview so the two always match.
+    val FREEZE_TILE_COLOR: Int = 0xFF29B6F6.toInt()   // sky blue
+    val UNFREEZE_TILE_COLOR: Int = 0xFFFB8C00.toInt() // orange
+
     /** Stable, package-scoped id for a per-app frozen-app shortcut. */
     fun appShortcutId(packageName: String): String = "$APP_SHORTCUT_PREFIX$packageName"
 

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -33,9 +33,9 @@ class FreezerShortcutManager(
     // App-scoped: bulk work must survive the (finishing) trampoline activity.
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    // Solid launcher-tile backgrounds for the bulk action shortcuts (white glyph on colour).
-    private val freezeShortcutBg = Color.parseColor("#1E88E5")   // cold blue
-    private val unfreezeShortcutBg = Color.parseColor("#EF6C00")  // warm orange
+    // Solid launcher-tile backgrounds for the bulk action shortcuts (shared with the in-app preview).
+    private val freezeShortcutBg = FreezerShortcutContract.FREEZE_TILE_COLOR
+    private val unfreezeShortcutBg = FreezerShortcutContract.UNFREEZE_TILE_COLOR
 
     private companion object {
         const val LAUNCH_ACTIVITY = "com.valhalla.thor.presentation.launcher.FreezerLaunchActivity"
@@ -157,6 +157,9 @@ class FreezerShortcutManager(
         Intent().apply {
             setClassName(context, LAUNCH_ACTIVITY)
             this.action = Intent.ACTION_VIEW
+            // Start the trampoline in its own task (it also declares an empty taskAffinity), so tapping
+            // a shortcut never brings Thor's existing task to the foreground.
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             putExtra(FreezerShortcutContract.EXTRA_ACTION, action)
         }
 

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -49,6 +49,9 @@ class FreezerShortcutManager(
                     .putExtra(FreezerShortcutContract.EXTRA_PACKAGE, packageName)
             )
             .build()
+        // A shortcut id previously greyed by disableShortcuts stays disabled on re-pin unless we
+        // re-enable it — otherwise a re-frozen app comes back greyed/uninteractive.
+        ShortcutManagerCompat.enableShortcuts(context, listOf(shortcut))
         ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
     }
 
@@ -59,25 +62,28 @@ class FreezerShortcutManager(
 
     /** Publish (or remove) the Freeze-all + Unfreeze-all long-press dynamic shortcuts. */
     fun syncDynamicShortcuts(enabled: Boolean) {
-        if (enabled) {
-            ShortcutManagerCompat.setDynamicShortcuts(
-                context,
-                listOf(
-                    bulkShortcut(FreezerShortcutContract.ACTION_FREEZE_ALL),
-                    bulkShortcut(FreezerShortcutContract.ACTION_UNFREEZE_ALL),
+        // Binder IPC — called from Main (cold-start + Settings); keep it off the caller's thread.
+        scope.launch {
+            if (enabled) {
+                ShortcutManagerCompat.setDynamicShortcuts(
+                    context,
+                    listOf(
+                        bulkShortcut(FreezerShortcutContract.ACTION_FREEZE_ALL),
+                        bulkShortcut(FreezerShortcutContract.ACTION_UNFREEZE_ALL),
+                    )
                 )
-            )
-        } else {
-            ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+            } else {
+                ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+            }
         }
     }
 
     /** Grey out a per-app shortcut (the ceiling — pinned icons can't be silently removed). */
-    fun disableAppShortcut(packageName: String, reason: CharSequence) {
+    fun disableAppShortcut(packageName: String) {
         ShortcutManagerCompat.disableShortcuts(
             context,
             listOf(FreezerShortcutContract.appShortcutId(packageName)),
-            reason
+            context.getString(R.string.shortcut_no_longer_frozen)
         )
     }
 
@@ -91,17 +97,18 @@ class FreezerShortcutManager(
     }
 
     private fun bulkShortcut(action: String): ShortcutInfoCompat {
-        val id: String
-        val labelRes: Int
-        val iconRes: Int
-        if (action == FreezerShortcutContract.ACTION_FREEZE_ALL) {
-            id = FreezerShortcutContract.SHORTCUT_FREEZE_ALL
-            labelRes = R.string.freeze_all_apps
-            iconRes = R.drawable.frozen
-        } else {
-            id = FreezerShortcutContract.SHORTCUT_UNFREEZE_ALL
-            labelRes = R.string.unfreeze_all_apps
-            iconRes = R.drawable.unfreeze
+        val (id, labelRes, iconRes) = when (action) {
+            FreezerShortcutContract.ACTION_FREEZE_ALL -> Triple(
+                FreezerShortcutContract.SHORTCUT_FREEZE_ALL,
+                R.string.freeze_all_apps,
+                R.drawable.frozen
+            )
+            FreezerShortcutContract.ACTION_UNFREEZE_ALL -> Triple(
+                FreezerShortcutContract.SHORTCUT_UNFREEZE_ALL,
+                R.string.unfreeze_all_apps,
+                R.drawable.unfreeze
+            )
+            else -> error("Unsupported bulk shortcut action: $action")
         }
         val label = context.getString(labelRes)
         return ShortcutInfoCompat.Builder(context, id)

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -1,5 +1,6 @@
 package com.valhalla.thor.data.launcher
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -15,6 +16,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import androidx.core.graphics.drawable.toBitmap
 import com.valhalla.thor.R
+import com.valhalla.thor.data.receivers.FreezerShortcutPinnedReceiver
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.util.Logger
@@ -54,7 +56,7 @@ class FreezerShortcutManager(
             // A shortcut id previously greyed by disableShortcuts stays disabled on re-pin unless we
             // re-enable it — otherwise a re-frozen app comes back greyed/uninteractive.
             ShortcutManagerCompat.enableShortcuts(context, listOf(shortcut))
-            ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+            ShortcutManagerCompat.requestPinShortcut(context, shortcut, pinnedCallback(label).intentSender)
         }
     }
 
@@ -66,7 +68,9 @@ class FreezerShortcutManager(
 
     /** Ask the launcher to pin a Freeze-all / Unfreeze-all action shortcut. */
     fun pinBulkShortcut(action: String) {
-        ShortcutManagerCompat.requestPinShortcut(context, bulkShortcut(action), null)
+        val shortcut = bulkShortcut(action)
+        val label = shortcut.shortLabel.toString()
+        ShortcutManagerCompat.requestPinShortcut(context, shortcut, pinnedCallback(label).intentSender)
     }
 
     /** Publish (or remove) the Freeze-all + Unfreeze-all long-press dynamic shortcuts. */
@@ -153,6 +157,19 @@ class FreezerShortcutManager(
             Logger.e("FreezerShortcut", "bulk icon glyph load failed", e)
         }
         return IconCompat.createWithAdaptiveBitmap(bitmap)
+    }
+
+    // Fires (broadcast) ONLY when the launcher actually pins the shortcut — Android provides no
+    // failure/cancel callback, so this confirms success and can't detect a user cancel.
+    private fun pinnedCallback(label: String): PendingIntent {
+        val intent = Intent(context, FreezerShortcutPinnedReceiver::class.java)
+            .putExtra(FreezerShortcutPinnedReceiver.EXTRA_LABEL, label)
+        return PendingIntent.getBroadcast(
+            context,
+            label.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
     }
 
     // Explicit-component intent → our (non-exported) trampoline, targeted by string class name so

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -2,6 +2,7 @@ package com.valhalla.thor.data.launcher
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
@@ -44,21 +45,23 @@ class FreezerShortcutManager(
     fun isPinSupported(): Boolean =
         ShortcutManagerCompat.isRequestPinShortcutSupported(context)
 
-    /** Ask the launcher to pin a home-screen shortcut for a frozen app (grayscale icon). */
+    /** Ask the launcher to pin a home-screen shortcut for an app. The icon follows the app's state
+     *  (grey while frozen, full colour while enabled). Runs off the caller's thread — the icon
+     *  decode is heavy — so any surface (dialog, details, freezer) can call this directly. */
     fun pinAppShortcut(packageName: String, label: String) {
-        val shortcut = ShortcutInfoCompat.Builder(context, FreezerShortcutContract.appShortcutId(packageName))
-            .setShortLabel(label)
-            .setLongLabel(label)
-            .setIcon(grayscaleIcon(packageName))
-            .setIntent(
-                trampolineIntent(FreezerShortcutContract.ACTION_LAUNCH)
-                    .putExtra(FreezerShortcutContract.EXTRA_PACKAGE, packageName)
-            )
-            .build()
-        // A shortcut id previously greyed by disableShortcuts stays disabled on re-pin unless we
-        // re-enable it — otherwise a re-frozen app comes back greyed/uninteractive.
-        ShortcutManagerCompat.enableShortcuts(context, listOf(shortcut))
-        ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+        scope.launch {
+            val shortcut = buildAppShortcut(packageName, label)
+            // A shortcut id previously greyed by disableShortcuts stays disabled on re-pin unless we
+            // re-enable it — otherwise a re-frozen app comes back greyed/uninteractive.
+            ShortcutManagerCompat.enableShortcuts(context, listOf(shortcut))
+            ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+        }
+    }
+
+    /** Update an already-pinned per-app shortcut so its icon reflects the app's current state.
+     *  No-op if no such shortcut exists. Call after any freeze/unfreeze of the package. */
+    fun refreshAppShortcut(packageName: String) {
+        scope.launch { updateShortcutIcon(packageName) }
     }
 
     /** Ask the launcher to pin a Freeze-all / Unfreeze-all action shortcut. */
@@ -98,6 +101,7 @@ class FreezerShortcutManager(
         scope.launch {
             freezerRepository.getAllPackageNames().forEach { pkg ->
                 manageAppUseCase.setAppDisabled(pkg, disable)
+                updateShortcutIcon(pkg) // keep the launcher icon in sync with the new state
             }
         }
     }
@@ -163,18 +167,58 @@ class FreezerShortcutManager(
             putExtra(FreezerShortcutContract.EXTRA_ACTION, action)
         }
 
-    // Saturation-0 grayscale of the app's own icon (loadable for a disabled-but-installed app).
-    private fun grayscaleIcon(packageName: String): IconCompat {
+    private fun buildAppShortcut(packageName: String, label: String): ShortcutInfoCompat =
+        ShortcutInfoCompat.Builder(context, FreezerShortcutContract.appShortcutId(packageName))
+            .setShortLabel(label)
+            .setLongLabel(label)
+            .setIcon(appIcon(packageName, grayscale = isFrozen(packageName)))
+            .setIntent(
+                trampolineIntent(FreezerShortcutContract.ACTION_LAUNCH)
+                    .putExtra(FreezerShortcutContract.EXTRA_PACKAGE, packageName)
+            )
+            .build()
+
+    // Rebuild + push the current-state icon for a package's pinned shortcut (no-op if absent).
+    private fun updateShortcutIcon(packageName: String) {
+        val label = appLabel(packageName) ?: return
+        ShortcutManagerCompat.updateShortcuts(context, listOf(buildAppShortcut(packageName, label)))
+    }
+
+    // "Frozen" == the app is currently disabled. MATCH_DISABLED_COMPONENTS so we can still read it.
+    private fun isFrozen(packageName: String): Boolean = try {
+        !context.packageManager
+            .getApplicationInfo(packageName, PackageManager.MATCH_DISABLED_COMPONENTS)
+            .enabled
+    } catch (e: Exception) {
+        false
+    }
+
+    private fun appLabel(packageName: String): String? = try {
+        val pm = context.packageManager
+        pm.getApplicationLabel(
+            pm.getApplicationInfo(packageName, PackageManager.MATCH_DISABLED_COMPONENTS)
+        ).toString()
+    } catch (e: Exception) {
+        null
+    }
+
+    // The app's own icon, optionally desaturated to grey (used while the app is frozen).
+    private fun appIcon(packageName: String, grayscale: Boolean): IconCompat {
         return try {
             val src = context.packageManager.getApplicationIcon(packageName).toBitmap()
-            val gray = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
-            Canvas(gray).drawBitmap(
-                src, 0f, 0f,
-                Paint().apply {
-                    colorFilter = ColorMatrixColorFilter(ColorMatrix().apply { setSaturation(0f) })
+            val out = if (grayscale) {
+                Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888).also { gray ->
+                    Canvas(gray).drawBitmap(
+                        src, 0f, 0f,
+                        Paint().apply {
+                            colorFilter = ColorMatrixColorFilter(ColorMatrix().apply { setSaturation(0f) })
+                        }
+                    )
                 }
-            )
-            IconCompat.createWithBitmap(gray)
+            } else {
+                src
+            }
+            IconCompat.createWithBitmap(out)
         } catch (e: Exception) {
             Logger.e("FreezerShortcut", "icon load failed for $packageName", e)
             IconCompat.createWithResource(context, R.drawable.frozen)

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -1,0 +1,141 @@
+package com.valhalla.thor.data.launcher
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import androidx.core.graphics.drawable.toBitmap
+import com.valhalla.thor.R
+import com.valhalla.thor.domain.repository.FreezerRepository
+import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
+
+/** Owns all launcher-shortcut plumbing for the Freezer feature. */
+@Single
+class FreezerShortcutManager(
+    private val context: Context,
+    private val freezerRepository: FreezerRepository,
+    private val manageAppUseCase: ManageAppUseCase,
+) {
+    // App-scoped: bulk work must survive the (finishing) trampoline activity.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private companion object {
+        const val LAUNCH_ACTIVITY = "com.valhalla.thor.presentation.launcher.FreezerLaunchActivity"
+    }
+
+    fun isPinSupported(): Boolean =
+        ShortcutManagerCompat.isRequestPinShortcutSupported(context)
+
+    /** Ask the launcher to pin a home-screen shortcut for a frozen app (grayscale icon). */
+    fun pinAppShortcut(packageName: String, label: String) {
+        val shortcut = ShortcutInfoCompat.Builder(context, FreezerShortcutContract.appShortcutId(packageName))
+            .setShortLabel(label)
+            .setLongLabel(label)
+            .setIcon(grayscaleIcon(packageName))
+            .setIntent(
+                trampolineIntent(FreezerShortcutContract.ACTION_LAUNCH)
+                    .putExtra(FreezerShortcutContract.EXTRA_PACKAGE, packageName)
+            )
+            .build()
+        ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+    }
+
+    /** Ask the launcher to pin a Freeze-all / Unfreeze-all action shortcut. */
+    fun pinBulkShortcut(action: String) {
+        ShortcutManagerCompat.requestPinShortcut(context, bulkShortcut(action), null)
+    }
+
+    /** Publish (or remove) the Freeze-all + Unfreeze-all long-press dynamic shortcuts. */
+    fun syncDynamicShortcuts(enabled: Boolean) {
+        if (enabled) {
+            ShortcutManagerCompat.setDynamicShortcuts(
+                context,
+                listOf(
+                    bulkShortcut(FreezerShortcutContract.ACTION_FREEZE_ALL),
+                    bulkShortcut(FreezerShortcutContract.ACTION_UNFREEZE_ALL),
+                )
+            )
+        } else {
+            ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+        }
+    }
+
+    /** Grey out a per-app shortcut (the ceiling — pinned icons can't be silently removed). */
+    fun disableAppShortcut(packageName: String, reason: CharSequence) {
+        ShortcutManagerCompat.disableShortcuts(
+            context,
+            listOf(FreezerShortcutContract.appShortcutId(packageName)),
+            reason
+        )
+    }
+
+    /** Bulk freeze/unfreeze every package in the freezer, off the finishing activity. */
+    fun runBulk(disable: Boolean) {
+        scope.launch {
+            freezerRepository.getAllPackageNames().forEach { pkg ->
+                manageAppUseCase.setAppDisabled(pkg, disable)
+            }
+        }
+    }
+
+    private fun bulkShortcut(action: String): ShortcutInfoCompat {
+        val id: String
+        val labelRes: Int
+        val iconRes: Int
+        if (action == FreezerShortcutContract.ACTION_FREEZE_ALL) {
+            id = FreezerShortcutContract.SHORTCUT_FREEZE_ALL
+            labelRes = R.string.freeze_all_apps
+            iconRes = R.drawable.frozen
+        } else {
+            id = FreezerShortcutContract.SHORTCUT_UNFREEZE_ALL
+            labelRes = R.string.unfreeze_all_apps
+            iconRes = R.drawable.unfreeze
+        }
+        val label = context.getString(labelRes)
+        return ShortcutInfoCompat.Builder(context, id)
+            .setShortLabel(label)
+            .setLongLabel(label)
+            .setIcon(IconCompat.createWithResource(context, iconRes))
+            .setIntent(trampolineIntent(action))
+            .build()
+    }
+
+    // Explicit-component intent → our (non-exported) trampoline, targeted by string class name so
+    // this class doesn't compile-depend on FreezerLaunchActivity. Shortcuts require an action.
+    private fun trampolineIntent(action: String): Intent =
+        Intent().apply {
+            setClassName(context, LAUNCH_ACTIVITY)
+            this.action = Intent.ACTION_VIEW
+            putExtra(FreezerShortcutContract.EXTRA_ACTION, action)
+        }
+
+    // Saturation-0 grayscale of the app's own icon (loadable for a disabled-but-installed app).
+    private fun grayscaleIcon(packageName: String): IconCompat {
+        return try {
+            val src = context.packageManager.getApplicationIcon(packageName).toBitmap()
+            val gray = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
+            Canvas(gray).drawBitmap(
+                src, 0f, 0f,
+                Paint().apply {
+                    colorFilter = ColorMatrixColorFilter(ColorMatrix().apply { setSaturation(0f) })
+                }
+            )
+            IconCompat.createWithBitmap(gray)
+        } catch (e: Exception) {
+            Logger.e("FreezerShortcut", "icon load failed for $packageName", e)
+            IconCompat.createWithResource(context, R.drawable.frozen)
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.graphics.Paint
+import androidx.core.content.ContextCompat
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -30,6 +32,10 @@ class FreezerShortcutManager(
 ) {
     // App-scoped: bulk work must survive the (finishing) trampoline activity.
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Solid launcher-tile backgrounds for the bulk action shortcuts (white glyph on colour).
+    private val freezeShortcutBg = Color.parseColor("#1E88E5")   // cold blue
+    private val unfreezeShortcutBg = Color.parseColor("#EF6C00")  // warm orange
 
     private companion object {
         const val LAUNCH_ACTIVITY = "com.valhalla.thor.presentation.launcher.FreezerLaunchActivity"
@@ -97,26 +103,52 @@ class FreezerShortcutManager(
     }
 
     private fun bulkShortcut(action: String): ShortcutInfoCompat {
-        val (id, labelRes, iconRes) = when (action) {
-            FreezerShortcutContract.ACTION_FREEZE_ALL -> Triple(
+        val spec = when (action) {
+            FreezerShortcutContract.ACTION_FREEZE_ALL -> BulkSpec(
                 FreezerShortcutContract.SHORTCUT_FREEZE_ALL,
                 R.string.freeze_all_apps,
-                R.drawable.frozen
+                R.drawable.frozen,
+                freezeShortcutBg
             )
-            FreezerShortcutContract.ACTION_UNFREEZE_ALL -> Triple(
+            FreezerShortcutContract.ACTION_UNFREEZE_ALL -> BulkSpec(
                 FreezerShortcutContract.SHORTCUT_UNFREEZE_ALL,
                 R.string.unfreeze_all_apps,
-                R.drawable.unfreeze
+                R.drawable.unfreeze,
+                unfreezeShortcutBg
             )
             else -> error("Unsupported bulk shortcut action: $action")
         }
-        val label = context.getString(labelRes)
-        return ShortcutInfoCompat.Builder(context, id)
+        val label = context.getString(spec.labelRes)
+        return ShortcutInfoCompat.Builder(context, spec.id)
             .setShortLabel(label)
             .setLongLabel(label)
-            .setIcon(IconCompat.createWithResource(context, iconRes))
+            .setIcon(bulkIcon(spec.iconRes, spec.background))
             .setIntent(trampolineIntent(action))
             .build()
+    }
+
+    private data class BulkSpec(val id: String, val labelRes: Int, val iconRes: Int, val background: Int)
+
+    // A launcher-visible adaptive icon: the white-tinted glyph centred on a solid colour tile. The raw
+    // frozen/unfreeze vectors are white-on-transparent (meant to be tinted by the host), so passing them
+    // to createWithResource renders an invisible/white blob on the launcher — hence this composed bitmap.
+    private fun bulkIcon(iconRes: Int, backgroundColor: Int): IconCompat {
+        val size = 216
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(backgroundColor)
+        try {
+            ContextCompat.getDrawable(context, iconRes)?.mutate()?.apply {
+                setTint(Color.WHITE)
+                val inset = size / 4 // glyph fills the centre ~50%, within the adaptive safe zone
+                setBounds(inset, inset, size - inset, size - inset)
+                draw(canvas)
+            }
+        } catch (e: Exception) {
+            // Fall back to a solid coloured tile rather than a broken/blank icon.
+            Logger.e("FreezerShortcut", "bulk icon glyph load failed", e)
+        }
+        return IconCompat.createWithAdaptiveBitmap(bitmap)
     }
 
     // Explicit-component intent → our (non-exported) trampoline, targeted by string class name so

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -51,13 +51,17 @@ class FreezerShortcutManager(
      *  (grey while frozen, full colour while enabled). Runs off the caller's thread — the icon
      *  decode is heavy — so any surface (dialog, details, freezer) can call this directly. */
     fun pinAppShortcut(packageName: String, label: String) {
-        scope.launch {
-            val shortcut = buildAppShortcut(packageName, label)
-            // A shortcut id previously greyed by disableShortcuts stays disabled on re-pin unless we
-            // re-enable it — otherwise a re-frozen app comes back greyed/uninteractive.
-            ShortcutManagerCompat.enableShortcuts(context, listOf(shortcut))
-            ShortcutManagerCompat.requestPinShortcut(context, shortcut, pinnedCallback(label).intentSender)
-        }
+        scope.launch { pinAppShortcutSuspend(packageName, label) }
+    }
+
+    /** Suspending pin so bulk callers can pin sequentially instead of spawning N concurrent bitmap
+     *  decodes + binder pin requests (which risks OOM / overwhelming the shortcut service). */
+    suspend fun pinAppShortcutSuspend(packageName: String, label: String) {
+        val shortcut = buildAppShortcut(packageName, label)
+        // A shortcut id previously greyed by disableShortcuts stays disabled on re-pin unless we
+        // re-enable it — otherwise a re-frozen app comes back greyed/uninteractive.
+        ShortcutManagerCompat.enableShortcuts(context, listOf(shortcut))
+        ShortcutManagerCompat.requestPinShortcut(context, shortcut, pinnedCallback(label).intentSender)
     }
 
     /** Update an already-pinned per-app shortcut so its icon reflects the app's current state.
@@ -103,12 +107,25 @@ class FreezerShortcutManager(
     /** Bulk freeze/unfreeze every package in the freezer, off the finishing activity. */
     fun runBulk(disable: Boolean) {
         scope.launch {
+            val pinnedIds = pinnedShortcutIds()
+            val updated = mutableListOf<ShortcutInfoCompat>()
             freezerRepository.getAllPackageNames().forEach { pkg ->
                 manageAppUseCase.setAppDisabled(pkg, disable)
-                updateShortcutIcon(pkg) // keep the launcher icon in sync with the new state
+                // Only apps that actually have a pinned shortcut need a state-following icon refresh;
+                // accumulate them and push ONE updateShortcuts IPC instead of N.
+                if (FreezerShortcutContract.appShortcutId(pkg) in pinnedIds) {
+                    appLabel(pkg)?.let { updated.add(buildAppShortcut(pkg, it)) }
+                }
+            }
+            if (updated.isNotEmpty()) {
+                ShortcutManagerCompat.updateShortcuts(context, updated)
             }
         }
     }
+
+    private fun pinnedShortcutIds(): Set<String> =
+        ShortcutManagerCompat.getShortcuts(context, ShortcutManagerCompat.FLAG_MATCH_PINNED)
+            .mapTo(HashSet()) { it.id }
 
     private fun bulkShortcut(action: String): ShortcutInfoCompat {
         val spec = when (action) {

--- a/app/src/main/java/com/valhalla/thor/data/receivers/FreezerShortcutPinnedReceiver.kt
+++ b/app/src/main/java/com/valhalla/thor/data/receivers/FreezerShortcutPinnedReceiver.kt
@@ -1,0 +1,28 @@
+package com.valhalla.thor.data.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import com.valhalla.thor.R
+
+/**
+ * Fired by the system (via the [android.content.IntentSender] passed to
+ * `ShortcutManagerCompat.requestPinShortcut`) ONLY when a shortcut is successfully pinned to the
+ * launcher. Android provides no cancel/failure callback, so this confirms success only.
+ */
+class FreezerShortcutPinnedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val label = intent.getStringExtra(EXTRA_LABEL)
+        val message = if (!label.isNullOrEmpty()) {
+            context.getString(R.string.shortcut_added_named, label)
+        } else {
+            context.getString(R.string.shortcut_added)
+        }
+        Toast.makeText(context.applicationContext, message, Toast.LENGTH_SHORT).show()
+    }
+
+    companion object {
+        const val EXTRA_LABEL = "com.valhalla.thor.extra.SHORTCUT_LABEL"
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -53,6 +53,7 @@ class PreferenceRepositoryImpl(
 
         // Auto Freeze
         val AUTO_FREEZE = booleanPreferencesKey("auto_freeze")
+        val ADD_FREEZER_TO_LAUNCHER = booleanPreferencesKey("add_freezer_to_launcher")
 
         // Freezer Prompts
         val HAS_SHOWN_DISABLED_APPS_PROMPT = booleanPreferencesKey("has_shown_disabled_apps_prompt")
@@ -115,6 +116,7 @@ class PreferenceRepositoryImpl(
                 preferredPrivilegeMode = privilegeMode,
                 language = prefs[Keys.LANGUAGE],
                 autoFreezeEnabled = prefs[Keys.AUTO_FREEZE] ?: false,
+                addFreezerToLauncher = prefs[Keys.ADD_FREEZER_TO_LAUNCHER] ?: false,
                 hasShownDisabledAppsPrompt = prefs[Keys.HAS_SHOWN_DISABLED_APPS_PROMPT] ?: false,
                 hasShownSupportDeveloperPrompt = prefs[Keys.HAS_SHOWN_SUPPORT_DEVELOPER_PROMPT] ?: false,
                 useDetailedView = useDetailedView,
@@ -193,6 +195,12 @@ class PreferenceRepositoryImpl(
     override suspend fun setAutoFreezeEnabled(enabled: Boolean) {
         context.dataStore.edit {
             it[Keys.AUTO_FREEZE] = enabled
+        }
+    }
+
+    override suspend fun setAddFreezerToLauncher(enabled: Boolean) {
+        context.dataStore.edit {
+            it[Keys.ADD_FREEZER_TO_LAUNCHER] = enabled
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
@@ -29,7 +29,8 @@ class AutoFreezeManager(
     private val freezerRepository: FreezerRepository,
     private val manageAppUseCase: ManageAppUseCase,
     private val systemRepository: SystemRepository,
-    private val appRepository: AppRepository
+    private val appRepository: AppRepository,
+    private val freezerShortcutManager: com.valhalla.thor.data.launcher.FreezerShortcutManager
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -99,6 +100,7 @@ class AutoFreezeManager(
                                         val result = manageAppUseCase.setAppDisabled(pkg, true)
                                         if (result.isSuccess) {
                                             Logger.d("AutoFreezeManager", "Auto-froze: $pkg")
+                                            freezerShortcutManager.refreshAppShortcut(pkg) // → grey the shortcut icon
                                         } else {
                                             Logger.e(
                                                 "AutoFreezeManager",

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppClickAction.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppClickAction.kt
@@ -18,4 +18,5 @@ sealed interface AppClickAction {
     data class UnSuspend(val appInfo: AppInfo) : AppClickAction
     data class ManagePermissions(val appInfo: AppInfo) : AppClickAction
     data class OpenDetails(val appInfo: AppInfo) : AppClickAction
+    data class AddToHomeScreen(val appInfo: AppInfo) : AppClickAction
 }

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -27,6 +27,9 @@ data class UserPreferences(
     // Auto Freeze
     val autoFreezeEnabled: Boolean = false,
 
+    // Add Freezer to launcher (home-screen shortcuts for frozen apps)
+    val addFreezerToLauncher: Boolean = false,
+
     // Freezer Prompts
     val hasShownDisabledAppsPrompt: Boolean = false,
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -39,6 +39,7 @@ interface PreferenceRepository {
 
     // --- Auto Freeze ---
     suspend fun setAutoFreezeEnabled(enabled: Boolean)
+    suspend fun setAddFreezerToLauncher(enabled: Boolean)
 
     // --- Freezer Prompts ---
     suspend fun setHasShownDisabledAppsPrompt(hasShown: Boolean)

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.valhalla.thor.data.launcher.FreezerShortcutManager
+import com.valhalla.thor.presentation.widgets.FreezerPromptSnackbar
 import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import org.koin.compose.koinInject
@@ -290,6 +291,18 @@ fun AppInfoDetailsScreen(
                     }
                 }
             }
+
+            FreezerPromptSnackbar(
+                visible = state.freezerPrompt != null,
+                appName = state.freezerPrompt?.appName,
+                onAddToFreezer = {
+                    state.freezerPrompt?.let { viewModel.addToFreezer(it.packageName) }
+                },
+                onDismiss = viewModel::dismissFreezerPrompt,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp)
+            )
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -66,6 +66,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.valhalla.thor.data.launcher.FreezerShortcutManager
+import com.valhalla.thor.domain.model.UserPreferences
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import org.koin.compose.koinInject
 import coil3.compose.AsyncImage
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.R
@@ -677,6 +681,11 @@ private fun AppDetailsActionRow(
     val isFrozen = !appInfo.enabled
     val isSuspended = appInfo.isSuspended
 
+    // Self-contained launcher-shortcut action — gated on the feature setting + pin support + user app.
+    val shortcutManager = koinInject<FreezerShortcutManager>()
+    val preferenceRepository = koinInject<PreferenceRepository>()
+    val prefs by preferenceRepository.userPreferences.collectAsStateWithLifecycle(UserPreferences())
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -765,6 +774,19 @@ private fun AppDetailsActionRow(
             label = stringResource(R.string.action_export),
             onClick = onExport
         )
+
+        if (prefs.addFreezerToLauncher && !appInfo.isSystem && shortcutManager.isPinSupported()) {
+            ActionItem(
+                icon = R.drawable.home,
+                label = stringResource(R.string.add_to_home_screen),
+                onClick = {
+                    shortcutManager.pinAppShortcut(
+                        appInfo.packageName,
+                        appInfo.appName ?: appInfo.packageName
+                    )
+                }
+            )
+        }
 
         if (appInfo.packageName != BuildConfig.APPLICATION_ID) {
             ActionItem(

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -705,7 +705,7 @@ private fun AppDetailsActionRow(
             .horizontalScroll(rememberScrollState())
             .padding(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.Top
     ) {
         ActionItem(
             icon = R.drawable.open_in_new,

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -3,6 +3,7 @@ package com.valhalla.thor.presentation.appList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
+import com.valhalla.thor.data.launcher.FreezerShortcutManager
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.FreezerRepository
@@ -34,7 +35,8 @@ class AppInfoDetailsViewModel(
     private val appRepository: AppRepository,
     private val systemRepository: SystemRepository,
     private val manageAppUseCase: ManageAppUseCase,
-    private val freezerRepository: FreezerRepository
+    private val freezerRepository: FreezerRepository,
+    private val freezerShortcutManager: FreezerShortcutManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AppInfoDetailsUiState())
@@ -221,6 +223,7 @@ class AppInfoDetailsViewModel(
             val currentlyIn = freezerRepository.contains(packageName)
             if (currentlyIn) {
                 freezerRepository.remove(packageName)
+                freezerShortcutManager.disableAppShortcut(packageName)
                 _uiState.update {
                     it.copy(
                         isInFreezer = false,

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
 import com.valhalla.thor.data.launcher.FreezerShortcutManager
 import com.valhalla.thor.domain.model.DetailedAppInfo
+import com.valhalla.thor.presentation.freezer.FreezerPrompt
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.SystemRepository
@@ -27,6 +28,7 @@ data class AppInfoDetailsUiState(
     val detailedInfo: DetailedAppInfo? = null,
     val isInFreezer: Boolean = false,
     val actionMessage: UiText? = null,
+    val freezerPrompt: FreezerPrompt? = null,
     val errorMessage: UiText? = null
 )
 
@@ -94,19 +96,19 @@ class AppInfoDetailsViewModel(
         viewModelScope.launch {
             val result = manageAppUseCase.setAppDisabled(packageName, freeze)
             result.onSuccess {
-                val updatedInFreezer = withContext(Dispatchers.IO) {
-                    if (freeze && !freezerRepository.contains(packageName)) {
-                        freezerRepository.add(packageName)
+                freezerShortcutManager.refreshAppShortcut(packageName)
+                val inFreezer = withContext(Dispatchers.IO) { freezerRepository.contains(packageName) }
+                if (freeze && !inFreezer) {
+                    // Don't auto-add — prompt the user to add it to the Freezer instead.
+                    _uiState.update { it.copy(freezerPrompt = FreezerPrompt(packageName, appName)) }
+                } else {
+                    val msgRes = if (freeze) R.string.frozen_success else R.string.unfrozen_success
+                    _uiState.update {
+                        it.copy(
+                            actionMessage = UiText.StringResource(msgRes, appName ?: packageName),
+                            isInFreezer = inFreezer
+                        )
                     }
-                    freezerRepository.contains(packageName)
-                }
-
-                val msgRes = if (freeze) R.string.frozen_success else R.string.unfrozen_success
-                _uiState.update {
-                    it.copy(
-                        actionMessage = UiText.StringResource(msgRes, appName ?: packageName),
-                        isInFreezer = updatedInFreezer
-                    )
                 }
                 // Reload state
                 loadAppDetails(packageName)
@@ -216,6 +218,18 @@ class AppInfoDetailsViewModel(
                 }
             }
         }
+    }
+
+    fun addToFreezer(packageName: String) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) { freezerRepository.add(packageName) }
+            _uiState.update { it.copy(freezerPrompt = null, isInFreezer = true) }
+            loadAppDetails(packageName)
+        }
+    }
+
+    fun dismissFreezerPrompt() {
+        _uiState.update { it.copy(freezerPrompt = null) }
     }
 
     fun addOrRemoveFromFreezer(packageName: String) {

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
@@ -221,10 +221,14 @@ fun AppListScreen(
                 isDhizuku = state.isDhizuku,
                 onDismiss = { selectedAppForDialog = null },
                 onAppAction = { action ->
-                    if (action is AppClickAction.OpenDetails) {
-                        onNavigateToAppInfo(app.packageName, app.appName ?: "")
-                    } else {
-                        onAppAction(action)
+                    when {
+                        action is AppClickAction.OpenDetails ->
+                            onNavigateToAppInfo(app.packageName, app.appName ?: "")
+                        // Freeze from the dialog goes through the local VM so it surfaces the
+                        // "Frozen — Add to Freezer?" prompt instead of silently just disabling.
+                        action is AppClickAction.Freeze ->
+                            viewModel.freezeApp(action.appInfo.packageName, action.appInfo.appName, true)
+                        else -> onAppAction(action)
                     }
                     selectedAppForDialog = null
                 }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -410,6 +410,7 @@ fun FreezerScreen(
             isRoot = state.isRoot,
             isShizuku = state.isShizuku,
             isDhizuku = state.isDhizuku,
+            showAddToHomeScreen = state.addFreezerToLauncher && viewModel.isPinSupported(),
             onDismiss = { selectedPackageName = null },
             onAppAction = { action ->
                 when (action) {
@@ -424,6 +425,11 @@ fun FreezerScreen(
 
                     is AppClickAction.UnFreeze -> {
                         viewModel.unfreezeSingleApp(app.packageName, app.appName)
+                        selectedPackageName = null
+                    }
+
+                    is AppClickAction.AddToHomeScreen -> {
+                        viewModel.pinAppToLauncher(app)
                         selectedPackageName = null
                     }
 
@@ -454,10 +460,14 @@ fun FreezerScreen(
             hasPrivilege = hasPrivilege,
             showImportDisabledApps = disabledAppsNotInFreezer.isNotEmpty(),
             appListType = state.appListType,
+            showLauncherPinActions = state.addFreezerToLauncher && viewModel.isPinSupported(),
             onToggleView = viewModel::toggleGridMode,
             onToggleAutoFreeze = viewModel::setAutoFreezeEnabled,
             onDismiss = { showSettingsSheet = false },
             onUnfreezeAll = { onMultiAppAction(MultiAppAction.UnFreeze(appsToUnfreeze)) },
+            onPinAllToLauncher = viewModel::pinAllToLauncher,
+            onPinFreezeAllShortcut = { viewModel.pinBulkShortcut(freeze = true) },
+            onPinUnfreezeAllShortcut = { viewModel.pinBulkShortcut(freeze = false) },
             onImportDisabledApps = {
                 showSettingsSheet = false
                 if (disabledAppsNotInFreezer.isNotEmpty()) {

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -466,6 +466,7 @@ fun FreezerScreen(
             onDismiss = { showSettingsSheet = false },
             onUnfreezeAll = { onMultiAppAction(MultiAppAction.UnFreeze(appsToUnfreeze)) },
             onPinAllToLauncher = viewModel::pinAllToLauncher,
+            pinAllCount = state.freezerApps.count { !it.isSystem },
             onPinFreezeAllShortcut = { viewModel.pinBulkShortcut(freeze = true) },
             onPinUnfreezeAllShortcut = { viewModel.pinBulkShortcut(freeze = false) },
             onImportDisabledApps = {

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
@@ -1,5 +1,6 @@
 package com.valhalla.thor.presentation.freezer
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -8,8 +9,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -36,6 +37,7 @@ import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppListType
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import com.valhalla.asgard.components.AsgardActionItem
 import com.valhalla.asgard.components.ConnectedButtonGroup
 import com.valhalla.asgard.components.ConnectedButtonGroupItem
 
@@ -228,28 +230,41 @@ fun FreezerSettingsSheet(
                 )
             }
 
-            // Launcher-shortcut pin actions — only when the launcher integration is enabled
-            // and the current launcher supports pinning.
+            // Launcher-shortcut actions — a dedicated "Shortcuts" section, shown only when the
+            // launcher integration is enabled and the current launcher supports pinning. Rendered as
+            // action-item rows (matching the app-info dialog) rather than full-width buttons.
             if (showLauncherPinActions) {
                 Spacer(Modifier.height(24.dp))
 
-                PinActionButton(
-                    icon = R.drawable.home,
-                    label = stringResource(R.string.pin_all_to_home_screen),
-                    onClick = onPinAllToLauncher
+                Text(
+                    stringResource(R.string.shortcuts),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
                 )
                 Spacer(Modifier.height(12.dp))
-                PinActionButton(
-                    icon = R.drawable.frozen,
-                    label = stringResource(R.string.freeze_all_apps),
-                    onClick = onPinFreezeAllShortcut
-                )
-                Spacer(Modifier.height(12.dp))
-                PinActionButton(
-                    icon = R.drawable.unfreeze,
-                    label = stringResource(R.string.unfreeze_all_apps),
-                    onClick = onPinUnfreezeAllShortcut
-                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    ShortcutActionItem(
+                        icon = R.drawable.frozen,
+                        label = stringResource(R.string.freeze_all_apps),
+                        onClick = onPinFreezeAllShortcut
+                    )
+                    ShortcutActionItem(
+                        icon = R.drawable.unfreeze,
+                        label = stringResource(R.string.unfreeze_all_apps),
+                        onClick = onPinUnfreezeAllShortcut
+                    )
+                    ShortcutActionItem(
+                        icon = R.drawable.home,
+                        label = stringResource(R.string.shortcut_add_all),
+                        onClick = onPinAllToLauncher
+                    )
+                }
             }
 
             Spacer(Modifier.height(24.dp))
@@ -258,26 +273,10 @@ fun FreezerSettingsSheet(
 }
 
 @Composable
-private fun PinActionButton(
-    icon: Int,
-    label: String,
-    onClick: () -> Unit
-) {
-    Button(
+private fun ShortcutActionItem(icon: Int, label: String, onClick: () -> Unit) {
+    AsgardActionItem(
+        icon = ImageVector.vectorResource(icon),
+        label = label,
         onClick = onClick,
-        modifier = Modifier.fillMaxWidth(),
-        colors = ButtonDefaults.buttonColors(
-            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-        ),
-        shape = RoundedCornerShape(16.dp)
-    ) {
-        Icon(
-            painter = painterResource(icon),
-            contentDescription = null,
-            modifier = Modifier.size(20.dp)
-        )
-        Spacer(Modifier.width(12.dp))
-        Text(label)
-    }
+    )
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
@@ -60,9 +60,11 @@ fun FreezerSettingsSheet(
     onListTypeChanged: (AppListType) -> Unit,
     onPinAllToLauncher: () -> Unit = {},
     onPinFreezeAllShortcut: () -> Unit = {},
-    onPinUnfreezeAllShortcut: () -> Unit = {}
+    onPinUnfreezeAllShortcut: () -> Unit = {},
+    pinAllCount: Int = 0
 ) {
     var showUnfreezeConfirmation by remember { mutableStateOf(false) }
+    var showPinAllConfirmation by remember { mutableStateOf(false) }
 
     if (showUnfreezeConfirmation) {
         AlertDialog(
@@ -89,6 +91,37 @@ fun FreezerSettingsSheet(
             },
             dismissButton = {
                 TextButton(onClick = { showUnfreezeConfirmation = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    if (showPinAllConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showPinAllConfirmation = false },
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.home),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            },
+            title = { Text(stringResource(R.string.pin_all_confirm_title)) },
+            text = { Text(stringResource(R.string.pin_all_confirm_desc, pinAllCount)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onPinAllToLauncher()
+                        showPinAllConfirmation = false
+                        onDismiss()
+                    }
+                ) {
+                    Text(stringResource(R.string.add))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPinAllConfirmation = false }) {
                     Text(stringResource(R.string.cancel))
                 }
             }
@@ -267,7 +300,7 @@ fun FreezerSettingsSheet(
                         icon = R.drawable.home,
                         label = stringResource(R.string.shortcut_add_all),
                         tileColor = Color(0xFF607D8B),
-                        onClick = onPinAllToLauncher
+                        onClick = { showPinAllConfirmation = true }
                     )
                 }
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
@@ -46,12 +47,16 @@ fun FreezerSettingsSheet(
     hasPrivilege: Boolean,
     showImportDisabledApps: Boolean,
     appListType: AppListType,
+    showLauncherPinActions: Boolean = false,
     onToggleView: () -> Unit,
     onToggleAutoFreeze: (Boolean) -> Unit,
     onDismiss: () -> Unit,
     onUnfreezeAll: () -> Unit,
     onImportDisabledApps: () -> Unit,
-    onListTypeChanged: (AppListType) -> Unit
+    onListTypeChanged: (AppListType) -> Unit,
+    onPinAllToLauncher: () -> Unit = {},
+    onPinFreezeAllShortcut: () -> Unit = {},
+    onPinUnfreezeAllShortcut: () -> Unit = {}
 ) {
     var showUnfreezeConfirmation by remember { mutableStateOf(false) }
 
@@ -222,7 +227,57 @@ fun FreezerSettingsSheet(
                     enabled = hasPrivilege
                 )
             }
+
+            // Launcher-shortcut pin actions — only when the launcher integration is enabled
+            // and the current launcher supports pinning.
+            if (showLauncherPinActions) {
+                Spacer(Modifier.height(24.dp))
+
+                PinActionButton(
+                    icon = R.drawable.home,
+                    label = stringResource(R.string.pin_all_to_home_screen),
+                    onClick = onPinAllToLauncher
+                )
+                Spacer(Modifier.height(12.dp))
+                PinActionButton(
+                    icon = R.drawable.frozen,
+                    label = stringResource(R.string.freeze_all_apps),
+                    onClick = onPinFreezeAllShortcut
+                )
+                Spacer(Modifier.height(12.dp))
+                PinActionButton(
+                    icon = R.drawable.unfreeze,
+                    label = stringResource(R.string.unfreeze_all_apps),
+                    onClick = onPinUnfreezeAllShortcut
+                )
+            }
+
             Spacer(Modifier.height(24.dp))
         }
+    }
+}
+
+@Composable
+private fun PinActionButton(
+    icon: Int,
+    label: String,
+    onClick: () -> Unit
+) {
+    Button(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+        ),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Icon(
+            painter = painterResource(icon),
+            contentDescription = null,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(Modifier.width(12.dp))
+        Text(label)
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
@@ -29,11 +29,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.valhalla.thor.R
+import com.valhalla.thor.data.launcher.FreezerShortcutContract
 import com.valhalla.thor.domain.model.AppListType
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
@@ -247,21 +249,24 @@ fun FreezerSettingsSheet(
                         .fillMaxWidth()
                         .horizontalScroll(rememberScrollState()),
                     horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.Top
                 ) {
                     ShortcutActionItem(
                         icon = R.drawable.frozen,
                         label = stringResource(R.string.freeze_all_apps),
+                        tileColor = Color(FreezerShortcutContract.FREEZE_TILE_COLOR),
                         onClick = onPinFreezeAllShortcut
                     )
                     ShortcutActionItem(
                         icon = R.drawable.unfreeze,
                         label = stringResource(R.string.unfreeze_all_apps),
+                        tileColor = Color(FreezerShortcutContract.UNFREEZE_TILE_COLOR),
                         onClick = onPinUnfreezeAllShortcut
                     )
                     ShortcutActionItem(
                         icon = R.drawable.home,
                         label = stringResource(R.string.shortcut_add_all),
+                        tileColor = Color(0xFF607D8B),
                         onClick = onPinAllToLauncher
                     )
                 }
@@ -273,10 +278,13 @@ fun FreezerSettingsSheet(
 }
 
 @Composable
-private fun ShortcutActionItem(icon: Int, label: String, onClick: () -> Unit) {
+private fun ShortcutActionItem(icon: Int, label: String, tileColor: Color, onClick: () -> Unit) {
+    // Preview the actual pinned-shortcut tile: white glyph on the same coloured background.
     AsgardActionItem(
         icon = ImageVector.vectorResource(icon),
         label = label,
         onClick = onClick,
+        containerColor = tileColor,
+        iconTint = Color.White,
     )
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -225,6 +225,7 @@ class FreezerViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             manageAppUseCase.setAppDisabled(packageName, true)
                 .onSuccess {
+                    freezerShortcutManager.refreshAppShortcut(packageName)
                     if (!inFreezer) {
                         _uiState.update {
                             it.copy(
@@ -262,6 +263,7 @@ class FreezerViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             manageAppUseCase.setAppDisabled(packageName, false)
                 .onSuccess {
+                    freezerShortcutManager.refreshAppShortcut(packageName)
                     _uiState.update {
                         it.copy(
                             actionMessage = UiText.StringResource(

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -138,6 +138,7 @@ class FreezerViewModel(
             packageNames.forEach { pkg ->
                 freezerRepository.remove(pkg)
                 manageAppUseCase.setAppDisabled(pkg, false)
+                freezerShortcutManager.disableAppShortcut(pkg, "No longer frozen")
             }
             _uiState.update {
                 it.copy(
@@ -172,6 +173,7 @@ class FreezerViewModel(
                     }
             } else {
                 freezerRepository.remove(packageName)
+                freezerShortcutManager.disableAppShortcut(packageName, "No longer frozen")
                 manageAppUseCase.setAppDisabled(packageName, false)
                     .onFailure { e ->
                         _uiState.update {

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -15,6 +15,7 @@ import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -354,11 +355,16 @@ class FreezerViewModel(
     }
 
     fun pinAllToLauncher() {
-        // N grayscale icon decodes — must not run on Main (would jank/ANR for large lists).
+        // Pin sequentially (suspending) off Main: a rapid loop of the fire-and-forget pinAppShortcut
+        // would spawn N concurrent bitmap decodes + binder pin requests and risk OOM / overwhelming
+        // the shortcut service. A small gap keeps the per-shortcut system prompts orderly too.
         viewModelScope.launch(Dispatchers.Default) {
             _uiState.value.freezerApps
                 .filter { !it.isSystem }
-                .forEach { freezerShortcutManager.pinAppShortcut(it.packageName, it.appName ?: it.packageName) }
+                .forEach {
+                    freezerShortcutManager.pinAppShortcutSuspend(it.packageName, it.appName ?: it.packageName)
+                    delay(100)
+                }
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -3,6 +3,8 @@ package com.valhalla.thor.presentation.freezer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
+import com.valhalla.thor.data.launcher.FreezerShortcutContract
+import com.valhalla.thor.data.launcher.FreezerShortcutManager
 import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
@@ -41,7 +43,8 @@ data class FreezerUiState(
     val isDhizuku: Boolean = false,
     val hasShownDisabledAppsPrompt: Boolean = false,
     val appListType: AppListType = AppListType.USER,
-    val isGrid: Boolean = true
+    val isGrid: Boolean = true,
+    val addFreezerToLauncher: Boolean = false
 )
 
 @KoinViewModel
@@ -50,7 +53,8 @@ class FreezerViewModel(
     private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
     private val manageAppUseCase: ManageAppUseCase,
     private val privilegeManager: PrivilegeManager,
-    private val preferenceRepository: PreferenceRepository
+    private val preferenceRepository: PreferenceRepository,
+    private val freezerShortcutManager: FreezerShortcutManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(FreezerUiState())
@@ -291,7 +295,8 @@ class FreezerViewModel(
                     it.copy(
                         autoFreezeEnabled = prefs.autoFreezeEnabled,
                         hasShownDisabledAppsPrompt = prefs.hasShownDisabledAppsPrompt,
-                        isGrid = prefs.freezerIsGrid
+                        isGrid = prefs.freezerIsGrid,
+                        addFreezerToLauncher = prefs.addFreezerToLauncher
                     )
                 }
             }
@@ -330,5 +335,27 @@ class FreezerViewModel(
                 )
             }
         }
+    }
+
+    // --- Launcher shortcuts (gated by the "Add Freezer to launcher" preference) ---
+
+    fun isPinSupported(): Boolean = freezerShortcutManager.isPinSupported()
+
+    fun pinAppToLauncher(app: AppInfo) {
+        if (app.isSystem) return // v1: user apps only
+        freezerShortcutManager.pinAppShortcut(app.packageName, app.appName ?: app.packageName)
+    }
+
+    fun pinAllToLauncher() {
+        _uiState.value.freezerApps
+            .filter { !it.isSystem }
+            .forEach { freezerShortcutManager.pinAppShortcut(it.packageName, it.appName ?: it.packageName) }
+    }
+
+    fun pinBulkShortcut(freeze: Boolean) {
+        freezerShortcutManager.pinBulkShortcut(
+            if (freeze) FreezerShortcutContract.ACTION_FREEZE_ALL
+            else FreezerShortcutContract.ACTION_UNFREEZE_ALL
+        )
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -138,7 +138,7 @@ class FreezerViewModel(
             packageNames.forEach { pkg ->
                 freezerRepository.remove(pkg)
                 manageAppUseCase.setAppDisabled(pkg, false)
-                freezerShortcutManager.disableAppShortcut(pkg, "No longer frozen")
+                freezerShortcutManager.disableAppShortcut(pkg)
             }
             _uiState.update {
                 it.copy(
@@ -173,7 +173,7 @@ class FreezerViewModel(
                     }
             } else {
                 freezerRepository.remove(packageName)
-                freezerShortcutManager.disableAppShortcut(packageName, "No longer frozen")
+                freezerShortcutManager.disableAppShortcut(packageName)
                 manageAppUseCase.setAppDisabled(packageName, false)
                     .onFailure { e ->
                         _uiState.update {
@@ -345,13 +345,19 @@ class FreezerViewModel(
 
     fun pinAppToLauncher(app: AppInfo) {
         if (app.isSystem) return // v1: user apps only
-        freezerShortcutManager.pinAppShortcut(app.packageName, app.appName ?: app.packageName)
+        // Grayscale icon decode + binder pin request — keep it off Main to avoid jank.
+        viewModelScope.launch(Dispatchers.Default) {
+            freezerShortcutManager.pinAppShortcut(app.packageName, app.appName ?: app.packageName)
+        }
     }
 
     fun pinAllToLauncher() {
-        _uiState.value.freezerApps
-            .filter { !it.isSystem }
-            .forEach { freezerShortcutManager.pinAppShortcut(it.packageName, it.appName ?: it.packageName) }
+        // N grayscale icon decodes — must not run on Main (would jank/ANR for large lists).
+        viewModelScope.launch(Dispatchers.Default) {
+            _uiState.value.freezerApps
+                .filter { !it.isSystem }
+                .forEach { freezerShortcutManager.pinAppShortcut(it.packageName, it.appName ?: it.packageName) }
+        }
     }
 
     fun pinBulkShortcut(freeze: Boolean) {

--- a/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
@@ -64,10 +64,11 @@ class FreezerLaunchActivity : Activity() {
                     finish(); return@launch
                 }
                 withContext(Dispatchers.IO) { manageAppUseCase.setAppDisabled(pkg, false) }
-                // Enabled state / launcher intent may not be visible instantly — retry briefly.
-                repeat(10) {
+                // Enabled state / launcher intent may not be visible instantly — retry briefly
+                // (~10×150ms budget), stopping as soon as the intent resolves.
+                for (attempt in 0 until 10) {
                     launchIntent = packageManager.getLaunchIntentForPackage(pkg)
-                    if (launchIntent != null) return@repeat
+                    if (launchIntent != null) break
                     delay(150)
                 }
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
@@ -75,6 +75,7 @@ class FreezerLaunchActivity : Activity() {
             val toStart = launchIntent
             if (toStart != null) startActivity(toStart)
             else toast(getString(R.string.freezer_launch_failed))
+            freezerShortcutManager.refreshAppShortcut(pkg) // now enabled → recolour the shortcut icon
             finish()
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
@@ -1,0 +1,94 @@
+package com.valhalla.thor.presentation.launcher
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.Toast
+import com.valhalla.thor.R
+import com.valhalla.thor.data.launcher.FreezerShortcutContract
+import com.valhalla.thor.data.launcher.FreezerShortcutManager
+import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.android.ext.android.inject
+
+/**
+ * Invisible (translucent) trampoline for Freezer launcher shortcuts. Translucent — not
+ * Theme.NoDisplay — because it does async work (enable-then-launch) and NoDisplay requires
+ * finish() before onResume completes.
+ */
+class FreezerLaunchActivity : Activity() {
+
+    private val systemRepository: SystemRepository by inject()
+    private val manageAppUseCase: ManageAppUseCase by inject()
+    private val freezerShortcutManager: FreezerShortcutManager by inject()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        when (FreezerShortcutContract.parseAction(intent?.getStringExtra(FreezerShortcutContract.EXTRA_ACTION))) {
+            FreezerShortcutContract.ACTION_FREEZE_ALL -> guardThenBulk(disable = true)
+            FreezerShortcutContract.ACTION_UNFREEZE_ALL -> guardThenBulk(disable = false)
+            FreezerShortcutContract.ACTION_LAUNCH -> {
+                val pkg = intent?.getStringExtra(FreezerShortcutContract.EXTRA_PACKAGE)
+                if (pkg.isNullOrEmpty()) finish() else launchApp(pkg)
+            }
+            else -> finish()
+        }
+    }
+
+    // Bulk: privilege-guard, hand off to the app-scoped manager, finish immediately.
+    private fun guardThenBulk(disable: Boolean) {
+        scope.launch {
+            if (!hasPrivilege()) {
+                toast(getString(R.string.tile_grant_privilege_toast))
+            } else {
+                freezerShortcutManager.runBulk(disable)
+            }
+            finish()
+        }
+    }
+
+    // Launch: stay foreground through startActivity (Android 10+ background-launch rule).
+    private fun launchApp(pkg: String) {
+        scope.launch {
+            var launchIntent = packageManager.getLaunchIntentForPackage(pkg)
+            if (launchIntent == null) {
+                if (!hasPrivilege()) {
+                    toast(getString(R.string.tile_grant_privilege_toast))
+                    finish(); return@launch
+                }
+                withContext(Dispatchers.IO) { manageAppUseCase.setAppDisabled(pkg, false) }
+                // Enabled state / launcher intent may not be visible instantly — retry briefly.
+                repeat(10) {
+                    launchIntent = packageManager.getLaunchIntentForPackage(pkg)
+                    if (launchIntent != null) return@repeat
+                    delay(150)
+                }
+            }
+            val toStart = launchIntent
+            if (toStart != null) startActivity(toStart)
+            else toast(getString(R.string.freezer_launch_failed))
+            finish()
+        }
+    }
+
+    private suspend fun hasPrivilege(): Boolean = withContext(Dispatchers.IO) {
+        systemRepository.isRootAvailable() ||
+                systemRepository.isShizukuAvailable() ||
+                systemRepository.isDhizukuAvailable()
+    }
+
+    private fun toast(msg: String) =
+        Toast.makeText(applicationContext, msg, Toast.LENGTH_SHORT).show()
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
@@ -63,7 +63,12 @@ class FreezerLaunchActivity : Activity() {
                     toast(getString(R.string.tile_grant_privilege_toast))
                     finish(); return@launch
                 }
-                withContext(Dispatchers.IO) { manageAppUseCase.setAppDisabled(pkg, false) }
+                val enabled = withContext(Dispatchers.IO) { manageAppUseCase.setAppDisabled(pkg, false) }
+                if (enabled.isFailure) {
+                    // Enable failed (privilege/shell error) — fail fast instead of waiting out the retry loop.
+                    toast(getString(R.string.freezer_launch_failed))
+                    finish(); return@launch
+                }
                 // Enabled state / launcher intent may not be visible instantly — retry briefly
                 // (~10×150ms budget), stopping as soon as the intent resolves.
                 for (attempt in 0 until 10) {

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -356,6 +356,8 @@ class MainViewModel(
                 is AppClickAction.UnSuspend -> quickAction(action) { manageAppUseCase.setAppSuspended(it.packageName, false) }
                 is AppClickAction.ManagePermissions -> {}
                 is AppClickAction.OpenDetails -> {}
+                // Handled entirely in FreezerScreen (viewModel.pinAppToLauncher); never routed here.
+                is AppClickAction.AddToHomeScreen -> {}
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -405,6 +405,17 @@ fun SettingsScreen(
                 enabled = hasPrivilege,
                 onClick = { showUnfreezeConfirmation = true }
             )
+
+            SettingsSwitchRow(
+                icon = R.drawable.frozen,
+                title = stringResource(R.string.add_freezer_to_launcher),
+                subtitle = if (hasPrivilege) stringResource(R.string.add_freezer_to_launcher_desc) else stringResource(
+                    R.string.privilege_required_warning
+                ),
+                checked = prefs.addFreezerToLauncher,
+                enabled = hasPrivilege,
+                onCheckedChange = { viewModel.setAddFreezerToLauncher(it) }
+            )
         }
 
         // ── EXTENSIONS ──────────────────────────────────────────────────────

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -138,6 +138,12 @@ class SettingsViewModel(
         }
     }
 
+    fun setAddFreezerToLauncher(enabled: Boolean) {
+        viewModelScope.launch {
+            preferenceRepository.setAddFreezerToLauncher(enabled)
+        }
+    }
+
     fun unfreezeAll() {
         viewModelScope.launch {
             val pkgs = freezerRepository.getAllPackageNames()

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -35,7 +35,8 @@ class SettingsViewModel(
     private val biometricHelper: BiometricHelper,
     private val localeManager: LocaleManager,
     private val freezerRepository: FreezerRepository,
-    private val manageAppUseCase: ManageAppUseCase
+    private val manageAppUseCase: ManageAppUseCase,
+    private val freezerShortcutManager: com.valhalla.thor.data.launcher.FreezerShortcutManager
 ) : ViewModel() {
 
     data class SettingsUiState(
@@ -141,6 +142,7 @@ class SettingsViewModel(
     fun setAddFreezerToLauncher(enabled: Boolean) {
         viewModelScope.launch {
             preferenceRepository.setAddFreezerToLauncher(enabled)
+            freezerShortcutManager.syncDynamicShortcuts(enabled)
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
@@ -38,8 +38,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.valhalla.asgard.components.AsgardActionItem
 import com.valhalla.asgard.components.StatusChip as AsgardStatusChip
+import com.valhalla.thor.data.launcher.FreezerShortcutManager
+import com.valhalla.thor.domain.model.UserPreferences
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import org.koin.compose.koinInject
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -608,10 +613,14 @@ private fun AppActionRow(
             )
         }
 
-        // Freezer launcher shortcut — user apps only, gated by the caller
-        if (showAddToHomeScreen && !appInfo.isSystem) {
+        // Freezer launcher shortcut — self-contained so it's available wherever this dialog shows
+        // (app list, freezer, …). Gated on the feature setting + launcher pin support + user apps.
+        val shortcutManager = koinInject<FreezerShortcutManager>()
+        val preferenceRepository = koinInject<PreferenceRepository>()
+        val prefs by preferenceRepository.userPreferences.collectAsStateWithLifecycle(UserPreferences())
+        if (prefs.addFreezerToLauncher && !appInfo.isSystem && shortcutManager.isPinSupported()) {
             ActionItem(R.drawable.home, stringResource(R.string.add_to_home_screen)) {
-                onAction(AppClickAction.AddToHomeScreen(appInfo))
+                shortcutManager.pinAppShortcut(appInfo.packageName, appInfo.appName ?: appInfo.packageName)
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
@@ -524,7 +524,7 @@ private fun AppActionRow(
             .horizontalScroll(rememberScrollState())
             .padding(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.Top
     ) {
         // 1. Standard Actions
         ActionItem(R.drawable.open_in_new, stringResource(R.string.action_launch)) {

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
@@ -62,6 +62,7 @@ fun AppInfoDialog(
     isRoot: Boolean = false,
     isShizuku: Boolean = false,
     isDhizuku: Boolean = false,
+    showAddToHomeScreen: Boolean = false,
     onDismiss: () -> Unit,
     onAppAction: (AppClickAction) -> Unit = {}
 ) {
@@ -107,6 +108,7 @@ fun AppInfoDialog(
                 isRoot = isRoot,
                 isShizuku = isShizuku,
                 isDhizuku = isDhizuku,
+                showAddToHomeScreen = showAddToHomeScreen,
                 onExport = { showExportSheet = true },
                 onAction = { action ->
                     // Intercept dangerous actions for local confirmation
@@ -503,6 +505,7 @@ private fun AppActionRow(
     isRoot: Boolean,
     isShizuku: Boolean,
     isDhizuku: Boolean,
+    showAddToHomeScreen: Boolean,
     onExport: () -> Unit,
     onAction: (AppClickAction) -> Unit
 ) {
@@ -605,7 +608,12 @@ private fun AppActionRow(
             )
         }
 
-
+        // Freezer launcher shortcut — user apps only, gated by the caller
+        if (showAddToHomeScreen && !appInfo.isSystem) {
+            ActionItem(R.drawable.home, stringResource(R.string.add_to_home_screen)) {
+                onAction(AppClickAction.AddToHomeScreen(appInfo))
+            }
+        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,8 @@
     <string name="shortcut_add_all">Add all apps</string>
     <string name="shortcut_added_named">%1$s added to Home screen</string>
     <string name="shortcut_added">Shortcut added to Home screen</string>
+    <string name="pin_all_confirm_title">Add all apps to Home screen?</string>
+    <string name="pin_all_confirm_desc">This adds a home-screen shortcut for each of your %1$d frozen apps and may fill up your home screen. Your launcher will ask you to confirm each one.</string>
     <string name="freezer_launch_failed">Couldn\'t launch this app</string>
     <string name="shortcut_no_longer_frozen">No longer frozen</string>
     <string name="privilege_required_warning">Privilege required (Root, Shizuku or Dhizuku)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,7 @@
     <string name="pin_all_to_home_screen">Pin all to Home screen</string>
     <string name="freeze_all_apps">Freeze all</string>
     <string name="freezer_launch_failed">Couldn\'t launch this app</string>
+    <string name="shortcut_no_longer_frozen">No longer frozen</string>
     <string name="privilege_required_warning">Privilege required (Root, Shizuku or Dhizuku)</string>
     <string name="unfreeze_all_confirmation_title">Unfreeze All Apps?</string>
     <string name="unfreeze_all_confirmation_desc">This will unfreeze (enable) all apps currently in the Freezer list. Are you sure you want to proceed?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,6 +220,8 @@
     <string name="freeze_all_apps">Freeze all</string>
     <string name="shortcuts">Shortcuts</string>
     <string name="shortcut_add_all">Add all apps</string>
+    <string name="shortcut_added_named">%1$s added to Home screen</string>
+    <string name="shortcut_added">Shortcut added to Home screen</string>
     <string name="freezer_launch_failed">Couldn\'t launch this app</string>
     <string name="shortcut_no_longer_frozen">No longer frozen</string>
     <string name="privilege_required_warning">Privilege required (Root, Shizuku or Dhizuku)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,6 +218,8 @@
     <string name="add_to_home_screen">Add to Home screen</string>
     <string name="pin_all_to_home_screen">Pin all to Home screen</string>
     <string name="freeze_all_apps">Freeze all</string>
+    <string name="shortcuts">Shortcuts</string>
+    <string name="shortcut_add_all">Add all apps</string>
     <string name="freezer_launch_failed">Couldn\'t launch this app</string>
     <string name="shortcut_no_longer_frozen">No longer frozen</string>
     <string name="privilege_required_warning">Privilege required (Root, Shizuku or Dhizuku)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,12 @@
     <string name="unfreeze_all_apps_desc">Enable all apps currently in the Freezer list</string>
     <string name="auto_freeze">Auto Freeze</string>
     <string name="auto_freeze_desc">Freeze apps automatically when screen is locked</string>
+    <string name="add_freezer_to_launcher">Add Freezer to launcher</string>
+    <string name="add_freezer_to_launcher_desc">Show frozen apps as home-screen shortcuts you can tap to launch</string>
+    <string name="add_to_home_screen">Add to Home screen</string>
+    <string name="pin_all_to_home_screen">Pin all to Home screen</string>
+    <string name="freeze_all_apps">Freeze all</string>
+    <string name="freezer_launch_failed">Couldn\'t launch this app</string>
     <string name="privilege_required_warning">Privilege required (Root, Shizuku or Dhizuku)</string>
     <string name="unfreeze_all_confirmation_title">Unfreeze All Apps?</string>
     <string name="unfreeze_all_confirmation_desc">This will unfreeze (enable) all apps currently in the Freezer list. Are you sure you want to proceed?</string>

--- a/app/src/test/java/com/valhalla/thor/data/launcher/FreezerShortcutContractTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/launcher/FreezerShortcutContractTest.kt
@@ -1,0 +1,32 @@
+package com.valhalla.thor.data.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FreezerShortcutContractTest {
+
+    @Test
+    fun parseAction_returns_known_actions() {
+        assertEquals(FreezerShortcutContract.ACTION_LAUNCH, FreezerShortcutContract.parseAction("launch"))
+        assertEquals(FreezerShortcutContract.ACTION_FREEZE_ALL, FreezerShortcutContract.parseAction("freeze_all"))
+        assertEquals(FreezerShortcutContract.ACTION_UNFREEZE_ALL, FreezerShortcutContract.parseAction("unfreeze_all"))
+    }
+
+    @Test
+    fun parseAction_returns_null_for_unknown_or_missing() {
+        assertNull(FreezerShortcutContract.parseAction(null))
+        assertNull(FreezerShortcutContract.parseAction(""))
+        assertNull(FreezerShortcutContract.parseAction("delete_all"))
+    }
+
+    @Test
+    fun appShortcutId_is_stable_and_package_scoped() {
+        assertEquals("freezer_app_com.amazon.mShop.android.shopping",
+            FreezerShortcutContract.appShortcutId("com.amazon.mShop.android.shopping"))
+        assertEquals(
+            FreezerShortcutContract.appShortcutId("a"),
+            FreezerShortcutContract.appShortcutId("a")
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-07-04-add-freezer-to-launcher.md
+++ b/docs/superpowers/plans/2026-07-04-add-freezer-to-launcher.md
@@ -1,0 +1,686 @@
+# Add Freezer to Launcher — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in "Add Freezer to launcher" setting that places home-screen shortcuts for frozen apps (grayscale icon → enable-then-launch) plus Freeze-all / Unfreeze-all shortcuts, re-freezing via Thor's existing screen-off AutoFreeze.
+
+**Architecture:** A Thor-owned pinned shortcut per frozen app trampolines through an invisible (translucent) `FreezerLaunchActivity`, which enables the app (via the active privilege gateway) then launches it — or launches directly if already enabled. Bulk Freeze-all / Unfreeze-all run through the same trampoline and are also long-press dynamic shortcuts. Re-freeze is unchanged (existing `AutoFreezeManager` screen-off path). All shortcut plumbing lives in a new `FreezerShortcutManager` (`@Single`).
+
+**Tech Stack:** Kotlin, Jetpack Compose, Koin (annotation DI), `androidx.core` `ShortcutManagerCompat`/`IconCompat`, DataStore Preferences, coroutines.
+
+Design spec: `docs/superpowers/specs/2026-07-04-add-freezer-to-launcher-design.md`.
+
+## Global Constraints
+
+- **minSdk 28**, targetSdk/compileSdk 37. `applicationId com.valhalla.thor` (debug suffix `.debug`).
+- **DI is Koin annotation-based**, component-scanned over `com.valhalla.thor`: `@Single` for singletons, `@Factory` for use cases, `@KoinViewModel` for view models. Android `Activity`/`Service` are NOT Koin-instantiated — they retrieve deps via `org.koin.android.ext.android.inject`.
+- **"Freeze" = disable**: `ManageAppUseCase.setAppDisabled(packageName, disabled): Result<Unit>`. A disabled app has no launcher entry and cannot be launched until re-enabled.
+- **Privilege check** (copy verbatim from `FreezerTileService`): `systemRepository.isRootAvailable() || systemRepository.isShizukuAvailable() || systemRepository.isDhizukuAvailable()`, always on `Dispatchers.IO`.
+- **No new dangerous permissions.** `requestPinShortcut` / dynamic shortcuts need none; `QUERY_ALL_PACKAGES` is already declared; no foreground service.
+- **v1 scope: user apps only** (`AppInfo.isSystem == false`). No launcher shortcuts for system apps.
+- Build command: `./gradlew assembleFossDebug`. Unit tests: `./gradlew :app:testFossDebugUnitTest --tests "<FQN>"`. Device: `adb install -r <apk>` + `adb shell` / `adb exec-out screencap`.
+- Follow existing patterns: settings toggles mirror `autoFreezeEnabled` (4 files); trampoline mirrors `PortableInstallerActivity` (translucent) — **not** `ShortcutTriggerActivity` (`Theme.NoDisplay`), because our trampoline does async work and a NoDisplay activity must `finish()` synchronously.
+
+---
+
+### Task 1: "Add Freezer to launcher" preference + Settings toggle row
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt`
+- Modify: `app/src/main/res/values/strings.xml`
+
+**Interfaces:**
+- Produces: `UserPreferences.addFreezerToLauncher: Boolean`; `PreferenceRepository.setAddFreezerToLauncher(enabled: Boolean)`; `SettingsViewModel.setAddFreezerToLauncher(enabled: Boolean)`.
+
+- [ ] **Step 1: Add the model field.** In `UserPreferences.kt`, after the `autoFreezeEnabled` line (`// Auto Freeze` block):
+
+```kotlin
+    // Auto Freeze
+    val autoFreezeEnabled: Boolean = false,
+
+    // Add Freezer to launcher (home-screen shortcuts for frozen apps)
+    val addFreezerToLauncher: Boolean = false,
+```
+
+- [ ] **Step 2: Add the DataStore key.** In `PreferenceRepositoryImpl.kt` `Keys`, after `AUTO_FREEZE`:
+
+```kotlin
+        // Auto Freeze
+        val AUTO_FREEZE = booleanPreferencesKey("auto_freeze")
+        val ADD_FREEZER_TO_LAUNCHER = booleanPreferencesKey("add_freezer_to_launcher")
+```
+
+- [ ] **Step 3: Map the key into `userPreferences`.** In the `UserPreferences(...)` constructor block, after `autoFreezeEnabled = prefs[Keys.AUTO_FREEZE] ?: false,`:
+
+```kotlin
+                autoFreezeEnabled = prefs[Keys.AUTO_FREEZE] ?: false,
+                addFreezerToLauncher = prefs[Keys.ADD_FREEZER_TO_LAUNCHER] ?: false,
+```
+
+- [ ] **Step 4: Add the writer + interface method.** In `PreferenceRepositoryImpl.kt`, after `setAutoFreezeEnabled`:
+
+```kotlin
+    override suspend fun setAddFreezerToLauncher(enabled: Boolean) {
+        context.dataStore.edit {
+            it[Keys.ADD_FREEZER_TO_LAUNCHER] = enabled
+        }
+    }
+```
+
+In `PreferenceRepository.kt`, after `suspend fun setAutoFreezeEnabled(enabled: Boolean)`:
+
+```kotlin
+    // --- Auto Freeze ---
+    suspend fun setAutoFreezeEnabled(enabled: Boolean)
+    suspend fun setAddFreezerToLauncher(enabled: Boolean)
+```
+
+- [ ] **Step 5: Add the ViewModel setter.** In `SettingsViewModel.kt`, after `setAutoFreezeEnabled`:
+
+```kotlin
+    fun setAddFreezerToLauncher(enabled: Boolean) {
+        viewModelScope.launch {
+            preferenceRepository.setAddFreezerToLauncher(enabled)
+        }
+    }
+```
+
+- [ ] **Step 6: Add the string resources.** In `app/src/main/res/values/strings.xml`:
+
+```xml
+    <string name="add_freezer_to_launcher">Add Freezer to launcher</string>
+    <string name="add_freezer_to_launcher_desc">Show frozen apps as home-screen shortcuts you can tap to launch</string>
+    <string name="add_to_home_screen">Add to Home screen</string>
+    <string name="pin_all_to_home_screen">Pin all to Home screen</string>
+    <string name="freeze_all_apps">Freeze all</string>
+    <string name="freezer_launch_failed">Couldn\'t launch this app</string>
+```
+
+- [ ] **Step 7: Render the toggle.** In `SettingsScreen.kt`, inside the Freezer `Column` (the one holding the `auto_freeze` `SettingsSwitchRow`), add after the `SettingsClickRow` for `unfreeze_all_apps` (before the Column closes at line ~408):
+
+```kotlin
+            SettingsSwitchRow(
+                icon = R.drawable.frozen,
+                title = stringResource(R.string.add_freezer_to_launcher),
+                subtitle = if (hasPrivilege) stringResource(R.string.add_freezer_to_launcher_desc) else stringResource(
+                    R.string.privilege_required_warning
+                ),
+                checked = prefs.addFreezerToLauncher,
+                enabled = hasPrivilege,
+                onCheckedChange = { viewModel.setAddFreezerToLauncher(it) }
+            )
+```
+
+- [ ] **Step 8: Build.** Run: `./gradlew assembleFossDebug`. Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 9: Device-verify.** `adb install -r app/build/outputs/apk/foss/debug/*.apk`; open Settings → Freezer; confirm the new "Add Freezer to launcher" switch appears, flips, and survives an app restart (`adb shell am force-stop com.valhalla.thor.debug` then relaunch).
+
+- [ ] **Step 10: Commit.**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt app/src/main/res/values/strings.xml
+git commit -m "feat(freezer): add 'Add Freezer to launcher' setting (#210)"
+```
+
+---
+
+### Task 2: `FreezerShortcutContract` — pure action model (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutContract.kt`
+- Test: `app/src/test/java/com/valhalla/thor/data/launcher/FreezerShortcutContractTest.kt`
+
+**Interfaces:**
+- Produces: `object FreezerShortcutContract` with `EXTRA_ACTION`, `EXTRA_PACKAGE`, `ACTION_LAUNCH`, `ACTION_FREEZE_ALL`, `ACTION_UNFREEZE_ALL`, `SHORTCUT_FREEZE_ALL`, `SHORTCUT_UNFREEZE_ALL` (String consts); `appShortcutId(packageName: String): String`; `parseAction(raw: String?): String?`.
+
+- [ ] **Step 1: Write the failing test.** Create `FreezerShortcutContractTest.kt`:
+
+```kotlin
+package com.valhalla.thor.data.launcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FreezerShortcutContractTest {
+
+    @Test
+    fun parseAction_returns_known_actions() {
+        assertEquals(FreezerShortcutContract.ACTION_LAUNCH, FreezerShortcutContract.parseAction("launch"))
+        assertEquals(FreezerShortcutContract.ACTION_FREEZE_ALL, FreezerShortcutContract.parseAction("freeze_all"))
+        assertEquals(FreezerShortcutContract.ACTION_UNFREEZE_ALL, FreezerShortcutContract.parseAction("unfreeze_all"))
+    }
+
+    @Test
+    fun parseAction_returns_null_for_unknown_or_missing() {
+        assertNull(FreezerShortcutContract.parseAction(null))
+        assertNull(FreezerShortcutContract.parseAction(""))
+        assertNull(FreezerShortcutContract.parseAction("delete_all"))
+    }
+
+    @Test
+    fun appShortcutId_is_stable_and_package_scoped() {
+        assertEquals("freezer_app_com.amazon.mShop.android.shopping",
+            FreezerShortcutContract.appShortcutId("com.amazon.mShop.android.shopping"))
+        assertEquals(
+            FreezerShortcutContract.appShortcutId("a"),
+            FreezerShortcutContract.appShortcutId("a")
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails.** Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.data.launcher.FreezerShortcutContractTest"`. Expected: FAIL (unresolved `FreezerShortcutContract`).
+
+- [ ] **Step 3: Write the implementation.** Create `FreezerShortcutContract.kt`:
+
+```kotlin
+package com.valhalla.thor.data.launcher
+
+/** Pure contract shared between the shortcut publisher and the launch trampoline. */
+object FreezerShortcutContract {
+    const val EXTRA_ACTION = "com.valhalla.thor.extra.FREEZER_SHORTCUT_ACTION"
+    const val EXTRA_PACKAGE = "com.valhalla.thor.extra.FREEZER_SHORTCUT_PACKAGE"
+
+    const val ACTION_LAUNCH = "launch"
+    const val ACTION_FREEZE_ALL = "freeze_all"
+    const val ACTION_UNFREEZE_ALL = "unfreeze_all"
+
+    const val SHORTCUT_FREEZE_ALL = "freezer_freeze_all"
+    const val SHORTCUT_UNFREEZE_ALL = "freezer_unfreeze_all"
+    private const val APP_SHORTCUT_PREFIX = "freezer_app_"
+
+    /** Stable, package-scoped id for a per-app frozen-app shortcut. */
+    fun appShortcutId(packageName: String): String = "$APP_SHORTCUT_PREFIX$packageName"
+
+    /** Normalize a raw intent extra to a known action, or null if unrecognized. */
+    fun parseAction(raw: String?): String? = when (raw) {
+        ACTION_LAUNCH, ACTION_FREEZE_ALL, ACTION_UNFREEZE_ALL -> raw
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes.** Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.data.launcher.FreezerShortcutContractTest"`. Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutContract.kt app/src/test/java/com/valhalla/thor/data/launcher/FreezerShortcutContractTest.kt
+git commit -m "feat(freezer): pure shortcut contract for launcher shortcuts (#210)"
+```
+
+---
+
+### Task 3: `FreezerShortcutManager` (`@Single`) — icons, pinning, dynamic shortcuts
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt`
+- Verify: `app/build.gradle.kts` (confirm `androidx.core` / `core-ktx` is a dependency — it is, transitively via Compose; add explicit `implementation(libs.androidx.core.ktx)` only if the build fails to resolve `ShortcutManagerCompat`).
+
+**Interfaces:**
+- Consumes: `FreezerShortcutContract` (Task 2); `FreezerRepository.getAllPackageNames()`; `ManageAppUseCase.setAppDisabled(pkg, disabled)`. The trampoline is referenced by **string class name** (`setClassName`), so this task builds independently of Task 4.
+- Produces: `@Single class FreezerShortcutManager` with `isPinSupported(): Boolean`, `pinAppShortcut(packageName: String, label: String)`, `pinBulkShortcut(action: String)`, `syncDynamicShortcuts(enabled: Boolean)`, `disableAppShortcut(packageName: String, reason: CharSequence)`, `runBulk(disable: Boolean)`.
+
+- [ ] **Step 1: Write the implementation.** Create `FreezerShortcutManager.kt`:
+
+```kotlin
+package com.valhalla.thor.data.launcher
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import androidx.core.graphics.drawable.toBitmap
+import com.valhalla.thor.R
+import com.valhalla.thor.domain.repository.FreezerRepository
+import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
+
+/** Owns all launcher-shortcut plumbing for the Freezer feature. */
+@Single
+class FreezerShortcutManager(
+    private val context: Context,
+    private val freezerRepository: FreezerRepository,
+    private val manageAppUseCase: ManageAppUseCase,
+) {
+    // App-scoped: bulk work must survive the (finishing) trampoline activity.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private companion object {
+        const val LAUNCH_ACTIVITY = "com.valhalla.thor.presentation.launcher.FreezerLaunchActivity"
+    }
+
+    fun isPinSupported(): Boolean =
+        ShortcutManagerCompat.isRequestPinShortcutSupported(context)
+
+    /** Ask the launcher to pin a home-screen shortcut for a frozen app (grayscale icon). */
+    fun pinAppShortcut(packageName: String, label: String) {
+        val shortcut = ShortcutInfoCompat.Builder(context, FreezerShortcutContract.appShortcutId(packageName))
+            .setShortLabel(label)
+            .setLongLabel(label)
+            .setIcon(grayscaleIcon(packageName))
+            .setIntent(
+                trampolineIntent(FreezerShortcutContract.ACTION_LAUNCH)
+                    .putExtra(FreezerShortcutContract.EXTRA_PACKAGE, packageName)
+            )
+            .build()
+        ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+    }
+
+    /** Ask the launcher to pin a Freeze-all / Unfreeze-all action shortcut. */
+    fun pinBulkShortcut(action: String) {
+        ShortcutManagerCompat.requestPinShortcut(context, bulkShortcut(action), null)
+    }
+
+    /** Publish (or remove) the Freeze-all + Unfreeze-all long-press dynamic shortcuts. */
+    fun syncDynamicShortcuts(enabled: Boolean) {
+        if (enabled) {
+            ShortcutManagerCompat.setDynamicShortcuts(
+                context,
+                listOf(
+                    bulkShortcut(FreezerShortcutContract.ACTION_FREEZE_ALL),
+                    bulkShortcut(FreezerShortcutContract.ACTION_UNFREEZE_ALL),
+                )
+            )
+        } else {
+            ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+        }
+    }
+
+    /** Grey out a per-app shortcut (the ceiling — pinned icons can't be silently removed). */
+    fun disableAppShortcut(packageName: String, reason: CharSequence) {
+        ShortcutManagerCompat.disableShortcuts(
+            context,
+            listOf(FreezerShortcutContract.appShortcutId(packageName)),
+            reason
+        )
+    }
+
+    /** Bulk freeze/unfreeze every package in the freezer, off the finishing activity. */
+    fun runBulk(disable: Boolean) {
+        scope.launch {
+            freezerRepository.getAllPackageNames().forEach { pkg ->
+                manageAppUseCase.setAppDisabled(pkg, disable)
+            }
+        }
+    }
+
+    private fun bulkShortcut(action: String): ShortcutInfoCompat {
+        val id: String
+        val labelRes: Int
+        val iconRes: Int
+        if (action == FreezerShortcutContract.ACTION_FREEZE_ALL) {
+            id = FreezerShortcutContract.SHORTCUT_FREEZE_ALL
+            labelRes = R.string.freeze_all_apps
+            iconRes = R.drawable.frozen
+        } else {
+            id = FreezerShortcutContract.SHORTCUT_UNFREEZE_ALL
+            labelRes = R.string.unfreeze_all_apps
+            iconRes = R.drawable.unfreeze
+        }
+        val label = context.getString(labelRes)
+        return ShortcutInfoCompat.Builder(context, id)
+            .setShortLabel(label)
+            .setLongLabel(label)
+            .setIcon(IconCompat.createWithResource(context, iconRes))
+            .setIntent(trampolineIntent(action))
+            .build()
+    }
+
+    // Explicit-component intent → our (non-exported) trampoline, targeted by string class name so
+    // this class doesn't compile-depend on FreezerLaunchActivity. Shortcuts require an action.
+    private fun trampolineIntent(action: String): Intent =
+        Intent().apply {
+            setClassName(context, LAUNCH_ACTIVITY)
+            this.action = Intent.ACTION_VIEW
+            putExtra(FreezerShortcutContract.EXTRA_ACTION, action)
+        }
+
+    // Saturation-0 grayscale of the app's own icon (loadable for a disabled-but-installed app).
+    private fun grayscaleIcon(packageName: String): IconCompat {
+        return try {
+            val src = context.packageManager.getApplicationIcon(packageName).toBitmap()
+            val gray = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
+            Canvas(gray).drawBitmap(
+                src, 0f, 0f,
+                Paint().apply {
+                    colorFilter = ColorMatrixColorFilter(ColorMatrix().apply { setSaturation(0f) })
+                }
+            )
+            IconCompat.createWithBitmap(gray)
+        } catch (e: Exception) {
+            Logger.e("FreezerShortcut", "icon load failed for $packageName", e)
+            IconCompat.createWithResource(context, R.drawable.frozen)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build.** Run: `./gradlew assembleFossDebug`. Expected: `BUILD SUCCESSFUL` (this task builds standalone — the trampoline is referenced by string class name). If `ShortcutManagerCompat` is unresolved, add `implementation(libs.androidx.core.ktx)` to `app/build.gradle.kts` and re-run.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+git commit -m "feat(freezer): FreezerShortcutManager — pin/dynamic/disable + grayscale icon (#210)"
+```
+
+---
+
+### Task 4: `FreezerLaunchActivity` trampoline + manifest registration
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt`
+- Modify: `app/src/main/AndroidManifest.xml`
+
+**Interfaces:**
+- Consumes: `FreezerShortcutContract` (Task 2); `FreezerShortcutManager.runBulk` (Task 3); `SystemRepository.isRootAvailable()/isShizukuAvailable()/isDhizukuAvailable()`; `ManageAppUseCase.setAppDisabled(pkg, disabled)`; `PackageManager.getLaunchIntentForPackage`.
+- Produces: `class FreezerLaunchActivity : Activity` (the shortcut trampoline target).
+
+- [ ] **Step 1: Write the activity.** Create `FreezerLaunchActivity.kt`:
+
+```kotlin
+package com.valhalla.thor.presentation.launcher
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.Toast
+import com.valhalla.thor.R
+import com.valhalla.thor.data.launcher.FreezerShortcutContract
+import com.valhalla.thor.data.launcher.FreezerShortcutManager
+import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.android.ext.android.inject
+
+/**
+ * Invisible (translucent) trampoline for Freezer launcher shortcuts. Translucent — not
+ * Theme.NoDisplay — because it does async work (enable-then-launch) and NoDisplay requires
+ * finish() before onResume completes.
+ */
+class FreezerLaunchActivity : Activity() {
+
+    private val systemRepository: SystemRepository by inject()
+    private val manageAppUseCase: ManageAppUseCase by inject()
+    private val freezerShortcutManager: FreezerShortcutManager by inject()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        when (FreezerShortcutContract.parseAction(intent?.getStringExtra(FreezerShortcutContract.EXTRA_ACTION))) {
+            FreezerShortcutContract.ACTION_FREEZE_ALL -> guardThenBulk(disable = true)
+            FreezerShortcutContract.ACTION_UNFREEZE_ALL -> guardThenBulk(disable = false)
+            FreezerShortcutContract.ACTION_LAUNCH -> {
+                val pkg = intent?.getStringExtra(FreezerShortcutContract.EXTRA_PACKAGE)
+                if (pkg.isNullOrEmpty()) finish() else launchApp(pkg)
+            }
+            else -> finish()
+        }
+    }
+
+    // Bulk: privilege-guard, hand off to the app-scoped manager, finish immediately.
+    private fun guardThenBulk(disable: Boolean) {
+        scope.launch {
+            if (!hasPrivilege()) {
+                toast(getString(R.string.tile_grant_privilege_toast))
+            } else {
+                freezerShortcutManager.runBulk(disable)
+            }
+            finish()
+        }
+    }
+
+    // Launch: stay foreground through startActivity (Android 10+ background-launch rule).
+    private fun launchApp(pkg: String) {
+        scope.launch {
+            var launchIntent = packageManager.getLaunchIntentForPackage(pkg)
+            if (launchIntent == null) {
+                if (!hasPrivilege()) {
+                    toast(getString(R.string.tile_grant_privilege_toast))
+                    finish(); return@launch
+                }
+                withContext(Dispatchers.IO) { manageAppUseCase.setAppDisabled(pkg, false) }
+                // Enabled state / launcher intent may not be visible instantly — retry briefly.
+                repeat(10) {
+                    launchIntent = packageManager.getLaunchIntentForPackage(pkg)
+                    if (launchIntent != null) return@repeat
+                    delay(150)
+                }
+            }
+            val toStart = launchIntent
+            if (toStart != null) startActivity(toStart)
+            else toast(getString(R.string.freezer_launch_failed))
+            finish()
+        }
+    }
+
+    private suspend fun hasPrivilege(): Boolean = withContext(Dispatchers.IO) {
+        systemRepository.isRootAvailable() ||
+                systemRepository.isShizukuAvailable() ||
+                systemRepository.isDhizukuAvailable()
+    }
+
+    private fun toast(msg: String) =
+        Toast.makeText(applicationContext, msg, Toast.LENGTH_SHORT).show()
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+}
+```
+
+- [ ] **Step 2: Register in the manifest.** In `AndroidManifest.xml`, next to the `ShortcutTriggerActivity` block (~line 302), add:
+
+```xml
+        <activity
+            android:name=".presentation.launcher.FreezerLaunchActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+```
+
+- [ ] **Step 3: Build.** Run: `./gradlew assembleFossDebug`. Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Device-verify.** With a privilege mode active and at least one user app in the freezer: `adb shell cmd shortcut` isn't needed — instead drive it directly:
+  - `adb shell am start -n com.valhalla.thor.debug/com.valhalla.thor.presentation.launcher.FreezerLaunchActivity --es com.valhalla.thor.extra.FREEZER_SHORTCUT_ACTION launch --es com.valhalla.thor.extra.FREEZER_SHORTCUT_PACKAGE <frozen.pkg>` → the frozen app enables and launches; nothing from Thor flashes.
+  - Repeat with `--es ...ACTION freeze_all` and `unfreeze_all` → the freezer set toggles (verify with `adb shell pm list packages -d`).
+  - With no privilege active → a toast appears and nothing launches.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt app/src/main/AndroidManifest.xml
+git commit -m "feat(freezer): FreezerLaunchActivity trampoline for launcher shortcuts (#210)"
+```
+
+---
+
+### Task 5: Freezer UI actions — "Add to Home screen", "Pin all", bulk pins
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt` (and/or `ManageFreezerSheet.kt` / `FreezerSettingsSheet.kt` where per-app and bulk actions already live — follow the existing action layout).
+
+**Interfaces:**
+- Consumes: `FreezerShortcutManager` (Task 3); `FreezerShortcutContract` (Task 2); `AppInfo.packageName`, `AppInfo.appName`, `AppInfo.isSystem`.
+- Produces: `FreezerUiState.addFreezerToLauncher: Boolean`; `FreezerViewModel.isPinSupported()`, `pinAppToLauncher(app: AppInfo)`, `pinAllToLauncher()`, `pinBulkShortcut(freeze: Boolean)`.
+
+- [ ] **Step 1: Inject the manager + surface the setting.** In `FreezerViewModel.kt` constructor, add the dependency:
+
+```kotlin
+@KoinViewModel
+class FreezerViewModel(
+    private val freezerRepository: FreezerRepository,
+    private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
+    private val manageAppUseCase: ManageAppUseCase,
+    private val privilegeManager: PrivilegeManager,
+    private val preferenceRepository: PreferenceRepository,
+    private val freezerShortcutManager: com.valhalla.thor.data.launcher.FreezerShortcutManager
+) : ViewModel() {
+```
+
+Add to `FreezerUiState`:
+
+```kotlin
+    val isGrid: Boolean = true,
+    val addFreezerToLauncher: Boolean = false
+```
+
+In `observePreferences()` (where `autoFreezeEnabled` is copied from `preferenceRepository.userPreferences` into the state), also copy `addFreezerToLauncher = prefs.addFreezerToLauncher`.
+
+- [ ] **Step 2: Add the ViewModel actions.** In `FreezerViewModel.kt`:
+
+```kotlin
+    fun isPinSupported(): Boolean = freezerShortcutManager.isPinSupported()
+
+    fun pinAppToLauncher(app: AppInfo) {
+        if (app.isSystem) return // v1: user apps only
+        freezerShortcutManager.pinAppShortcut(app.packageName, app.appName)
+    }
+
+    fun pinAllToLauncher() {
+        _uiState.value.freezerApps
+            .filter { !it.isSystem }
+            .forEach { freezerShortcutManager.pinAppShortcut(it.packageName, it.appName) }
+    }
+
+    fun pinBulkShortcut(freeze: Boolean) {
+        freezerShortcutManager.pinBulkShortcut(
+            if (freeze) FreezerShortcutContract.ACTION_FREEZE_ALL
+            else FreezerShortcutContract.ACTION_UNFREEZE_ALL
+        )
+    }
+```
+
+Add the imports `com.valhalla.thor.data.launcher.FreezerShortcutContract`.
+
+- [ ] **Step 3: Wire the per-app action.** In the freezer app's action UI (the per-app overflow/menu in `FreezerScreen.kt` / `ManageFreezerSheet.kt` — follow the existing per-app action items such as unfreeze/remove), add an "Add to Home screen" item shown only when `uiState.addFreezerToLauncher && viewModel.isPinSupported() && !app.isSystem`:
+
+```kotlin
+if (uiState.addFreezerToLauncher && !app.isSystem) {
+    DropdownMenuItem(
+        text = { Text(stringResource(R.string.add_to_home_screen)) },
+        leadingIcon = { Icon(painterResource(R.drawable.frozen), contentDescription = null) },
+        onClick = { viewModel.pinAppToLauncher(app); /* close menu */ }
+    )
+}
+```
+
+- [ ] **Step 4: Wire the bulk actions.** In `FreezerSettingsSheet.kt` (where "Unfreeze all" and grid/auto-freeze controls live), gated on `uiState.addFreezerToLauncher && viewModel.isPinSupported()`, add three `SettingsClickRow`/button entries: "Pin all to Home screen" → `viewModel.pinAllToLauncher()`; "Freeze all" (pin) → `viewModel.pinBulkShortcut(freeze = true)`; "Unfreeze all" (pin) → `viewModel.pinBulkShortcut(freeze = false)`. Use `R.string.pin_all_to_home_screen`, `R.string.freeze_all_apps`, `R.string.unfreeze_all_apps`.
+
+- [ ] **Step 5: Build.** Run: `./gradlew assembleFossDebug`. Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 6: Device-verify.** Enable the setting; in the Freezer, use a user app's "Add to Home screen" → the system pin dialog appears → confirm → a **grayscale** shortcut with the app's icon lands on the home screen; tap it → the app enables + launches. Use "Pin all" and the Freeze all / Unfreeze all pin actions → dialogs appear per shortcut.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/freezer/
+git commit -m "feat(freezer): launcher-shortcut actions in the Freezer UI (#210)"
+```
+
+---
+
+### Task 6: Dynamic shortcuts sync + cleanup wiring
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/ThorApplication.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt`
+
+**Interfaces:**
+- Consumes: `FreezerShortcutManager.syncDynamicShortcuts(enabled)`, `FreezerShortcutManager.disableAppShortcut(packageName, reason)`.
+
+- [ ] **Step 1: Sync dynamic shortcuts at app start.** In `ThorApplication.kt`, add the injected manager and call sync inside the existing `MainScope().launch` block:
+
+```kotlin
+    private val autoFreezeManager: AutoFreezeManager by inject()
+    private val freezerShortcutManager: com.valhalla.thor.data.launcher.FreezerShortcutManager by inject()
+```
+
+```kotlin
+        MainScope().launch {
+            val prefs = preferenceRepository.userPreferences.first()
+            freezerShortcutManager.syncDynamicShortcuts(prefs.addFreezerToLauncher)
+            withContext(Dispatchers.Main) {
+                localeManager.applyLocale(prefs.language)
+            }
+        }
+```
+
+- [ ] **Step 2: Sync on setting toggle.** In `SettingsViewModel.kt`, inject the manager (add to constructor: `private val freezerShortcutManager: com.valhalla.thor.data.launcher.FreezerShortcutManager`) and update the setter from Task 1:
+
+```kotlin
+    fun setAddFreezerToLauncher(enabled: Boolean) {
+        viewModelScope.launch {
+            preferenceRepository.setAddFreezerToLauncher(enabled)
+            freezerShortcutManager.syncDynamicShortcuts(enabled)
+        }
+    }
+```
+
+- [ ] **Step 3: Disable a shortcut on permanent unfreeze.** In `FreezerViewModel.kt`, in the code path that removes an app from the freezer (`removeFromFreezer` / the removal branch of `toggleManaged`), after the app is removed from the Room set, call:
+
+```kotlin
+        freezerShortcutManager.disableAppShortcut(
+            packageName,
+            "No longer frozen"
+        )
+```
+
+(Use the actual removed package name variable in scope. Do this for each removed package in bulk-remove paths.)
+
+- [ ] **Step 4: Build.** Run: `./gradlew assembleFossDebug`. Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Device-verify.**
+  - With the setting ON, long-press Thor's launcher icon → "Freeze all" and "Unfreeze all" appear; tap each → freezer set toggles.
+  - Turn the setting OFF → long-press Thor icon → the two dynamic shortcuts are gone.
+  - Pin a frozen app, then unfreeze it permanently (remove from freezer) → its home-screen shortcut greys out / shows disabled.
+  - Full loop: freeze user app → pin → tap (enables + launches) → lock screen (with auto-freeze on) → app re-freezes (`adb shell pm list packages -d` shows it disabled again).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/ThorApplication.kt app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+git commit -m "feat(freezer): sync dynamic shortcuts + cleanup on unfreeze/toggle-off (#210)"
+```
+
+---
+
+## Release (after all tasks land + review)
+
+- [ ] Bump `versionCode` in `gradle.properties` (per Thor's single-integer scheme; e.g. `1900 → 1910`).
+- [ ] Update `CHANGELOG`/release notes as the repo requires.
+- [ ] Full build: `./gradlew assembleFossRelease assembleStoreRelease`.
+
+## Notes for the implementer
+
+- **Testability reality:** Only the pure `FreezerShortcutContract` (Task 2) is JVM-unit-tested. The rest is Android-framework glue (ShortcutManagerCompat, Bitmap, Activity, PackageManager) and is verified by build + on-device steps — that matches how this area of Thor is currently exercised. Do not fake unit tests for the glue.
+- **`AppInfo.appName`** is the label; **`AppInfo.isSystem`** gates user-apps-only. Confirm both against `domain/model/AppInfo.kt` before use.
+- **`SystemRepository`** is already a constructor dep of `SettingsViewModel`/`FreezerTileService`; the trampoline injects it via `by inject()`.
+- **String reuse:** `R.string.tile_grant_privilege_toast` (no-privilege) and `R.string.unfreeze_all_apps` already exist; only add the six strings in Task 1 Step 6.
+- If `androidx.core`’s `ShortcutManagerCompat`/`IconCompat`/`toBitmap` don’t resolve, add `implementation(libs.androidx.core.ktx)` to `app/build.gradle.kts`.

--- a/docs/superpowers/specs/2026-07-04-add-freezer-to-launcher-design.md
+++ b/docs/superpowers/specs/2026-07-04-add-freezer-to-launcher-design.md
@@ -1,0 +1,118 @@
+# Add Freezer to Launcher — Design
+
+**Issue:** [#210](https://github.com/trinadhthatakula/Thor/issues/210) · **Date:** 2026-07-04 · **Status:** Approved design, pre-implementation
+
+## Summary
+
+An opt-in setting, **"Add Freezer to launcher"**, that lets a user place **home-screen shortcuts for frozen apps** (and two bulk actions) so frozen apps can be launched without opening Thor:
+
+- Each frozen app can get a home-screen shortcut showing its **grayscale icon** (matching the freezer list). Tapping it **enables the app in the background, then launches it** (or launches directly if already enabled).
+- Two **bulk-action** shortcuts — **Freeze all** and **Unfreeze all** — pinnable to the home screen **and** exposed as long-press dynamic shortcuts on Thor's launcher icon.
+- **Re-freeze is unchanged**: a launched app stays in the freezer set (just temporarily enabled), so the existing screen-off `AutoFreezeManager` re-disables it on lock — only when the existing auto-freeze setting is on.
+
+The whole feature reuses Thor's existing freeze/enable path and screen-off re-freeze; it adds one shortcut manager, one invisible trampoline activity, a settings toggle, and Freezer UI actions.
+
+## Background (how the codebase constrains this)
+
+- **"Frozen" = disabled**, not suspended/hidden. Freezing calls `ManageAppUseCase.setAppDisabled(pkg, true)` (`domain/usecase/ManageAppUseCase.kt`), which resolves to `COMPONENT_ENABLED_STATE_DISABLED_USER` via the active gateway (Root `pm disable`, Shizuku/Dhizuku `setApplicationEnabledSetting`). Freezer *membership* is a Room `freezer` table (`FreezerRepository`), independent of the OS enabled flag.
+- **A disabled app's own launcher icon disappears and it cannot be launched** until re-enabled. So surfacing a frozen app in the launcher **cannot** reuse the target's launcher entry — it requires a **Thor-owned pinned shortcut** that trampolines through Thor to enable-then-launch.
+- **No launcher/shortcut code exists** in the app today (net-new). **No foreground/recents watcher exists.** The only re-freeze mechanism is `AutoFreezeManager` (`data/service/AutoFreezeManager.kt`), a `@Single` that registers a runtime `ACTION_SCREEN_OFF` receiver and re-disables every freezer package on screen-off + keyguard-locked, gated on `prefs.autoFreezeEnabled`, started from `ThorApplication.onCreate()`.
+- **Trampoline precedent:** `ShortcutTriggerActivity` (`Theme.NoDisplay`, not exported, finishes synchronously) — the template for the invisible launch activity.
+- **minSdk 28.** `requestPinShortcut` / dynamic shortcuts / `ShortcutManagerCompat` require **no permission**. No foreground service is needed.
+
+## Non-goals (v1)
+
+- **User apps only.** System apps freeze via *uninstall-for-user* and re-enable via *install-existing* (heavier, slower); their launcher shortcuts are deferred to a later version.
+- **No "removed from recents" detection.** Re-freeze rides the existing screen-off path. A foreground-leave watcher (UsageStats) is possible future work but is explicitly out of scope here.
+- **No force-removal of pinned icons.** Android cannot silently remove a pinned shortcut; cleanup can only *disable* it (greys it with a short message).
+
+## User flow
+
+1. User enables **Settings → "Add Freezer to launcher"** (off by default).
+2. In the Freezer, each frozen **user** app shows an **"Add to Home screen"** action; a **"Pin all to Home screen"** button pins every eligible frozen app (sequential system dialogs). Bulk **Freeze all** / **Unfreeze all** can be pinned the same way, and also appear on long-press of Thor's icon.
+3. Tapping a per-app shortcut → invisible `FreezerLaunchActivity`:
+   - App disabled → `setAppDisabled(pkg, false)` via active gateway → resolve launch intent → `startActivity`.
+   - App already enabled → launch directly.
+   - No active privilege → toast, finish.
+4. Tapping **Freeze all** / **Unfreeze all** → same trampoline, bulk `setAppDisabled(all freezer pkgs, true/false)`, privilege-guarded, finish.
+5. On screen lock (if auto-freeze is on), `AutoFreezeManager` re-disables freezer apps as it already does — **no change**.
+
+## Architecture & components
+
+### 1. Settings toggle (standard 4-file pattern)
+Mirror `autoFreezeEnabled`:
+- `domain/model/UserPreferences.kt` — add `val addFreezerToLauncher: Boolean = false`.
+- `data/repository/PreferenceRepositoryImpl.kt` — `booleanPreferencesKey("add_freezer_to_launcher")`, map into read, add `setAddFreezerToLauncher(...)` writer.
+- `domain/repository/PreferenceRepository.kt` — `suspend fun setAddFreezerToLauncher(enabled: Boolean)`.
+- `presentation/settings/SettingsViewModel.kt` + `SettingsScreen.kt` — `setAddFreezerToLauncher(...)` + a `SettingsSwitchRow` in the Freezer settings area.
+
+### 2. `FreezerShortcutManager` (`@Single`, e.g. `data/launcher/FreezerShortcutManager.kt`)
+Wraps `androidx.core.content.pm.ShortcutManagerCompat`. Injected where needed via `by inject()` (Activity) / constructor (ViewModel). Responsibilities:
+- `pinAppShortcut(app)` — build `ShortcutInfoCompat` id = package name, short/long label = app label, icon = **grayscale bitmap** (see Icon handling), intent = explicit `FreezerLaunchActivity` intent with `EXTRA_ACTION=LAUNCH`, `EXTRA_PACKAGE=pkg`; call `requestPinShortcut`.
+- `pinBulkShortcut(FREEZE_ALL | UNFREEZE_ALL)` — Thor vector icon, explicit trampoline intent with the action.
+- `syncDynamicShortcuts(enabled)` — when the setting is on, publish Freeze all / Unfreeze all as **dynamic** shortcuts (long-press Thor icon); when off, remove them.
+- `disableAppShortcut(pkg, reason)` — `ShortcutManagerCompat.disableShortcuts` for cleanup.
+- `isPinSupported()` — `ShortcutManagerCompat.isRequestPinShortcutSupported`.
+
+### 3. `FreezerLaunchActivity` (invisible trampoline, `presentation/launcher/FreezerLaunchActivity.kt`)
+- `Theme.NoDisplay`, `exported=false` (launched only by Thor-published shortcut intents targeting it explicitly), mirrors `ShortcutTriggerActivity`. `by inject()` its deps (`ManageAppUseCase`/`SystemRepository`, `FreezerRepository`, `PrivilegeManager`, `FreezerShortcutManager`, `PackageManager`).
+- Reads `EXTRA_ACTION`:
+  - `LAUNCH` → if the app is disabled and `!hasPrivilege` → toast + `finish()`. Otherwise the (still-invisible, still-**foreground**) activity awaits `setAppDisabled(pkg, false)` off the main thread, then `getLaunchIntentForPackage(pkg)` → `startActivity`, then `finish()`. It must remain the foreground activity through `startActivity` so the target launch satisfies Android 10+ background-activity-launch rules — so the LAUNCH path is *not* fire-and-finish.
+  - `FREEZE_ALL` / `UNFREEZE_ALL` → privilege-guard, then hand the bulk `setAppDisabled` loop over `FreezerRepository.getAllPackageNames()` to `FreezerShortcutManager`'s **app-scoped `CoroutineScope`** (survives the finishing activity), and `finish()` immediately — no activity is started here, so there's no background-launch concern.
+- Being `Theme.NoDisplay`, nothing visible flashes in either case; the LAUNCH path lives only for the brief enable-then-start window.
+
+### 4. Freezer UI actions (`presentation/freezer/*`)
+- Per frozen **user** app: an **"Add to Home screen"** action (in the app's action menu / `ManageFreezerSheet`), visible only when `addFreezerToLauncher` is on and `isPinSupported()`.
+- A **"Pin all to Home screen"** action and **Freeze all / Unfreeze all** pin actions in the Freezer settings sheet.
+- Wire through `FreezerViewModel` → `FreezerShortcutManager`.
+
+### 5. Dynamic shortcuts lifecycle
+`syncDynamicShortcuts` is called when the setting toggles (from `SettingsViewModel`) and at app start (`ThorApplication`, next to `autoFreezeManager` startup) so the long-press actions reflect the current setting.
+
+## Icon handling
+
+Build the shortcut icon from `PackageManager.getApplicationIcon(pkg)` (works for a disabled-but-installed package in Thor's own process, given `QUERY_ALL_PACKAGES`), draw to a `Bitmap`, apply a **saturation-0 `ColorMatrixColorFilter`** to grayscale it, wrap via `IconCompat.createWithBitmap`. Capture at pin time; if the icon fails to load, fall back to an icon cached when the app was frozen. (Reuses the same grayscale treatment the freezer list already applies.)
+
+## Cleanup / lifecycle
+
+- **Permanent unfreeze** (app removed from the Room freezer set) → `disableAppShortcut(pkg, "No longer frozen")`.
+- **Setting turned off** → disable all Thor freezer shortcuts + remove the dynamic bulk shortcuts.
+- **Re-freeze** (screen-off) → shortcut keeps working (enable-then-launch next tap).
+
+## Edge cases
+
+- **No active privilege on tap** → toast ("Enable Root / Shizuku / Dhizuku to launch frozen apps"), finish. Mirrors `FreezerTileService` `hasPrivilege` guard.
+- **Launcher doesn't support pinning** (`isRequestPinShortcutSupported == false`) → hide/disable the pin actions, surface a short explanation; dynamic long-press actions still work.
+- **Enable→launch race** (enabled state / launch intent not instantly visible) → after `setAppDisabled(false)` returns, retry `getLaunchIntentForPackage` briefly before giving up.
+- **System app in freezer** → no "Add to Home screen" action offered in v1.
+- **Icon load failure** → cached-at-freeze fallback.
+
+## Manifest / DI
+
+- Register `FreezerLaunchActivity` (`exported=false`, `Theme.NoDisplay`, `excludeFromRecents=true`, `noHistory=true`).
+- **No new permissions.** (`requestPinShortcut`/dynamic shortcuts need none; `QUERY_ALL_PACKAGES` already present; no foreground service.)
+- Confirm `androidx.core` (ShortcutManagerCompat/IconCompat) is on the classpath (it is, transitively via Compose/AndroidX; add explicit `androidx.core:core-ktx` if not).
+- DI: `FreezerShortcutManager` = `@Single` (Koin component-scan), like `AutoFreezeManager`; the trampoline activity retrieves deps via `by inject()`.
+
+## Testing
+
+- **Unit:** grayscale-bitmap util; trampoline action decision (disabled→enable+launch, enabled→launch-direct, no-privilege→toast+finish, FREEZE_ALL/UNFREEZE_ALL loop over the freezer set); `FreezerShortcutManager` builds correct `ShortcutInfoCompat` (id/label/intent/action extras) and disable logic.
+- **Device:** enable setting → pin a frozen user app → grayscale icon appears → tap enables + launches → lock screen → app re-freezes; pin/long-press Freeze all & Unfreeze all → freezer set toggles; unfreeze an app → its shortcut greys out.
+
+## File-by-file change list
+
+**New**
+- `data/launcher/FreezerShortcutManager.kt` — `@Single` shortcut wrapper + grayscale icon util.
+- `presentation/launcher/FreezerLaunchActivity.kt` — invisible action-dispatched trampoline.
+
+**Modified**
+- `domain/model/UserPreferences.kt`, `domain/repository/PreferenceRepository.kt`, `data/repository/PreferenceRepositoryImpl.kt` — new toggle.
+- `presentation/settings/SettingsViewModel.kt`, `presentation/settings/SettingsScreen.kt` — toggle row + `syncDynamicShortcuts` on change.
+- `presentation/freezer/FreezerViewModel.kt` + freezer sheets/screen — "Add to Home screen", "Pin all", "Freeze all/Unfreeze all" pin actions (gated on setting + `isPinSupported`).
+- `ThorApplication.kt` — `syncDynamicShortcuts(prefs.addFreezerToLauncher)` at start (next to `autoFreezeManager`).
+- `app/src/main/AndroidManifest.xml` — register `FreezerLaunchActivity`.
+
+## Future work
+
+- System-app launcher shortcuts (account for install-existing re-enable).
+- Optional foreground-leave re-freeze (UsageStats) as an alternative to screen-off, for users who want instant re-freeze after closing an app.

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,6 @@ org.gradle.welcome=never
 initialVersionCode=1900
 # REQUIRED: The active source of truth for our release manager
 # Logic: 1822 -> 1.82.2 (based on math: code/1000 . code%1000/10 . code%10)
-versionCode=1903
-versionName=1.90.3
+versionCode=1904
+versionName=1.90.4
 

--- a/release-notes/v1.90.4/github.md
+++ b/release-notes/v1.90.4/github.md
@@ -1,0 +1,27 @@
+# Thor v1.90.4 Release Notes
+
+**Add Freezer to launcher (#210)** — launch your frozen apps straight from the home screen, and keep Freeze-all / Unfreeze-all one tap away.
+
+## What's Changed
+
+### 🧊 Freezer shortcuts (#210)
+A new opt-in **Settings → Freezer → "Add Freezer to launcher"** unlocks launcher shortcuts for your apps:
+
+*   **Per-app home-screen shortcuts.** Pin any user app as a shortcut. Tapping it **enables the app in the background and launches it** (or launches it directly if it's already enabled) — so a frozen app is one tap away, and re-freezes on screen-off if Auto-Freeze is on.
+*   **State-following icons.** A shortcut's icon is **grayscale while the app is frozen** and **full-colour while it's enabled**, updating as the app's state changes (launching, screen-off auto-freeze, manual freeze/unfreeze).
+*   **Freeze all / Unfreeze all shortcuts.** Pin them to the home screen **and** reach them from a long-press on Thor's icon.
+*   **Pin from anywhere.** An **"Add to Home screen"** action in the app-info dialog (from any screen) and on the app-details page, plus a dedicated **"Shortcuts"** section in Freezer settings.
+*   **Pin confirmation.** A toast confirms when a shortcut is actually added to the home screen.
+
+### ❄️ Freeze → "Add to Freezer?" prompt
+*   Freezing an app from the **app-info dialog** or the **app-details page** now shows the same **"Frozen — Add to Freezer?"** prompt used elsewhere, instead of silently just-disabling (dialog) or auto-adding (details). You decide whether it joins the Freezer.
+
+### 🛠 Polish
+*   Launcher shortcuts open cleanly even when Thor is already in the recents stack — the launch trampoline now runs in its own task instead of surfacing Thor.
+*   Action rows in the app-info dialog and app-details page are top-aligned, so labels that wrap to two lines no longer knock the icons out of alignment.
+
+### ✅ Issues Resolved
+*   **#210** — show frozen apps in the launcher and launch them from the home screen.
+
+## 📦 Build
+*   Version bumped to **1.90.4 (1904)**.

--- a/release-notes/v1.90.4/playstore.txt
+++ b/release-notes/v1.90.4/playstore.txt
@@ -1,0 +1,9 @@
+What's new in Thor v1.90.4
+
+• New: Add Freezer to launcher — pin your frozen apps to the home screen and tap to launch them (they re-freeze on screen-off).
+• Shortcut icons follow app state: grey while frozen, colour while enabled.
+• Freeze all / Unfreeze all shortcuts, plus quick actions from a long-press on Thor's icon.
+• "Add to Home screen" from the app info dialog and the app details page.
+• Freezing an app now asks before adding it to the Freezer.
+
+Thanks for using Thor!

--- a/release-notes/v1.90.4/telegram.md
+++ b/release-notes/v1.90.4/telegram.md
@@ -1,0 +1,11 @@
+⚡️ **Thor v1.90.4 is here!**
+
+🧊 **Add Freezer to launcher** (#210):
+
+• Pin your **frozen apps** to the home screen — tap to launch them (they re-freeze on screen-off)
+• Shortcut icons **follow state**: grey while frozen, colour while enabled
+• **Freeze all / Unfreeze all** shortcuts — pinned, or from a long-press on Thor's icon
+• **"Add to Home screen"** from the app-info dialog & the app-details page
+• Freezing an app now **asks before adding** it to the Freezer
+
+Fixes #210. Update & enjoy! 🚀


### PR DESCRIPTION
## Summary
Implements **#210 "Add Freezer to launcher"** — an opt-in setting that surfaces your frozen apps on the home screen as launcher shortcuts, so a frozen app is one tap away: tapping enables it in the background, launches it, and it re-freezes on screen-off (if Auto-Freeze is on).

## Highlights
- **Setting:** Settings → Freezer → *Add Freezer to launcher* (opt-in).
- **Per-app shortcuts** with **state-following icons** — grayscale while frozen, full colour while enabled — that tap through to enable-then-launch (or launch directly if already enabled).
- **Freeze all / Unfreeze all** as pinned home-screen shortcuts **and** long-press dynamic shortcuts on Thor's icon.
- **Pin from anywhere:** an *Add to Home screen* action in the app-info dialog (any screen) + the app-details page, plus a dedicated **Shortcuts** section in Freezer settings.
- **Pin confirmation** toast when a shortcut is actually added.
- **Freeze → "Add to Freezer?" prompt** from the app-info dialog / details page — no more silent just-disable (dialog) or silent auto-add (details).
- Re-freeze reuses the **existing screen-off AutoFreeze** — no new service, **no new dangerous permissions** (user apps only for v1).

## New components
`FreezerShortcutContract` (pure, unit-tested) · `FreezerShortcutManager` (`@Single`) · `FreezerLaunchActivity` (translucent trampoline, own task) · `FreezerShortcutPinnedReceiver` (pin-success callback).

## Release
- Bumps to **1.90.4 (1904)** + release notes under `release-notes/v1.90.4/` (github / playstore / telegram).

## Process & verification
- Built via **spec → plan → subagent-driven implementation** with per-task + whole-branch review (design + plan in `docs/superpowers/`, ledger in `.superpowers/`).
- `assembleFossDebug` and `FreezerShortcutContractTest` green throughout; on-device UI verification done by the maintainer.

Closes #210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)