### PR TITLE
feat(freezer): choose Freeze or Suspend mode in the Freezer (#239)

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -150,25 +150,34 @@ class RootSystemGateway(
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
+        val hasReflection = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q
+
+        fun isCurrentlySuspended() = getApplicationInfoCompat(packageName)?.run {
+            (flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0
+        } ?: false
+
+        // SUSPEND: go through the reflection path (RootMain) so the *suspending package* is our own
+        // app id — setPackagesSuspendedAsUser(caller = BuildConfig.APPLICATION_ID). A bare
+        // `pm suspend` run in a root shell (uid 0) instead records the suspender as "root", a
+        // package that does not exist, so tapping the paused app crashes SuspendedAppActivity with
+        // "IllegalArgumentException: Package root does not exist". We deliberately do NOT fall back
+        // to `pm suspend` here — a broken suspension is worse than a reported failure. GH#239.
+        if (isSuspended && hasReflection) {
+            val taskResult = runRootTask("suspend", packageName, "true")
+            if (taskResult.isSuccess || isCurrentlySuspended()) return Result.success(Unit)
+            return Result.failure(Exception("Root suspend failed via reflection."))
+        }
+
+        // UNSUSPEND (any API) or SUSPEND on API < 29 (no SuspendDialogInfo): the shell path.
+        // Unsuspend needs no suspender attribution, so `pm unsuspend` is safe.
         val escapedPackage = ShellUtils.escapedString(packageName)
-        // 1. Try shell first
         val state = if (isSuspended) "suspend" else "unsuspend"
         val shellResult = runCommand("pm $state $escapedPackage")
         if (shellResult.isSuccess) return shellResult
 
-        // 2. Fallback to reflection via RootMain
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            val taskResult = runRootTask("suspend", packageName, isSuspended.toString())
-            if (taskResult.isSuccess) return Result.success(Unit)
-        }
+        if (isCurrentlySuspended() == isSuspended) return Result.success(Unit)
 
-        // 3. Check if already in the target state
-        val currentSuspended = getApplicationInfoCompat(packageName)?.run {
-            (flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0
-        } ?: false
-        if (currentSuspended == isSuspended) return Result.success(Unit)
-
-        return Result.failure(Exception("Root setAppSuspended failed. Shell command and reflection both failed."))
+        return Result.failure(Exception("Root setAppSuspended failed."))
     }
 
     override suspend fun setAppRestricted(

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -151,33 +151,42 @@ class RootSystemGateway(
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
         val hasReflection = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q
+        val escapedPackage = ShellUtils.escapedString(packageName)
 
         fun isCurrentlySuspended() = getApplicationInfoCompat(packageName)?.run {
             (flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0
         } ?: false
 
-        // SUSPEND: go through the reflection path (RootMain) so the *suspending package* is our own
-        // app id — setPackagesSuspendedAsUser(caller = BuildConfig.APPLICATION_ID). A bare
-        // `pm suspend` run in a root shell (uid 0) instead records the suspender as "root", a
-        // package that does not exist, so tapping the paused app crashes SuspendedAppActivity with
-        // "IllegalArgumentException: Package root does not exist". We deliberately do NOT fall back
-        // to `pm suspend` here — a broken suspension is worse than a reported failure. GH#239.
-        if (isSuspended && hasReflection) {
-            val taskResult = runRootTask("suspend", packageName, "true")
-            if (taskResult.isSuccess || isCurrentlySuspended()) return Result.success(Unit)
-            return Result.failure(Exception("Root suspend failed via reflection."))
+        if (isSuspended) {
+            // SUSPEND via the reflection path only: setPackagesSuspendedAsUser(caller = our app id).
+            // A root-shell `pm suspend` (uid 0) records the suspender as "root", a non-existent
+            // package, so tapping the paused app crashes SuspendedAppActivity
+            // ("IllegalArgumentException: Package root does not exist"). We never fall back to the
+            // shell for suspend — a broken suspension is worse than a reported failure. GH#239.
+            if (hasReflection) {
+                val taskResult = runRootTask("suspend", packageName, "true")
+                if (taskResult.isSuccess || isCurrentlySuspended()) return Result.success(Unit)
+                return Result.failure(Exception("Root suspend failed via reflection for $packageName."))
+            }
+            // API < 29 has no SuspendDialogInfo reflection path.
+            val shell = runCommand("pm suspend $escapedPackage")
+            return if (shell.isSuccess) shell
+            else Result.failure(Exception("Root suspend failed for $packageName."))
         }
 
-        // UNSUSPEND (any API) or SUSPEND on API < 29 (no SuspendDialogInfo): the shell path.
-        // Unsuspend needs no suspender attribution, so `pm unsuspend` is safe.
-        val escapedPackage = ShellUtils.escapedString(packageName)
-        val state = if (isSuspended) "suspend" else "unsuspend"
-        val shellResult = runCommand("pm $state $escapedPackage")
-        if (shellResult.isSuccess) return shellResult
-
-        if (isCurrentlySuspended() == isSuspended) return Result.success(Unit)
-
-        return Result.failure(Exception("Root setAppSuspended failed."))
+        // UNSUSPEND: a suspension can only be lifted by the package that set it, so clear BOTH
+        // possible owners — our own app (reflection, for suspensions this app set) AND
+        // "root"/"shell" (shell `pm unsuspend`, for any legacy suspension left by older builds).
+        // A root-shell `pm unsuspend` alone reports success yet leaves an app suspended by us still
+        // suspended. GH#239.
+        var cleared = false
+        if (hasReflection) {
+            cleared = runRootTask("suspend", packageName, "false").isSuccess
+        }
+        val shell = runCommand("pm unsuspend $escapedPackage")
+        cleared = cleared || shell.isSuccess
+        return if (cleared || !isCurrentlySuspended()) Result.success(Unit)
+        else Result.failure(Exception("Root unsuspend failed for $packageName."))
     }
 
     override suspend fun setAppRestricted(

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -110,7 +110,9 @@ class FreezerShortcutManager(
             val pinnedIds = pinnedShortcutIds()
             val updated = mutableListOf<ShortcutInfoCompat>()
             freezerRepository.getAllPackageNames().forEach { pkg ->
-                manageAppUseCase.setAppDisabled(pkg, disable)
+                // Unfreeze must restore suspended apps too, not just re-enable disabled ones.
+                if (disable) manageAppUseCase.setAppDisabled(pkg, true)
+                else manageAppUseCase.forceUnfreeze(pkg)
                 // Only apps that actually have a pinned shortcut need a state-following icon refresh;
                 // accumulate them and push ONE updateShortcuts IPC instead of N.
                 if (FreezerShortcutContract.appShortcutId(pkg) in pinnedIds) {

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.valhalla.thor.domain.model.AnimationIntensity
 import com.valhalla.thor.domain.model.FilterType
+import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
@@ -54,6 +55,7 @@ class PreferenceRepositoryImpl(
         // Auto Freeze
         val AUTO_FREEZE = booleanPreferencesKey("auto_freeze")
         val ADD_FREEZER_TO_LAUNCHER = booleanPreferencesKey("add_freezer_to_launcher")
+        val FREEZER_MODE = stringPreferencesKey("freezer_mode")
 
         // Freezer Prompts
         val HAS_SHOWN_DISABLED_APPS_PROMPT = booleanPreferencesKey("has_shown_disabled_apps_prompt")
@@ -102,6 +104,9 @@ class PreferenceRepositoryImpl(
             val useDetailedView = prefs[Keys.USE_DETAILED_VIEW] ?: true
             val appListIsGrid = prefs[Keys.APP_LIST_IS_GRID] ?: true
             val freezerIsGrid = prefs[Keys.FREEZER_IS_GRID] ?: true
+            val freezerMode = prefs[Keys.FREEZER_MODE]
+                ?.let { runCatching { FreezerMode.valueOf(it) }.getOrNull() }
+                ?: FreezerMode.FREEZE
 
             UserPreferences(
                 appSortBy = sortBy,
@@ -116,6 +121,7 @@ class PreferenceRepositoryImpl(
                 preferredPrivilegeMode = privilegeMode,
                 language = prefs[Keys.LANGUAGE],
                 autoFreezeEnabled = prefs[Keys.AUTO_FREEZE] ?: false,
+                freezerMode = freezerMode,
                 addFreezerToLauncher = prefs[Keys.ADD_FREEZER_TO_LAUNCHER] ?: false,
                 hasShownDisabledAppsPrompt = prefs[Keys.HAS_SHOWN_DISABLED_APPS_PROMPT] ?: false,
                 hasShownSupportDeveloperPrompt = prefs[Keys.HAS_SHOWN_SUPPORT_DEVELOPER_PROMPT] ?: false,
@@ -195,6 +201,12 @@ class PreferenceRepositoryImpl(
     override suspend fun setAutoFreezeEnabled(enabled: Boolean) {
         context.dataStore.edit {
             it[Keys.AUTO_FREEZE] = enabled
+        }
+    }
+
+    override suspend fun setFreezerMode(mode: FreezerMode) {
+        context.dataStore.edit {
+            it[Keys.FREEZER_MODE] = mode.name
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
@@ -5,7 +5,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
@@ -37,6 +39,9 @@ class AutoFreezeManager(
     private var observationJob: Job? = null
     private var isObserving = false
     private var isReceiverRegistered = false
+
+    @Volatile
+    private var currentMode: FreezerMode = FreezerMode.FREEZE
 
     private val screenReceiver = object : BroadcastReceiver() {
         override fun onReceive(ctx: Context, intent: Intent) {
@@ -95,7 +100,22 @@ class AutoFreezeManager(
                                         }
                                     }
                                     val appInfo = pm.getApplicationInfo(pkg, 0)
-                                    if (appInfo.enabled) {
+                                    if (currentMode == FreezerMode.SUSPEND) {
+                                        val alreadySuspended = (appInfo.flags and ApplicationInfo.FLAG_SUSPENDED) != 0
+                                        if (!alreadySuspended) {
+                                            Logger.d("AutoFreezeManager", "Auto-suspending app: $pkg")
+                                            val result = manageAppUseCase.setAppSuspended(pkg, true)
+                                            if (result.isSuccess) {
+                                                Logger.d("AutoFreezeManager", "Auto-suspended: $pkg")
+                                                freezerShortcutManager.refreshAppShortcut(pkg)
+                                            } else {
+                                                Logger.e(
+                                                    "AutoFreezeManager",
+                                                    "Failed to suspend $pkg: ${result.exceptionOrNull()?.message}"
+                                                )
+                                            }
+                                        }
+                                    } else if (appInfo.enabled) {
                                         Logger.d("AutoFreezeManager", "Auto-freezing app: $pkg")
                                         val result = manageAppUseCase.setAppDisabled(pkg, true)
                                         if (result.isSuccess) {
@@ -133,6 +153,7 @@ class AutoFreezeManager(
         isObserving = true
         observationJob = mainScope.launch {
             preferenceRepository.userPreferences.collectLatest { prefs ->
+                currentMode = prefs.freezerMode
                 if (prefs.autoFreezeEnabled) {
                     registerReceiver()
                 } else {

--- a/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
@@ -100,9 +100,11 @@ class AutoFreezeManager(
                                         }
                                     }
                                     val appInfo = pm.getApplicationInfo(pkg, 0)
-                                    if (currentMode == FreezerMode.SUSPEND) {
-                                        val alreadySuspended = (appInfo.flags and ApplicationInfo.FLAG_SUSPENDED) != 0
-                                        if (!alreadySuspended) {
+                                    val alreadySuspended = (appInfo.flags and ApplicationInfo.FLAG_SUSPENDED) != 0
+                                    // Only act on ACTIVE apps (enabled & not suspended) so auto-freeze
+                                    // never stacks disable+suspend into an un-restorable mixed state.
+                                    if (appInfo.enabled && !alreadySuspended) {
+                                        if (currentMode == FreezerMode.SUSPEND) {
                                             Logger.d("AutoFreezeManager", "Auto-suspending app: $pkg")
                                             val result = manageAppUseCase.setAppSuspended(pkg, true)
                                             if (result.isSuccess) {
@@ -114,18 +116,18 @@ class AutoFreezeManager(
                                                     "Failed to suspend $pkg: ${result.exceptionOrNull()?.message}"
                                                 )
                                             }
-                                        }
-                                    } else if (appInfo.enabled) {
-                                        Logger.d("AutoFreezeManager", "Auto-freezing app: $pkg")
-                                        val result = manageAppUseCase.setAppDisabled(pkg, true)
-                                        if (result.isSuccess) {
-                                            Logger.d("AutoFreezeManager", "Auto-froze: $pkg")
-                                            freezerShortcutManager.refreshAppShortcut(pkg) // → grey the shortcut icon
                                         } else {
-                                            Logger.e(
-                                                "AutoFreezeManager",
-                                                "Failed to freeze $pkg: ${result.exceptionOrNull()?.message}"
-                                            )
+                                            Logger.d("AutoFreezeManager", "Auto-freezing app: $pkg")
+                                            val result = manageAppUseCase.setAppDisabled(pkg, true)
+                                            if (result.isSuccess) {
+                                                Logger.d("AutoFreezeManager", "Auto-froze: $pkg")
+                                                freezerShortcutManager.refreshAppShortcut(pkg) // → grey the shortcut icon
+                                            } else {
+                                                Logger.e(
+                                                    "AutoFreezeManager",
+                                                    "Failed to freeze $pkg: ${result.exceptionOrNull()?.message}"
+                                                )
+                                            }
                                         }
                                     }
                                 } catch (_: PackageManager.NameNotFoundException) {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/root/RootMain.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/root/RootMain.kt
@@ -102,6 +102,24 @@ object RootMain {
             ).invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller, 0, 0)
             return
         } catch (_: NoSuchMethodException) {
+            // fall through to the 8-arg signature
+        }
+
+        // Some API 33 builds: 8-arg — a `flags` Int between dialogInfo and caller, single userId.
+        try {
+            pmClass.getDeclaredMethod(
+                "setPackagesSuspendedAsUser",
+                Array<String>::class.java,
+                Boolean::class.javaPrimitiveType,
+                android.os.PersistableBundle::class.java,
+                android.os.PersistableBundle::class.java,
+                dialogInfoClass,
+                Int::class.javaPrimitiveType,   // flags
+                String::class.java,             // callingPackage
+                Int::class.javaPrimitiveType    // userId
+            ).invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller, 0)
+            return
+        } catch (_: NoSuchMethodException) {
             // fall through to the older 7-arg signature
         }
 

--- a/app/src/main/java/com/valhalla/thor/data/source/local/root/RootMain.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/root/RootMain.kt
@@ -29,7 +29,8 @@ object RootMain {
                 }
             }
         } catch (e: Exception) {
-            e.printStackTrace()
+            // Surface the real cause to logcat — libsu only reports "code 1" to the caller.
+            android.util.Log.e("RootMain", "task '${args.getOrNull(0)}' failed", e)
             exitProcess(1)
         }
         exitProcess(0)
@@ -84,8 +85,9 @@ object RootMain {
         pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
         packageName: String, suspended: Boolean, dialogInfo: Any?, caller: String
     ) {
+        // Android 14+ (API 34+): 9-arg — adds `flags` plus separate suspendingUserId + targetUserId
+        // (the quarantine-era signature; confirmed present on Android 16 / API 36).
         try {
-            // Android 13+ (API 33): 8-arg — extra flags Int between dialogInfo and caller
             pmClass.getDeclaredMethod(
                 "setPackagesSuspendedAsUser",
                 Array<String>::class.java,
@@ -93,19 +95,23 @@ object RootMain {
                 android.os.PersistableBundle::class.java,
                 android.os.PersistableBundle::class.java,
                 dialogInfoClass,
-                Int::class.javaPrimitiveType,
-                String::class.java,
-                Int::class.javaPrimitiveType
-            ).invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller, 0)
+                Int::class.javaPrimitiveType,   // flags
+                String::class.java,             // callingPackage
+                Int::class.javaPrimitiveType,   // suspendingUserId
+                Int::class.javaPrimitiveType    // targetUserId
+            ).invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller, 0, 0)
+            return
         } catch (_: NoSuchMethodException) {
-            // Android 10-12 (API 29-32): 7-arg
-            pmClass.getDeclaredMethod(
-                "setPackagesSuspendedAsUser",
-                Array<String>::class.java, Boolean::class.javaPrimitiveType,
-                android.os.PersistableBundle::class.java, android.os.PersistableBundle::class.java,
-                dialogInfoClass, String::class.java, Int::class.javaPrimitiveType
-            ).invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, caller, 0)
+            // fall through to the older 7-arg signature
         }
+
+        // Android 10-13 (API 29-33): 7-arg — SuspendDialogInfo, callingPackage, userId.
+        pmClass.getDeclaredMethod(
+            "setPackagesSuspendedAsUser",
+            Array<String>::class.java, Boolean::class.javaPrimitiveType,
+            android.os.PersistableBundle::class.java, android.os.PersistableBundle::class.java,
+            dialogInfoClass, String::class.java, Int::class.javaPrimitiveType
+        ).invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, caller, 0)
     }
 
     private fun buildSuspendDialogInfo(): Any? = try {

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt
@@ -3,23 +3,24 @@ package com.valhalla.thor.domain.model
 /** What the Freezer does when it "freezes" an app. GH#239. */
 enum class FreezerMode { FREEZE, SUSPEND }
 
-/** How a frozen app is restored to active, based on its actual current state. */
-enum class FreezerRestore { ENABLE, UNSUSPEND, NONE }
-
 /** Freezer treats an app as "frozen" when it is disabled OR suspended. */
 fun isFrozen(enabled: Boolean, isSuspended: Boolean): Boolean = !enabled || isSuspended
 
 /** "Active" = not frozen: enabled and not suspended (i.e. freezable). */
 fun isActive(enabled: Boolean, isSuspended: Boolean): Boolean = enabled && !isSuspended
 
-/** Pick the inverse op to bring a frozen app back to active (suspended wins if somehow both). */
-fun restoreActionFor(enabled: Boolean, isSuspended: Boolean): FreezerRestore = when {
-    isSuspended -> FreezerRestore.UNSUSPEND
-    !enabled -> FreezerRestore.ENABLE
-    else -> FreezerRestore.NONE
-}
+/** The inverse ops needed to bring an app fully back to active. */
+data class RestorePlan(val unsuspend: Boolean, val enable: Boolean)
+
+/**
+ * Plan to restore an app to active. Clears BOTH freeze dimensions when both are set —
+ * an app can be disabled AND suspended (e.g. after a mode switch), and reversing only one
+ * leaves it frozen. For an already-active app it defaults to a harmless enable so
+ * "remove from freezer" keeps its prior always-enable behavior.
+ */
+fun restorePlanFor(enabled: Boolean, isSuspended: Boolean): RestorePlan =
+    RestorePlan(unsuspend = isSuspended, enable = !enabled || !isSuspended)
 
 // Ergonomic call-site helpers over AppInfo.
 val AppInfo.isFrozen: Boolean get() = isFrozen(enabled, isSuspended)
 val AppInfo.isActive: Boolean get() = isActive(enabled, isSuspended)
-val AppInfo.restoreAction: FreezerRestore get() = restoreActionFor(enabled, isSuspended)

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt
@@ -15,11 +15,10 @@ data class RestorePlan(val unsuspend: Boolean, val enable: Boolean)
 /**
  * Plan to restore an app to active. Clears BOTH freeze dimensions when both are set —
  * an app can be disabled AND suspended (e.g. after a mode switch), and reversing only one
- * leaves it frozen. For an already-active app it defaults to a harmless enable so
- * "remove from freezer" keeps its prior always-enable behavior.
+ * leaves it frozen. An already-active app yields a no-op plan (no redundant pm enable).
  */
 fun restorePlanFor(enabled: Boolean, isSuspended: Boolean): RestorePlan =
-    RestorePlan(unsuspend = isSuspended, enable = !enabled || !isSuspended)
+    RestorePlan(unsuspend = isSuspended, enable = !enabled)
 
 // Ergonomic call-site helpers over AppInfo.
 val AppInfo.isFrozen: Boolean get() = isFrozen(enabled, isSuspended)

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt
@@ -1,0 +1,25 @@
+package com.valhalla.thor.domain.model
+
+/** What the Freezer does when it "freezes" an app. GH#239. */
+enum class FreezerMode { FREEZE, SUSPEND }
+
+/** How a frozen app is restored to active, based on its actual current state. */
+enum class FreezerRestore { ENABLE, UNSUSPEND, NONE }
+
+/** Freezer treats an app as "frozen" when it is disabled OR suspended. */
+fun isFrozen(enabled: Boolean, isSuspended: Boolean): Boolean = !enabled || isSuspended
+
+/** "Active" = not frozen: enabled and not suspended (i.e. freezable). */
+fun isActive(enabled: Boolean, isSuspended: Boolean): Boolean = enabled && !isSuspended
+
+/** Pick the inverse op to bring a frozen app back to active (suspended wins if somehow both). */
+fun restoreActionFor(enabled: Boolean, isSuspended: Boolean): FreezerRestore = when {
+    isSuspended -> FreezerRestore.UNSUSPEND
+    !enabled -> FreezerRestore.ENABLE
+    else -> FreezerRestore.NONE
+}
+
+// Ergonomic call-site helpers over AppInfo.
+val AppInfo.isFrozen: Boolean get() = isFrozen(enabled, isSuspended)
+val AppInfo.isActive: Boolean get() = isActive(enabled, isSuspended)
+val AppInfo.restoreAction: FreezerRestore get() = restoreActionFor(enabled, isSuspended)

--- a/app/src/main/java/com/valhalla/thor/domain/model/MultiAppAction.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/MultiAppAction.kt
@@ -3,7 +3,7 @@ package com.valhalla.thor.domain.model
 sealed interface MultiAppAction {
     data class ReInstall(val appList: List<AppInfo>) : MultiAppAction
     data class Uninstall(val appList: List<AppInfo>) : MultiAppAction
-    data class Freeze(val appList: List<AppInfo>) : MultiAppAction
+    data class Freeze(val appList: List<AppInfo>, val useSuspend: Boolean = false) : MultiAppAction
     data class UnFreeze(val appList: List<AppInfo>) : MultiAppAction
     data class Share(val appList: List<AppInfo>) : MultiAppAction
     data class Kill(val appList: List<AppInfo>) : MultiAppAction

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -27,6 +27,9 @@ data class UserPreferences(
     // Auto Freeze
     val autoFreezeEnabled: Boolean = false,
 
+    // Freezer action mode: FREEZE = pm disable, SUSPEND = pm suspend
+    val freezerMode: FreezerMode = FreezerMode.FREEZE,
+
     // Add Freezer to launcher (home-screen shortcuts for frozen apps)
     val addFreezerToLauncher: Boolean = false,
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -2,6 +2,7 @@ package com.valhalla.thor.domain.repository
 
 import com.valhalla.thor.domain.model.AnimationIntensity
 import com.valhalla.thor.domain.model.FilterType
+import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
@@ -40,6 +41,7 @@ interface PreferenceRepository {
     // --- Auto Freeze ---
     suspend fun setAutoFreezeEnabled(enabled: Boolean)
     suspend fun setAddFreezerToLauncher(enabled: Boolean)
+    suspend fun setFreezerMode(mode: FreezerMode)
 
     // --- Freezer Prompts ---
     suspend fun setHasShownDisabledAppsPrompt(hasShown: Boolean)

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ManageAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ManageAppUseCase.kt
@@ -35,6 +35,18 @@ class ManageAppUseCase(
         return if (plan.enable) setAppDisabled(packageName, false) else Result.success(Unit)
     }
 
+    /**
+     * Force an app fully back to active for bulk "unfreeze all" when per-app state isn't known:
+     * unsuspend then enable, unconditionally. Unsuspending a non-suspended app and enabling an
+     * already-enabled app are no-ops, so this restores disabled AND suspended apps alike without a
+     * prior state query. GH#239.
+     */
+    suspend fun forceUnfreeze(packageName: String): Result<Unit> {
+        val unsuspend = setAppSuspended(packageName, false)
+        if (unsuspend.isFailure) return unsuspend
+        return setAppDisabled(packageName, false)
+    }
+
     suspend fun uninstallApp(packageName: String): Result<Unit> =
         systemRepository.uninstallApp(packageName)
 

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ManageAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ManageAppUseCase.kt
@@ -1,5 +1,6 @@
 package com.valhalla.thor.domain.usecase
 
+import com.valhalla.thor.domain.model.restorePlanFor
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -20,6 +21,19 @@ class ManageAppUseCase(
 
     suspend fun setAppSuspended(packageName: String, suspended: Boolean): Result<Unit> =
         systemRepository.setAppSuspended(packageName, suspended)
+
+    /**
+     * Bring an app fully back to active: unsuspend if suspended AND enable if disabled
+     * (both, when both apply). Safely handles the mixed disabled+suspended state. GH#239.
+     */
+    suspend fun restoreApp(packageName: String, enabled: Boolean, isSuspended: Boolean): Result<Unit> {
+        val plan = restorePlanFor(enabled, isSuspended)
+        if (plan.unsuspend) {
+            val r = setAppSuspended(packageName, false)
+            if (r.isFailure) return r
+        }
+        return if (plan.enable) setAppDisabled(packageName, false) else Result.success(Unit)
+    }
 
     suspend fun uninstallApp(packageName: String): Result<Unit> =
         systemRepository.uninstallApp(packageName)

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -710,7 +710,9 @@ private fun AppDetailsActionRow(
         ActionItem(
             icon = R.drawable.open_in_new,
             label = stringResource(R.string.action_open),
-            enabled = appInfo.enabled,
+            // Always tappable: Launch restores (unsuspends / enables) a frozen or suspended app
+            // before launching. Non-launchable apps fall through to a "can't launch" toast.
+            enabled = true,
             onClick = onLaunch
         )
 

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -53,6 +53,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.valhalla.thor.domain.model.FreezerMode
+import com.valhalla.thor.domain.model.isActive
+import com.valhalla.thor.domain.model.isFrozen
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
@@ -117,15 +120,16 @@ fun FreezerScreen(
         filtered.sortedBy { it.appName }
     }
 
-    val hasEnabled = remember(state.freezerApps) { state.freezerApps.any { it.enabled } }
-    val hasDisabled = remember(state.freezerApps) { state.freezerApps.any { !it.enabled } }
+    // "Active" = freezable (enabled & not suspended); "frozen" = disabled OR suspended (GH#239).
+    val hasEnabled = remember(state.freezerApps) { state.freezerApps.any { it.isActive } }
+    val hasDisabled = remember(state.freezerApps) { state.freezerApps.any { it.isFrozen } }
 
     // Apps the "Freeze all" / "Unfreeze all" toolbar acts on. These route through the
-    // shared batch action (MultiAppAction) so progress streams into the TermLoggerDialog
-    // (rendered by MainScreen), identical to multi-select. The unsafe/UAD eligibility
-    // skip is applied once, centrally, by MainViewModel.onMultiAppAction.
-    val appsToFreeze = remember(state.freezerApps) { state.freezerApps.filter { it.enabled } }
-    val appsToUnfreeze = remember(state.freezerApps) { state.freezerApps.filter { !it.enabled } }
+    // shared batch action (MultiAppAction) so progress streams into the FreezeLoggerDialog;
+    // the unsafe/UAD eligibility skip is applied once, centrally, by
+    // MainViewModel.performCountedFreeze. Unfreeze restores by each app's actual state.
+    val appsToFreeze = remember(state.freezerApps) { state.freezerApps.filter { it.isActive } }
+    val appsToUnfreeze = remember(state.freezerApps) { state.freezerApps.filter { it.isFrozen } }
 
 
     LaunchedEffect(state.actionMessage) {
@@ -369,7 +373,14 @@ fun FreezerScreen(
                             disabledContentColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f)
                         )
                         IconButton(
-                            onClick = { onMultiAppAction(MultiAppAction.Freeze(appsToFreeze)) },
+                            onClick = {
+                                onMultiAppAction(
+                                    MultiAppAction.Freeze(
+                                        appsToFreeze,
+                                        useSuspend = state.freezerMode == FreezerMode.SUSPEND
+                                    )
+                                )
+                            },
                             enabled = hasEnabled && hasPrivilege,
                             colors = iconButtonColors
                         ) {
@@ -463,6 +474,8 @@ fun FreezerScreen(
             showLauncherPinActions = state.addFreezerToLauncher && viewModel.isPinSupported(),
             onToggleView = viewModel::toggleGridMode,
             onToggleAutoFreeze = viewModel::setAutoFreezeEnabled,
+            freezerMode = state.freezerMode,
+            onFreezerModeChange = viewModel::setFreezerMode,
             onDismiss = { showSettingsSheet = false },
             onUnfreezeAll = { onMultiAppAction(MultiAppAction.UnFreeze(appsToUnfreeze)) },
             onPinAllToLauncher = viewModel::pinAllToLauncher,

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -342,6 +342,7 @@ fun FreezerScreen(
                     isRoot = state.isRoot,
                     isShizuku = state.isShizuku,
                     isDhizuku = state.isDhizuku,
+                    freezerMode = state.freezerMode,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .padding(bottom = 16.dp),

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -120,16 +120,15 @@ fun FreezerScreen(
         filtered.sortedBy { it.appName }
     }
 
-    // "Active" = freezable (enabled & not suspended); "frozen" = disabled OR suspended (GH#239).
-    val hasEnabled = remember(state.freezerApps) { state.freezerApps.any { it.isActive } }
-    val hasDisabled = remember(state.freezerApps) { state.freezerApps.any { it.isFrozen } }
-
     // Apps the "Freeze all" / "Unfreeze all" toolbar acts on. These route through the
     // shared batch action (MultiAppAction) so progress streams into the FreezeLoggerDialog;
     // the unsafe/UAD eligibility skip is applied once, centrally, by
     // MainViewModel.performCountedFreeze. Unfreeze restores by each app's actual state.
+    // "Active" = freezable (enabled & not suspended); "frozen" = disabled OR suspended (GH#239).
     val appsToFreeze = remember(state.freezerApps) { state.freezerApps.filter { it.isActive } }
     val appsToUnfreeze = remember(state.freezerApps) { state.freezerApps.filter { it.isFrozen } }
+    val hasEnabled = appsToFreeze.isNotEmpty()
+    val hasDisabled = appsToUnfreeze.isNotEmpty()
 
 
     LaunchedEffect(state.actionMessage) {

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSelectToolBox.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSelectToolBox.kt
@@ -19,11 +19,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,13 +50,8 @@ fun FreezerSelectToolBox(
     freezerMode: FreezerMode = FreezerMode.FREEZE
 ) {
     // "Frozen" = disabled OR suspended; "active" = freezable (enabled & not suspended). GH#239.
-    var hasFrozen by remember { mutableStateOf(selected.any { it.isFrozen }) }
-    var hasUnFrozen by remember { mutableStateOf(selected.any { it.isActive }) }
-
-    LaunchedEffect(selected) {
-        hasFrozen = selected.any { it.isFrozen }
-        hasUnFrozen = selected.any { it.isActive }
-    }
+    val hasFrozen = remember(selected) { selected.any { it.isFrozen } }
+    val hasUnFrozen = remember(selected) { selected.any { it.isActive } }
 
     Card(
         modifier = modifier,

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSelectToolBox.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSelectToolBox.kt
@@ -36,7 +36,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.MultiAppAction
+import com.valhalla.thor.domain.model.isActive
+import com.valhalla.thor.domain.model.isFrozen
 
 @Composable
 fun FreezerSelectToolBox(
@@ -47,14 +50,16 @@ fun FreezerSelectToolBox(
     isDhizuku: Boolean = false,
     onCancel: () -> Unit = {},
     onRemoveFromFreezer: () -> Unit = {},
-    onMultiAppAction: (MultiAppAction) -> Unit = {}
+    onMultiAppAction: (MultiAppAction) -> Unit = {},
+    freezerMode: FreezerMode = FreezerMode.FREEZE
 ) {
-    var hasFrozen by remember { mutableStateOf(selected.any { !it.enabled }) }
-    var hasUnFrozen by remember { mutableStateOf(selected.any { it.enabled }) }
+    // "Frozen" = disabled OR suspended; "active" = freezable (enabled & not suspended). GH#239.
+    var hasFrozen by remember { mutableStateOf(selected.any { it.isFrozen }) }
+    var hasUnFrozen by remember { mutableStateOf(selected.any { it.isActive }) }
 
     LaunchedEffect(selected) {
-        hasFrozen = selected.any { !it.enabled }
-        hasUnFrozen = selected.any { it.enabled }
+        hasFrozen = selected.any { it.isFrozen }
+        hasUnFrozen = selected.any { it.isActive }
     }
 
     Card(
@@ -78,7 +83,11 @@ fun FreezerSelectToolBox(
                     FreezerToolItem(
                         icon = R.drawable.frozen,
                         label = stringResource(R.string.action_freeze),
-                        onClick = { onMultiAppAction(MultiAppAction.Freeze(selected)) }
+                        onClick = {
+                            onMultiAppAction(
+                                MultiAppAction.Freeze(selected, useSuspend = freezerMode == FreezerMode.SUSPEND)
+                            )
+                        }
                     )
                 }
                 if (hasFrozen) {

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.sp
 import com.valhalla.thor.R
 import com.valhalla.thor.data.launcher.FreezerShortcutContract
 import com.valhalla.thor.domain.model.AppListType
+import com.valhalla.thor.domain.model.FreezerMode
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import com.valhalla.asgard.components.AsgardActionItem
@@ -48,6 +49,8 @@ import com.valhalla.asgard.components.ConnectedButtonGroupItem
 fun FreezerSettingsSheet(
     isGrid: Boolean,
     autoFreezeEnabled: Boolean,
+    freezerMode: FreezerMode,
+    onFreezerModeChange: (FreezerMode) -> Unit,
     hasPrivilege: Boolean,
     showImportDisabledApps: Boolean,
     appListType: AppListType,
@@ -233,6 +236,31 @@ fun FreezerSettingsSheet(
                 ) {
                     Text(stringResource(R.string.import_disabled_apps_button))
                 }
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // Freeze vs Suspend mode (GH#239) — same segmented control style as the selectors above.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(R.string.freeze_mode),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                )
+                ConnectedButtonGroup(
+                    items = listOf(
+                        ConnectedButtonGroupItem.Label(stringResource(R.string.action_freeze)),
+                        ConnectedButtonGroupItem.Label(stringResource(R.string.action_suspend))
+                    ),
+                    selectedIndex = freezerMode.ordinal,
+                    onItemSelected = { onFreezerModeChange(FreezerMode.entries[it]) },
+                    enabled = hasPrivilege,
+                    modifier = Modifier.width(IntrinsicSize.Max)
+                )
             }
 
             Spacer(Modifier.height(24.dp))

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -8,6 +8,9 @@ import com.valhalla.thor.data.launcher.FreezerShortcutManager
 import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
+import com.valhalla.thor.domain.model.FreezerMode
+import com.valhalla.thor.domain.model.FreezerRestore
+import com.valhalla.thor.domain.model.restoreAction
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
@@ -41,6 +44,7 @@ data class FreezerUiState(
     val actionMessage: UiText? = null,
     val freezerPrompt: FreezerPrompt? = null,
     val autoFreezeEnabled: Boolean = false,
+    val freezerMode: FreezerMode = FreezerMode.FREEZE,
     val isDhizuku: Boolean = false,
     val hasShownDisabledAppsPrompt: Boolean = false,
     val appListType: AppListType = AppListType.USER,
@@ -224,7 +228,10 @@ class FreezerViewModel(
 
     fun freezeSingleApp(packageName: String, appName: String?, inFreezer: Boolean) {
         viewModelScope.launch(Dispatchers.IO) {
-            manageAppUseCase.setAppDisabled(packageName, true)
+            val freezeResult = if (_uiState.value.freezerMode == FreezerMode.SUSPEND)
+                manageAppUseCase.setAppSuspended(packageName, true)
+            else manageAppUseCase.setAppDisabled(packageName, true)
+            freezeResult
                 .onSuccess {
                     freezerShortcutManager.refreshAppShortcut(packageName)
                     if (!inFreezer) {
@@ -262,7 +269,13 @@ class FreezerViewModel(
 
     fun unfreezeSingleApp(packageName: String, appName: String?) {
         viewModelScope.launch(Dispatchers.IO) {
-            manageAppUseCase.setAppDisabled(packageName, false)
+            val app = _uiState.value.freezerApps.firstOrNull { it.packageName == packageName }
+                ?: _uiState.value.allInstalledApps.firstOrNull { it.packageName == packageName }
+            val restoreResult = when (app?.restoreAction) {
+                FreezerRestore.UNSUSPEND -> manageAppUseCase.setAppSuspended(packageName, false)
+                else -> manageAppUseCase.setAppDisabled(packageName, false)
+            }
+            restoreResult
                 .onSuccess {
                     freezerShortcutManager.refreshAppShortcut(packageName)
                     _uiState.update {
@@ -299,6 +312,7 @@ class FreezerViewModel(
                 _uiState.update {
                     it.copy(
                         autoFreezeEnabled = prefs.autoFreezeEnabled,
+                        freezerMode = prefs.freezerMode,
                         hasShownDisabledAppsPrompt = prefs.hasShownDisabledAppsPrompt,
                         isGrid = prefs.freezerIsGrid,
                         addFreezerToLauncher = prefs.addFreezerToLauncher
@@ -311,6 +325,12 @@ class FreezerViewModel(
     fun setAutoFreezeEnabled(enabled: Boolean) {
         viewModelScope.launch(Dispatchers.IO) {
             preferenceRepository.setAutoFreezeEnabled(enabled)
+        }
+    }
+
+    fun setFreezerMode(mode: FreezerMode) {
+        viewModelScope.launch(Dispatchers.IO) {
+            preferenceRepository.setFreezerMode(mode)
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -9,8 +9,6 @@ import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.FreezerMode
-import com.valhalla.thor.domain.model.FreezerRestore
-import com.valhalla.thor.domain.model.restoreAction
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
@@ -142,7 +140,14 @@ class FreezerViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             packageNames.forEach { pkg ->
                 freezerRepository.remove(pkg)
-                manageAppUseCase.setAppDisabled(pkg, false)
+                val app = _uiState.value.freezerApps.firstOrNull { it.packageName == pkg }
+                    ?: _uiState.value.allInstalledApps.firstOrNull { it.packageName == pkg }
+                // Restore to active (unsuspend and/or enable) so a suspended app isn't stranded.
+                manageAppUseCase.restoreApp(
+                    pkg,
+                    enabled = app?.enabled ?: false,
+                    isSuspended = app?.isSuspended ?: false
+                )
                 freezerShortcutManager.disableAppShortcut(pkg)
             }
             _uiState.update {
@@ -162,7 +167,10 @@ class FreezerViewModel(
     fun toggleManaged(packageName: String, add: Boolean) {
         viewModelScope.launch(Dispatchers.IO) {
             if (add) {
-                manageAppUseCase.setAppDisabled(packageName, true)
+                val freezeResult = if (_uiState.value.freezerMode == FreezerMode.SUSPEND)
+                    manageAppUseCase.setAppSuspended(packageName, true)
+                else manageAppUseCase.setAppDisabled(packageName, true)
+                freezeResult
                     .onSuccess {
                         freezerRepository.add(packageName)
                     }
@@ -179,7 +187,13 @@ class FreezerViewModel(
             } else {
                 freezerRepository.remove(packageName)
                 freezerShortcutManager.disableAppShortcut(packageName)
-                manageAppUseCase.setAppDisabled(packageName, false)
+                val app = _uiState.value.freezerApps.firstOrNull { it.packageName == packageName }
+                    ?: _uiState.value.allInstalledApps.firstOrNull { it.packageName == packageName }
+                manageAppUseCase.restoreApp(
+                    packageName,
+                    enabled = app?.enabled ?: false,
+                    isSuspended = app?.isSuspended ?: false
+                )
                     .onFailure { e ->
                         _uiState.update {
                             it.copy(
@@ -271,10 +285,11 @@ class FreezerViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             val app = _uiState.value.freezerApps.firstOrNull { it.packageName == packageName }
                 ?: _uiState.value.allInstalledApps.firstOrNull { it.packageName == packageName }
-            val restoreResult = when (app?.restoreAction) {
-                FreezerRestore.UNSUSPEND -> manageAppUseCase.setAppSuspended(packageName, false)
-                else -> manageAppUseCase.setAppDisabled(packageName, false)
-            }
+            val restoreResult = manageAppUseCase.restoreApp(
+                packageName,
+                enabled = app?.enabled ?: false,
+                isSuspended = app?.isSuspended ?: false
+            )
             restoreResult
                 .onSuccess {
                     freezerShortcutManager.refreshAppShortcut(packageName)

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -141,13 +141,10 @@ class FreezerViewModel(
             val appByPkg = _uiState.value.allInstalledApps.associateBy { it.packageName }
             packageNames.forEach { pkg ->
                 freezerRepository.remove(pkg)
-                val app = appByPkg[pkg]
                 // Restore to active (unsuspend and/or enable) so a suspended app isn't stranded.
-                manageAppUseCase.restoreApp(
-                    pkg,
-                    enabled = app?.enabled ?: false,
-                    isSuspended = app?.isSuspended ?: false
-                )
+                val app = appByPkg[pkg]
+                if (app != null) manageAppUseCase.restoreApp(pkg, app.enabled, app.isSuspended)
+                else manageAppUseCase.forceUnfreeze(pkg)
                 freezerShortcutManager.disableAppShortcut(pkg)
             }
             _uiState.update {
@@ -189,11 +186,8 @@ class FreezerViewModel(
                 freezerShortcutManager.disableAppShortcut(packageName)
                 val app = _uiState.value.freezerApps.firstOrNull { it.packageName == packageName }
                     ?: _uiState.value.allInstalledApps.firstOrNull { it.packageName == packageName }
-                manageAppUseCase.restoreApp(
-                    packageName,
-                    enabled = app?.enabled ?: false,
-                    isSuspended = app?.isSuspended ?: false
-                )
+                (if (app != null) manageAppUseCase.restoreApp(packageName, app.enabled, app.isSuspended)
+                else manageAppUseCase.forceUnfreeze(packageName))
                     .onFailure { e ->
                         _uiState.update {
                             it.copy(
@@ -285,11 +279,12 @@ class FreezerViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             val app = _uiState.value.freezerApps.firstOrNull { it.packageName == packageName }
                 ?: _uiState.value.allInstalledApps.firstOrNull { it.packageName == packageName }
-            val restoreResult = manageAppUseCase.restoreApp(
-                packageName,
-                enabled = app?.enabled ?: false,
-                isSuspended = app?.isSuspended ?: false
-            )
+            val restoreResult = if (app != null) {
+                manageAppUseCase.restoreApp(packageName, app.enabled, app.isSuspended)
+            } else {
+                // Unknown state (e.g. externally uninstalled): clear both dimensions best-effort.
+                manageAppUseCase.forceUnfreeze(packageName)
+            }
             restoreResult
                 .onSuccess {
                     freezerShortcutManager.refreshAppShortcut(packageName)

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -138,10 +138,10 @@ class FreezerViewModel(
 
     fun removeFromFreezer(packageNames: Set<String>) {
         viewModelScope.launch(Dispatchers.IO) {
+            val appByPkg = _uiState.value.allInstalledApps.associateBy { it.packageName }
             packageNames.forEach { pkg ->
                 freezerRepository.remove(pkg)
-                val app = _uiState.value.freezerApps.firstOrNull { it.packageName == pkg }
-                    ?: _uiState.value.allInstalledApps.firstOrNull { it.packageName == pkg }
+                val app = appByPkg[pkg]
                 // Restore to active (unsuspend and/or enable) so a suspended app isn't stranded.
                 manageAppUseCase.restoreApp(
                     pkg,

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -10,6 +10,7 @@ import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.MultiAppAction
 import com.valhalla.thor.domain.model.isActive
+import com.valhalla.thor.domain.model.isFrozen
 import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
@@ -220,20 +221,23 @@ class MainViewModel(
             when (action) {
                 // 1. SMART LAUNCH
                 is AppClickAction.Launch -> {
-                    if (!action.appInfo.enabled) {
+                    val app = action.appInfo
+                    // Smart launch: a frozen app is disabled OR suspended. Restore it (enable
+                    // and/or unsuspend) before launching — otherwise a suspended app just opens the
+                    // system "app paused" dialog instead of the app.
+                    if (app.isFrozen) {
                         _uiState.update {
                             it.copy(
                                 actionMessage = UiText.StringResource(
                                     R.string.unfreezing_app,
-                                    action.appInfo.appName ?: action.appInfo.packageName
+                                    app.appName ?: app.packageName
                                 )
                             )
                         }
 
-                        val result =
-                            manageAppUseCase.setAppDisabled(action.appInfo.packageName, false)
+                        val result = manageAppUseCase.restoreApp(app.packageName, app.enabled, app.isSuspended)
                         if (result.isSuccess) {
-                            _effect.send(MainSideEffect.LaunchApp(action.appInfo.packageName))
+                            _effect.send(MainSideEffect.LaunchApp(app.packageName))
                         } else {
                             _uiState.update {
                                 it.copy(
@@ -245,7 +249,7 @@ class MainViewModel(
                             }
                         }
                     } else {
-                        _effect.send(MainSideEffect.LaunchApp(action.appInfo.packageName))
+                        _effect.send(MainSideEffect.LaunchApp(app.packageName))
                     }
                 }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -8,9 +8,8 @@ import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
-import com.valhalla.thor.domain.model.FreezerRestore
 import com.valhalla.thor.domain.model.MultiAppAction
-import com.valhalla.thor.domain.model.restoreAction
+import com.valhalla.thor.domain.model.isActive
 import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
@@ -493,8 +492,10 @@ class MainViewModel(
      */
     private suspend fun performCountedFreeze(apps: List<AppInfo>, isFreeze: Boolean, useSuspend: Boolean = false) {
         val targets = if (isFreeze) {
+            // Only freeze ACTIVE apps: skip unsafe/UAD system apps AND anything already frozen
+            // (disabled or suspended) so we never stack disable+suspend into a mixed state.
             apps.filter { app ->
-                !(app.isSystem && (app.isUadLoadFailed ||
+                app.isActive && !(app.isSystem && (app.isUadLoadFailed ||
                     app.bloatRecommendation?.lowercase() == "unsafe"))
             }
         } else {
@@ -519,12 +520,8 @@ class MainViewModel(
                     if (useSuspend) manageAppUseCase.setAppSuspended(app.packageName, true)
                     else manageAppUseCase.setAppDisabled(app.packageName, true)
                 } else {
-                    // State-aware restore: unsuspend suspended apps, enable disabled apps.
-                    when (app.restoreAction) {
-                        FreezerRestore.UNSUSPEND -> manageAppUseCase.setAppSuspended(app.packageName, false)
-                        FreezerRestore.ENABLE -> manageAppUseCase.setAppDisabled(app.packageName, false)
-                        FreezerRestore.NONE -> Result.success(Unit)
-                    }
+                    // State-aware restore: clears suspend AND disable, incl. mixed state.
+                    manageAppUseCase.restoreApp(app.packageName, app.enabled, app.isSuspended)
                 }
                 processed++
                 if (result.isFailure) failed++

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -8,7 +8,9 @@ import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
+import com.valhalla.thor.domain.model.FreezerRestore
 import com.valhalla.thor.domain.model.MultiAppAction
+import com.valhalla.thor.domain.model.restoreAction
 import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
@@ -390,7 +392,7 @@ class MainViewModel(
                     }
                 }
 
-                is MultiAppAction.Freeze -> performCountedFreeze(action.appList, isFreeze = true)
+                is MultiAppAction.Freeze -> performCountedFreeze(action.appList, isFreeze = true, useSuspend = action.useSuspend)
 
                 is MultiAppAction.UnFreeze -> performCountedFreeze(action.appList, isFreeze = false)
 
@@ -489,7 +491,7 @@ class MainViewModel(
      * total reflects only what we actually attempt), then each app is toggled
      * sequentially with a live `processed / total` count.
      */
-    private suspend fun performCountedFreeze(apps: List<AppInfo>, isFreeze: Boolean) {
+    private suspend fun performCountedFreeze(apps: List<AppInfo>, isFreeze: Boolean, useSuspend: Boolean = false) {
         val targets = if (isFreeze) {
             apps.filter { app ->
                 !(app.isSystem && (app.isUadLoadFailed ||
@@ -513,7 +515,17 @@ class MainViewModel(
         var failed = 0
         withContext(Dispatchers.IO) {
             targets.forEach { app ->
-                val result = manageAppUseCase.setAppDisabled(app.packageName, disabled = isFreeze)
+                val result = if (isFreeze) {
+                    if (useSuspend) manageAppUseCase.setAppSuspended(app.packageName, true)
+                    else manageAppUseCase.setAppDisabled(app.packageName, true)
+                } else {
+                    // State-aware restore: unsuspend suspended apps, enable disabled apps.
+                    when (app.restoreAction) {
+                        FreezerRestore.UNSUSPEND -> manageAppUseCase.setAppSuspended(app.packageName, false)
+                        FreezerRestore.ENABLE -> manageAppUseCase.setAppDisabled(app.packageName, false)
+                        FreezerRestore.NONE -> Result.success(Unit)
+                    }
+                }
                 processed++
                 if (result.isFailure) failed++
                 val p = processed

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -57,6 +57,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.valhalla.thor.R
 import com.valhalla.thor.data.manager.UsageAccessManager
 import com.valhalla.thor.domain.model.AnimationIntensity
+import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.ThemeMode
 import com.valhalla.asgard.components.ConnectedButtonGroup
@@ -394,6 +395,17 @@ fun SettingsScreen(
                 checked = prefs.autoFreezeEnabled,
                 enabled = hasPrivilege,
                 onCheckedChange = { viewModel.setAutoFreezeEnabled(it) }
+            )
+
+            SettingsSwitchRow(
+                icon = R.drawable.frozen,
+                title = stringResource(R.string.suspend_instead_of_freeze),
+                subtitle = if (hasPrivilege) stringResource(R.string.suspend_instead_of_freeze_desc) else stringResource(
+                    R.string.privilege_required_warning
+                ),
+                checked = prefs.freezerMode == FreezerMode.SUSPEND,
+                enabled = hasPrivilege,
+                onCheckedChange = { viewModel.setFreezerMode(if (it) FreezerMode.SUSPEND else FreezerMode.FREEZE) }
             )
 
             SettingsClickRow(

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
 import com.valhalla.thor.data.security.BiometricHelper
 import com.valhalla.thor.domain.model.AnimationIntensity
+import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.ThemeMode
 import com.valhalla.thor.domain.model.UserPreferences
@@ -136,6 +137,12 @@ class SettingsViewModel(
     fun setAutoFreezeEnabled(enabled: Boolean) {
         viewModelScope.launch {
             preferenceRepository.setAutoFreezeEnabled(enabled)
+        }
+    }
+
+    fun setFreezerMode(mode: FreezerMode) {
+        viewModelScope.launch {
+            preferenceRepository.setFreezerMode(mode)
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -162,7 +162,8 @@ class SettingsViewModel(
             }
             val results = withContext(Dispatchers.IO) {
                 pkgs.map { pkg ->
-                    async { manageAppUseCase.setAppDisabled(pkg, false) }
+                    // forceUnfreeze restores BOTH disabled and suspended apps (not just enable).
+                    async { manageAppUseCase.forceUnfreeze(pkg) }
                 }.awaitAll()
             }
             val failures = results.count { it.isFailure }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,6 +212,9 @@
     <string name="unfreeze_all_apps">Unfreeze All Apps</string>
     <string name="unfreeze_all_apps_desc">Enable all apps currently in the Freezer list</string>
     <string name="auto_freeze">Auto Freeze</string>
+    <string name="freeze_mode">Freeze Mode</string>
+    <string name="suspend_instead_of_freeze">Suspend instead of freeze</string>
+    <string name="suspend_instead_of_freeze_desc">When freezing (including auto-freeze), suspend apps instead of disabling them. Suspended apps stay visible but paused.</string>
     <string name="auto_freeze_desc">Freeze apps automatically when screen is locked</string>
     <string name="add_freezer_to_launcher">Add Freezer to launcher</string>
     <string name="add_freezer_to_launcher_desc">Show frozen apps as home-screen shortcuts you can tap to launch</string>

--- a/app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
@@ -27,18 +27,35 @@ class FreezerModeTest {
     }
 
     @Test
-    fun `restore of a suspended app unsuspends`() {
-        assertEquals(FreezerRestore.UNSUSPEND, restoreActionFor(enabled = true, isSuspended = true))
+    fun `restore of a suspended-only app just unsuspends`() {
+        assertEquals(
+            RestorePlan(unsuspend = true, enable = false),
+            restorePlanFor(enabled = true, isSuspended = true)
+        )
     }
 
     @Test
-    fun `restore of a disabled app enables`() {
-        assertEquals(FreezerRestore.ENABLE, restoreActionFor(enabled = false, isSuspended = false))
+    fun `restore of a disabled-only app just enables`() {
+        assertEquals(
+            RestorePlan(unsuspend = false, enable = true),
+            restorePlanFor(enabled = false, isSuspended = false)
+        )
     }
 
     @Test
-    fun `restore of an already-active app is a no-op`() {
-        assertEquals(FreezerRestore.NONE, restoreActionFor(enabled = true, isSuspended = false))
+    fun `restore of a disabled AND suspended app clears both dimensions`() {
+        assertEquals(
+            RestorePlan(unsuspend = true, enable = true),
+            restorePlanFor(enabled = false, isSuspended = true)
+        )
+    }
+
+    @Test
+    fun `restore of an already-active app defaults to a harmless enable`() {
+        assertEquals(
+            RestorePlan(unsuspend = false, enable = true),
+            restorePlanFor(enabled = true, isSuspended = false)
+        )
     }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
@@ -1,0 +1,48 @@
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure decision logic for Freezer freeze/suspend mode (GH#239). No Android deps. */
+class FreezerModeTest {
+
+    @Test
+    fun `enabled non-suspended app is active and not frozen`() {
+        assertTrue(isActive(enabled = true, isSuspended = false))
+        assertFalse(isFrozen(enabled = true, isSuspended = false))
+    }
+
+    @Test
+    fun `disabled app is frozen`() {
+        assertTrue(isFrozen(enabled = false, isSuspended = false))
+        assertFalse(isActive(enabled = false, isSuspended = false))
+    }
+
+    @Test
+    fun `suspended app is frozen even while still enabled`() {
+        assertTrue(isFrozen(enabled = true, isSuspended = true))
+        assertFalse(isActive(enabled = true, isSuspended = true))
+    }
+
+    @Test
+    fun `restore of a suspended app unsuspends`() {
+        assertEquals(FreezerRestore.UNSUSPEND, restoreActionFor(enabled = true, isSuspended = true))
+    }
+
+    @Test
+    fun `restore of a disabled app enables`() {
+        assertEquals(FreezerRestore.ENABLE, restoreActionFor(enabled = false, isSuspended = false))
+    }
+
+    @Test
+    fun `restore of an already-active app is a no-op`() {
+        assertEquals(FreezerRestore.NONE, restoreActionFor(enabled = true, isSuspended = false))
+    }
+
+    @Test
+    fun `default freezer mode is FREEZE`() {
+        assertEquals(FreezerMode.FREEZE, FreezerMode.entries.first())
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
@@ -51,9 +51,9 @@ class FreezerModeTest {
     }
 
     @Test
-    fun `restore of an already-active app defaults to a harmless enable`() {
+    fun `restore of an already-active app is a no-op`() {
         assertEquals(
-            RestorePlan(unsuspend = false, enable = true),
+            RestorePlan(unsuspend = false, enable = false),
             restorePlanFor(enabled = true, isSuspended = false)
         )
     }

--- a/docs/superpowers/plans/2026-07-06-freezer-suspend-mode.md
+++ b/docs/superpowers/plans/2026-07-06-freezer-suspend-mode.md
@@ -1,0 +1,730 @@
+# Freezer Suspend-vs-Freeze Mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a global Freezer "action mode" (Freeze | Suspend) so the Freezer — including screen-off auto-freeze — can suspend apps (`pm suspend`) instead of disabling them (`pm disable`), with Freeze as the default.
+
+**Architecture:** `setAppSuspended` is already implemented across all gateways/usecase/actions; this feature adds one `FreezerMode` preference and routes every freeze entry point (single-app, batch toolbar, auto-freeze) through it. The Freezer's "frozen == disabled" assumption is generalized to "disabled **or** suspended," and unfreeze becomes state-aware (restore each app by its actual state). The freeze/restore decision is extracted into a pure, unit-tested helper.
+
+**Tech Stack:** Kotlin, Jetpack Compose (Material3-Expressive), Koin, DataStore Preferences, Asgard 2.0 UI (`ConnectedButtonGroup`), JUnit4 (pure unit tests).
+
+## Global Constraints
+
+- **Default mode is `FreezerMode.FREEZE`** — existing users see no behavior change on update (absent DataStore key → `FREEZE`).
+- **Work on branch `feat/freezer-suspend-mode`** (off `dev`).
+- **Named-argument Compose calls** (Asgard `modifier` is the 2nd param).
+- **Theme-agnostic** — no hardcoded colors; `ConnectedButtonGroup` inherits `MaterialTheme`.
+- **Enums persist as strings** via `stringPreferencesKey` with a `runCatching { valueOf }` fallback (existing `ThemeMode`/`AnimationIntensity` pattern).
+- **Per-task verification:** `./gradlew :app:compileFossDebugKotlin`; full `./gradlew assembleFossDebug` + unit tests at the end.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `domain/model/FreezerMode.kt` | Enum + pure `isFrozen`/`isActive`/`restoreActionFor` decision logic + `AppInfo` ergonomic extensions | **Create** |
+| `test/.../domain/model/FreezerModeTest.kt` | Pure JUnit tests for the decision logic | **Create** |
+| `domain/model/UserPreferences.kt` | Add `freezerMode` field | Modify |
+| `domain/repository/PreferenceRepository.kt` | Add `setFreezerMode` | Modify |
+| `data/repository/PreferenceRepositoryImpl.kt` | Persist/hydrate `freezerMode` | Modify |
+| `domain/model/MultiAppAction.kt` | `Freeze` carries `useSuspend` | Modify |
+| `presentation/main/MainViewModel.kt` | `performCountedFreeze` mode-aware + state-aware restore | Modify |
+| `presentation/freezer/FreezerViewModel.kt` | State field, hydration, `setFreezerMode`, mode-aware single freeze/unfreeze | Modify |
+| `presentation/freezer/FreezerScreen.kt` | Frozen predicate, toolbar dispatch, settings-sheet wiring | Modify |
+| `data/service/AutoFreezeManager.kt` | Suspend branch in the screen-off loop | Modify |
+| `presentation/freezer/FreezerSettingsSheet.kt` | `ConnectedButtonGroup` mode selector | Modify |
+| `presentation/settings/SettingsViewModel.kt` | `setFreezerMode` | Modify |
+| `presentation/settings/SettingsScreen.kt` | "Suspend instead of freeze" switch | Modify |
+| `res/values/strings.xml` | 3 new strings | Modify |
+
+---
+
+## Task 1: `FreezerMode` enum + pure decision logic (TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt`
+- Test: `app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt`
+
+**Interfaces:**
+- Produces: `enum class FreezerMode { FREEZE, SUSPEND }`; `enum class FreezerRestore { ENABLE, UNSUSPEND, NONE }`; `fun isFrozen(enabled: Boolean, isSuspended: Boolean): Boolean`; `fun isActive(enabled: Boolean, isSuspended: Boolean): Boolean`; `fun restoreActionFor(enabled: Boolean, isSuspended: Boolean): FreezerRestore`; extension vals `AppInfo.isFrozen`, `AppInfo.isActive`, `AppInfo.restoreAction`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt`:
+```kotlin
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure decision logic for Freezer freeze/suspend mode (GH#239). No Android deps. */
+class FreezerModeTest {
+
+    @Test
+    fun `enabled non-suspended app is active and not frozen`() {
+        assertTrue(isActive(enabled = true, isSuspended = false))
+        assertFalse(isFrozen(enabled = true, isSuspended = false))
+    }
+
+    @Test
+    fun `disabled app is frozen`() {
+        assertTrue(isFrozen(enabled = false, isSuspended = false))
+        assertFalse(isActive(enabled = false, isSuspended = false))
+    }
+
+    @Test
+    fun `suspended app is frozen even while still enabled`() {
+        assertTrue(isFrozen(enabled = true, isSuspended = true))
+        assertFalse(isActive(enabled = true, isSuspended = true))
+    }
+
+    @Test
+    fun `restore of a suspended app unsuspends`() {
+        assertEquals(FreezerRestore.UNSUSPEND, restoreActionFor(enabled = true, isSuspended = true))
+    }
+
+    @Test
+    fun `restore of a disabled app enables`() {
+        assertEquals(FreezerRestore.ENABLE, restoreActionFor(enabled = false, isSuspended = false))
+    }
+
+    @Test
+    fun `restore of an already-active app is a no-op`() {
+        assertEquals(FreezerRestore.NONE, restoreActionFor(enabled = true, isSuspended = false))
+    }
+
+    @Test
+    fun `default freezer mode is FREEZE`() {
+        assertEquals(FreezerMode.FREEZE, FreezerMode.entries.first())
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.FreezerModeTest"`
+Expected: FAIL — unresolved references `isActive`, `isFrozen`, `FreezerMode`, etc.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt`:
+```kotlin
+package com.valhalla.thor.domain.model
+
+/** What the Freezer does when it "freezes" an app. GH#239. */
+enum class FreezerMode { FREEZE, SUSPEND }
+
+/** How a frozen app is restored to active, based on its actual current state. */
+enum class FreezerRestore { ENABLE, UNSUSPEND, NONE }
+
+/** Freezer treats an app as "frozen" when it is disabled OR suspended. */
+fun isFrozen(enabled: Boolean, isSuspended: Boolean): Boolean = !enabled || isSuspended
+
+/** "Active" = not frozen: enabled and not suspended (i.e. freezable). */
+fun isActive(enabled: Boolean, isSuspended: Boolean): Boolean = enabled && !isSuspended
+
+/** Pick the inverse op to bring a frozen app back to active (suspended wins if somehow both). */
+fun restoreActionFor(enabled: Boolean, isSuspended: Boolean): FreezerRestore = when {
+    isSuspended -> FreezerRestore.UNSUSPEND
+    !enabled -> FreezerRestore.ENABLE
+    else -> FreezerRestore.NONE
+}
+
+// Ergonomic call-site helpers over AppInfo.
+val AppInfo.isFrozen: Boolean get() = isFrozen(enabled, isSuspended)
+val AppInfo.isActive: Boolean get() = isActive(enabled, isSuspended)
+val AppInfo.restoreAction: FreezerRestore get() = restoreActionFor(enabled, isSuspended)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.FreezerModeTest"`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt \
+        app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
+git commit -m "feat(freezer): add FreezerMode enum + pure freeze/restore decision logic (#239)"
+```
+
+---
+
+## Task 2: Persist `freezerMode` preference
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt:28`
+- Modify: `app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt:41`
+- Modify: `app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt`
+
+**Interfaces:**
+- Consumes: `FreezerMode` (Task 1).
+- Produces: `UserPreferences.freezerMode: FreezerMode`; `PreferenceRepository.setFreezerMode(mode: FreezerMode)`.
+
+- [ ] **Step 1: Add the field to `UserPreferences`**
+
+In `UserPreferences.kt`, after the `autoFreezeEnabled` line (currently line 28), add:
+```kotlin
+    // Auto Freeze
+    val autoFreezeEnabled: Boolean = false,
+
+    // Freezer action mode: FREEZE = pm disable, SUSPEND = pm suspend
+    val freezerMode: FreezerMode = FreezerMode.FREEZE,
+```
+(`FreezerMode` is in the same package — no import needed.)
+
+- [ ] **Step 2: Add the setter to the `PreferenceRepository` interface**
+
+In `PreferenceRepository.kt`, under the `// --- Auto Freeze ---` group (after line 42 `setAddFreezerToLauncher`), add:
+```kotlin
+    suspend fun setFreezerMode(mode: FreezerMode)
+```
+Add the import near the other model imports at the top:
+```kotlin
+import com.valhalla.thor.domain.model.FreezerMode
+```
+
+- [ ] **Step 3: Persist + hydrate in `PreferenceRepositoryImpl`**
+
+In `PreferenceRepositoryImpl.kt`:
+
+(a) Add the key inside `object Keys`, after `AUTO_FREEZE` / `ADD_FREEZER_TO_LAUNCHER` (line 56):
+```kotlin
+        val FREEZER_MODE = stringPreferencesKey("freezer_mode")
+```
+(b) Add the hydration local before the `UserPreferences(` construction (near line 104, beside `freezerIsGrid`):
+```kotlin
+            val freezerMode = prefs[Keys.FREEZER_MODE]
+                ?.let { runCatching { FreezerMode.valueOf(it) }.getOrNull() }
+                ?: FreezerMode.FREEZE
+```
+(c) Pass it into the `UserPreferences(...)` builder, right after `autoFreezeEnabled = ...` (line 118):
+```kotlin
+                autoFreezeEnabled = prefs[Keys.AUTO_FREEZE] ?: false,
+                freezerMode = freezerMode,
+```
+(d) Add the setter next to `setAutoFreezeEnabled` (after line 199):
+```kotlin
+    override suspend fun setFreezerMode(mode: FreezerMode) {
+        context.dataStore.edit {
+            it[Keys.FREEZER_MODE] = mode.name
+        }
+    }
+```
+(e) Add the import at the top, with the other model imports:
+```kotlin
+import com.valhalla.thor.domain.model.FreezerMode
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt \
+        app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt \
+        app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+git commit -m "feat(freezer): persist freezerMode preference (default FREEZE) (#239)"
+```
+
+---
+
+## Task 3: `MultiAppAction.Freeze.useSuspend` + mode-aware / state-aware batch freeze
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/domain/model/MultiAppAction.kt:6`
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt` (dispatch ~line 393; `performCountedFreeze` ~line 492-525)
+
+**Interfaces:**
+- Consumes: `FreezerRestore`, `AppInfo.restoreAction` (Task 1).
+- Produces: `MultiAppAction.Freeze(appList, useSuspend: Boolean = false)`; `performCountedFreeze(apps, isFreeze, useSuspend)`.
+
+**Rationale:** The Freezer toolbar's "Freeze all" uses `performCountedFreeze` (compact count UI) and skips unsafe/UAD system apps. Keep that UI + skip when suspending by branching *inside* `performCountedFreeze`, instead of routing to `MultiAppAction.Suspend` (which uses a different verbose logger and no skip). Unfreeze restores each app by its actual state, fixing mixed sets.
+
+- [ ] **Step 1: Add `useSuspend` to `MultiAppAction.Freeze`**
+
+In `MultiAppAction.kt`, change line 6:
+```kotlin
+    data class Freeze(val appList: List<AppInfo>, val useSuspend: Boolean = false) : MultiAppAction
+```
+(`UnFreeze` is unchanged — restore is state-driven.)
+
+- [ ] **Step 2: Branch the dispatch**
+
+In `MainViewModel.kt`, the `MultiAppAction.Freeze` case (currently line 393):
+```kotlin
+                is MultiAppAction.Freeze -> performCountedFreeze(action.appList, isFreeze = true, useSuspend = action.useSuspend)
+```
+Leave the `UnFreeze` case as-is:
+```kotlin
+                is MultiAppAction.UnFreeze -> performCountedFreeze(action.appList, isFreeze = false)
+```
+
+- [ ] **Step 3: Make `performCountedFreeze` mode-aware and restore-aware**
+
+In `MainViewModel.kt`, update the signature (line 492) and the per-app call (line 516). Replace the signature line:
+```kotlin
+    private suspend fun performCountedFreeze(apps: List<AppInfo>, isFreeze: Boolean, useSuspend: Boolean = false) {
+```
+Replace the `targets.forEach { app -> ... }` body (lines 515-524) with:
+```kotlin
+            targets.forEach { app ->
+                val result = if (isFreeze) {
+                    if (useSuspend) manageAppUseCase.setAppSuspended(app.packageName, true)
+                    else manageAppUseCase.setAppDisabled(app.packageName, true)
+                } else {
+                    // State-aware restore: unsuspend suspended apps, enable disabled apps.
+                    when (app.restoreAction) {
+                        FreezerRestore.UNSUSPEND -> manageAppUseCase.setAppSuspended(app.packageName, false)
+                        FreezerRestore.ENABLE -> manageAppUseCase.setAppDisabled(app.packageName, false)
+                        FreezerRestore.NONE -> Result.success(Unit)
+                    }
+                }
+                processed++
+                if (result.isFailure) failed++
+                val p = processed
+                val f = failed
+                _uiState.update {
+                    it.copy(freezeLoggerState = it.freezeLoggerState.copy(processed = p, failed = f))
+                }
+            }
+```
+Add imports at the top of `MainViewModel.kt` (with the other `domain.model` imports):
+```kotlin
+import com.valhalla.thor.domain.model.FreezerRestore
+import com.valhalla.thor.domain.model.restoreAction
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/valhalla/thor/domain/model/MultiAppAction.kt \
+        app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+git commit -m "feat(freezer): batch freeze honors suspend mode + state-aware restore (#239)"
+```
+
+---
+
+## Task 4: `FreezerViewModel` — state, hydration, setter, mode-aware single freeze/unfreeze
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt` (state `:31-49`; `freezeSingleApp` `:225`; `unfreezeSingleApp` `:263`; `observePreferences` `:296`; new setter after `:315`)
+
+**Interfaces:**
+- Consumes: `FreezerMode`, `FreezerRestore`, `AppInfo.restoreAction` (Task 1); `preferenceRepository.setFreezerMode` (Task 2).
+- Produces: `FreezerUiState.freezerMode`; `FreezerViewModel.setFreezerMode(mode)`.
+
+- [ ] **Step 1: Add `freezerMode` to `FreezerUiState`**
+
+In `FreezerViewModel.kt`, add to the `FreezerUiState` data class (after `autoFreezeEnabled` at line 43):
+```kotlin
+    val autoFreezeEnabled: Boolean = false,
+    val freezerMode: FreezerMode = FreezerMode.FREEZE,
+```
+Add imports near the top (with the other `domain.model` imports):
+```kotlin
+import com.valhalla.thor.domain.model.FreezerMode
+import com.valhalla.thor.domain.model.FreezerRestore
+import com.valhalla.thor.domain.model.restoreAction
+```
+
+- [ ] **Step 2: Hydrate it in `observePreferences`**
+
+In `observePreferences` (line 299-305), add the field to the `copy`:
+```kotlin
+                    it.copy(
+                        autoFreezeEnabled = prefs.autoFreezeEnabled,
+                        freezerMode = prefs.freezerMode,
+                        hasShownDisabledAppsPrompt = prefs.hasShownDisabledAppsPrompt,
+                        isGrid = prefs.freezerIsGrid,
+                        addFreezerToLauncher = prefs.addFreezerToLauncher
+                    )
+```
+
+- [ ] **Step 3: Add the setter (mirror `setAutoFreezeEnabled`)**
+
+After `setAutoFreezeEnabled` (line 315), add:
+```kotlin
+    fun setFreezerMode(mode: FreezerMode) {
+        viewModelScope.launch(Dispatchers.IO) {
+            preferenceRepository.setFreezerMode(mode)
+        }
+    }
+```
+
+- [ ] **Step 4: Make `freezeSingleApp` mode-aware**
+
+In `freezeSingleApp` (line 226-227), replace the first line inside the launch:
+```kotlin
+        viewModelScope.launch(Dispatchers.IO) {
+            val freezeResult = if (_uiState.value.freezerMode == FreezerMode.SUSPEND)
+                manageAppUseCase.setAppSuspended(packageName, true)
+            else manageAppUseCase.setAppDisabled(packageName, true)
+            freezeResult
+                .onSuccess {
+```
+(The existing `.onSuccess { ... }.onFailure { ... }` chain — lines 228-259 — stays exactly the same; only the receiver changed from the inline `setAppDisabled(...)` call to `freezeResult`.)
+
+- [ ] **Step 5: Make `unfreezeSingleApp` state-aware**
+
+In `unfreezeSingleApp` (line 264-265), replace the first line inside the launch:
+```kotlin
+        viewModelScope.launch(Dispatchers.IO) {
+            val app = _uiState.value.freezerApps.firstOrNull { it.packageName == packageName }
+                ?: _uiState.value.allInstalledApps.firstOrNull { it.packageName == packageName }
+            val restoreResult = when (app?.restoreAction) {
+                FreezerRestore.UNSUSPEND -> manageAppUseCase.setAppSuspended(packageName, false)
+                else -> manageAppUseCase.setAppDisabled(packageName, false)
+            }
+            restoreResult
+                .onSuccess {
+```
+(The existing `.onSuccess { ... }.onFailure { ... }` chain — lines 266-286 — stays the same; receiver is now `restoreResult`. `null`/`NONE`/`ENABLE` all fall to `setAppDisabled(false)`, preserving today's behavior.)
+
+- [ ] **Step 6: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+git commit -m "feat(freezer): mode-aware single freeze + state-aware unfreeze in ViewModel (#239)"
+```
+
+---
+
+## Task 5: `FreezerScreen` — frozen predicate, toolbar dispatch, settings wiring
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt` (filters `:120-128`; toolbar `:372`; settings-sheet call site `:456`)
+
+**Interfaces:**
+- Consumes: `AppInfo.isActive`, `AppInfo.isFrozen` (Task 1); `MultiAppAction.Freeze(..., useSuspend)` (Task 3); `state.freezerMode`, `viewModel.setFreezerMode` (Task 4); `FreezerSettingsSheet(freezerMode, onFreezerModeChange, ...)` (Task 7).
+
+- [ ] **Step 1: Generalize the frozen predicate**
+
+In `FreezerScreen.kt`, replace the four `remember` blocks at lines 120-128 with:
+```kotlin
+    // "Active" = freezable (enabled & not suspended); "frozen" = disabled OR suspended (GH#239).
+    val hasEnabled = remember(state.freezerApps) { state.freezerApps.any { it.isActive } }
+    val hasDisabled = remember(state.freezerApps) { state.freezerApps.any { it.isFrozen } }
+
+    // Apps the "Freeze all" / "Unfreeze all" toolbar acts on. These route through the
+    // shared batch action (MultiAppAction) so progress streams into the FreezeLoggerDialog;
+    // the unsafe/UAD eligibility skip is applied centrally by MainViewModel.performCountedFreeze.
+    val appsToFreeze = remember(state.freezerApps) { state.freezerApps.filter { it.isActive } }
+    val appsToUnfreeze = remember(state.freezerApps) { state.freezerApps.filter { it.isFrozen } }
+```
+Add imports (with the other `domain.model` imports):
+```kotlin
+import com.valhalla.thor.domain.model.isActive
+import com.valhalla.thor.domain.model.isFrozen
+```
+
+- [ ] **Step 2: Route the toolbar Freeze button through the mode**
+
+In `FreezerScreen.kt`, the Freeze `IconButton` (line 372), change `onClick`:
+```kotlin
+                        IconButton(
+                            onClick = {
+                                onMultiAppAction(
+                                    MultiAppAction.Freeze(
+                                        appsToFreeze,
+                                        useSuspend = state.freezerMode == FreezerMode.SUSPEND
+                                    )
+                                )
+                            },
+                            enabled = hasEnabled && hasPrivilege,
+                            colors = iconButtonColors
+                        ) {
+```
+(The Unfreeze button at line 391 is unchanged — `MultiAppAction.UnFreeze(appsToUnfreeze)` now restores mixed states via Task 3.)
+Add the import:
+```kotlin
+import com.valhalla.thor.domain.model.FreezerMode
+```
+
+- [ ] **Step 3: Pass the mode into the settings sheet**
+
+In `FreezerScreen.kt`, the `FreezerSettingsSheet(...)` call site (line 456), add two arguments (e.g. right after `autoFreezeEnabled = state.autoFreezeEnabled,`):
+```kotlin
+            autoFreezeEnabled = state.autoFreezeEnabled,
+            freezerMode = state.freezerMode,
+            onFreezerModeChange = viewModel::setFreezerMode,
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: FAIL initially at the `FreezerSettingsSheet` call (params don't exist yet) — that is wired in Task 7. If implementing strictly task-by-task, do Task 7 before re-running; otherwise the compile passes once Task 7 lands. (Tasks 5 and 7 form one compilable pair — commit both, then verify.)
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+git commit -m "feat(freezer): frozen=disabled-or-suspended predicate + mode-aware toolbar (#239)"
+```
+
+---
+
+## Task 6: `AutoFreezeManager` — suspend branch in the screen-off loop
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt` (fields; `startObserving` `:135`; freeze loop `:97-110`)
+
+**Interfaces:**
+- Consumes: `FreezerMode` (Task 1); `prefs.freezerMode` (Task 2); `manageAppUseCase.setAppSuspended` (existing).
+
+- [ ] **Step 1: Track the current mode**
+
+In `AutoFreezeManager.kt`, add a volatile field beside `isReceiverRegistered` (line ~39):
+```kotlin
+    @Volatile
+    private var currentMode: FreezerMode = FreezerMode.FREEZE
+```
+Add the import:
+```kotlin
+import android.content.pm.ApplicationInfo
+import com.valhalla.thor.domain.model.FreezerMode
+```
+
+- [ ] **Step 2: Update the mode inside the existing preference observer**
+
+In `startObserving` (line 135-141), capture the mode before the enable check:
+```kotlin
+            preferenceRepository.userPreferences.collectLatest { prefs ->
+                currentMode = prefs.freezerMode
+                if (prefs.autoFreezeEnabled) {
+                    registerReceiver()
+                } else {
+                    unregisterReceiver()
+                }
+            }
+```
+
+- [ ] **Step 3: Branch the per-package freeze in the screen-off loop**
+
+In the loop, replace the `val appInfo = pm.getApplicationInfo(pkg, 0)` block (lines 97-110) with:
+```kotlin
+                                    val appInfo = pm.getApplicationInfo(pkg, 0)
+                                    if (currentMode == FreezerMode.SUSPEND) {
+                                        val alreadySuspended = (appInfo.flags and ApplicationInfo.FLAG_SUSPENDED) != 0
+                                        if (!alreadySuspended) {
+                                            Logger.d("AutoFreezeManager", "Auto-suspending app: $pkg")
+                                            val result = manageAppUseCase.setAppSuspended(pkg, true)
+                                            if (result.isSuccess) {
+                                                Logger.d("AutoFreezeManager", "Auto-suspended: $pkg")
+                                                freezerShortcutManager.refreshAppShortcut(pkg)
+                                            } else {
+                                                Logger.e(
+                                                    "AutoFreezeManager",
+                                                    "Failed to suspend $pkg: ${result.exceptionOrNull()?.message}"
+                                                )
+                                            }
+                                        }
+                                    } else if (appInfo.enabled) {
+                                        Logger.d("AutoFreezeManager", "Auto-freezing app: $pkg")
+                                        val result = manageAppUseCase.setAppDisabled(pkg, true)
+                                        if (result.isSuccess) {
+                                            Logger.d("AutoFreezeManager", "Auto-froze: $pkg")
+                                            freezerShortcutManager.refreshAppShortcut(pkg) // → grey the shortcut icon
+                                        } else {
+                                            Logger.e(
+                                                "AutoFreezeManager",
+                                                "Failed to freeze $pkg: ${result.exceptionOrNull()?.message}"
+                                            )
+                                        }
+                                    }
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+git commit -m "feat(freezer): auto-freeze suspends apps when suspend mode is active (#239)"
+```
+
+---
+
+## Task 7: `FreezerSettingsSheet` — `ConnectedButtonGroup` mode selector + strings
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt` (params `:48-65`; insert selector before the Auto Freeze row at `:240`)
+- Modify: `app/src/main/res/values/strings.xml`
+
+**Interfaces:**
+- Consumes: `FreezerMode` (Task 1). Called by `FreezerScreen` (Task 5) with `freezerMode` + `onFreezerModeChange`.
+
+- [ ] **Step 1: Add the strings**
+
+In `strings.xml`, add near the other freezer strings (e.g. after `freezer_settings` at line 210). `action_freeze` ("Freeze") and `action_suspend` ("Suspend") already exist and are reused for the segmented labels:
+```xml
+    <string name="freeze_mode">Freeze Mode</string>
+    <string name="suspend_instead_of_freeze">Suspend instead of freeze</string>
+    <string name="suspend_instead_of_freeze_desc">When freezing (including auto-freeze), suspend apps instead of disabling them. Suspended apps stay visible but paused.</string>
+```
+
+- [ ] **Step 2: Add the two params to `FreezerSettingsSheet`**
+
+In `FreezerSettingsSheet.kt`, add to the parameter list (after `autoFreezeEnabled: Boolean,` at line 50):
+```kotlin
+    autoFreezeEnabled: Boolean,
+    freezerMode: FreezerMode,
+    onFreezerModeChange: (FreezerMode) -> Unit,
+```
+Add the import:
+```kotlin
+import com.valhalla.thor.domain.model.FreezerMode
+```
+
+- [ ] **Step 3: Render the mode selector before the Auto Freeze row**
+
+In `FreezerSettingsSheet.kt`, immediately before the Auto Freeze `Row` (the `Spacer(Modifier.height(24.dp))` at line 238 that precedes it), insert:
+```kotlin
+            Spacer(Modifier.height(24.dp))
+
+            // Freeze vs Suspend mode (GH#239) — same segmented control style as the selectors above.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    stringResource(R.string.freeze_mode),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                )
+                ConnectedButtonGroup(
+                    items = listOf(
+                        ConnectedButtonGroupItem.Label(stringResource(R.string.action_freeze)),
+                        ConnectedButtonGroupItem.Label(stringResource(R.string.action_suspend))
+                    ),
+                    selectedIndex = freezerMode.ordinal,
+                    onItemSelected = { onFreezerModeChange(FreezerMode.entries[it]) },
+                    enabled = hasPrivilege,
+                    modifier = Modifier.width(IntrinsicSize.Max)
+                )
+            }
+```
+(`ConnectedButtonGroup` / `ConnectedButtonGroupItem` are already imported at lines 43-44.)
+
+- [ ] **Step 4: Verify it compiles (with Task 5 this is the full pair)**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt \
+        app/src/main/res/values/strings.xml
+git commit -m "feat(freezer): Freeze/Suspend segmented selector in the settings sheet (#239)"
+```
+
+---
+
+## Task 8: Settings screen — "Suspend instead of freeze" switch
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt` (after `setAutoFreezeEnabled` `:136-139`)
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt` (Freezer section, before the auto-freeze `SettingsSwitchRow` at `:388`)
+
+**Interfaces:**
+- Consumes: `FreezerMode` (Task 1); `preferenceRepository.setFreezerMode` (Task 2); `prefs.freezerMode` from the collected `preferences` flow.
+- Produces: `SettingsViewModel.setFreezerMode(mode)`.
+
+- [ ] **Step 1: Add the setter to `SettingsViewModel`**
+
+In `SettingsViewModel.kt`, after `setAutoFreezeEnabled` (line 136-139), add:
+```kotlin
+    fun setFreezerMode(mode: FreezerMode) {
+        viewModelScope.launch {
+            preferenceRepository.setFreezerMode(mode)
+        }
+    }
+```
+Add the import (with the other `domain.model` imports):
+```kotlin
+import com.valhalla.thor.domain.model.FreezerMode
+```
+
+- [ ] **Step 2: Add the switch to the Freezer section**
+
+In `SettingsScreen.kt`, immediately before the Auto Freeze `SettingsSwitchRow` (line 388, `checked = prefs.autoFreezeEnabled`), add:
+```kotlin
+            SettingsSwitchRow(
+                title = stringResource(R.string.suspend_instead_of_freeze),
+                subtitle = stringResource(R.string.suspend_instead_of_freeze_desc),
+                checked = prefs.freezerMode == FreezerMode.SUSPEND,
+                onCheckedChange = { viewModel.setFreezerMode(if (it) FreezerMode.SUSPEND else FreezerMode.FREEZE) }
+            )
+```
+Add the import (with the other `domain.model` imports):
+```kotlin
+import com.valhalla.thor.domain.model.FreezerMode
+```
+Note: this switch and the sheet's `ConnectedButtonGroup` both read/write the single `freezerMode` preference, so they stay in sync automatically. Verify `prefs` in this scope is the collected `preferences` flow value (the same `prefs` used by `prefs.autoFreezeEnabled` on line 394).
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt \
+        app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+git commit -m "feat(freezer): add 'Suspend instead of freeze' switch to Settings (#239)"
+```
+
+---
+
+## Task 9: Full build, unit tests, and on-device verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full assemble + unit tests**
+
+Run: `./gradlew :app:testFossDebugUnitTest assembleFossDebug`
+Expected: BUILD SUCCESSFUL; `FreezerModeTest` green; no Asgard/Kotlin errors (pre-existing deprecation warnings OK).
+
+- [ ] **Step 2: Install + on-device matrix**
+
+Run: `adb install -r app/build/outputs/apk/fossDebug/*.apk` (or `foss/debug`), then verify per available backend (Root / Shizuku / Dhizuku):
+- Toggle the mode via **both** the Freezer sheet segmented control and the Settings switch — confirm they stay in sync.
+- **Suspend mode:** single-app freeze, multi "Freeze all", and screen-off auto-freeze (lock the device) all *suspend* (app greyed/paused, stays in launcher, shows the "suspended by Thor" dialog on tap).
+- **Unfreeze a mixed set** (some disabled, some suspended) → all return to active.
+- **Freeze mode** unchanged from today (apps `pm disable`, disappear from launcher).
+- Suspend failure on a backend surfaces an error in the count dialog (no silent disable fallback).
+
+- [ ] **Step 3 (optional, on release): bump version**
+
+Per `CLAUDE.md`, releasing bumps `versionCode` in `gradle.properties` (version name auto-derives). Do this only when cutting the release, not per-feature.
+
+- [ ] **Step 4: Request code review**
+
+Use superpowers:requesting-code-review (or the `/code-review` skill) on the branch diff before opening the PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §5 data model → Tasks 1-2; §6 ViewModel → Task 4; §7 entry points → Tasks 3 (batch), 4 (single), 6 (auto-freeze); §7.4 launcher shortcuts → **see note below**; §8 state-aware restore → Tasks 3-4 (+Task 1 logic); §9 frozen predicate → Task 5; §10 UI (both controls) → Tasks 7-8; §11 error handling → inherited (Result pipeline) + Task 3 keeps the unsafe skip; §12 testing → Tasks 1 + 9; §13 out-of-scope respected.
+
+**Launcher-shortcut note (spec §7.4):** the pinned "Freeze all"/"Unfreeze all" launcher shortcuts trigger via `FreezerShortcutContract` and are **not** re-routed through the mode in this plan (they remain disable-based). This is the documented fast-follow from the spec, intentionally deferred — not silently dropped. If it should honor the mode now, add a task to branch the shortcut handler on `freezerMode`.
+
+**Placeholder scan:** none — every code step shows complete code.
+
+**Type consistency:** `FreezerMode`, `FreezerRestore`, `isActive`/`isFrozen`/`restoreAction`, `MultiAppAction.Freeze(..., useSuspend)`, `performCountedFreeze(apps, isFreeze, useSuspend)`, `setFreezerMode` — names identical across Tasks 1-8.

--- a/docs/superpowers/specs/2026-07-06-freezer-suspend-mode-design.md
+++ b/docs/superpowers/specs/2026-07-06-freezer-suspend-mode-design.md
@@ -1,0 +1,204 @@
+# Freezer: Suspend-vs-Freeze mode — Design Spec
+
+**Issue:** [#239 "[Feature]: Suspend by default"](https://github.com/trinadhthatakula/Thor/issues/239) (enhancement, area: Freezer)
+**Date:** 2026-07-06
+**Status:** Design approved (pending spec review)
+
+## 1. Goal
+
+Let the user choose the **action the Freezer performs** when it "freezes" an app:
+
+- **Freeze** (current behavior) — `setAppDisabled(pkg, true)` = `pm disable`. App is fully disabled and disappears from the launcher.
+- **Suspend** (new) — `setAppSuspended(pkg, true)` = `pm suspend`. App stays installed and visible but is paused: it can't run, shows a "paused" dialog on tap, and its notifications are suppressed.
+
+The choice is **global** (one mode for the whole Freezer) and is honored by **every** freeze path: single-app freeze, the multi-select / "Freeze all" toolbar, and the screen-off **auto-freeze**. Default stays **Freeze** so existing users see no behavior change on update.
+
+## 2. Why this is small
+
+`setAppSuspended` is **already implemented end-to-end** and simply never wired into the Freezer:
+
+- `SystemGateway.setAppSuspended()` — `domain/gateway/SystemGateway.kt:19`, implemented in all three backends:
+  - `RootSystemGateway.kt:149` (shell `pm suspend` + reflection fallback)
+  - `ShizukuSystemGateway.kt:73` (`reflector.setAppSuspended`)
+  - `DhizukuSystemGateway.kt:134` (`reflector.setAppSuspended` / DevicePolicyManager)
+- `ManageAppUseCase.setAppSuspended()` — `domain/usecase/ManageAppUseCase.kt:21`
+- `MainViewModel` already routes both action families symmetrically:
+  - `AppClickAction.Suspend/UnSuspend` → `setAppSuspended` (`MainViewModel.kt:355-356`)
+  - `MultiAppAction.Suspend/UnSuspend` → `performLoggedMultiAction { setAppSuspended }` (`MainViewModel.kt:429-440`)
+- `AppInfo.isSuspended` already exists and is rendered (e.g. `ManageFreezerSheet.kt:179`).
+
+So we do **not** write any new gateway/usecase/action code. We add one preference, thread it through the Freezer, and fix the places that assume **"frozen == disabled."**
+
+## 3. The one real subtlety: "frozen" is currently defined as "disabled"
+
+Today the Freezer treats an app as frozen iff `!app.enabled`. A **suspended** app is still `enabled`, so without changes a suspended app would look "not frozen." Two consequences must be handled:
+
+1. **Frozen predicate.** Redefine frozen as `!enabled || isSuspended` everywhere the Freezer reasons about state (toolbar enablement, `appsToFreeze` / `appsToUnfreeze`, empty/active/frozen filters at `FreezerScreen.kt:120-128`).
+2. **State-aware unfreeze.** After a mode switch a user can have a *mixed* set (some disabled, some suspended). "Unfreeze" must restore each app by its actual state: **unsuspend** suspended apps and **enable** disabled apps. A uniform `UnFreeze` (which only calls `setAppDisabled(false)`) would leave suspended apps still suspended, and vice-versa.
+
+## 4. Design decisions (confirmed with user)
+
+| Decision | Choice |
+|---|---|
+| Scope | **Global** — one mode, honored by all freeze paths |
+| Default for existing users | **Freeze** (no behavior change on update) |
+| UI | **Both**: a `ConnectedButtonGroup` (Freeze \| Suspend) in the Freezer settings sheet **and** a "Suspend instead of freeze" switch in the main Settings screen — both backed by the single `freezerMode` preference so they always agree |
+
+## 5. Data model & persistence
+
+**New:** `domain/model/FreezerMode.kt`
+```kotlin
+enum class FreezerMode { FREEZE, SUSPEND }
+```
+
+**`domain/model/UserPreferences.kt`** — add near the Auto-Freeze field (line ~28):
+```kotlin
+// Freezer action: what "freeze" does (FREEZE = pm disable, SUSPEND = pm suspend)
+val freezerMode: FreezerMode = FreezerMode.FREEZE,
+```
+
+**`domain/repository/PreferenceRepository.kt`** — add (near line 41):
+```kotlin
+suspend fun setFreezerMode(mode: FreezerMode)
+```
+
+**`data/repository/PreferenceRepositoryImpl.kt`** — mirror the `ThemeMode`/`AnimationIntensity` string-enum pattern (both already stored via `stringPreferencesKey`):
+- Key: `val FREEZER_MODE = stringPreferencesKey("freezer_mode")` (in `Keys`, ~line 55).
+- Hydrate in the `map`/`userPreferences` builder (~line 118):
+  ```kotlin
+  freezerMode = prefs[Keys.FREEZER_MODE]
+      ?.let { runCatching { FreezerMode.valueOf(it) }.getOrNull() }
+      ?: FreezerMode.FREEZE,
+  ```
+- Setter (mirror `setAutoFreezeEnabled`, ~line 195):
+  ```kotlin
+  override suspend fun setFreezerMode(mode: FreezerMode) {
+      dataStore.edit { it[Keys.FREEZER_MODE] = mode.name }
+  }
+  ```
+
+No Room/DataStore migration needed — absent key falls back to `FREEZE`.
+
+## 6. ViewModel & state
+
+**`FreezerViewModel.kt`**
+- `FreezerUiState` (`:31`) — add `val freezerMode: FreezerMode = FreezerMode.FREEZE`.
+- `observePreferences` (`:296`) — hydrate `freezerMode` from prefs alongside `autoFreezeEnabled`.
+- New setter mirroring `setAutoFreezeEnabled` (`:311`):
+  ```kotlin
+  fun setFreezerMode(mode: FreezerMode) = viewModelScope.launch {
+      preferenceRepository.setFreezerMode(mode)
+  }
+  ```
+- `freezeSingleApp` (`:225`) — when `state.freezerMode == SUSPEND`, call `manageAppUseCase.setAppSuspended(pkg, true)` instead of `setAppDisabled(pkg, true)`.
+- `unfreezeSingleApp` (`:263`) — **state-aware restore**: if `app.isSuspended` → `setAppSuspended(pkg, false)`; else if `!app.enabled` → `setAppDisabled(pkg, false)`.
+
+## 7. Freeze entry points — how each honors the mode
+
+All four paths already have a Freeze *and* a Suspend variant; we select the variant by mode rather than adding new logic.
+
+1. **Multi-select / "Freeze all" toolbar** (`FreezerScreen.kt:357-401`, and `onUnfreezeAll` at the settings-sheet call site `:466`).
+   Emit the mode-appropriate `MultiAppAction`:
+   ```kotlin
+   val freezeAction = if (state.freezerMode == SUSPEND)
+       MultiAppAction.Suspend(appsToFreeze) else MultiAppAction.Freeze(appsToFreeze)
+   ```
+   For **unfreeze/restore** of a possibly-mixed set, restore by state (see §8).
+
+2. **Single app** — handled in `FreezerViewModel.freezeSingleApp/unfreezeSingleApp` (§6).
+
+3. **Auto-freeze** (`AutoFreezeManager.kt`). It already injects `PreferenceRepository` and observes `userPreferences` in `startObserving()` (`:135`). Capture the current mode (e.g. a `@Volatile var currentMode` updated inside the existing `collectLatest`) and branch the per-package call in the screen-off loop (~`:100`) from `setAppDisabled(pkg, true)` to `setAppSuspended(pkg, true)` when `SUSPEND`. The existing keyguard-locked, privilege, and UAD/unsafe-skip guards are unchanged.
+
+4. **Launcher bulk shortcuts** (`viewModel.pinBulkShortcut(freeze = …)`). The pinned shortcut's *action* should also honor the mode. **Flag for implementation:** confirm what the shortcut invokes when tapped and route it through the same mode branch; if that expands scope materially, it can be a fast-follow (documented, not silently dropped).
+
+## 8. State-aware unfreeze (mixed sets)
+
+`unfreezeSingleApp` handles the single case (§6). For the batch "Unfreeze all" / multi-select restore, split the frozen set and dispatch the correct inverse per app. Preferred implementation (least new surface, reuses `MainViewModel`):
+
+- In `FreezerScreen`, compute:
+  ```kotlin
+  val frozenApps   = state.freezerApps.filter { !it.enabled || it.isSuspended }
+  val toEnable     = frozenApps.filter { !it.enabled }      // disabled → pm enable
+  val toUnsuspend  = frozenApps.filter { it.enabled && it.isSuspended }
+  ```
+- Restore = `MultiAppAction.UnFreeze(toEnable)` and/or `MultiAppAction.UnSuspend(toUnsuspend)`.
+
+Because both stream progress through the single `TermLoggerDialog`, dispatch them so they don't overlap (sequential, or a thin `MainViewModel` "restore" entry that iterates once and picks the inverse per app). **Recommended:** add a small state-aware restore in `MainViewModel` (`Restore(appList)` that, per app, calls `setAppSuspended(false)` if suspended else `setAppDisabled(false)`) — one action, one log stream, future-proof. Confirm during implementation whether to add `Restore` vs. sequential dispatch.
+
+## 9. Frozen-predicate fix (`FreezerScreen.kt:120-128`)
+
+```kotlin
+val hasActive = remember(state.freezerApps) { state.freezerApps.any { it.enabled && !it.isSuspended } }
+val hasFrozen = remember(state.freezerApps) { state.freezerApps.any { !it.enabled || it.isSuspended } }
+
+val appsToFreeze   = remember(state.freezerApps) { state.freezerApps.filter { it.enabled && !it.isSuspended } }
+val appsToUnfreeze = remember(state.freezerApps) { state.freezerApps.filter { !it.enabled || it.isSuspended } }
+```
+Update the toolbar's Freeze/Unfreeze button enablement to use `hasActive`/`hasFrozen`. (This keeps behavior identical in FREEZE mode, since a frozen app is `!enabled` and `isSuspended` is false.)
+
+## 10. UI
+
+**A. `FreezerSettingsSheet.kt`** — it already imports `ConnectedButtonGroup` + `ConnectedButtonGroupItem`. Add params:
+```kotlin
+freezerMode: FreezerMode,
+onFreezerModeChange: (FreezerMode) -> Unit,
+```
+Render a labeled mode selector next to the Auto Freeze switch (`~:68`), gated on `hasPrivilege`:
+```kotlin
+ConnectedButtonGroup(
+    items = listOf(
+        ConnectedButtonGroupItem.Label(stringResource(R.string.freeze)),
+        ConnectedButtonGroupItem.Label(stringResource(R.string.suspend)),
+    ),
+    selectedIndex = freezerMode.ordinal,
+    onItemSelected = { onFreezerModeChange(FreezerMode.entries[it]) },
+    enabled = hasPrivilege,
+)
+```
+Wire the new params at the `FreezerScreen.kt` call site (`:456`): `freezerMode = state.freezerMode`, `onFreezerModeChange = viewModel::setFreezerMode`.
+
+**B. Main Settings screen** (`presentation/settings/SettingsScreen.kt` + `SettingsViewModel`). Add a **"Suspend instead of freeze"** switch following the existing switch pattern (biometric lock / dynamic color), backed by the same preference:
+```kotlin
+checked = freezerMode == FreezerMode.SUSPEND
+onCheckedChange = { setFreezerMode(if (it) FreezerMode.SUSPEND else FreezerMode.FREEZE) }
+```
+Because both controls read/write the one `freezerMode` preference (single source of truth), they stay in sync automatically.
+
+**C. Strings** (`res/values/strings.xml`, + translations later): `freeze`, `suspend`, `freezer_mode` (section label), `suspend_instead_of_freeze`, `suspend_instead_of_freeze_desc`.
+
+## 11. Error handling & edge cases
+
+- **Backend suspend failure.** Gateways already return `Result.failure`; errors surface through the existing action/log pipeline (`TermLoggerDialog`, `actionMessage`) exactly like a freeze failure. **No silent fallback to disable** — the user picked suspend; a failure is reported, not masked.
+- **UAD/unsafe skip preserved.** The Freeze multi-action skips unsafe/UAD-failed system apps (`MainViewModel.kt:416-419, 495-496`). Ensure the **Suspend** multi-path applies the same skip. If `performLoggedMultiAction` (`:429`) does not currently filter, add the same eligibility guard so switching to suspend doesn't bypass the safety check. **(Verify during implementation.)**
+- **Mixed states** after a mode switch — handled by the frozen predicate (§9) and state-aware restore (§8).
+- **Auto-freeze mode read** — snapshot the latest mode in `AutoFreezeManager`'s existing `collectLatest`; the screen-off receiver reads that volatile value.
+
+## 12. Testing
+
+**Unit**
+- `PreferenceRepositoryImpl`: `freezerMode` write→read round-trip; absent key defaults to `FREEZE`; invalid stored string falls back to `FREEZE`.
+- `FreezerViewModel`: `freezeSingleApp`/`unfreezeSingleApp` call `setAppSuspended` vs `setAppDisabled` per mode; state-aware unfreeze picks the correct inverse.
+
+**Manual / on-device (per backend: Root, Shizuku, Dhizuku)**
+- Toggle mode via both controls; confirm they stay in sync.
+- Suspend mode: single freeze, multi "Freeze all", and screen-off auto-freeze all *suspend* (app greyed/paused, still in launcher).
+- Unfreeze a mixed set (some disabled, some suspended) → all become active.
+- Freeze mode unchanged from today.
+- Suspend failure on an unsupported device surfaces an error (no disable fallback).
+
+## 13. Out of scope (YAGNI)
+
+- Per-app freeze/suspend choice.
+- Scheduled/timed auto-freeze (auto-freeze stays screen-off triggered).
+- Changing the default to Suspend (explicitly kept as Freeze).
+
+## 14. Build sequence
+
+1. `FreezerMode` enum + `UserPreferences` field + `PreferenceRepository`(+`Impl`) key/hydration/setter.
+2. `FreezerViewModel`: state field, hydration, `setFreezerMode`, mode-aware single freeze/unfreeze.
+3. Frozen-predicate fix in `FreezerScreen` (§9) + mode-aware toolbar dispatch (§7.1) + state-aware batch restore (§8).
+4. `AutoFreezeManager` mode branch (§7.3).
+5. `MainViewModel`: ensure Suspend multi-path has the UAD/unsafe skip; add `Restore` if chosen (§8, §11).
+6. UI: `FreezerSettingsSheet` `ConnectedButtonGroup` + Settings switch + strings (§10).
+7. Launcher-shortcut mode routing (§7.4) or document as fast-follow.
+8. Tests (§12); build `assembleFossDebug`; on-device pass per backend.


### PR DESCRIPTION
Closes #239.

## What & why
Adds a global **Freezer action mode** so the Freezer — including screen-off **auto-freeze** — can **suspend** apps (`pm suspend`, app stays visible but paused) instead of **freezing/disabling** them (`pm disable`). Default stays **Freeze**, so existing users see no change on update.

Requested in #239 ("Suspend by default"): *"choose the freezing mode for the Freezer … suspend the application instead of freezing it … when automatic freezing is enabled, the apps would be suspended."*

## Approach
`setAppSuspended` was already implemented end-to-end (all three gateways, use-case, `MainViewModel` actions, `AppInfo.isSuspended`) but never wired into the Freezer. This PR adds one `FreezerMode` preference and routes every freeze path through it:

- **Data:** `FreezerMode` enum + `freezerMode` DataStore preference (default `FREEZE`, string-key with safe `valueOf` fallback).
- **Freeze paths honor the mode:** single-app freeze, batch "Freeze all" (`performCountedFreeze` carries `useSuspend`, keeping the compact count UI **and** the unsafe/UAD skip), the multi-select toolbar, and `AutoFreezeManager`.
- **Core generalization:** the Freezer previously equated *frozen* with *disabled*; now **frozen = disabled OR suspended** (`isFrozen`/`isActive` predicates), and **unfreeze is state-aware** (`restoreApp` unsuspends and/or enables as needed).
- **UI (both, one shared preference so they stay in sync):** a `ConnectedButtonGroup` (Freeze | Suspend) in the Freezer settings sheet, and a "Suspend instead of freeze" switch in Settings.

## Robustness — adversarial review
An automated multi-agent review of the diff found **5 real bugs** around the mixed *disabled+suspended* state (single-op restore reporting false success; multi-select toolbar using the raw `enabled` flag; non-state-aware remove paths; auto-freeze stacking disable onto a suspended app). **All 5 are fixed and re-verified** in this branch:
- restore now clears **both** dimensions;
- freeze only ever acts on **active** apps (never creates mixed state);
- the multi-select `FreezerSelectToolBox` uses `isFrozen`/`isActive` + `useSuspend`.

## Testing
- `FreezerModeTest` — 8 pure unit tests (predicates + restore plan incl. mixed state). ✅
- `./gradlew :app:testFossDebugUnitTest assembleFossDebug` — green. ✅
- ⚠️ **Not yet exercised on a device** — on-device pass per backend (Root/Shizuku/Dhizuku) still recommended.

## Known limitations (documented fast-follow)
- Launcher-shortcut **bulk** freeze and the **AppList** multi-freeze remain disable-only (suspend-mode unaware). Pre-existing surfaces, out of scope here.

## Docs
Design spec + implementation plan included under `docs/superpowers/` — happy to drop them from the PR if you'd rather not track them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)