### PR TITLE
feat(strombringer): base-Thor foundation for the Xposed extension (restore bridge + design)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -326,6 +326,15 @@
             </intent-filter>
         </receiver>
 
+        <!-- Strombringer bridge: lets the (LSPosed) launcher hook ask Thor to unsuspend a frozen
+             app on launch. exported so the hook's process can reach it; access is bounded to
+             Freezer packages inside the provider (the caller runs in the launcher, so it can't be
+             signature-verified). -->
+        <provider
+            android:name=".data.provider.FreezerBridgeProvider"
+            android:authorities="${applicationId}.freezerbridge"
+            android:exported="true" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
@@ -1,0 +1,53 @@
+package com.valhalla.thor.data.provider
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Binder
+import android.os.Bundle
+import com.valhalla.thor.domain.model.mayRestore
+import com.valhalla.thor.domain.repository.FreezerRepository
+import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.runBlocking
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Lets the Strombringer launcher hook ask Thor (which holds root/Shizuku/Dhizuku privilege) to
+ * unsuspend an app on launch. Bounded to Freezer packages (see mayRestore) since the caller is the
+ * launcher process and can't be cryptographically verified as our extension.
+ */
+class FreezerBridgeProvider : ContentProvider(), KoinComponent {
+    private val freezerRepository: FreezerRepository by inject()
+    private val manageAppUseCase: ManageAppUseCase by inject()
+
+    override fun onCreate() = true
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
+        val result = Bundle()
+        if (method != "restore") { result.putBoolean("ok", false); return result }
+        val pkg = extras?.getString("pkg") ?: arg ?: run {
+            result.putBoolean("ok", false); return result
+        }
+        val ok = runBlocking {
+            val inFreezer = freezerRepository.getAllPackageNames().toSet()
+            if (!mayRestore(pkg, inFreezer)) {
+                Logger.d("FreezerBridge", "restore refused (not in freezer): $pkg from uid ${Binder.getCallingUid()}")
+                false
+            } else {
+                manageAppUseCase.forceUnfreeze(pkg).isSuccess
+            }
+        }
+        result.putBoolean("ok", ok)
+        return result
+    }
+
+    // Unused CRUD surface.
+    override fun query(u: Uri, p: Array<out String>?, s: String?, sa: Array<out String>?, o: String?): Cursor? = null
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, s: String?, sa: Array<out String>?): Int = 0
+    override fun update(uri: Uri, v: ContentValues?, s: String?, sa: Array<out String>?): Int = 0
+}

--- a/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
@@ -43,19 +43,26 @@ class FreezerBridgeProvider : ContentProvider(), KoinComponent {
             return result
         }
 
-        val ok = runCatching {
-            runBlocking {
-                val inFreezer = freezerRepository.getAllPackageNames().toSet()
-                if (!mayRestore(pkg, inFreezer)) {
-                    Logger.d("FreezerBridge", "restore refused (not in freezer): $pkg")
-                    false
-                } else {
-                    manageAppUseCase.forceUnfreeze(pkg).isSuccess
+        // Caller verified above; run the privileged unfreeze under Thor's OWN identity (not the
+        // launcher's) so any downstream permission checks attribute to Thor. Restore in finally.
+        val token = Binder.clearCallingIdentity()
+        val ok = try {
+            runCatching {
+                runBlocking {
+                    val inFreezer = freezerRepository.getAllPackageNames().toSet()
+                    if (!mayRestore(pkg, inFreezer)) {
+                        Logger.d("FreezerBridge", "restore refused (not in freezer): $pkg")
+                        false
+                    } else {
+                        manageAppUseCase.forceUnfreeze(pkg).isSuccess
+                    }
                 }
+            }.getOrElse {
+                Logger.e("FreezerBridge", "restore failed for $pkg", it)
+                false
             }
-        }.getOrElse {
-            Logger.e("FreezerBridge", "restore failed for $pkg", it)
-            false
+        } finally {
+            Binder.restoreCallingIdentity(token)
         }
         result.putBoolean("ok", ok)
         return result

--- a/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
@@ -2,6 +2,7 @@ package com.valhalla.thor.data.provider
 
 import android.content.ContentProvider
 import android.content.ContentValues
+import android.content.Intent
 import android.database.Cursor
 import android.net.Uri
 import android.os.Binder
@@ -16,8 +17,14 @@ import org.koin.core.component.inject
 
 /**
  * Lets the Strombringer launcher hook ask Thor (which holds root/Shizuku/Dhizuku privilege) to
- * unsuspend an app on launch. Bounded to Freezer packages (see mayRestore) since the caller is the
- * launcher process and can't be cryptographically verified as our extension.
+ * unsuspend an app on launch.
+ *
+ * The hook runs INSIDE the launcher's process, so the caller is the launcher — it cannot be
+ * signature-verified as our extension, and a `signature`-level permission can't span Thor's key and
+ * the (dedicated) extension key. So we defend with two independent bounds, both applied before any
+ * privileged work:
+ *   1. the caller must be a HOME/launcher app (the only place the hook legitimately runs), and
+ *   2. the target must already be in the user's Freezer (`mayRestore`).
  */
 class FreezerBridgeProvider : ContentProvider(), KoinComponent {
     private val freezerRepository: FreezerRepository by inject()
@@ -26,22 +33,41 @@ class FreezerBridgeProvider : ContentProvider(), KoinComponent {
     override fun onCreate() = true
 
     override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
-        val result = Bundle()
-        if (method != "restore") { result.putBoolean("ok", false); return result }
-        val pkg = extras?.getString("pkg") ?: arg ?: run {
-            result.putBoolean("ok", false); return result
+        val result = Bundle().apply { putBoolean("ok", false) }
+        if (method != "restore") return result
+        val pkg = extras?.getString("pkg") ?: arg ?: return result
+
+        if (!callerIsHomeApp()) {
+            Logger.d("FreezerBridge", "restore refused (caller not a launcher): uid ${Binder.getCallingUid()}")
+            return result
         }
-        val ok = runBlocking {
-            val inFreezer = freezerRepository.getAllPackageNames().toSet()
-            if (!mayRestore(pkg, inFreezer)) {
-                Logger.d("FreezerBridge", "restore refused (not in freezer): $pkg from uid ${Binder.getCallingUid()}")
-                false
-            } else {
-                manageAppUseCase.forceUnfreeze(pkg).isSuccess
+
+        val ok = runCatching {
+            runBlocking {
+                val inFreezer = freezerRepository.getAllPackageNames().toSet()
+                if (!mayRestore(pkg, inFreezer)) {
+                    Logger.d("FreezerBridge", "restore refused (not in freezer): $pkg")
+                    false
+                } else {
+                    manageAppUseCase.forceUnfreeze(pkg).isSuccess
+                }
             }
+        }.getOrElse {
+            Logger.e("FreezerBridge", "restore failed for $pkg", it)
+            false
         }
         result.putBoolean("ok", ok)
         return result
+    }
+
+    /** True when the calling UID owns a package that is a HOME/launcher app. */
+    private fun callerIsHomeApp(): Boolean {
+        val pm = context?.packageManager ?: return false
+        val callers = pm.getPackagesForUid(Binder.getCallingUid())?.toSet() ?: return false
+        val homeApps = pm.queryIntentActivities(
+            Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME), 0
+        ).mapNotNull { it.activityInfo?.packageName }.toSet()
+        return callers.any { it in homeApps }
     }
 
     // Unused CRUD surface.

--- a/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
@@ -3,6 +3,7 @@ package com.valhalla.thor.data.provider
 import android.content.ContentProvider
 import android.content.ContentValues
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.database.Cursor
 import android.net.Uri
 import android.os.Binder
@@ -37,8 +38,8 @@ class FreezerBridgeProvider : ContentProvider(), KoinComponent {
         if (method != "restore") return result
         val pkg = extras?.getString("pkg") ?: arg ?: return result
 
-        if (!callerIsHomeApp()) {
-            Logger.d("FreezerBridge", "restore refused (caller not a launcher): uid ${Binder.getCallingUid()}")
+        if (!callerIsDefaultLauncher()) {
+            Logger.d("FreezerBridge", "restore refused (caller not the default launcher): uid ${Binder.getCallingUid()}")
             return result
         }
 
@@ -60,14 +61,20 @@ class FreezerBridgeProvider : ContentProvider(), KoinComponent {
         return result
     }
 
-    /** True when the calling UID owns a package that is a HOME/launcher app. */
-    private fun callerIsHomeApp(): Boolean {
+    /**
+     * True only when the calling UID owns the device's CURRENT default home launcher. We resolve the
+     * *default* (`MATCH_DEFAULT_ONLY`) rather than querying every HOME-category app: any app can
+     * declare a HOME activity, so an all-apps query would let a malicious app spoof launcher status.
+     * The Strombringer hook only runs in the real launcher, so this is exactly the legitimate caller.
+     */
+    private fun callerIsDefaultLauncher(): Boolean {
         val pm = context?.packageManager ?: return false
         val callers = pm.getPackagesForUid(Binder.getCallingUid())?.toSet() ?: return false
-        val homeApps = pm.queryIntentActivities(
-            Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME), 0
-        ).mapNotNull { it.activityInfo?.packageName }.toSet()
-        return callers.any { it in homeApps }
+        val defaultHome = pm.resolveActivity(
+            Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_HOME),
+            PackageManager.MATCH_DEFAULT_ONLY
+        )?.activityInfo?.packageName ?: return false
+        return defaultHome in callers
     }
 
     // Unused CRUD surface.

--- a/app/src/main/java/com/valhalla/thor/domain/model/RestoreRequest.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/RestoreRequest.kt
@@ -1,0 +1,9 @@
+package com.valhalla.thor.domain.model
+
+/**
+ * The Strombringer launcher hook runs in the launcher's process, so the ContentProvider cannot
+ * cryptographically prove the caller is our extension. We bound the blast radius instead: only
+ * packages the user already put in the Freezer may be restored. GH#239 / Strombringer.
+ */
+fun mayRestore(packageName: String, freezerPackages: Set<String>): Boolean =
+    packageName.isNotBlank() && packageName in freezerPackages

--- a/app/src/test/java/com/valhalla/thor/domain/model/RestoreGateTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/RestoreGateTest.kt
@@ -1,0 +1,17 @@
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RestoreGateTest {
+    @Test fun `allows a package that is in the freezer`() {
+        assertTrue(mayRestore("com.foo", setOf("com.foo", "com.bar")))
+    }
+    @Test fun `blocks a package not in the freezer`() {
+        assertFalse(mayRestore("com.evil", setOf("com.foo")))
+    }
+    @Test fun `blocks a blank package`() {
+        assertFalse(mayRestore("", setOf("com.foo")))
+    }
+}

--- a/docs/superpowers/plans/2026-07-07-strombringer-auto-unfreeze.md
+++ b/docs/superpowers/plans/2026-07-07-strombringer-auto-unfreeze.md
@@ -1,0 +1,395 @@
+# Strombringer — Auto-Unfreeze Slice — Implementation Plan (Plan 1 of Spec A)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the whole Strombringer architecture end-to-end with its lowest-risk feature: tapping a **suspended** app's real launcher icon auto-unsuspends and opens it — via a headless LSPosed module that calls a new base-Thor `restore` provider.
+
+**Architecture:** A new `com.valhalla.thor.ext.strombringer` extension APK is **dual-role** — Thor loads its `AutomationExtension` config class in-process (existing framework), and LSPosed loads its `IXposedHookLoadPackage` launcher hook into the launcher. The launcher hook, on a suspended-target launch, calls Thor's new **`restore` `ContentProvider`** (Thor holds root/Shizuku/Dhizuku privilege) which unsuspends via the #239 gateway. **Debug-tested** — `ExtensionManager.verifySignature()` already bypasses the cert check in `BuildConfig.DEBUG`, so no cert-allowlist/dedicated-key work is needed here (that's Spec B).
+
+**Tech Stack:** Kotlin, Android (minSdk 28/29), LSPosed/Xposed API (`de.robv.android.xposed:api:82`, `compileOnly`), Jetpack Compose (host-provided), Koin, `thor-extension-api` (`compileOnly`).
+
+## Global Constraints
+- **Extension applicationId MUST start with `com.valhalla.thor.ext.`** — `ExtensionManager` (`ExtensionManager.kt:14`) discovers extensions by that prefix. Use `com.valhalla.thor.ext.strombringer`.
+- **`compileOnly`** for `thor-extension-api`, `asgard`, AND the Xposed API — the host (Thor) provides api+asgard+compose at runtime; the Xposed framework provides `de.robv.*`. The extension APK must bundle none of them.
+- **Headless:** no `<activity MAIN/LAUNCHER>` in Strombringer — it cannot be opened standalone.
+- **Base-Thor changes stay store-safe:** the `restore` provider contains **no Xposed code**; it's a plain provider over the existing freezer gateway.
+- **Two repos:** base-Thor changes land in `StudioProjects/Thor` (branch `feat/strombringer`); the module is a new project `StudioProjects/Strombringer` (later mirrored into `Thor-Extensions/verified/strombringer/` — Spec B).
+- Reuse `restoreApp`/`forceUnfreeze` from `ManageAppUseCase` (#239) — never re-implement unsuspend.
+
+---
+
+## File Structure
+
+**Base Thor (`app/`):**
+| File | Responsibility | Change |
+|---|---|---|
+| `domain/model/RestoreRequest.kt` | pure: decide if a package may be restored (in-freezer gate) | Create |
+| `test/.../domain/model/RestoreGateTest.kt` | unit tests for the gate | Create |
+| `data/provider/FreezerBridgeProvider.kt` | `ContentProvider.call("restore", pkg)` → gateway, freezer-scoped | Create |
+| `AndroidManifest.xml` | register the provider | Modify |
+
+**Strombringer (new project `StudioProjects/Strombringer`, mirrors automation-extension):**
+| File | Responsibility |
+|---|---|
+| `app/build.gradle.kts` | app module; `compileOnly` api/asgard/xposed |
+| `settings.gradle.kts` | + `maven("https://api.xposed.info/")` |
+| `app/src/main/assets/xposed_init` | `com.valhalla.thor.ext.strombringer.XposedEntry` |
+| `app/src/main/AndroidManifest.xml` | `thor.extension.class` + xposed meta-data (no launcher activity) |
+| `.../strombringer/StrombringerExtension.kt` | `AutomationExtension` — minimal ConfigurationScreen (auto-unfreeze toggle) |
+| `.../strombringer/XposedEntry.kt` | `IXposedHookLoadPackage` — dispatch to the launcher hook + self-active flag |
+| `.../strombringer/LaunchAppHook.kt` | hook launcher `startActivity*`; suspended target → call Thor provider |
+| `.../strombringer/Config.kt` | read/write config via its own prefs (hook side = `XSharedPreferences`) |
+
+---
+
+## Task 1: Base-Thor — restore gate (pure, TDD)
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/domain/model/RestoreRequest.kt`
+- Test: `app/src/test/java/com/valhalla/thor/domain/model/RestoreGateTest.kt`
+
+**Interfaces:**
+- Produces: `fun mayRestore(packageName: String, freezerPackages: Set<String>): Boolean`
+
+- [ ] **Step 1: Write the failing test**
+```kotlin
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RestoreGateTest {
+    @Test fun `allows a package that is in the freezer`() {
+        assertTrue(mayRestore("com.foo", setOf("com.foo", "com.bar")))
+    }
+    @Test fun `blocks a package not in the freezer`() {
+        assertFalse(mayRestore("com.evil", setOf("com.foo")))
+    }
+    @Test fun `blocks a blank package`() {
+        assertFalse(mayRestore("", setOf("com.foo")))
+    }
+}
+```
+- [ ] **Step 2: Run — expect FAIL** `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.domain.model.RestoreGateTest"` → unresolved `mayRestore`.
+- [ ] **Step 3: Implement** — `RestoreRequest.kt`:
+```kotlin
+package com.valhalla.thor.domain.model
+
+/**
+ * The Strombringer launcher hook runs in the launcher's process, so the ContentProvider cannot
+ * cryptographically prove the caller is our extension. We bound the blast radius instead: only
+ * packages the user already put in the Freezer may be restored. GH#239 / Strombringer.
+ */
+fun mayRestore(packageName: String, freezerPackages: Set<String>): Boolean =
+    packageName.isNotBlank() && packageName in freezerPackages
+```
+- [ ] **Step 4: Run — expect PASS** (3 tests).
+- [ ] **Step 5: Commit** `git add app/src/main/java/com/valhalla/thor/domain/model/RestoreRequest.kt app/src/test/java/com/valhalla/thor/domain/model/RestoreGateTest.kt && git commit -m "feat(strombringer): freezer-scoped restore gate (pure)"`
+
+## Task 2: Base-Thor — `FreezerBridgeProvider`
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt`
+- Modify: `app/src/main/AndroidManifest.xml` (register provider, before `</application>`)
+
+**Interfaces:**
+- Consumes: `mayRestore` (Task 1); `FreezerRepository.getAllPackageNames()`, `ManageAppUseCase.forceUnfreeze(pkg)` (#239); Koin `KoinComponent`/`inject` (pattern: `ExtensionTriggerReceiver.kt:18-22`).
+- Produces: provider authority `"${applicationId}.freezerbridge"`, method `"restore"`, arg key `"pkg"`, result bundle `{ "ok": Boolean }`.
+
+- [ ] **Step 1: Implement the provider** — `FreezerBridgeProvider.kt`:
+```kotlin
+package com.valhalla.thor.data.provider
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.os.Binder
+import android.os.Bundle
+import com.valhalla.thor.domain.model.mayRestore
+import com.valhalla.thor.domain.repository.FreezerRepository
+import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.runBlocking
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Lets the Strombringer launcher hook ask Thor (which holds root/Shizuku/Dhizuku privilege) to
+ * unsuspend an app on launch. Bounded to Freezer packages (see mayRestore) since the caller is the
+ * launcher process and can't be cryptographically verified as our extension.
+ */
+class FreezerBridgeProvider : ContentProvider(), KoinComponent {
+    private val freezerRepository: FreezerRepository by inject()
+    private val manageAppUseCase: ManageAppUseCase by inject()
+
+    override fun onCreate() = true
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
+        val result = Bundle()
+        if (method != "restore") { result.putBoolean("ok", false); return result }
+        val pkg = extras?.getString("pkg") ?: arg ?: run {
+            result.putBoolean("ok", false); return result
+        }
+        val ok = runBlocking {
+            val inFreezer = freezerRepository.getAllPackageNames().toSet()
+            if (!mayRestore(pkg, inFreezer)) {
+                Logger.d("FreezerBridge", "restore refused (not in freezer): $pkg from uid ${Binder.getCallingUid()}")
+                false
+            } else {
+                manageAppUseCase.forceUnfreeze(pkg).isSuccess
+            }
+        }
+        result.putBoolean("ok", ok)
+        return result
+    }
+
+    // Unused CRUD surface.
+    override fun query(u: Uri, p: Array<out String>?, s: String?, sa: Array<out String>?, o: String?): Cursor? = null
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, s: String?, sa: Array<out String>?): Int = 0
+    override fun update(uri: Uri, v: ContentValues?, s: String?, sa: Array<out String>?): Int = 0
+}
+```
+- [ ] **Step 2: Register in `AndroidManifest.xml`** — add before the closing `</application>` (near the other `<provider>` blocks, ~line 287):
+```xml
+        <!-- Strombringer bridge: lets the (LSPosed) launcher hook ask Thor to unsuspend a frozen
+             app on launch. exported so the hook's process can reach it; access is bounded to
+             Freezer packages inside the provider (the caller runs in the launcher, so it can't be
+             signature-verified). -->
+        <provider
+            android:name=".data.provider.FreezerBridgeProvider"
+            android:authorities="${applicationId}.freezerbridge"
+            android:exported="true" />
+```
+- [ ] **Step 3: Verify compile** `./gradlew :app:compileFossDebugKotlin` → BUILD SUCCESSFUL.
+- [ ] **Step 4: Commit** `git add app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt app/src/main/AndroidManifest.xml && git commit -m "feat(strombringer): FreezerBridge restore ContentProvider (freezer-scoped)"`
+
+## Task 3: Scaffold the Strombringer project
+
+**Files (new project `StudioProjects/Strombringer/`):** copy the automation-extension project structure (`verified/thor-automation-extension/`) as the base — same Gradle wrapper, `settings.gradle.kts`, `gradle/libs.versions.toml`, root `build.gradle.kts`. Then the deltas below.
+
+- [ ] **Step 1: Copy the template**
+```bash
+cp -R /Users/trinadhthatakula/StudioProjects/Thor-Extensions/verified/thor-automation-extension \
+      /Users/trinadhthatakula/StudioProjects/Strombringer
+cd /Users/trinadhthatakula/StudioProjects/Strombringer
+rm -rf .git .gradle build app/build app/src/main/java/com/valhalla/thor/ext/automation
+git init -q
+```
+- [ ] **Step 2: `settings.gradle.kts` — add the Xposed maven repo** inside `dependencyResolutionManagement { repositories { … } }`:
+```kotlin
+        maven("https://api.xposed.info/")
+```
+- [ ] **Step 3: `gradle/libs.versions.toml` — add the Xposed API**
+```toml
+# [versions]
+xposed = "82"
+# [libraries]
+xposed = { module = "de.robv.android.xposed:api", version.ref = "xposed" }
+```
+- [ ] **Step 4: `app/build.gradle.kts` — namespace + xposed dep.** Set `namespace`/`applicationId` to `com.valhalla.thor.ext.strombringer`, `versionCode = 1000`, `versionName = "1.00.0"`, and add to `dependencies`:
+```kotlin
+    // Xposed API — provided by the LSPosed framework at runtime; never bundled.
+    compileOnly(libs.xposed)
+```
+- [ ] **Step 5: `app/src/main/assets/xposed_init`** (new file, one line, no trailing content):
+```
+com.valhalla.thor.ext.strombringer.XposedEntry
+```
+- [ ] **Step 6: `app/src/main/AndroidManifest.xml`** (headless, dual-role):
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:hasCode="true"
+        android:label="Strombringer"
+        android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
+
+        <!-- Thor extension entry -->
+        <meta-data android:name="thor.extension.class"
+            android:value="com.valhalla.thor.ext.strombringer.StrombringerExtension" />
+        <meta-data android:name="thor.extension.api.version" android:value="1" />
+
+        <!-- LSPosed module descriptor -->
+        <meta-data android:name="xposedmodule" android:value="true" />
+        <meta-data android:name="xposeddescription"
+            android:value="Auto-unfreeze suspended apps on launch (controlled from Thor)." />
+        <meta-data android:name="xposedminversion" android:value="82" />
+        <meta-data android:name="xposedscope" android:resource="@array/xposed_scope" />
+    </application>
+</manifest>
+```
+- [ ] **Step 7: `app/src/main/res/values/arrays.xml`** — the default launcher scope:
+```xml
+<resources>
+    <string-array name="xposed_scope">
+        <item>com.android.launcher</item>
+        <item>com.android.launcher3</item>
+        <item>com.miui.home</item>
+    </string-array>
+</resources>
+```
+- [ ] **Step 8: Commit** `git add -A && git commit -m "chore(strombringer): scaffold dual-role extension (Thor + LSPosed), no UI"`
+
+## Task 4: Strombringer config bridge
+
+**Files:** Create `.../strombringer/Config.kt`.
+
+**Interfaces:**
+- Produces: `Config.PREFS = "strombringer_prefs"`, `Config.KEY_AUTO_UNFREEZE = "auto_unfreeze"`; `Config.hostAuthority(ctx)` = Thor's bridge authority; a `ContentProvider` (`StrombringerConfigProvider`) the Thor-side UI writes.
+
+- [ ] **Step 1: Implement `Config.kt`** — prefs constants + host-authority helper + a config provider the Thor UI calls, persisting to world-readable prefs the hook reads via `XSharedPreferences`:
+```kotlin
+package com.valhalla.thor.ext.strombringer
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.os.Bundle
+
+object Config {
+    const val PREFS = "strombringer_prefs"                       // XSharedPreferences file name
+    const val KEY_AUTO_UNFREEZE = "auto_unfreeze"
+    const val AUTHORITY = "com.valhalla.thor.ext.strombringer.config"
+    // Thor's package differs by build (…​.debug); the hook resolves the installed Thor at call time.
+    val THOR_PACKAGES = listOf("com.valhalla.thor", "com.valhalla.thor.debug")
+}
+
+/** Thor's ConfigurationScreen writes here (cross-process); the hooks read via XSharedPreferences. */
+class StrombringerConfigProvider : ContentProvider() {
+    override fun onCreate() = true
+    @Suppress("DEPRECATION")
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
+        val ctx = context!!
+        // MODE_WORLD_READABLE so an LSPosed XSharedPreferences in system/launcher can read it.
+        val prefs = ctx.getSharedPreferences(Config.PREFS, Context.MODE_WORLD_READABLE)
+        val out = Bundle()
+        when (method) {
+            "set" -> prefs.edit().putBoolean(Config.KEY_AUTO_UNFREEZE, extras?.getBoolean("value") == true).apply()
+            "get" -> out.putBoolean("value", prefs.getBoolean(Config.KEY_AUTO_UNFREEZE, false))
+        }
+        return out
+    }
+    override fun query(u: Uri, p: Array<out String>?, s: String?, a: Array<out String>?, o: String?): Cursor? = null
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, v: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, s: String?, a: Array<out String>?): Int = 0
+    override fun update(uri: Uri, v: ContentValues?, s: String?, a: Array<out String>?): Int = 0
+}
+```
+Register the provider in the manifest (`android:name=".StrombringerConfigProvider"`, `authorities="com.valhalla.thor.ext.strombringer.config"`, `exported="true"`).
+> NOTE for the implementer: `MODE_WORLD_READABLE` throws on modern targetSdk unless you `StrictMode.VmPolicy` allow it or lower this module's `targetSdk`; the standard LSPosed pattern is to set this module's `targetSdk` ≤ 26 OR use LSPosed's remote-prefs. Confirm the approach on-device in Task 6 and pick whichever the device accepts; this is the one genuinely LSPosed-version-sensitive spot.
+- [ ] **Step 2: Commit** `git add -A && git commit -m "feat(strombringer): world-readable config bridge for hooks"`
+
+## Task 5: The launcher hook + Xposed entry
+
+**Files:** Create `.../strombringer/XposedEntry.kt`, `.../strombringer/LaunchAppHook.kt`. Reference: Hail `XposedInterface.kt` + `LaunchAppHook.kt` (`StudioProjects/references/Hail-master/.../xposed/`).
+
+**Interfaces:**
+- Consumes: `Config` (Task 4); Thor's `FreezerBridgeProvider` authority `"${thorPkg}.freezerbridge"`, method `"restore"`, `pkg` extra (Task 2).
+
+- [ ] **Step 1: `XposedEntry.kt`** — self-active flag + dispatch:
+```kotlin
+package com.valhalla.thor.ext.strombringer
+
+import de.robv.android.xposed.IXposedHookLoadPackage
+import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
+
+class XposedEntry : IXposedHookLoadPackage {
+    override fun handleLoadPackage(lpp: LoadPackageParam) {
+        // Self-hook: when Strombringer's own process is hooked, mark active (Thor reads this).
+        if (lpp.packageName == "com.valhalla.thor.ext.strombringer") { Active.value = true; return }
+        LaunchAppHook(lpp.classLoader).start()
+    }
+    object Active { @Volatile @JvmStatic var value = false }
+}
+```
+- [ ] **Step 2: `LaunchAppHook.kt`** — hook launcher `startActivity*`; on a suspended target, ask Thor to restore (Hail-proven public-API hook). Read `auto_unfreeze` from `XSharedPreferences`.
+```kotlin
+package com.valhalla.thor.ext.strombringer
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.os.Bundle
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XSharedPreferences
+import de.robv.android.xposed.XposedHelpers
+
+class LaunchAppHook(private val cl: ClassLoader) {
+    private val prefs = XSharedPreferences("com.valhalla.thor.ext.strombringer", Config.PREFS)
+
+    fun start() {
+        val hook = object : XC_MethodHook() {
+            override fun beforeHookedMethod(p: MethodHookParam) {
+                prefs.reload()
+                if (!prefs.getBoolean(Config.KEY_AUTO_UNFREEZE, false)) return
+                val intent = p.args.getOrNull(0) as? Intent ?: return
+                val target = intent.`package` ?: intent.component?.packageName ?: return
+                val ctx = p.thisObject as? Context ?: return
+                if (target == ctx.packageName) return
+                if (isSuspended(ctx, target)) requestRestore(ctx, target)
+            }
+        }
+        XposedHelpers.findAndHookMethod(Activity::class.java.name, cl, "startActivityForResult",
+            Intent::class.java, Int::class.javaPrimitiveType, Bundle::class.java, hook)
+        val ctxWrapper = XposedHelpers.findClass(ContextWrapper::class.java.name, cl)
+        XposedHelpers.findAndHookMethod(ctxWrapper, "startActivity", Intent::class.java, hook)
+        XposedHelpers.findAndHookMethod(ctxWrapper, "startActivity", Intent::class.java, Bundle::class.java, hook)
+    }
+
+    private fun isSuspended(ctx: Context, pkg: String): Boolean = runCatching {
+        val m = ctx.packageManager.javaClass.getMethod("isPackageSuspended", String::class.java)
+        m.invoke(ctx.packageManager, pkg) as Boolean
+    }.getOrDefault(false)
+
+    private fun requestRestore(ctx: Context, pkg: String) {
+        for (thor in Config.THOR_PACKAGES) {
+            val ok = runCatching {
+                val extras = Bundle().apply { putString("pkg", pkg) }
+                val res = ctx.contentResolver.call("$thor.freezerbridge".toUri(), "restore", null, extras)
+                res?.getBoolean("ok") == true
+            }.getOrDefault(false)
+            if (ok) {
+                // Wait briefly for the unsuspend to land so the original launch proceeds.
+                repeat(6) { if (!isSuspended(ctx, pkg)) return; Thread.sleep(60) }
+                return
+            }
+        }
+    }
+    private fun String.toUri() = android.net.Uri.parse("content://$this")
+}
+```
+- [ ] **Step 3: Build the module** `cd /Users/trinadhthatakula/StudioProjects/Strombringer && ./gradlew :app:assembleDebug` → BUILD SUCCESSFUL. Confirm the APK bundles **no** `de.robv` / api / asgard classes (`unzip -l app/build/outputs/apk/debug/app-debug.apk | grep -ciE 'xposed|extension/api|asgard'` → 0).
+- [ ] **Step 4: Commit** `git add -A && git commit -m "feat(strombringer): launcher hook auto-unfreezes suspended apps via Thor bridge"`
+
+## Task 6: Thor-side config UI (minimal)
+
+**Files:** Create `.../strombringer/StrombringerExtension.kt` — `AutomationExtension` whose `ConfigurationScreen` renders in Thor and toggles `auto_unfreeze` through the config provider (Task 4). Reference the automation-extension `AutomationCluster.kt` for the Compose+Asgard style.
+
+- [ ] **Step 1: Implement** a minimal `StrombringerExtension : AutomationExtension` — `name/description/version/author`, a no-op `onTrigger`, and a `ConfigurationScreen` with one `AsgardSettingToggleRow`("Auto-unfreeze on launch") whose state reads/writes via `LocalContext.current.contentResolver.call("content://com.valhalla.thor.ext.strombringer.config", "get"/"set", …)`. (Full code follows the automation-extension composable pattern; the load-bearing part is the two `contentResolver.call` sites.)
+- [ ] **Step 2: Build** `./gradlew :app:assembleDebug` → SUCCESSFUL.
+- [ ] **Step 3: Commit** `git add -A && git commit -m "feat(strombringer): Thor-rendered config screen (auto-unfreeze toggle)"`
+
+## Task 7: End-to-end device verification (debug, LSPosed)
+
+**Files:** none.
+
+- [ ] **Step 1: Install both** — Thor debug (`feat/strombringer`, with Tasks 1-2) + Strombringer debug (`adb install -r`). Because both are debug-signed, `ExtensionManager.verifySignature` (DEBUG) loads Strombringer without any cert work.
+- [ ] **Step 2: Activate** Strombringer in **LSPosed Manager**, scope = your launcher; reboot or restart the launcher.
+- [ ] **Step 3: Configure** — open Thor → Extensions → Strombringer → toggle **Auto-unfreeze on launch** ON (verify `adb shell run-as com.valhalla.thor.ext.strombringer cat …/shared_prefs/strombringer_prefs.xml` shows `auto_unfreeze=true`, or the provider `get` returns true).
+- [ ] **Step 4: Prove it** — with Thor's Freezer in **Suspend** mode, suspend a benign app; from the **home screen** tap its icon → it should **auto-unsuspend and open** (no "paused" dialog). Confirm `adb shell dumpsys package <pkg> | grep suspended` flips to `false`, and `logcat` shows the `FreezerBridge` "restore" call succeeding.
+- [ ] **Step 5: Negative check** — an app **not** in the Freezer, if suspended by something else, is **not** restored (provider refuses; logcat "restore refused"). Confirm the bridge is freezer-scoped.
+
+## Self-Review
+- **Spec A coverage:** §3 dual-role → Tasks 3/5/6; §4.3 restore provider → Tasks 1/2; §5.1 manifest → Task 3; §5.2 config store + active flag → Tasks 4/5; §5.4 auto-unfreeze hook → Task 5; §6 config bridge → Tasks 4/6; §8 build-order "auto-unfreeze slice first" → this whole plan. Deferred to later plans (correctly): §4.1 cert allowlist + §4.2 foss INTERNET (Spec B), installer-spoof (Plan 3), CorePatch (Plan 4).
+- **Placeholder scan:** the one soft spot is Task 6 Step 1 (Compose UI described, not fully coded) — the load-bearing `contentResolver.call` sites are shown; the surrounding composable is boilerplate mirrored from `AutomationCluster.kt`. Task 4 flags the single genuinely device-sensitive decision (`MODE_WORLD_READABLE` vs LSPosed remote-prefs) to resolve on-device rather than guess.
+- **Type consistency:** `mayRestore`, `forceUnfreeze`, authority `${applicationId}.freezerbridge`, method `"restore"`, `pkg` extra, `Config.KEY_AUTO_UNFREEZE` — consistent across base-Thor and module tasks.
+
+## Known risk
+The `MODE_WORLD_READABLE`/`XSharedPreferences` handshake (Task 4) is the one LSPosed-version-sensitive piece; Task 7 validates it on the real device before we build on it. Everything else uses public APIs (Hail-proven launcher hook, a plain ContentProvider, the #239 gateway).

--- a/docs/superpowers/plans/2026-07-07-strombringer-auto-unfreeze.md
+++ b/docs/superpowers/plans/2026-07-07-strombringer-auto-unfreeze.md
@@ -89,6 +89,8 @@ fun mayRestore(packageName: String, freezerPackages: Set<String>): Boolean =
 
 ## Task 2: Base-Thor — `FreezerBridgeProvider`
 
+> **Hardened post-review (PR #242):** the shipped provider additionally (a) verifies the caller is a HOME/launcher app before any privileged work — a signature permission can't be used because the caller is the launcher process, not the extension, and extensions use a different signing key — and (b) wraps the restore in `runCatching` so a transient failure returns `ok=false` instead of throwing across Binder. See the actual `FreezerBridgeProvider.kt`; the snippet below is the pre-hardening baseline.
+
 **Files:**
 - Create: `app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt`
 - Modify: `app/src/main/AndroidManifest.xml` (register provider, before `</application>`)

--- a/docs/superpowers/plans/2026-07-07-strombringer-auto-unfreeze.md
+++ b/docs/superpowers/plans/2026-07-07-strombringer-auto-unfreeze.md
@@ -89,7 +89,7 @@ fun mayRestore(packageName: String, freezerPackages: Set<String>): Boolean =
 
 ## Task 2: Base-Thor — `FreezerBridgeProvider`
 
-> **Hardened post-review (PR #242):** the shipped provider additionally (a) verifies the caller is a HOME/launcher app before any privileged work — a signature permission can't be used because the caller is the launcher process, not the extension, and extensions use a different signing key — and (b) wraps the restore in `runCatching` so a transient failure returns `ok=false` instead of throwing across Binder. See the actual `FreezerBridgeProvider.kt`; the snippet below is the pre-hardening baseline.
+> **Hardened post-review (PR #242):** the shipped provider additionally (a) verifies the caller is the device's **current default launcher** (`resolveActivity(HOME, MATCH_DEFAULT_ONLY)` — not just any HOME-declaring app, which is spoofable) before any privileged work; (b) **clears the calling identity** (`Binder.clearCallingIdentity()`) so the restore runs under Thor's own identity, not the launcher's; and (c) wraps the restore in `runCatching` so a transient failure returns `ok=false` instead of throwing across Binder. A signature permission can't be used because the caller is the launcher process, not the extension, and extensions use a different signing key. See the actual `FreezerBridgeProvider.kt`; the snippet below is the pre-hardening baseline.
 
 **Files:**
 - Create: `app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt`
@@ -358,7 +358,11 @@ class LaunchAppHook(private val cl: ClassLoader) {
                 res?.getBoolean("ok") == true
             }.getOrDefault(false)
             if (ok) {
-                // Wait briefly for the unsuspend to land so the original launch proceeds.
+                // Wait briefly for the unsuspend to land so the original launch proceeds. This runs
+                // on the launcher's main thread by necessity — the launch must not proceed until the
+                // target is active — but is bounded (~360ms worst case) and typically returns on the
+                // first poll, since the privileged unfreeze is fast. If a slower gateway ever makes
+                // this janky, move to cancelling + re-issuing the launch after an async restore.
                 repeat(6) { if (!isSuspended(ctx, pkg)) return; Thread.sleep(60) }
                 return
             }

--- a/docs/superpowers/specs/2026-07-07-strombringer-xposed-extension-design.md
+++ b/docs/superpowers/specs/2026-07-07-strombringer-xposed-extension-design.md
@@ -1,0 +1,116 @@
+# Strombringer — Thor's Xposed Extension — Design Spec
+
+**Date:** 2026-07-07
+**Status:** Design (pending user review)
+**Related:** Spec B — [Thor-Extensions distribution](2026-07-07-thor-extensions-distribution-design.md); builds on [Freezer suspend mode (#239)](2026-07-06-freezer-suspend-mode-design.md).
+
+## 1. Goal
+
+Ship **Strombringer**, an optional, LSPosed-activated **Xposed module** that adds three power-user capabilities on top of Thor, while keeping the **base Thor app (both `foss` and `store` flavors) 100% free of Xposed code** so the Play build carries zero policy risk:
+
+1. **Auto-unfreeze suspended apps** — tapping a suspended app's real launcher icon unsuspends and opens it (no system "paused" dialog).
+2. **Signature-bypass + downgrade** — install a mismatched-signature update or an older version without uninstalling (data-loss-free). Delivered by a **fork of CorePatch** (GPLv3).
+3. **Installer spoof** — make a chosen app report `getInstallerPackageName() == com.android.vending`, without reinstalling.
+
+Strombringer is **headless**: no launcher activity, no standalone UI. It is discovered, configured, and controlled **only through Thor**.
+
+## 2. Non-negotiable constraints
+
+- **Base Thor stays Xposed-free.** No `xposed_init`, no `xposedmodule` meta-data, no Xposed API dependency, no danger-zone UI in `:app`. The `store` APK is byte-for-byte unaffected by this feature except the small, store-safe `ExtensionManager` trust change (a signature check) and the foss-only `INTERNET` addition.
+- **GPLv3** — Thor and all extensions are GPLv3; the CorePatch fork inherits it. No license conflict.
+- **No `extension-api` changes** for v1 (verified against the published contract).
+
+## 3. Architecture — the dual-role APK
+
+Strombringer is one installed APK that plays two independent roles, loaded by two different loaders into different processes:
+
+| Role | Loaded by | Runs in | Entry point |
+|---|---|---|---|
+| **Thor extension** (config surface) | Thor `PathClassLoader` | Thor's process | class named in `metaData["thor.extension.class"]`, implements `AutomationExtension` |
+| **LSPosed module** (the hooks) | LSPosed | launcher / `system_server` / target apps | `assets/xposed_init` → `IXposedHookLoadPackage` |
+
+The two roles share **the extension's own config store** (a `ContentProvider` + prefs Strombringer owns). Thor's config UI writes it; the hooks read it via `XSharedPreferences`. Thor's loader ignores the Xposed manifest bits; LSPosed ignores the Thor meta-data.
+
+```
+User taps a suspended app
+  → Strombringer launcher-hook (in launcher proc) sees a suspended target
+  → calls Thor's unsuspend ContentProvider (Thor holds root/Shizuku/Dhizuku privilege)
+  → Thor unsuspends via its gateway → launch proceeds to the now-active app
+```
+
+## 4. Base-Thor changes (in `:app`, both flavors, store-safe)
+
+### 4.1 `ExtensionManager` trust: same-signature → pinned allowlist
+**Problem:** Thor ships under two signatures (Play App Signing key vs. FOSS release key), so the current `isSignatureVerified()` (compare extension cert to *Thor's own* cert, `ExtensionManager.kt:50-74`) can never hold for both. **Fix:** trust extensions signed by a **pinned, dedicated "Thor Extensions" signing certificate**, independent of Thor's own signature.
+
+- Add a constant allowlist of trusted signer SHA-256 cert hashes (the dedicated extension key's cert — see Spec B §2), baked into both flavors (e.g. `res/values/` string-array or a `BuildConfig` field).
+- Rewrite `isSignatureVerified(packageName)` to: read the extension's signing cert (`GET_SIGNING_CERTIFICATES`), SHA-256 it, return `hash in ALLOWLIST`.
+- **Dev ergonomics:** in `BuildConfig.DEBUG`, *also* accept a cert equal to Thor's own (so debug-key local extensions still load without the release extension key).
+- Everything else (`thor.extension.class` discovery, `PathClassLoader` load) is unchanged.
+
+### 4.2 foss gets `INTERNET`
+Move `<uses-permission android:name="android.permission.INTERNET"/>` into `app/src/main/AndroidManifest.xml` (both flavors) and drop the now-redundant one in `app/src/store/AndroidManifest.xml`. Needed for the in-app extension browser (Spec B). *(Store already declared it; net effect on store = none.)*
+
+### 4.3 The `unsuspend` `ContentProvider`
+A base-app provider — **no Xposed code** — that Strombringer's launcher hook calls to unsuspend an app (Thor is where the privilege lives).
+
+- Authority e.g. `com.valhalla.thor.freezer.bridge`; a `call("restore", pkg)` method → `manageAppUseCase.restoreApp(pkg, …)` (reuses the #239 gateway).
+- **Caller-identity reality:** the hook runs in the *launcher's* process, so `Binder.getCallingUid()` is the launcher, not Strombringer — we cannot cryptographically prove "the trusted extension called us." We bound the risk instead:
+  1. The provider **only restores packages currently in the user's freezer** (it can't touch arbitrary app state).
+  2. Restrict callers to system/home-app UIDs.
+  3. Unsuspending a frozen app is inherently low-impact (worst case: an app you froze gets unfrozen).
+- `exported=true` with a custom `android:permission` is *not* used for trust (signature perms require same-signer, which the extension isn't) — gating is the freezer-scope + caller checks above.
+
+## 5. Strombringer module (`verified/strombringer/`, new)
+
+### 5.1 Manifest (dual-role, headless)
+- Thor-extension meta-data: `<meta-data android:name="thor.extension.class" android:value="…StrombringerExtension"/>`.
+- Xposed meta-data: `xposedmodule=true`, `xposeddescription`, `xposedminversion`, `xposedscope` (launchers + `android` + user-selected).
+- `assets/xposed_init` → the `IXposedHookLoadPackage` FQN.
+- **No launcher `<activity>`** with `MAIN/LAUNCHER` → nothing to open standalone.
+
+### 5.2 Config store
+- A `ContentProvider` Strombringer owns (`call()` get/set) persisting to prefs; hooks read via `XSharedPreferences`.
+- Keys: `autoUnfreeze: Boolean`, `sigBypass: Boolean` (default false), `downgrade: Boolean`, `spoofInstaller: Set<pkg>`.
+- A **self-hook** flips a static "active" flag Thor reads (so Thor shows "installed & LSPosed-active").
+
+### 5.3 Thor-side config UI
+`StrombringerExtension : AutomationExtension` — `ConfigurationScreen(shellExecutor, dataStore, onBack)` renders **inside Thor** (existing framework), reads/writes the config store via `LocalContext.current.contentResolver.call(strombringerAuthority, …)`. This is the danger-zone screen; it lives in the extension APK (outside Play), not in `:app`.
+
+### 5.4 Hooks
+| Hook | LSPosed scope | Does |
+|---|---|---|
+| **Auto-unfreeze** | launchers | hook `Activity.startActivityForResult` / `ContextWrapper.startActivity` (Hail-proven, *public* API — low fragility); if target `isPackageSuspended` and `autoUnfreeze` on → call Thor's `restore` provider, then let the launch proceed |
+| **Sig-bypass + downgrade** | `android` (system_server) | **forked CorePatch** hooks on the signature-verify / downgrade paths, gated on `sigBypass`/`downgrade` prefs (default off) |
+| **Installer spoof** | user-selected packages | hook `PackageManager.getInstallerPackageName` / `getInstallSourceInfo` → return `com.android.vending` for `spoofInstaller` packages |
+
+The **auto-unfreeze** hook is the *tractable* one (public API, no system_server internals); the sig-bypass is the fragile forked-CorePatch surface.
+
+## 6. Config bridge (Thor UI ↔ hooks)
+`ConfigurationScreen` runs as Thor's UID, so `ExtensionDataStore` (Thor's storage) can't reach the hooks. Instead the UI calls **Strombringer's own `ContentProvider`** (cross-process to Strombringer), which persists to Strombringer's prefs; hooks read via `XSharedPreferences`. No `extension-api` change; no shared secret.
+
+## 7. Security & safety
+- **Sig-bypass / downgrade default OFF**, behind a confirm dialog + "Thor is not responsible" warning (per product decision); each is an explicit manual toggle.
+- Installer spoof is per-package opt-in.
+- The base-app `restore` provider is freezer-scoped + caller-restricted (§4.3).
+- Strombringer is Thor-Extensions-key-signed → passes the §4.1 allowlist; a repackaged/untrusted build won't load in Thor.
+
+## 8. Build order (proves the risky parts last)
+1. **Auto-unfreeze slice** — base-app `restore` provider + `ExtensionManager` trust change + foss `INTERNET` + a minimal Strombringer with the launcher hook + config store + `ConfigurationScreen`. End-to-end proof of the dual-role + IPC + trust wiring.
+2. **Installer spoof** hook + its toggle.
+3. **Forked CorePatch** sig-bypass/downgrade (the fragile part) + danger-zone toggles/warnings.
+
+## 9. Testing
+- **Base Thor:** unit-test the SHA-256 allowlist match in `isSignatureVerified` (pure); on-device: verified extension loads under both a release-key Thor and a debug-key Thor; an untrusted-signed extension is rejected; the `restore` provider only touches freezer packages.
+- **Strombringer:** device matrix — tap a suspended app → unsuspends + opens; installer spoof flips `getInstallerPackageName` for a chosen app; sig-bypass installs a mismatched-signature update (danger-zone) on the target Android version.
+- **Store build regression:** confirm the `store` APK gains nothing but the signature-check change (no Xposed refs, no danger-zone UI).
+
+## 10. Out of scope (v1)
+- Force-grant restricted permissions (root already covers it).
+- The third-party *untrusted*-extension opt-in trust flow (danger-zone "trust this cert") — future.
+- Multi-user / work-profile suspension nuances beyond current freezer behavior.
+
+## 11. Open risks (honest)
+- **Forked CorePatch maintenance** — re-sync per Android version; this is the accepted cost of the "integrate, don't build" decision.
+- **system_server hook fragility** — sig-bypass may break on new Android releases until re-synced; auto-unfreeze (public-API launcher hook) is far more stable.
+- **`restore` provider exposure** — mitigated (freezer-scoped, low-impact), not cryptographically caller-verified; documented.

--- a/docs/superpowers/specs/2026-07-07-thor-extensions-distribution-design.md
+++ b/docs/superpowers/specs/2026-07-07-thor-extensions-distribution-design.md
@@ -1,0 +1,97 @@
+# Thor-Extensions — Distribution, Signing & In-App Browser — Design Spec
+
+**Date:** 2026-07-07
+**Status:** Design (pending user review)
+**Related:** Spec A — [Strombringer](2026-07-07-strombringer-xposed-extension-design.md).
+
+## 1. Goal
+
+Turn the bare `Thor-Extensions` repo into the **distribution rail** for Thor extensions: source hosting (verified/unverified), a **dedicated signing key**, **GitHub-Actions-built signed release APKs**, a machine-readable **`catalog/extensions.json`**, and an **in-app browser** in Thor that lists + one-tap-installs verified extensions. Third-party developers can submit extensions.
+
+## 2. The dedicated "Thor Extensions" signing key (trust anchor)
+
+- Generate a **new keystore, separate from both Thor app keys** (its own alias/passwords). This is the single trust anchor: **all `verified/` extensions are signed with it**, and Thor pins **its cert SHA-256** in the allowlist (Spec A §4.1).
+- Store it in **Thor-Extensions GitHub secrets** (`EXT_KEYSTORE_BASE64`, `EXT_KEY_ALIAS`, `EXT_KEY_PASSWORD`, `EXT_KEYSTORE_PASSWORD`). CI decodes the base64 keystore to a file at build time.
+- The cert SHA-256 is recorded in `docs/` here and hard-coded in Thor. Rotating it is a coordinated change (new Thor release adds the new hash to the allowlist before extensions switch keys).
+- **Blast radius:** compromise of this key ≠ compromise of the Thor app-release key; the two roles stay separate.
+
+## 3. Repo structure
+
+```
+Thor-Extensions/
+├── README.md               # what extensions are, install/safety, LSPosed note for Strombringer
+├── CONTRIBUTING.md         # third-party submission flow
+├── catalog/extensions.json # machine-readable index Thor fetches
+├── scripts/build-changed.sh# CI helper: build+release only version-bumped verified exts
+├── .github/workflows/release.yml
+├── verified/               # SOURCE of first-party / vetted extensions
+│   ├── thor-automation-extension/   # add a release signingConfig (currently has none)
+│   └── strombringer/                # Spec A
+└── unverified/             # SOURCE of third-party submissions (pre-vetting), source-only
+```
+
+Each `verified/<ext>/` is a standalone Gradle project that (a) declares a `version` (e.g. in `gradle.properties`), (b) has a **`release` `signingConfig`** reading the dedicated key from env (mirrors Thor's `app/build.gradle.kts:93-106` pattern — the automation-extension currently has **no** signing config and must gain one), and (c) `compileOnly`s `thor-extension-api` (+ Asgard, + Xposed API for Strombringer).
+
+## 4. CI (`release.yml`) — version-bump-triggered, like Asgard/extension-api
+
+- **Trigger:** push to `main` touching `verified/**`.
+- **Detect:** `scripts/build-changed.sh` walks each `verified/<ext>/`, reads its `version`, and skips any where a release tag `<ext-id>-v<version>` already exists (idempotent — bumping one extension doesn't rebuild all).
+- **Build + sign:** JDK 21; `./gradlew :app:assembleRelease` with the decoded dedicated keystore → a signed APK.
+- **Release:** create GitHub Release `<ext-id>-v<version>`, attach `<ext-id>-<version>.apk`.
+- **Catalog:** rewrite that extension's entry in `catalog/extensions.json` (version, `apkUrl` = the release asset URL, `sha256` of the APK) and **commit it back** to `main` (`[skip ci]`).
+
+Result: bump a verified extension's version → CI builds, signs, releases, and updates the catalog, hands-free.
+
+## 5. `catalog/extensions.json` schema
+
+```json
+{
+  "schemaVersion": 1,
+  "extensions": [
+    {
+      "id": "com.valhalla.strombringer",
+      "name": "Strombringer",
+      "description": "Auto-unfreeze suspended apps; danger-zone installer (sig-bypass, downgrade); installer spoof.",
+      "author": "Thor",
+      "version": "1.0.0",
+      "verified": true,
+      "requiresLSPosed": true,
+      "minThorVersionCode": 1910,
+      "minSdk": 29,
+      "apkUrl": "https://github.com/trinadhthatakula/Thor-Extensions/releases/download/com.valhalla.strombringer-v1.0.0/strombringer-1.0.0.apk",
+      "sha256": "…",
+      "sourcePath": "verified/strombringer"
+    }
+  ]
+}
+```
+`unverified` entries may appear with `"verified": false` and **no `apkUrl`** (source-only) — the browser shows them as "source only, build yourself."
+
+## 6. In-app extension browser (Thor `:app`, foss now has INTERNET)
+
+- New "Extensions → Browse" screen: fetch `catalog/extensions.json` (raw GitHub URL), render the list (name, version, verified badge, `requiresLSPosed` hint, size).
+- **Install:** download the APK, **verify its SHA-256 against the catalog** (integrity layer), then hand off to Thor's existing installer (`PortableInstaller`). After install, `ExtensionManager` gates loading on the **cert allowlist** (Spec A §4.1) — so download-integrity *and* signer-authenticity are both enforced.
+- **Strombringer** entry shows a "Requires LSPosed — activate after install" note; Thor detects the active flag (Spec A §5.2) and surfaces the danger-zone config once active.
+- Offline/failure: graceful empty/error state; the screen is opt-in (not on a hot path).
+
+## 7. Third-party submission flow (`CONTRIBUTING.md`)
+
+1. Dev opens a PR adding `unverified/<their-ext>/` (source only).
+2. Maintainer reviews source (safety, policy, no malware).
+3. On approval: move to `verified/`, add/confirm the **release `signingConfig`**, bump version → CI signs with the dedicated key + releases + catalogs it. The extension is now Thor-signed → loadable.
+4. Until then it stays `unverified/` (source-only; a user can build+self-sign, but a stock Thor won't load a non-allowlisted signature — the future untrusted-trust opt-in will relax this).
+
+## 8. Security
+- **Authenticity:** cert allowlist (Spec A §4.1) — only dedicated-key-signed extensions load.
+- **Integrity:** catalog `sha256` verified on download.
+- **Transport:** HTTPS raw-GitHub for the catalog + release assets.
+- Dedicated key isolated from app-release keys; lives only in Thor-Extensions CI secrets.
+
+## 9. Testing
+- `scripts/build-changed.sh`: unit/dry-run — detects exactly the version-bumped extensions; idempotent when tags exist.
+- CI on a throwaway version bump: produces a signed APK whose cert SHA-256 == the pinned allowlist value; catalog entry rewritten with the correct `apkUrl` + `sha256`.
+- In Thor: browse → download → SHA-256 mismatch is rejected; a good APK installs and `ExtensionManager` loads it; an APK signed by a non-dedicated key is rejected.
+
+## 10. Build order & out of scope
+- **Order:** (1) dedicated key + pin its hash in Thor (unblocks Spec A trust); (2) add release `signingConfig` to the automation-extension + `release.yml` + `build-changed.sh`; (3) `catalog/extensions.json` + README/CONTRIBUTING; (4) in-app browser.
+- **Out of scope:** the untrusted/third-party-cert opt-in trust UI (future); paid/licensed extensions; delta updates.


### PR DESCRIPTION
Base-Thor foundation for **Strombringer** — Thor's optional, LSPosed-activated Xposed extension. This PR contains **only the store-safe base-app pieces + the design docs**; the module itself lives in a separate repo (`StudioProjects/Strombringer`, GPLv3) and is **not** part of the Play/base app.

## Why
Strombringer keeps the base Thor app (both `foss` and `store`) **100% Xposed-free** — the hooks ship in a separately-installed module, so the Play build carries zero policy risk. The base app only needs a small, privileged bridge so the module's launcher hook can ask Thor to unsuspend a frozen app on launch.

## What's here
- **`RestoreRequest.kt`** — pure `mayRestore(pkg, freezerPkgs)` gate (unit-tested, 3 tests). Bounds the bridge to Freezer packages.
- **`FreezerBridgeProvider`** — an exported `ContentProvider.call("restore", pkg)` → `ManageAppUseCase.forceUnfreeze` (reuses the #239 gateway). No Xposed code. The caller (the module's launcher hook) runs in the launcher process and can't be signature-verified, so access is bounded to Freezer packages rather than cryptographically gated.
- **Design specs + Plan 1** under `docs/superpowers/` (Strombringer architecture + the extensions-distribution design).

## Status
The **auto-unfreeze slice is complete and device-verified on Android 16** (KernelSU + LSPosed): tapping a suspended app's real launcher icon auto-unsuspends and opens it. Built subagent-driven; every task review was clean.

## Notes / follow-ups
- The provider is **inert without the module** (nothing calls it), so it's safe to land now.
- Known Minor (non-blocking): the provider's `getAllPackageNames()` read isn't wrapped in `runCatching`, so a transient DAO failure would throw across the Binder boundary instead of returning `ok=false` (the hook catches it caller-side anyway).
- Release trust (a pinned dedicated-key cert allowlist replacing the current same-signature check), foss `INTERNET` + in-app extension browser, and the danger-zone hooks (installer-spoof, forked-CorePatch sig-bypass) are separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)