### PR TITLE
feat(home): adaptive bento actions grid + Extension Manager entry

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -100,9 +100,9 @@ fun HomeScreen(
     ) {
         Column(
             modifier = Modifier
+                .then(if (isExpanded) Modifier.widthIn(max = 1200.dp) else Modifier)
                 .fillMaxWidth()
                 .align(Alignment.TopCenter)
-                .then(if (isExpanded) Modifier.widthIn(max = 1200.dp) else Modifier)
         ) {
         // 1. Header (full width always)
         DashboardHeader(

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -274,7 +274,10 @@ fun HomeScreen(
 
             // 4. Social Links
             Spacer(Modifier.height(8.dp))
-            SupportCommunitySection(onSupportClick = { showSupportSheet = true })
+            SupportCommunitySection(
+                modifier = Modifier.padding(horizontal = 24.dp),
+                onSupportClick = { showSupportSheet = true }
+            )
         }
         Spacer(Modifier.height(32.dp))
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,14 +13,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -33,8 +31,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -48,6 +44,7 @@ import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.presentation.home.components.AppDistributionChart
 import com.valhalla.thor.presentation.home.components.DashboardHeader
+import com.valhalla.thor.presentation.home.components.HomeActionsBento
 import com.valhalla.thor.presentation.home.components.SupportCommunitySection
 import com.valhalla.thor.presentation.home.components.SummaryStatRow
 import com.valhalla.thor.presentation.settings.SupportDeveloperHelper
@@ -62,6 +59,7 @@ fun HomeScreen(
     onNavigateToFreezer: () -> Unit,
     onReinstallAll: () -> Unit,
     onClearAllCache: (AppListType) -> Unit,
+    onNavigateToExtensionManager: () -> Unit,
     viewModel: HomeViewModel = koinViewModel(),
     installerViewModel: InstallerViewModel = koinViewModel()
 ) {
@@ -84,17 +82,28 @@ fun HomeScreen(
 
     val adaptiveInfo = currentWindowAdaptiveInfoV2()
     val isWideScreen = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
+    val isExpanded = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
+    val hasPrivilege = state.activePrivilegeMode != null
+    val isRoot = state.activePrivilegeMode == PrivilegeMode.ROOT
+    val reinstallVisible = state.activePrivilegeMode != null &&
+        state.unknownInstallerCount > 0 && state.showReinstallCard
 
     // The bottom inset (nav-bar height + system navigation-bar insets) is already applied by
     // MainScreen, which hosts this screen inside Scaffold's Box(Modifier.padding(innerPadding)).
     // Adding another 80.dp + navigationBars here double-counted it and left a large empty gap
     // at the bottom of the scroll content, so this screen owns no bottom inset of its own.
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
             .verticalScroll(rememberScrollState())
     ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.TopCenter)
+                .then(if (isExpanded) Modifier.widthIn(max = 1200.dp) else Modifier)
+        ) {
         // 1. Header (full width always)
         DashboardHeader(
             isRoot = state.isRootAvailable,
@@ -134,45 +143,18 @@ fun HomeScreen(
 
                     Spacer(Modifier.height(16.dp))
 
-                    AnimatedVisibility(state.activePrivilegeMode != null && state.unknownInstallerCount > 0 && state.showReinstallCard) {
-                        Column {
-                            ActionCard(
-                                title = stringResource(R.string.reinstall_all),
-                                subtitle = stringResource(
-                                    R.string.reinstall_all_subtitle,
-                                    state.unknownInstallerCount,
-                                    state.selectedType.name.lowercase()
-                                ),
-                                icon = R.drawable.apk_install,
-                                isWarning = true,
-                                onClick = onReinstallAll,
-                                onClose = { viewModel.dismissReinstallCard() }
-                            )
-                            Spacer(Modifier.height(12.dp))
-                        }
-                    }
-
-                    ActionCard(
-                        title = stringResource(R.string.install_from_file),
-                        subtitle = stringResource(R.string.install_from_file_subtitle),
-                        icon = R.drawable.apk_install,
-                        isPrimary = true,
-                        onClick = {
-                            filePickerLauncher.launch(arrayOf("*/*"))
-                        }
+                    HomeActionsBento(
+                        reinstallVisible = reinstallVisible,
+                        isRoot = isRoot,
+                        hasPrivilege = hasPrivilege,
+                        unknownInstallerCount = state.unknownInstallerCount,
+                        selectedTypeName = state.selectedType.name.lowercase(),
+                        onReinstall = onReinstallAll,
+                        onDismissReinstall = { viewModel.dismissReinstallCard() },
+                        onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
+                        onClearCache = { showCacheDialog = true },
+                        onNavigateToExtensionManager = onNavigateToExtensionManager,
                     )
-
-                    AnimatedVisibility(state.activePrivilegeMode == PrivilegeMode.ROOT) {
-                        Column {
-                            Spacer(Modifier.height(12.dp))
-                            ActionCard(
-                                title = stringResource(R.string.clear_all_cache),
-                                subtitle = stringResource(R.string.clear_all_cache_subtitle),
-                                icon = R.drawable.clear_all,
-                                onClick = { showCacheDialog = true }
-                            )
-                        }
-                    }
                 }
 
                 // Right Column: Distribution & Support
@@ -234,48 +216,19 @@ fun HomeScreen(
             Spacer(Modifier.height(12.dp))
 
             // --- ACTIONS ---
-            AnimatedVisibility(state.activePrivilegeMode != null && state.unknownInstallerCount > 0 && state.showReinstallCard) {
-                Column {
-                    ActionCard(
-                        title = stringResource(R.string.reinstall_all),
-                        subtitle = stringResource(
-                            R.string.reinstall_all_subtitle,
-                            state.unknownInstallerCount,
-                            state.selectedType.name.lowercase()
-                        ),
-                        icon = R.drawable.apk_install,
-                        modifier = Modifier.padding(horizontal = 24.dp),
-                        isWarning = true,
-                        onClick = onReinstallAll,
-                        onClose = { viewModel.dismissReinstallCard() }
-                    )
-                    Spacer(Modifier.height(12.dp))
-                }
-            }
-
-            ActionCard(
-                title = stringResource(R.string.install_from_file),
-                subtitle = stringResource(R.string.install_from_file_subtitle),
-                icon = R.drawable.apk_install,
+            HomeActionsBento(
+                reinstallVisible = reinstallVisible,
+                isRoot = isRoot,
+                hasPrivilege = hasPrivilege,
+                unknownInstallerCount = state.unknownInstallerCount,
+                selectedTypeName = state.selectedType.name.lowercase(),
+                onReinstall = onReinstallAll,
+                onDismissReinstall = { viewModel.dismissReinstallCard() },
+                onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
+                onClearCache = { showCacheDialog = true },
+                onNavigateToExtensionManager = onNavigateToExtensionManager,
                 modifier = Modifier.padding(horizontal = 24.dp),
-                isPrimary = true,
-                onClick = {
-                    filePickerLauncher.launch(arrayOf("*/*"))
-                }
             )
-
-            AnimatedVisibility(state.activePrivilegeMode == PrivilegeMode.ROOT) {
-                Column {
-                    Spacer(Modifier.height(12.dp))
-                    ActionCard(
-                        title = stringResource(R.string.clear_all_cache),
-                        subtitle = stringResource(R.string.clear_all_cache_subtitle),
-                        icon = R.drawable.clear_all,
-                        modifier = Modifier.padding(horizontal = 24.dp),
-                        onClick = { showCacheDialog = true }
-                    )
-                }
-            }
 
             Spacer(Modifier.height(24.dp))
 
@@ -324,6 +277,7 @@ fun HomeScreen(
             SupportCommunitySection(onSupportClick = { showSupportSheet = true })
         }
         Spacer(Modifier.height(32.dp))
+        }
     }
 
     // --- Dialogs ---
@@ -403,102 +357,5 @@ fun HomeScreen(
         SupportDeveloperHelper(
             onDismiss = { showSupportSheet = false }
         )
-    }
-}
-
-@Composable
-private fun ActionCard(
-    title: String,
-    subtitle: String,
-    icon: Int,
-    modifier: Modifier = Modifier,
-    isPrimary: Boolean = false,
-    isWarning: Boolean = false,
-    onClick: () -> Unit,
-    onClose: (() -> Unit)? = null
-) {
-    val containerColor = when {
-        isPrimary -> MaterialTheme.colorScheme.primaryContainer
-        isWarning -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.1f)
-        else -> MaterialTheme.colorScheme.surfaceContainerHigh
-    }
-
-    val contentColor = when {
-        isPrimary -> MaterialTheme.colorScheme.onPrimaryContainer
-        isWarning -> MaterialTheme.colorScheme.tertiary
-        else -> MaterialTheme.colorScheme.onSurface
-    }
-
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(32.dp))
-            .background(containerColor)
-            .then(
-                if (isWarning) {
-                    Modifier.background(
-                        Brush.linearGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.tertiary.copy(alpha = 0.05f),
-                                Color.Transparent
-                            )
-                        )
-                    )
-                } else Modifier
-            )
-            .clickable(onClick = onClick)
-            .padding(if (isPrimary) 24.dp else 20.dp)
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Box(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(24.dp))
-                    .background(
-                        if (isPrimary) MaterialTheme.colorScheme.onPrimaryContainer
-                        else MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f)
-                    )
-                    .padding(if (isPrimary) 16.dp else 12.dp)
-            ) {
-                Icon(
-                    painter = painterResource(icon),
-                    contentDescription = null,
-                    modifier = Modifier.size(if (isPrimary) 24.dp else 20.dp),
-                    tint = if (isPrimary) MaterialTheme.colorScheme.primaryContainer else contentColor
-                )
-            }
-
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = title,
-                    style = if (isPrimary) MaterialTheme.typography.titleLarge else MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.ExtraBold,
-                    color = contentColor
-                )
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (isPrimary) contentColor.copy(alpha = 0.8f) else MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-
-            if (onClose != null) {
-                IconButton(onClick = onClose) {
-                    Icon(
-                        painter = painterResource(R.drawable.round_close),
-                        contentDescription = stringResource(R.string.dismiss),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            } else if (isPrimary) {
-                Icon(
-                    painter = painterResource(R.drawable.open_in_new), // Arrow forward fallback
-                    contentDescription = null,
-                    tint = contentColor.copy(alpha = 0.4f)
-                )
-            }
-        }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
@@ -62,7 +62,7 @@ fun BentoTile(
         if (onClose != null) {
             IconButton(
                 onClick = onClose,
-                modifier = Modifier.align(Alignment.TopEnd).size(28.dp)
+                modifier = Modifier.align(Alignment.TopEnd)
             ) {
                 Icon(
                     painter = painterResource(R.drawable.round_close),

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
@@ -1,0 +1,112 @@
+package com.valhalla.thor.presentation.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.valhalla.thor.R
+
+/**
+ * Compact, size-adaptive action tile for the Home bento grid. Renders correctly both at
+ * Modifier.weight(1f) (half-width, paired) and fillMaxWidth() (full-width, solo). Icon chip on
+ * top, then title + subtitle. Uniform min height so paired tiles align. Mirrors the color logic
+ * of the former ActionCard (isPrimary/isWarning/neutral).
+ */
+@Composable
+fun BentoTile(
+    title: String,
+    subtitle: String,
+    icon: Int,
+    modifier: Modifier = Modifier,
+    isPrimary: Boolean = false,
+    isWarning: Boolean = false,
+    onClose: (() -> Unit)? = null,
+    onClick: () -> Unit,
+) {
+    val containerColor = when {
+        isPrimary -> MaterialTheme.colorScheme.primaryContainer
+        isWarning -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.15f)
+        else -> MaterialTheme.colorScheme.surfaceContainerHigh
+    }
+    val contentColor = when {
+        isPrimary -> MaterialTheme.colorScheme.onPrimaryContainer
+        isWarning -> MaterialTheme.colorScheme.tertiary
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(28.dp))
+            .background(containerColor)
+            .clickable(onClick = onClick)
+            .defaultMinSize(minHeight = 112.dp)
+            .padding(18.dp)
+    ) {
+        if (onClose != null) {
+            IconButton(
+                onClick = onClose,
+                modifier = Modifier.align(Alignment.TopEnd).size(28.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.round_close),
+                    contentDescription = stringResource(R.string.dismiss),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(
+                        if (isPrimary) MaterialTheme.colorScheme.onPrimaryContainer
+                        else MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f)
+                    )
+                    .padding(12.dp)
+            ) {
+                Icon(
+                    painter = painterResource(icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(22.dp),
+                    tint = if (isPrimary) MaterialTheme.colorScheme.primaryContainer else contentColor
+                )
+            }
+            Column {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (isPrimary) contentColor.copy(alpha = 0.8f)
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
@@ -1,0 +1,26 @@
+package com.valhalla.thor.presentation.home.components
+
+/** The four Home action tiles, in bento order. */
+enum class HomeAction { REINSTALL, INSTALL, CLEAR_CACHE, EXTENSIONS }
+
+/**
+ * Computes the Home bento rows from the current privilege/state flags.
+ * Row 1 = [Reinstall?] + Install (Install is always present).
+ * Row 2 = [Clear cache (root)?] + [Extensions (privilege)?].
+ * A row that ends up with a single tile renders full-width; empty rows are dropped.
+ */
+fun homeActionRows(
+    reinstallVisible: Boolean,
+    isRoot: Boolean,
+    hasPrivilege: Boolean,
+): List<List<HomeAction>> {
+    val row1 = listOfNotNull(
+        HomeAction.REINSTALL.takeIf { reinstallVisible },
+        HomeAction.INSTALL,
+    )
+    val row2 = listOfNotNull(
+        HomeAction.CLEAR_CACHE.takeIf { isRoot },
+        HomeAction.EXTENSIONS.takeIf { hasPrivilege },
+    )
+    return listOf(row1, row2).filter { it.isNotEmpty() }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
@@ -1,0 +1,93 @@
+package com.valhalla.thor.presentation.home.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.valhalla.thor.R
+
+/**
+ * The Home actions bento grid. Renders the rows from [homeActionRows]: a two-tile row is a
+ * weighted pair (equal height via IntrinsicSize.Min); a one-tile row spans full width.
+ * Shared by both HomeScreen layout branches. animateContentSize smooths reflow when a tile
+ * appears/disappears (privilege resolves, reinstall dismissed).
+ */
+@Composable
+fun HomeActionsBento(
+    reinstallVisible: Boolean,
+    isRoot: Boolean,
+    hasPrivilege: Boolean,
+    unknownInstallerCount: Int,
+    selectedTypeName: String,
+    onReinstall: () -> Unit,
+    onDismissReinstall: () -> Unit,
+    onInstall: () -> Unit,
+    onClearCache: () -> Unit,
+    onNavigateToExtensionManager: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val rows = homeActionRows(reinstallVisible, isRoot, hasPrivilege)
+
+    @Composable
+    fun Tile(action: HomeAction, tileModifier: Modifier) {
+        when (action) {
+            HomeAction.REINSTALL -> BentoTile(
+                title = stringResource(R.string.reinstall_all),
+                subtitle = stringResource(R.string.reinstall_all_subtitle, unknownInstallerCount, selectedTypeName),
+                icon = R.drawable.apk_install,
+                isWarning = true,
+                onClose = onDismissReinstall,
+                onClick = onReinstall,
+                modifier = tileModifier,
+            )
+            HomeAction.INSTALL -> BentoTile(
+                title = stringResource(R.string.install_from_file),
+                subtitle = stringResource(R.string.install_from_file_subtitle),
+                icon = R.drawable.apk_install,
+                isPrimary = true,
+                onClick = onInstall,
+                modifier = tileModifier,
+            )
+            HomeAction.CLEAR_CACHE -> BentoTile(
+                title = stringResource(R.string.clear_all_cache),
+                subtitle = stringResource(R.string.clear_all_cache_subtitle),
+                icon = R.drawable.clear_all,
+                onClick = onClearCache,
+                modifier = tileModifier,
+            )
+            HomeAction.EXTENSIONS -> BentoTile(
+                title = stringResource(R.string.home_extensions_title),
+                subtitle = stringResource(R.string.home_extensions_subtitle),
+                icon = R.drawable.round_extension,
+                onClick = onNavigateToExtensionManager,
+                modifier = tileModifier,
+            )
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth().animateContentSize(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        rows.forEach { row ->
+            if (row.size == 1) {
+                Tile(row[0], Modifier.fillMaxWidth())
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    row.forEach { action -> Tile(action, Modifier.weight(1f).fillMaxHeight()) }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/SupportCommunitySection.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/SupportCommunitySection.kt
@@ -109,7 +109,7 @@ fun SupportCommunitySection(
         // Three-across when the pane is wide enough; stacks vertically in a narrow pane
         // (landscape phone, foldable-open, medium tablet) so the brand labels never crop.
         BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-            if (maxWidth < 250.dp) {
+            if (maxWidth < 320.dp) {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     links.forEach { link ->
                         CommunityLinkButton(link, uriHandler, Modifier.fillMaxWidth())

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/SupportCommunitySection.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/SupportCommunitySection.kt
@@ -2,6 +2,7 @@ package com.valhalla.thor.presentation.home.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -22,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -62,10 +64,11 @@ fun SupportCommunitySection(
         )
     }
 
+    // Horizontal margin is caller-controlled (via `modifier`) so this card lines up with the
+    // distribution chart card in every layout — phone passes 24.dp, the wide two-pane passes none.
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp)
             .clip(RoundedCornerShape(48.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerLow)
             .padding(24.dp)
@@ -103,30 +106,48 @@ fun SupportCommunitySection(
 
         Spacer(Modifier.height(12.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            links.forEach { link ->
-                OutlinedButton(
-                    onClick = { uriHandler.openUri(link.url) },
-                    modifier = Modifier.weight(1f),
-                    contentPadding = PaddingValues(horizontal = 4.dp, vertical = 8.dp)
-                ) {
-                    Icon(
-                        painter = painterResource(link.iconRes),
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp)
-                    )
-                    Spacer(Modifier.width(4.dp))
-                    Text(
-                        text = stringResource(link.titleRes),
-                        style = MaterialTheme.typography.labelSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
+        // Three-across when the pane is wide enough; stacks vertically in a narrow pane
+        // (landscape phone, foldable-open, medium tablet) so the brand labels never crop.
+        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+            if (maxWidth < 250.dp) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    links.forEach { link ->
+                        CommunityLinkButton(link, uriHandler, Modifier.fillMaxWidth())
+                    }
+                }
+            } else {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    links.forEach { link ->
+                        CommunityLinkButton(link, uriHandler, Modifier.weight(1f))
+                    }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun CommunityLinkButton(
+    link: CommunityLink,
+    uriHandler: UriHandler,
+    modifier: Modifier = Modifier
+) {
+    OutlinedButton(
+        onClick = { uriHandler.openUri(link.url) },
+        modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp)
+    ) {
+        Icon(
+            painter = painterResource(link.iconRes),
+            contentDescription = null,
+            modifier = Modifier.size(16.dp)
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = stringResource(link.titleRes),
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -332,7 +332,10 @@ fun MainScreen(
                                 { mainViewModel.onAppAction(it) }
                             )
                         },
-                        onClearAllCache = { type -> mainViewModel.clearAllCache(type) }
+                        onClearAllCache = { type -> mainViewModel.clearAllCache(type) },
+                        onNavigateToExtensionManager = {
+                            homeBackStack.add(ThorRoute.ExtensionManager)
+                        }
                     )
                 }
 
@@ -460,12 +463,12 @@ fun MainScreen(
                 ) {
                     ExtensionManagerScreen(
                         onBack = {
-                            if (settingsBackStack.size > 1) {
-                                settingsBackStack.removeLastOrNull()
+                            if (currentBackStack.size > 1) {
+                                currentBackStack.removeLastOrNull()
                             }
                         },
                         onBrowse = {
-                            settingsBackStack.add(ThorRoute.ExtensionBrowse)
+                            currentBackStack.add(ThorRoute.ExtensionBrowse)
                         }
                     )
                 }
@@ -475,8 +478,8 @@ fun MainScreen(
                 ) {
                     ExtensionBrowseScreen(
                         onBack = {
-                            if (settingsBackStack.size > 1) {
-                                settingsBackStack.removeLastOrNull()
+                            if (currentBackStack.size > 1) {
+                                currentBackStack.removeLastOrNull()
                             }
                         }
                     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,8 @@
     <string name="reinstall_all_subtitle">%1$d %2$s apps not from Play Store. Fix them?</string>
     <string name="install_from_file">Install from File</string>
     <string name="install_from_file_subtitle">Install APK, XAPK, APKS or Split bundles</string>
+    <string name="home_extensions_title">Extensions</string>
+    <string name="home_extensions_subtitle">Manage &amp; open</string>
     <string name="app_distribution">App Distribution</string>
     <string name="total_apps">TOTAL: %1$d</string>
     <string name="others">Others</string>

--- a/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
@@ -1,0 +1,43 @@
+package com.valhalla.thor.presentation.home
+
+import com.valhalla.thor.presentation.home.components.HomeAction.CLEAR_CACHE
+import com.valhalla.thor.presentation.home.components.HomeAction.EXTENSIONS
+import com.valhalla.thor.presentation.home.components.HomeAction.INSTALL
+import com.valhalla.thor.presentation.home.components.HomeAction.REINSTALL
+import com.valhalla.thor.presentation.home.components.homeActionRows
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeActionsTest {
+    @Test fun noPrivilege_onlyInstallFullWidth() {
+        assertEquals(listOf(listOf(INSTALL)), homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = false))
+    }
+
+    @Test fun shizukuOrDhizuku_withReinstall_extensionsFullWidth() {
+        assertEquals(
+            listOf(listOf(REINSTALL, INSTALL), listOf(EXTENSIONS)),
+            homeActionRows(reinstallVisible = true, isRoot = false, hasPrivilege = true)
+        )
+    }
+
+    @Test fun shizukuOrDhizuku_noReinstall() {
+        assertEquals(
+            listOf(listOf(INSTALL), listOf(EXTENSIONS)),
+            homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = true)
+        )
+    }
+
+    @Test fun root_withReinstall_fullGrid() {
+        assertEquals(
+            listOf(listOf(REINSTALL, INSTALL), listOf(CLEAR_CACHE, EXTENSIONS)),
+            homeActionRows(reinstallVisible = true, isRoot = true, hasPrivilege = true)
+        )
+    }
+
+    @Test fun root_noReinstall() {
+        assertEquals(
+            listOf(listOf(INSTALL), listOf(CLEAR_CACHE, EXTENSIONS)),
+            homeActionRows(reinstallVisible = false, isRoot = true, hasPrivilege = true)
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-07-21-home-bento-extension-manager.md
+++ b/docs/superpowers/plans/2026-07-21-home-bento-extension-manager.md
@@ -1,0 +1,619 @@
+# Home Bento Actions + Extension Manager Entry — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface an Extension Manager entry on Home by restructuring Home's stacked action cards into an adaptive 2×2 "bento" grid, with the Extension tile gated on an active privilege.
+
+**Architecture:** A pure `homeActionRows(...)` function computes which action tiles sit in which row (unit-tested against the visibility matrix). A new size-adaptive `BentoTile` replaces the old full-width `ActionCard`. `HomeActionsBento` renders the rows (pair → weighted; solo → full-width) and is used by both HomeScreen layout branches. Navigation reuses the existing shared `ExtensionManager` destination, pushed onto the active tab's back stack.
+
+**Tech Stack:** Kotlin, Jetpack Compose (Material 3), `androidx.compose.material3.adaptive` (`currentWindowAdaptiveInfoV2` + `WindowSizeClass`), Koin, JUnit4 (unit test).
+
+## Global Constraints
+
+- minSdk 28; JDK 21 (Zulu); Compose Material 3.
+- No ViewModel/data-layer changes — every value already exists in `HomeUiState`.
+- Existing actions (reinstall / install / clear-cache) must stay behavior-identical.
+- Extension tile visible iff `state.activePrivilegeMode != null`; Clear-cache tile iff `== PrivilegeMode.ROOT`.
+- Adaptive across COMPACT/MEDIUM/EXPANDED width classes; tiles purely weight-based; EXPANDED caps Home content to a centered `1200.dp` max-width.
+- Both `assembleFossDebug` AND `assembleStoreDebug` must build green.
+- Extension icon = `R.drawable.round_extension` (same as the Settings row).
+- New user-facing strings must eventually be translated into `ar/es/fr/zh-rCN` (maintainer i18n pass) to keep lint clean.
+
+---
+
+### Task 1: Pure bento-row logic (+ unit test)
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt`
+- Test: `app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt`
+
+**Interfaces:**
+- Produces: `enum class HomeAction { REINSTALL, INSTALL, CLEAR_CACHE, EXTENSIONS }` and `fun homeActionRows(reinstallVisible: Boolean, isRoot: Boolean, hasPrivilege: Boolean): List<List<HomeAction>>` — a list of rows, each row 1–2 actions; empty rows dropped.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.valhalla.thor.presentation.home
+
+import com.valhalla.thor.presentation.home.components.HomeAction.CLEAR_CACHE
+import com.valhalla.thor.presentation.home.components.HomeAction.EXTENSIONS
+import com.valhalla.thor.presentation.home.components.HomeAction.INSTALL
+import com.valhalla.thor.presentation.home.components.HomeAction.REINSTALL
+import com.valhalla.thor.presentation.home.components.homeActionRows
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeActionsTest {
+    @Test fun noPrivilege_onlyInstallFullWidth() {
+        assertEquals(listOf(listOf(INSTALL)), homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = false))
+    }
+
+    @Test fun shizukuOrDhizuku_withReinstall_extensionsFullWidth() {
+        assertEquals(
+            listOf(listOf(REINSTALL, INSTALL), listOf(EXTENSIONS)),
+            homeActionRows(reinstallVisible = true, isRoot = false, hasPrivilege = true)
+        )
+    }
+
+    @Test fun shizukuOrDhizuku_noReinstall() {
+        assertEquals(
+            listOf(listOf(INSTALL), listOf(EXTENSIONS)),
+            homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = true)
+        )
+    }
+
+    @Test fun root_withReinstall_fullGrid() {
+        assertEquals(
+            listOf(listOf(REINSTALL, INSTALL), listOf(CLEAR_CACHE, EXTENSIONS)),
+            homeActionRows(reinstallVisible = true, isRoot = true, hasPrivilege = true)
+        )
+    }
+
+    @Test fun root_noReinstall() {
+        assertEquals(
+            listOf(listOf(INSTALL), listOf(CLEAR_CACHE, EXTENSIONS)),
+            homeActionRows(reinstallVisible = false, isRoot = true, hasPrivilege = true)
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.presentation.home.HomeActionsTest"`
+Expected: FAIL — unresolved reference `homeActionRows` / `HomeAction`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```kotlin
+package com.valhalla.thor.presentation.home.components
+
+/** The four Home action tiles, in bento order. */
+enum class HomeAction { REINSTALL, INSTALL, CLEAR_CACHE, EXTENSIONS }
+
+/**
+ * Computes the Home bento rows from the current privilege/state flags.
+ * Row 1 = [Reinstall?] + Install (Install is always present).
+ * Row 2 = [Clear cache (root)?] + [Extensions (privilege)?].
+ * A row that ends up with a single tile renders full-width; empty rows are dropped.
+ */
+fun homeActionRows(
+    reinstallVisible: Boolean,
+    isRoot: Boolean,
+    hasPrivilege: Boolean,
+): List<List<HomeAction>> {
+    val row1 = listOfNotNull(
+        HomeAction.REINSTALL.takeIf { reinstallVisible },
+        HomeAction.INSTALL,
+    )
+    val row2 = listOfNotNull(
+        HomeAction.CLEAR_CACHE.takeIf { isRoot },
+        HomeAction.EXTENSIONS.takeIf { hasPrivilege },
+    )
+    return listOf(row1, row2).filter { it.isNotEmpty() }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.presentation.home.HomeActionsTest"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt \
+        app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
+git commit -m "feat(home): pure bento-row logic for Home actions (+unit test)"
+```
+
+---
+
+### Task 2: `BentoTile` composable
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt`
+
+**Interfaces:**
+- Produces: `@Composable fun BentoTile(title: String, subtitle: String, icon: Int, modifier: Modifier = Modifier, isPrimary: Boolean = false, isWarning: Boolean = false, onClose: (() -> Unit)? = null, onClick: () -> Unit)` — the caller supplies width via `modifier` (`Modifier.weight(1f).fillMaxHeight()` for a pair, `Modifier.fillMaxWidth()` for solo).
+
+- [ ] **Step 1: Write the composable**
+
+```kotlin
+package com.valhalla.thor.presentation.home.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.valhalla.thor.R
+
+/**
+ * Compact, size-adaptive action tile for the Home bento grid. Renders correctly both at
+ * Modifier.weight(1f) (half-width, paired) and fillMaxWidth() (full-width, solo). Icon chip on
+ * top, then title + subtitle. Uniform min height so paired tiles align. Mirrors the color logic
+ * of the former ActionCard (isPrimary/isWarning/neutral).
+ */
+@Composable
+fun BentoTile(
+    title: String,
+    subtitle: String,
+    icon: Int,
+    modifier: Modifier = Modifier,
+    isPrimary: Boolean = false,
+    isWarning: Boolean = false,
+    onClose: (() -> Unit)? = null,
+    onClick: () -> Unit,
+) {
+    val containerColor = when {
+        isPrimary -> MaterialTheme.colorScheme.primaryContainer
+        isWarning -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.15f)
+        else -> MaterialTheme.colorScheme.surfaceContainerHigh
+    }
+    val contentColor = when {
+        isPrimary -> MaterialTheme.colorScheme.onPrimaryContainer
+        isWarning -> MaterialTheme.colorScheme.tertiary
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(28.dp))
+            .background(containerColor)
+            .clickable(onClick = onClick)
+            .defaultMinSize(minHeight = 112.dp)
+            .padding(18.dp)
+    ) {
+        if (onClose != null) {
+            IconButton(
+                onClick = onClose,
+                modifier = Modifier.align(Alignment.TopEnd).size(28.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.round_close),
+                    contentDescription = stringResource(R.string.dismiss),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(
+                        if (isPrimary) MaterialTheme.colorScheme.onPrimaryContainer
+                        else MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f)
+                    )
+                    .padding(12.dp)
+            ) {
+                Icon(
+                    painter = painterResource(icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(22.dp),
+                    tint = if (isPrimary) MaterialTheme.colorScheme.primaryContainer else contentColor
+                )
+            }
+            Column {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (isPrimary) contentColor.copy(alpha = 0.8f)
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL (no unresolved refs; all imports used).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
+git commit -m "feat(home): add size-adaptive BentoTile component"
+```
+
+---
+
+### Task 3: `HomeActionsBento` composable
+
+**Files:**
+- Create: `app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt`
+
+**Interfaces:**
+- Consumes: `homeActionRows(...)`, `HomeAction`, `BentoTile(...)`.
+- Produces: `@Composable fun HomeActionsBento(reinstallVisible: Boolean, isRoot: Boolean, hasPrivilege: Boolean, unknownInstallerCount: Int, selectedTypeName: String, onReinstall: () -> Unit, onDismissReinstall: () -> Unit, onInstall: () -> Unit, onClearCache: () -> Unit, onNavigateToExtensionManager: () -> Unit, modifier: Modifier = Modifier)`.
+
+- [ ] **Step 1: Write the composable**
+
+```kotlin
+package com.valhalla.thor.presentation.home.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.valhalla.thor.R
+
+/**
+ * The Home actions bento grid. Renders the rows from [homeActionRows]: a two-tile row is a
+ * weighted pair (equal height via IntrinsicSize.Min); a one-tile row spans full width.
+ * Shared by both HomeScreen layout branches. animateContentSize smooths reflow when a tile
+ * appears/disappears (privilege resolves, reinstall dismissed).
+ */
+@Composable
+fun HomeActionsBento(
+    reinstallVisible: Boolean,
+    isRoot: Boolean,
+    hasPrivilege: Boolean,
+    unknownInstallerCount: Int,
+    selectedTypeName: String,
+    onReinstall: () -> Unit,
+    onDismissReinstall: () -> Unit,
+    onInstall: () -> Unit,
+    onClearCache: () -> Unit,
+    onNavigateToExtensionManager: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val rows = homeActionRows(reinstallVisible, isRoot, hasPrivilege)
+
+    @Composable
+    fun Tile(action: HomeAction, tileModifier: Modifier) {
+        when (action) {
+            HomeAction.REINSTALL -> BentoTile(
+                title = stringResource(R.string.reinstall_all),
+                subtitle = stringResource(R.string.reinstall_all_subtitle, unknownInstallerCount, selectedTypeName),
+                icon = R.drawable.apk_install,
+                isWarning = true,
+                onClose = onDismissReinstall,
+                onClick = onReinstall,
+                modifier = tileModifier,
+            )
+            HomeAction.INSTALL -> BentoTile(
+                title = stringResource(R.string.install_from_file),
+                subtitle = stringResource(R.string.install_from_file_subtitle),
+                icon = R.drawable.apk_install,
+                isPrimary = true,
+                onClick = onInstall,
+                modifier = tileModifier,
+            )
+            HomeAction.CLEAR_CACHE -> BentoTile(
+                title = stringResource(R.string.clear_all_cache),
+                subtitle = stringResource(R.string.clear_all_cache_subtitle),
+                icon = R.drawable.clear_all,
+                onClick = onClearCache,
+                modifier = tileModifier,
+            )
+            HomeAction.EXTENSIONS -> BentoTile(
+                title = stringResource(R.string.home_extensions_title),
+                subtitle = stringResource(R.string.home_extensions_subtitle),
+                icon = R.drawable.round_extension,
+                onClick = onNavigateToExtensionManager,
+                modifier = tileModifier,
+            )
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth().animateContentSize(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        rows.forEach { row ->
+            if (row.size == 1) {
+                Tile(row[0], Modifier.fillMaxWidth())
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    row.forEach { action -> Tile(action, Modifier.weight(1f).fillMaxHeight()) }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
+git commit -m "feat(home): add HomeActionsBento adaptive grid"
+```
+
+---
+
+### Task 4: Integrate the bento into HomeScreen + remove ActionCard + expanded cap
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt`
+
+**Interfaces:**
+- Consumes: `HomeActionsBento(...)`.
+- Produces: updated `HomeScreen(onNavigateToApps, onNavigateToFreezer, onReinstallAll, onClearAllCache, onNavigateToExtensionManager, viewModel, installerViewModel)` — new `onNavigateToExtensionManager: () -> Unit` param.
+
+- [ ] **Step 1: Add the new callback param**
+
+In the `HomeScreen(...)` signature (HomeScreen.kt:60-67), add after `onClearAllCache`:
+
+```kotlin
+    onClearAllCache: (AppListType) -> Unit,
+    onNavigateToExtensionManager: () -> Unit,
+    viewModel: HomeViewModel = koinViewModel(),
+```
+
+- [ ] **Step 2: Add derived flags + expanded breakpoint**
+
+Right after the existing `isWideScreen` line (HomeScreen.kt:86), add:
+
+```kotlin
+    val isExpanded = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
+    val hasPrivilege = state.activePrivilegeMode != null
+    val isRoot = state.activePrivilegeMode == PrivilegeMode.ROOT
+    val reinstallVisible = state.activePrivilegeMode != null &&
+        state.unknownInstallerCount > 0 && state.showReinstallCard
+```
+
+- [ ] **Step 3: Wrap content in a centered, expanded-capped container**
+
+Replace the root `Column(...)` opener (HomeScreen.kt:92-97) with a `Box` that scrolls, holding a width-capped centered `Column`:
+
+```kotlin
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.TopCenter)
+                .then(if (isExpanded) Modifier.widthIn(max = 1200.dp) else Modifier)
+        ) {
+```
+
+Add the matching closing `}` for the new `Box` right after the existing `Spacer(Modifier.height(32.dp))` that ends the content Column (HomeScreen.kt:326-327). Add imports: `androidx.compose.foundation.layout.widthIn` (Alignment is already imported).
+
+- [ ] **Step 4: Replace the PHONE-branch action cards with the bento**
+
+Delete the three action blocks in the `else` (phone) branch — the reinstall `AnimatedVisibility` (HomeScreen.kt:237-254), the install `ActionCard` (256-265), and the clear-cache `AnimatedVisibility` (267-278) — and replace with:
+
+```kotlin
+            HomeActionsBento(
+                reinstallVisible = reinstallVisible,
+                isRoot = isRoot,
+                hasPrivilege = hasPrivilege,
+                unknownInstallerCount = state.unknownInstallerCount,
+                selectedTypeName = state.selectedType.name.lowercase(),
+                onReinstall = onReinstallAll,
+                onDismissReinstall = { viewModel.dismissReinstallCard() },
+                onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
+                onClearCache = { showCacheDialog = true },
+                onNavigateToExtensionManager = onNavigateToExtensionManager,
+                modifier = Modifier.padding(horizontal = 24.dp),
+            )
+```
+
+- [ ] **Step 5: Replace the WIDE-branch action cards with the bento**
+
+In the wide branch left column, delete the reinstall `AnimatedVisibility` (HomeScreen.kt:137-153), the install `ActionCard` (155-163), and the clear-cache `AnimatedVisibility` (165-175), and replace with the same call but no horizontal padding (the parent Row already pads 24dp):
+
+```kotlin
+                    HomeActionsBento(
+                        reinstallVisible = reinstallVisible,
+                        isRoot = isRoot,
+                        hasPrivilege = hasPrivilege,
+                        unknownInstallerCount = state.unknownInstallerCount,
+                        selectedTypeName = state.selectedType.name.lowercase(),
+                        onReinstall = onReinstallAll,
+                        onDismissReinstall = { viewModel.dismissReinstallCard() },
+                        onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
+                        onClearCache = { showCacheDialog = true },
+                        onNavigateToExtensionManager = onNavigateToExtensionManager,
+                    )
+```
+
+Add the import: `com.valhalla.thor.presentation.home.components.HomeActionsBento`.
+
+- [ ] **Step 6: Delete the now-orphaned `ActionCard`**
+
+Delete the entire `private fun ActionCard(...)` composable (HomeScreen.kt:409-504) and any now-unused imports it alone used (check: `Brush`, `Color`, `IconButton` — remove only if no other usage remains in the file after Steps 4–5).
+
+- [ ] **Step 7: Verify it compiles**
+
+Run: `./gradlew :app:compileFossDebugKotlin`
+Expected: BUILD SUCCESSFUL (no unresolved refs, no unused-import errors).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+git commit -m "feat(home): render actions as adaptive bento; add Extension Manager tile; drop ActionCard"
+```
+
+---
+
+### Task 5: Wire navigation in MainScreen + add strings
+
+**Files:**
+- Modify: `app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt:319-337, 458-483`
+- Modify: `app/src/main/res/values/strings.xml:69`
+
+**Interfaces:**
+- Consumes: `HomeScreen(..., onNavigateToExtensionManager)`, `ThorRoute.ExtensionManager`, `currentBackStack` (MainScreen.kt:138).
+
+- [ ] **Step 1: Pass the Home → Extension Manager callback**
+
+In the `entry<ThorRoute.Home> { HomeScreen(...) }` block (MainScreen.kt:319-337), add after `onClearAllCache = ...` (line 335):
+
+```kotlin
+                        onClearAllCache = { type -> mainViewModel.clearAllCache(type) },
+                        onNavigateToExtensionManager = {
+                            homeBackStack.add(ThorRoute.ExtensionManager)
+                        }
+```
+
+- [ ] **Step 2: Make the shared ExtensionManager entry pop/push the ACTIVE stack**
+
+In `entry<ThorRoute.ExtensionManager>` (MainScreen.kt:461-470), replace both `settingsBackStack` references with `currentBackStack` so back-nav works whether it was opened from Home or Settings:
+
+```kotlin
+                    ExtensionManagerScreen(
+                        onBack = {
+                            if (currentBackStack.size > 1) {
+                                currentBackStack.removeLastOrNull()
+                            }
+                        },
+                        onBrowse = {
+                            currentBackStack.add(ThorRoute.ExtensionBrowse)
+                        }
+                    )
+```
+
+- [ ] **Step 3: Same fix for the ExtensionBrowse entry**
+
+In `entry<ThorRoute.ExtensionBrowse>` (MainScreen.kt:476-482), replace `settingsBackStack` with `currentBackStack`:
+
+```kotlin
+                    ExtensionBrowseScreen(
+                        onBack = {
+                            if (currentBackStack.size > 1) {
+                                currentBackStack.removeLastOrNull()
+                            }
+                        }
+                    )
+```
+
+- [ ] **Step 4: Add the two strings**
+
+In `app/src/main/res/values/strings.xml`, after `install_from_file_subtitle` (line 69), add:
+
+```xml
+    <string name="home_extensions_title">Extensions</string>
+    <string name="home_extensions_subtitle">Manage &amp; open</string>
+```
+
+> i18n note: these two keys will show as `MissingTranslation` in `ar/es/fr/zh-rCN` until translated — add them in the locale `strings.xml` files (maintainer i18n pass) before release to keep lint clean. English text: "Extensions" / "Manage & open".
+
+- [ ] **Step 5: Verify both flavors compile**
+
+Run: `./gradlew :app:compileFossDebugKotlin :app:compileStoreDebugKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt \
+        app/src/main/res/values/strings.xml
+git commit -m "feat(home): open Extension Manager from Home; active-stack back handling; strings"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Unit tests**
+
+Run: `./gradlew :app:testFossDebugUnitTest --tests "com.valhalla.thor.presentation.home.HomeActionsTest"`
+Expected: PASS (5).
+
+- [ ] **Step 2: Build both flavors**
+
+Run: `./gradlew assembleFossDebug assembleStoreDebug`
+Expected: BUILD SUCCESSFUL for both.
+
+- [ ] **Step 3: Lint (expect only the 2 new-string translations pending)**
+
+Run: `./gradlew :app:lintFossDebug`
+Expected: the only *new* findings are `MissingTranslation` for `home_extensions_title` / `home_extensions_subtitle` (until the maintainer translates them). No new code warnings/errors.
+
+- [ ] **Step 4: Manual device/emulator matrix**
+
+Verify against the spec's visibility matrix and adaptivity:
+- COMPACT phone (portrait + landscape): bento renders; privilege states NONE / Shizuku / Dhizuku / ROOT × (with/without unknown installers) match the matrix; reinstall dismiss collapses row 1 to full-width Install.
+- MEDIUM/EXPANDED tablet: two-pane; bento in the left pane; EXPANDED content is centered/capped (no edge-to-edge sprawl).
+- Resize a freeform/ChromeOS/DeX window and fold/unfold a foldable → layout reflows live.
+- Tap **Extensions** on Home → opens Extension Manager (consent sheet on first run); **back** returns to Home (not Settings). Settings → Extension Manager still works and its back returns to Settings.
+
+- [ ] **Step 5: Commit any fixups** (only if the manual pass required changes)
+
+```bash
+git add -A && git commit -m "fix(home): address bento verification findings"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** visibility gate (T1/T3/T4), bento layout + pairing/fallback (T1/T3), adaptive BentoTile (T2), width classes + EXPANDED cap (T4), nav reuse + active-stack back fix (T5), Settings entry retained (unchanged), strings + i18n note (T5), testing matrix (T6). All covered.
+- **Placeholders:** none — every code step has complete code; the only "later" item is the maintainer i18n pass, explicitly flagged with the exact keys/text.
+- **Type consistency:** `homeActionRows(reinstallVisible, isRoot, hasPrivilege)` and `HomeAction` names are identical across T1/T3; `HomeActionsBento(...)` param list identical in T3 (definition) and T4 (both call sites); `onNavigateToExtensionManager` name consistent T4/T5; icon `R.drawable.round_extension` consistent.

--- a/docs/superpowers/specs/2026-07-21-home-bento-extension-manager-design.md
+++ b/docs/superpowers/specs/2026-07-21-home-bento-extension-manager-design.md
@@ -1,0 +1,90 @@
+# Home Bento Actions + Extension Manager Entry — Design
+
+**Date:** 2026-07-21
+**Branch:** `feat/home-bento-extension-manager`
+**Status:** Design — approved in brainstorming, pending spec review
+
+## Problem / Goal
+
+Reaching an extension today (e.g. Stormbringer) takes four steps: **Settings → scroll → Extension Manager → open extension**. We want a first-class **Extension Manager** entry on the **Home** screen. While adding it, restructure Home's stacked action cards into an **adaptive 2×2 "bento" grid** that stays elegant across phones, tablets, foldables, and resizable desktop/ChromeOS/browser windows.
+
+## Decisions (from brainstorming)
+
+1. **Visibility of the Extension Manager tile:** show iff `state.activePrivilegeMode != null` (a privilege is *actively resolved* — Root/Shizuku/Dhizuku). This is the exact predicate Home already uses to gate the reinstall card.
+2. **Layout:** an adaptive **2×2 bento** replacing the vertical `ActionCard` stack:
+   - **Row 1** = `[Reinstall All?] · [Install from file]`
+   - **Row 2** = `[Clear all cache (ROOT)?] · [Extension Manager (≠NONE)?]`
+   - When a row's *conditional* (left) tile is hidden, the surviving tile **spans the full row**.
+3. **Tile style:** a new compact, size-adaptive **`BentoTile`** (icon → title → one-line subtitle, stacked; uniform height). It **replaces** the existing `ActionCard`, which becomes orphaned and is deleted.
+4. **Adaptive behavior:** drive layout off the three width classes (`COMPACT / MEDIUM / EXPANDED`), weight-based tiles, reactive to window/fold changes. On **EXPANDED**, keep the 2×2 and **cap the Home content to a centered max-width (~1100–1200dp)** so tiles/text don't sprawl.
+5. **Retained defaults:** the Settings → Extension Manager entry **stays** (Home is an added shortcut). **Install from file stays the visually primary tile.** Reinstall keeps its warning tint + dismiss ✕. Paired tiles share a **uniform height**.
+
+## Architecture / Components
+
+All UI-layer; **no ViewModel/data changes** (every value already lives in `HomeUiState`).
+
+### `BentoTile` (new)
+Compact, width-agnostic card. Suggested signature:
+```
+@Composable private fun BentoTile(
+    title: String, subtitle: String, icon: Int,
+    modifier: Modifier = Modifier,
+    isPrimary: Boolean = false, isWarning: Boolean = false,
+    onClose: (() -> Unit)? = null,
+    onClick: () -> Unit,
+)
+```
+- Vertical layout: icon chip (top) → title → subtitle. `maxLines` + ellipsis on both texts so nothing breaks at half-width.
+- Uniform `minHeight` (~96dp) so paired tiles align; renders correctly at both `Modifier.weight(1f)` (half) and `fillMaxWidth()` (full).
+- Carries over the existing color logic (`isPrimary` → primaryContainer, `isWarning` → tertiary tint, else surfaceContainerHigh) and the optional close button.
+
+### `HomeActionsBento` (new)
+Encapsulates the grid so it's used by **both** layout branches (removing today's duplicated `ActionCard` blocks). Takes the relevant state (`activePrivilegeMode`, `unknownInstallerCount`, `showReinstallCard`, `selectedType`) + callbacks (`onReinstallAll`, `onDismissReinstall`, `onInstallFromFile`, `onClearCache`, `onNavigateToExtensionManager`) + a `modifier`.
+- Builds the two rows with `listOfNotNull`:
+  - `row1 = listOfNotNull(reinstallTile.takeIf { reinstallVisible }, installTile)`
+  - `row2 = listOfNotNull(clearCacheTile.takeIf { isRoot }, extensionTile.takeIf { hasPrivilege })`
+- A `BentoRow(tiles)` helper: **2 tiles** → `Row(height = IntrinsicSize.Min)` with each `weight(1f)`, 12dp gap; **1 tile** → full width; **0** → render nothing.
+- `Modifier.animateContentSize()` on the container so dismiss / privilege-resolution reflows smoothly.
+
+### Page layout (width-class driven)
+- **COMPACT** (phone): single column — `DashboardHeader`, `SummaryStatRow`, `HomeActionsBento` (full width, 24dp h-padding), distribution chart, support.
+- **MEDIUM / EXPANDED** (tablet/foldable/split window): two-pane `Row` — **left** = `SummaryStatRow` + `HomeActionsBento`; **right** = distribution + support (today's structure).
+- **EXPANDED**: wrap the whole content in a **centered, max-width-capped** container (~1100–1200dp).
+- Width classes via `currentWindowAdaptiveInfoV2().windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND / WIDTH_DP_EXPANDED_LOWER_BOUND)` (already a dependency). Recomputes on window/config/fold changes → live reflow on ChromeOS/DeX/browser resize and foldable posture changes.
+
+### Navigation
+Add `onNavigateToExtensionManager: () -> Unit` to `HomeScreen`. In `MainScreen`'s `entry<ThorRoute.Home>`, wire `onNavigateToExtensionManager = { homeBackStack.add(ThorRoute.ExtensionManager) }` — reuses the **shared** `ExtensionManager` destination (no new route/entry). The in-screen consent sheet (`extensionConsentAccepted`) still fires on first open regardless of entry point.
+
+## Visibility matrix
+
+| Privilege | unknown installers >0 & not dismissed | Row 1 | Row 2 |
+|---|---|---|---|
+| NONE | — | `[Install (full)]` | *(none)* |
+| Shizuku/Dhizuku | yes | `[Reinstall][Install]` | `[Extensions (full)]` |
+| Shizuku/Dhizuku | no | `[Install (full)]` | `[Extensions (full)]` |
+| ROOT | yes | `[Reinstall][Install]` | `[ClearCache][Extensions]` |
+| ROOT | no | `[Install (full)]` | `[ClearCache][Extensions]` |
+
+## Strings
+- `home_extensions_title` = "Extensions"
+- `home_extensions_subtitle` = "Manage & open"
+- Icon: reuse the extension icon used by the Settings "Extension Manager" row / `ExtensionManagerScreen`.
+
+## Edge cases
+- **Privilege resolves late** (`isPrivilegeReady` flips): tiles appear when `activePrivilegeMode` resolves; `animateContentSize` smooths the reflow.
+- **Reinstall dismissed:** Row 1 collapses `[Reinstall][Install]` → `[Install (full)]`.
+- **First-ever open:** consent sheet appears inside `ExtensionManagerScreen` (unchanged behavior).
+- **Very narrow left pane** (medium two-pane): tiles are weight-based, so they shrink gracefully; texts ellipsize.
+
+## Out of scope (YAGNI)
+- Extension count / badge on the tile (would need new IPC/repo wiring into `HomeViewModel`).
+- Opening a *specific* extension directly from Home (the tile opens the manager list).
+- 3+ column bento on expanded (we cap width instead).
+
+## Testing / verification
+- Build `assembleFossDebug` + `assembleStoreDebug` green.
+- Manual device/emulator matrix:
+  - **Compact** phone portrait + landscape.
+  - **Medium/Expanded** tablet; **resize** a freeform/ChromeOS/DeX window and confirm live reflow; **foldable** fold/unfold.
+  - Each privilege state (NONE / Shizuku / Dhizuku / ROOT) × (with / without unknown installers) matches the visibility matrix.
+  - Tap **Extensions** → opens Extension Manager (consent sheet on first run); Settings entry still works.


### PR DESCRIPTION
## Home: adaptive bento actions grid + Extension Manager entry

Surfaces an **Extension Manager** entry directly on Home (previously buried under Settings → scroll → Extension Manager), and restructures Home's stacked action cards into an **adaptive 2×2 "bento" grid**.

### What changed
- **New pure logic** `homeActionRows(...)` + `HomeAction` enum — encodes the visibility matrix, unit-tested (5 cases).
- **New `BentoTile`** — compact, size-adaptive tile (replaces the old full-width `ActionCard`, which is deleted).
- **New `HomeActionsBento`** — the grid, shared by both layout branches:
  - Row 1 = `[Reinstall All?] · [Install from file]`; Row 2 = `[Clear all cache (ROOT)?] · [Extension Manager (privilege≠NONE)?]`.
  - When a row's conditional tile is hidden, the surviving tile spans full width; `animateContentSize` smooths reflow.
- **Extension Manager tile** — visible only when `activePrivilegeMode != null`; opens the shared `ExtensionManager` destination via `homeBackStack`. The shared `ExtensionManager`/`ExtensionBrowse` entries now pop/push the **active tab's** back stack (`currentBackStack`), so back-nav is correct from Home *and* Settings (previously hard-coded to `settingsBackStack`).
- **Adaptive** across `COMPACT / MEDIUM / EXPANDED` width classes; tiles are weight-based; on EXPANDED the content is centered and capped at 1200dp so it doesn't sprawl.
- **QA polish (on-device):** fixed the Support & Community card to align its margins with the App Distribution card in the wide two-pane, and to stack its Play Store/GitHub/Telegram buttons vertically in narrow panes so the labels don't crop.

### Verification
- `HomeActionsTest` 5/5 pass; `assembleFossDebug` + `assembleStoreDebug` green.
- Built via subagent-driven development: fresh implementer + two-stage (spec + quality) review per task, plus a whole-branch review (its one Important finding — an EXPANDED width-cap modifier-order bug — is fixed in `1ab4a9f`).
- **On-device (maintainer):** bento confirmed on multiple phones + emulator; Support & Community fix confirmed.

### Deferred (non-blocking)
- **i18n:** `home_extensions_title` / `home_extensions_subtitle` need `ar/es/fr/zh-rCN` translations (the only lint findings — 2 `MissingTranslation`; the rest is the 28 pre-existing warnings). Same maintainer i18n workflow as before.
- Minor (from review, non-blocking): `BentoTile` dismiss touch target is 28dp; App-Distribution chart `Column` is duplicated across both branches (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
