### PR TITLE
Odin Phase 1: prep :suCore (MainShell hang fix + ThorRootService→:app + Apache-2.0)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
         </activity>
 
         <service
-            android:name="com.valhalla.superuser.ipc.ThorRootService"
+            android:name="com.valhalla.thor.rootservice.ThorRootService"
             android:process=":root"
             android:exported="false"
             tools:ignore="Instantiatable" />

--- a/app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl
+++ b/app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl
@@ -1,4 +1,4 @@
-package com.valhalla.superuser.ipc;
+package com.valhalla.thor.rootservice;
 
 interface IThorRootService {
     void setAppSuspended(String packageName, boolean suspended);

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -8,7 +8,7 @@ import android.content.ServiceConnection
 import android.os.IBinder
 import com.valhalla.superuser.ipc.RootService
 import com.valhalla.superuser.ShellUtils
-import com.valhalla.superuser.ipc.IThorRootService
+import com.valhalla.thor.rootservice.IThorRootService
 import com.valhalla.superuser.ktx.ShellRepository
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.domain.gateway.SystemGateway
@@ -85,7 +85,7 @@ class RootSystemGateway(
         withTimeoutOrNull(ROOT_SERVICE_BIND_TIMEOUT_MS) {
             withContext(Dispatchers.Main) {
                 suspendCancellableCoroutine { continuation ->
-                    val intent = Intent(context, com.valhalla.superuser.ipc.ThorRootService::class.java)
+                    val intent = Intent(context, com.valhalla.thor.rootservice.ThorRootService::class.java)
                     val conn = object : ServiceConnection {
                         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
                             val binder = IThorRootService.Stub.asInterface(service)

--- a/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
+++ b/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
@@ -1,6 +1,5 @@
 package com.valhalla.thor.rootservice
 
-import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
@@ -9,7 +8,6 @@ import com.valhalla.superuser.ipc.RootService
 import com.valhalla.superuser.utils.Logger
 import com.valhalla.thor.BuildConfig
 import java.lang.reflect.InvocationTargetException
-import java.lang.reflect.Method
 
 /**
  * A highly-stable, persistent root-level daemon service implementing privileged actions.

--- a/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
+++ b/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
@@ -6,7 +6,6 @@ import android.os.IBinder
 import android.os.PersistableBundle
 import com.valhalla.superuser.ipc.RootService
 import com.valhalla.superuser.utils.Logger
-import com.valhalla.thor.BuildConfig
 import java.lang.reflect.InvocationTargetException
 
 /**
@@ -50,7 +49,6 @@ class ThorRootService : RootService() {
             // Prioritize Thor's own package name so that the OS displays "Managed by Thor" on clicking a suspended app.
             val callers = listOf(
                 this@ThorRootService.packageName,
-                BuildConfig.APPLICATION_ID,
                 "com.android.shell",
                 "android"
             )

--- a/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
+++ b/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
@@ -1,4 +1,4 @@
-package com.valhalla.superuser.ipc
+package com.valhalla.thor.rootservice
 
 import android.content.Context
 import android.content.Intent
@@ -7,6 +7,7 @@ import android.os.IBinder
 import android.os.PersistableBundle
 import com.valhalla.superuser.ipc.RootService
 import com.valhalla.superuser.utils.Logger
+import com.valhalla.thor.BuildConfig
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
@@ -17,22 +18,13 @@ class ThorRootService : RootService() {
 
     override fun onBind(intent: Intent): IBinder {
         return object : IThorRootService.Stub() {
-            private fun enforceCaller() {
-                val callingUid = getCallingUid()
-                val authorizedUid = com.valhalla.superuser.internal.RootServiceServer.getInstanceOrNull()?.authorizedUid ?: -1
-                Logger.i("Odin", "enforceCaller: callingUid=$callingUid, authorizedUid=$authorizedUid")
-                if (callingUid != 0 && callingUid != 1000 && callingUid != authorizedUid) {
-                    throw SecurityException("Access denied: UID $callingUid is not authorized.")
-                }
-            }
-
             override fun setAppSuspended(packageName: String, suspended: Boolean) {
-                enforceCaller()
+                this@ThorRootService.enforceCaller()
                 this@ThorRootService.setAppSuspended(packageName, suspended)
             }
 
             override fun clearAppData(packageName: String) {
-                enforceCaller()
+                this@ThorRootService.enforceCaller()
                 this@ThorRootService.clearAppData(packageName)
             }
         }
@@ -60,8 +52,7 @@ class ThorRootService : RootService() {
             // Prioritize Thor's own package name so that the OS displays "Managed by Thor" on clicking a suspended app.
             val callers = listOf(
                 this@ThorRootService.packageName,
-                "com.valhalla.thor.debug",
-                "com.valhalla.thor",
+                BuildConfig.APPLICATION_ID,
                 "com.android.shell",
                 "android"
             )

--- a/docs/superpowers/plans/2026-07-21-odin-phase1-sucore-prep.md
+++ b/docs/superpowers/plans/2026-07-21-odin-phase1-sucore-prep.md
@@ -1,0 +1,352 @@
+# Odin Phase 1 — Prepare :suCore in Thor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Thor's `:suCore` (Odin) module clean + correct ahead of extracting it to a standalone Maven Central library — fix the MainShell shell-init hang, move the Thor-specific `ThorRootService` into `:app`, and add the minimal self-containment prep.
+
+**Architecture:** Three independent tasks, each a self-contained Thor change verified by building both flavors. Task 1 (shell-init failure channel + timeout) and Task 3 (coroutines dep + license) are `:suCore`-local; Task 2 moves app-domain code out of the library and adds a reusable caller-guard to Odin's `RootService` base.
+
+**Tech Stack:** Kotlin, Android (AGP), coroutines, AIDL/Binder root-service IPC, `./gradlew` (JDK 21).
+
+## Global Constraints
+
+- Build tool: `./gradlew` (JDK 21). A context-mode hook intercepts `./gradlew …` run via the Bash tool — run Gradle through the `mcp__plugin_context-mode_context-mode__ctx_execute` MCP tool (`language: "shell"`); load it via `ToolSearch "select:mcp__plugin_context-mode_context-mode__ctx_execute"` if absent. Use Bash for git/file ops.
+- Verify with `./gradlew assembleFossDebug assembleStoreDebug` (both must be green).
+- `:suCore` minSdk stays **24**; do NOT apply the Kotlin plugin explicitly, do NOT remove the `foss_release` build type, do NOT add publishing config — those are **Phase 2** (deferred, per spec).
+- Behavior must be preserved: root privilege probing and `ThorRootService`-backed ops (suspend / clear-data) work exactly as before; the only intended behavior change is that a hard shell-init failure resolves to `false` instead of hanging.
+- `GetShellCallback.onShellDied` is added as a **default no-op** method (source- and binary-compatible).
+- License target for Odin: **Apache-2.0**.
+- On-device verification (root probing on rooted + non-rooted; `ThorRootService` ops after the move) is done by the maintainer, not in CI.
+
+---
+
+### Task 1: MainShell shell-init hard-failure fix (1a)
+
+**Files:**
+- Modify: `suCore/src/main/java/com/valhalla/superuser/Shell.kt` (the `GetShellCallback` interface, ~line 436)
+- Modify: `suCore/src/main/java/com/valhalla/superuser/internal/MainShell.kt` (the `get(...)` catch, ~lines 51-76)
+- Modify: `suCore/src/main/java/com/valhalla/superuser/ktx/ShellExtensions.kt` (`getShellAwait()`, lines 60-68)
+- Modify: `suCore/src/main/java/com/valhalla/superuser/ktx/ShellRepository.kt` (`isRootGranted()`, lines 21-24)
+
+**Interfaces:**
+- Produces: `Shell.GetShellCallback.onShellDied(error: Throwable?)` (default no-op); unchanged `getShellAwait(): Shell` (now resumes exceptionally on failure); unchanged `ShellRepository.isRootGranted(): Boolean` (now bounded + returns false on failure/timeout).
+
+- [ ] **Step 1: Add the `onShellDied` default method to `GetShellCallback`**
+
+In `Shell.kt`, the interface currently is:
+```kotlin
+    interface GetShellCallback {
+        fun onShell(shell: Shell)
+    }
+```
+Replace with:
+```kotlin
+    interface GetShellCallback {
+        fun onShell(shell: Shell)
+
+        /**
+         * Called when the shell could NOT be created (hard init failure). Default no-op keeps this
+         * source- and binary-compatible; callers that await a shell (e.g. getShellAwait) should
+         * override it to fail fast instead of suspending forever.
+         */
+        fun onShellDied(error: Throwable?) {}
+    }
+```
+
+- [ ] **Step 2: Dispatch `onShellDied` from `MainShell.get(...)`'s catch**
+
+In `MainShell.kt`, the worker `catch` currently ends with `Utils.ex(e)`. Replace the catch body:
+```kotlin
+                } catch (e: Exception) {
+                    // Shell creation failed. Log it, keep the worker thread alive (catch-all), AND
+                    // signal the terminal failure to the callback via the same executor path
+                    // returnShell uses — so awaiting callers fail fast instead of suspending forever.
+                    Utils.ex(e)
+                    if (e is CancellationException) throw e
+                    if (executor == null) callback.onShellDied(e)
+                    else executor.execute { callback.onShellDied(e) }
+                }
+```
+Add the import `import kotlinx.coroutines.CancellationException` at the top of `MainShell.kt` if not already present. (Rethrow guard: this runs inside `Shell.EXECUTOR.execute { }`, a plain Runnable, so `CancellationException` is not expected here, but the guard keeps parity with the codebase's AP-K03 discipline and is harmless.)
+
+- [ ] **Step 3: Resume `getShellAwait()` exceptionally on failure**
+
+In `ShellExtensions.kt`, `getShellAwait()` (lines 60-68) currently only overrides `onShell`. Replace with:
+```kotlin
+suspend fun getShellAwait(): Shell = suspendCancellableCoroutine { cont ->
+    Shell.getShell(object : Shell.GetShellCallback {
+        override fun onShell(shell: Shell) {
+            if (cont.isActive) {
+                cont.resume(shell)
+            }
+        }
+
+        override fun onShellDied(error: Throwable?) {
+            if (cont.isActive) {
+                cont.resumeWithException(
+                    error ?: NoShellException("Root shell initialization failed")
+                )
+            }
+        }
+    })
+}
+```
+Add imports at the top of `ShellExtensions.kt`:
+```kotlin
+import com.valhalla.superuser.NoShellException
+import kotlin.coroutines.resumeWithException
+```
+
+- [ ] **Step 4: Make `isRootGranted()` bounded + failure-safe**
+
+In `ShellRepository.kt`, replace `isRootGranted()` (lines 21-24):
+```kotlin
+    // Lazy check for root status that doesn't block the UI thread
+    override suspend fun isRootGranted(): Boolean = withContext(Dispatchers.IO) {
+        // Ensure we have a shell first
+        getShellAwait().isRoot
+    }
+```
+with:
+```kotlin
+    // Lazy, bounded, failure-safe root check. A hard shell-init failure now resumes getShellAwait()
+    // exceptionally (via onShellDied); the timeout additionally covers a worker that never returns.
+    // Either way this UI-gating probe resolves to false instead of suspending indefinitely.
+    override suspend fun isRootGranted(): Boolean = withContext(Dispatchers.IO) {
+        withTimeoutOrNull(SHELL_INIT_TIMEOUT_MS) {
+            runCatching { getShellAwait().isRoot }.getOrDefault(false)
+        } ?: false
+    }
+```
+Add the import `import kotlinx.coroutines.withTimeoutOrNull` and a companion constant to `RealShellRepository`:
+```kotlin
+    companion object {
+        // Upper bound for shell-init before the root probe gives up and reports "no root".
+        private const val SHELL_INIT_TIMEOUT_MS = 10_000L
+    }
+```
+(`runInternal` at lines 34-50 already wraps `getShellAwait()` in try/catch → `Result.failure`, so it inherits the failure channel automatically — no change needed there.)
+
+- [ ] **Step 5: Verify compile (both flavors)**
+
+Run (via ctx_execute shell): `./gradlew assembleFossDebug assembleStoreDebug`
+Expected: BUILD SUCCESSFUL for both. No unresolved refs (`resumeWithException`, `NoShellException`, `withTimeoutOrNull`, `CancellationException`).
+
+> No unit test is added: `getShellAwait()`/`isRootGranted()` bottom out in the static `Shell.getShell(...)` Android path with no injection seam, so a unit test would exercise mocks, not behavior. Correctness is guaranteed by the compile + the timeout bound + the maintainer's device check (below). Do not fabricate a mock-only test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add suCore/src/main/java/com/valhalla/superuser/Shell.kt \
+        suCore/src/main/java/com/valhalla/superuser/internal/MainShell.kt \
+        suCore/src/main/java/com/valhalla/superuser/ktx/ShellExtensions.kt \
+        suCore/src/main/java/com/valhalla/superuser/ktx/ShellRepository.kt
+git commit -m "fix(sucore): signal shell-init failure via onShellDied + bound isRootGranted so it can't hang"
+```
+
+**Device acceptance (maintainer):** on a rooted device the root probe still resolves true and root ops work; on a non-rooted device the probe resolves false within ~10s without wedging the UI.
+
+---
+
+### Task 2: Move `ThorRootService` into `:app`; add `RootService.enforceCaller()` to Odin (1b)
+
+**Files:**
+- Modify: `suCore/src/main/java/com/valhalla/superuser/ipc/RootService.kt` (add `protected fun enforceCaller()`)
+- Create: `app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl`
+- Create: `app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt`
+- Delete: `suCore/src/main/aidl/com/valhalla/superuser/ipc/IThorRootService.aidl`
+- Delete: `suCore/src/main/java/com/valhalla/superuser/ipc/ThorRootService.kt`
+- Modify: `app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt` (imports at lines 11 + ~88)
+- Modify: `app/src/main/AndroidManifest.xml` (line 63 `android:name`)
+
+**Interfaces:**
+- Consumes: Odin's `abstract class RootService : ContextWrapper` (generic base, stays in `com.valhalla.superuser.ipc`) and `IIPC.aidl`/`IRootServiceManager.aidl` (stay in suCore).
+- Produces: `protected fun RootService.enforceCaller()` (throws `SecurityException` on an unauthorized caller UID) — reusable by any `RootService` subclass; and app-package `com.valhalla.thor.rootservice.{ThorRootService, IThorRootService}`.
+
+- [ ] **Step 1: Add `enforceCaller()` to Odin's `RootService` base**
+
+In `RootService.kt` (`abstract class RootService : ContextWrapper(null)`), add this protected method (it lives in the same module as the `internal` `RootServiceServer`, so it can read `authorizedUid`; subclasses in any module can call the `protected` method):
+```kotlin
+    /**
+     * Enforce that the current Binder transaction comes from an authorized caller: root (0),
+     * the system server (1000), or the UID that started this RootService. Call from inside your
+     * AIDL stub methods. Throws [SecurityException] otherwise.
+     */
+    protected fun enforceCaller() {
+        val callingUid = android.os.Binder.getCallingUid()
+        val authorizedUid =
+            com.valhalla.superuser.internal.RootServiceServer.getInstanceOrNull()?.authorizedUid ?: -1
+        if (callingUid != 0 && callingUid != 1000 && callingUid != authorizedUid) {
+            throw SecurityException("Access denied: UID $callingUid is not authorized.")
+        }
+    }
+```
+
+- [ ] **Step 2: Create the app-side AIDL**
+
+Create `app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl`:
+```aidl
+package com.valhalla.thor.rootservice;
+
+interface IThorRootService {
+    void setAppSuspended(String packageName, boolean suspended);
+    void clearAppData(String packageName);
+}
+```
+
+- [ ] **Step 3: Create the app-side `ThorRootService`**
+
+Create `app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt` by moving `suCore/.../ipc/ThorRootService.kt` **verbatim** with exactly these changes:
+1. Package line → `package com.valhalla.thor.rootservice`
+2. Imports: keep `com.valhalla.superuser.ipc.RootService` and `com.valhalla.superuser.utils.Logger`; add `import com.valhalla.thor.BuildConfig`. (Drop the now-unnecessary explicit `IThorRootService` import — it's in the same package now.)
+3. Replace the inline `enforceCaller()` local function inside the Stub (which reached into the internal `RootServiceServer`) with a call to the inherited base helper. The Stub's methods change from calling the local `enforceCaller()` to `this@ThorRootService.enforceCaller()`, and the local `private fun enforceCaller()` block is deleted. i.e.:
+```kotlin
+    override fun onBind(intent: Intent): IBinder {
+        return object : IThorRootService.Stub() {
+            override fun setAppSuspended(packageName: String, suspended: Boolean) {
+                this@ThorRootService.enforceCaller()
+                this@ThorRootService.setAppSuspended(packageName, suspended)
+            }
+
+            override fun clearAppData(packageName: String) {
+                this@ThorRootService.enforceCaller()
+                this@ThorRootService.clearAppData(packageName)
+            }
+        }
+    }
+```
+4. In `setAppSuspended`, replace the hardcoded Thor package strings in the `callers` list. Current:
+```kotlin
+            val callers = listOf(
+                this@ThorRootService.packageName,
+                "com.valhalla.thor.debug",
+                "com.valhalla.thor",
+                "com.android.shell",
+                "android"
+            )
+```
+→
+```kotlin
+            val callers = listOf(
+                this@ThorRootService.packageName,
+                BuildConfig.APPLICATION_ID,
+                "com.android.shell",
+                "android"
+            )
+```
+Everything else (`setAppSuspended`, `callSetSuspended`, `buildSuspendDialogInfo`, `clearAppData`) moves verbatim.
+
+- [ ] **Step 4: Delete the suCore copies**
+
+```bash
+rm suCore/src/main/java/com/valhalla/superuser/ipc/ThorRootService.kt \
+   suCore/src/main/aidl/com/valhalla/superuser/ipc/IThorRootService.aidl
+```
+
+- [ ] **Step 5: Update `RootSystemGateway.kt` imports**
+
+Change the two Thor-service imports to the new app package; leave the generic `RootService` import alone. In `RootSystemGateway.kt`:
+- Line 11 `import com.valhalla.superuser.ipc.IThorRootService` → `import com.valhalla.thor.rootservice.IThorRootService`
+- Line 9 `import com.valhalla.superuser.ipc.RootService` — **unchanged** (generic base stays in Odin).
+- Line ~88 `Intent(context, com.valhalla.superuser.ipc.ThorRootService::class.java)` → `Intent(context, com.valhalla.thor.rootservice.ThorRootService::class.java)`.
+
+- [ ] **Step 6: Update the manifest service name**
+
+In `app/src/main/AndroidManifest.xml`, the `<service>` at line 63:
+```xml
+            android:name="com.valhalla.superuser.ipc.ThorRootService"
+```
+→
+```xml
+            android:name="com.valhalla.thor.rootservice.ThorRootService"
+```
+(Keep `android:process=":root"`, `android:exported="false"`, `tools:ignore="Instantiatable"`.)
+
+- [ ] **Step 7: Verify suCore is Thor-free + build both flavors**
+
+Run (Bash): `grep -rn "com.valhalla.thor" suCore/src` → expected: **no matches**.
+Run (ctx_execute shell): `./gradlew assembleFossDebug assembleStoreDebug` → BUILD SUCCESSFUL for both. If the generic framework (`RootServiceServer`/`RootServiceManager`/`RootServerMain`) fails to compile referencing `ThorRootService`, decouple that reference (it should not exist) and report.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add suCore/src/main/java/com/valhalla/superuser/ipc/RootService.kt \
+        app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl \
+        app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt \
+        app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt \
+        app/src/main/AndroidManifest.xml
+git add -u suCore/src/main/java/com/valhalla/superuser/ipc/ThorRootService.kt \
+          suCore/src/main/aidl/com/valhalla/superuser/ipc/IThorRootService.aidl
+git commit -m "refactor(sucore): move Thor-specific ThorRootService into :app; add reusable RootService.enforceCaller()"
+```
+
+**Device acceptance (maintainer):** freezing/suspending and clear-data (which route through `ThorRootService`) still work with root; the OS still shows "Managed by Thor" on suspended apps.
+
+---
+
+### Task 3: coroutines dependency + Apache-2.0 license (1c)
+
+**Files:**
+- Modify: `gradle/libs.versions.toml` (add coroutines version + library)
+- Modify: `suCore/build.gradle.kts` (add the dependency)
+- Create: `suCore/LICENSE`
+- Modify: `suCore/README.md` (license note)
+
+**Interfaces:** none (build/config + docs).
+
+- [ ] **Step 1: Add the coroutines catalog entries**
+
+In `gradle/libs.versions.toml`, under `[versions]` add (near the `kotlin` line):
+```toml
+kotlinxCoroutines = "1.10.2"
+```
+and under `[libraries]` add:
+```toml
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+```
+(Verify `1.10.2` is the current stable compatible with Kotlin `2.4.10`; bump if a newer patch exists.)
+
+- [ ] **Step 2: Declare the dependency in suCore**
+
+In `suCore/build.gradle.kts`, the `dependencies { }` block currently has only `implementation(libs.androidx.core.ktx)`. Add the coroutines dep (the `ktx/` package uses `kotlinx.coroutines.*` but never declared it):
+```kotlin
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.kotlinx.coroutines.android)
+}
+```
+
+- [ ] **Step 3: Add the Apache-2.0 LICENSE to suCore**
+
+Create `suCore/LICENSE` containing the **standard Apache License 2.0 text** (the canonical text from https://www.apache.org/licenses/LICENSE-2.0.txt — the full "Apache License / Version 2.0, January 2004 / …" document, unmodified).
+
+- [ ] **Step 4: Update the README license note**
+
+In `suCore/README.md`, the license note currently states Odin (as part of Thor) is GPL-3.0. Update it to state that **Odin is licensed under Apache-2.0** (retaining the existing attribution to topjohnwu/libsu, itself Apache-2.0), e.g. replace the license paragraph with:
+```markdown
+## License
+
+Odin is licensed under the **Apache License 2.0** (see `LICENSE`). It is a Kotlin-first reimagining
+inspired by [topjohnwu/libsu](https://github.com/topjohnwu/libsu) (also Apache-2.0); credit to the
+original authors.
+```
+(Match the exact heading/wording style already in the README; only the license statement changes from GPL-3.0 to Apache-2.0.)
+
+- [ ] **Step 5: Verify build**
+
+Run (ctx_execute shell): `./gradlew assembleFossDebug assembleStoreDebug` → BUILD SUCCESSFUL for both (coroutines now resolves via the explicit dep).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add gradle/libs.versions.toml suCore/build.gradle.kts suCore/LICENSE suCore/README.md
+git commit -m "chore(sucore): declare kotlinx-coroutines dep + relicense Odin module to Apache-2.0"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Part 1 (MainShell fix) → Task 1; Part 2 (ThorRootService move) → Task 2 (incl. the `enforceCaller` helper needed because `RootServiceServer` is `internal`); Part 3 (coroutines dep + Apache LICENSE) → Task 3. Deferred items (explicit Kotlin plugin, `foss_release`, minSdk, publishing) are explicitly out of scope per Global Constraints. All covered.
+- **Placeholder scan:** none — every code step shows exact code; the LICENSE is a named canonical artifact (Apache-2.0 text), not a placeholder; the coroutines version has a concrete value with a verify note.
+- **Type consistency:** `onShellDied(error: Throwable?)` identical across Shell.kt (definition), MainShell.kt (call), ShellExtensions.kt (override). `enforceCaller()` defined in RootService (Task 2 Step 1), called in the moved ThorRootService (Step 3). `IThorRootService` / `ThorRootService` consistently repackaged to `com.valhalla.thor.rootservice` across the AIDL, class, gateway import, and manifest. `libs.kotlinx.coroutines.android` catalog alias matches the `kotlinx-coroutines-android` library key.

--- a/docs/superpowers/specs/2026-07-21-odin-phase1-sucore-prep-design.md
+++ b/docs/superpowers/specs/2026-07-21-odin-phase1-sucore-prep-design.md
@@ -1,0 +1,63 @@
+# Odin Phase 1 — Prepare `:suCore` in Thor (design)
+
+**Date:** 2026-07-21
+**Branch:** `feat/odin-phase1-sucore-prep`
+**Status:** Design — approved roadmap; this spec details Phase 1 only.
+
+## Context
+
+Roadmap (approved): publish the in-house libsu fork **Odin** (`:suCore`, namespace `com.valhalla.superuser`) to Maven Central as **`com.trinadhthatakula:odin`**, mirroring how Asgard + thor-extension-api are published (vanniktech maven-publish, standalone repo, CI on `production`, Thor consumes as a published dep). Three phases:
+
+1. **Phase 1 (this spec):** prep `:suCore` *inside Thor* so it's clean + correct — done as Thor PR(s), device-verified.
+2. **Phase 2:** extract to the standalone `Odin` repo + publish `1.0.0` (vanniktech + POM + CI + Apache-2.0 + the build-config self-containment).
+3. **Phase 3:** migrate Thor to the published dep (version catalog + local `includeBuild` override; drop the local `:suCore`).
+
+## Goal (Phase 1)
+
+Two code changes + minimal safe prep, all validated against the live Thor app:
+
+### Part 1 — MainShell shell-init hard-failure fix
+**Problem** (`docs/follow-ups/mainshell-shell-init-hard-failure.md`): `getShellAwait()` → `ShellRepository.isRootGranted()` can suspend forever on a hard shell-init failure because `Shell.GetShellCallback.onShell(Shell)` only accepts a non-null `Shell` — no failure channel.
+
+**Fix — failure channel + timeout (defense-in-depth):**
+- **`Shell.GetShellCallback`** (`Shell.kt:436`): add a **default no-op** method `fun onShellDied(error: Throwable?) {}`. Default keeps it source- & binary-compatible; the 2 internal implementers need no change unless they opt in.
+- **`internal/MainShell.get(...)`** (`MainShell.kt:51-76`): in the `catch`, dispatch the failure to the callback (via the same `executor` path `returnShell` uses) — `callback.onShellDied(e)` — instead of only `Utils.ex(e)`.
+- **`ktx/getShellAwait()`** (`ShellExtensions.kt:60-67`): override `onShellDied` to resume exceptionally — `if (cont.isActive) cont.resumeWithException(e ?: NoShellException("shell init failed"))`. Additionally guard the whole suspend in a bounded `withTimeoutOrNull(...)` (or the caller does) so a *never-returns* worker (no throw, no callback) also resolves — the failure channel handles thrown failures, the timeout handles hangs.
+- **`ktx/ShellRepository.isRootGranted()`** (`ShellRepository.kt:21-24`): resolve to **`false`** on failure/timeout instead of propagating/handing — wrap the `getShellAwait().isRoot` in `runCatching { ... }.getOrDefault(false)` and/or the timeout above so the privilege probe that gates the UI can never wedge. (`isRoot`-returning path stays: success → real value; failure/timeout → false.)
+- The other `GetShellCallback` implementer (`internal/PendingJob.kt:54`) keeps the no-op default (its path is job execution, not the await/probe path) — no behavior change.
+
+**Acceptance:** a simulated hard shell-init failure resolves `isRootGranted()` to `false` within a bounded time (no indefinite suspension); normal rooted / non-rooted probing is unchanged; the existing `onShell(Shell)` success path and worker-thread survival are preserved.
+
+### Part 2 — Move `ThorRootService` into `:app` (make Odin generic)
+**Boundary (confirmed):**
+- **Stays in `:suCore` (generic framework):** `ipc/RootService.kt` (base), `aidl/.../ipc/IIPC.aidl` (`IBinder getService(String)`), `aidl/.../internal/IRootServiceManager.aidl`, and the internal machinery (`RootServiceManager`, `RootServiceServer`, `RootServerMain`, etc.).
+- **Moves to `:app` (Thor-domain):** `ipc/ThorRootService.kt` (concrete suspend / data-clear service) + `aidl/.../ipc/IThorRootService.aidl`.
+
+**Steps:**
+1. Move `IThorRootService.aidl` into `app/src/main/aidl/…` under a Thor package (e.g. `com.valhalla.thor.rootservice`).
+2. Move `ThorRootService.kt` into `:app` under the matching Thor package; it `extends` Odin's generic `RootService` (imported from `com.valhalla.superuser.ipc`).
+3. Drop the hardcoded `"com.valhalla.thor"` / `".debug"` caller-package fallback strings — now that the service lives in `:app`, derive the package from `BuildConfig.APPLICATION_ID` / context.
+4. Update `RootSystemGateway.kt` imports: `ThorRootService` + `IThorRootService` now resolve from the new `:app` package; `RootService` (generic bind/unbind) still imports from `com.valhalla.superuser.ipc`. Bind intent + `IThorRootService.Stub.asInterface(...)` unchanged in behavior.
+5. Move the `<service>` registration for `ThorRootService` from the `:suCore` manifest into the `:app` manifest (if declared there).
+6. Verify the generic framework (`RootServiceServer`/`Manager`/`RootServerMain`) has **no** compile reference to `ThorRootService`/`IThorRootService`; decouple any found.
+
+**Acceptance:** Thor builds all variants; on-device root suspend / data-clear / uninstall (which go through `ThorRootService`) still work; `grep com.valhalla.thor suCore/` returns nothing.
+
+### Part 3 — Minimal safe self-containment prep
+- **Add the coroutines dependency** to `suCore/build.gradle.kts` — the `ktx/` package uses `kotlinx.coroutines.*` but declares no dep (currently resolves only via the ambient monorepo classpath). Add the catalog `kotlinx-coroutines-android` explicitly. (Additive; safe in Thor.)
+- **Add an Apache-2.0 `LICENSE`** to `suCore/` and update `suCore/README.md`'s license note (Odin → Apache-2.0 going forward; retains libsu attribution).
+
+**Deferred to Phase 2 (extraction) — with rationale:** applying the Kotlin plugin explicitly in-module (risks conflicting with Thor's AGP-9 built-in Kotlin plugin management), removing the empty `foss_release` build type (load-bearing for app-variant matching in the monorepo; the standalone repo won't have Thor's flavors), and the final `minSdk` decision (keep 24 for now — a library supporting API 24+ is fine inside a minSdk-28 app). None of these are needed for correctness inside Thor and are safer to do in the standalone repo where the module owns its own build.
+
+## Out of scope
+New Odin repo, vanniktech/POM/signing, CI `publish.yml`, publishing, and Thor's migration to the published coordinate — all Phase 2/3.
+
+## Testing / verification
+- `./gradlew assembleFossDebug assembleStoreDebug` — both green (Part 2 touches variant-relevant code).
+- Unit test for the failure wiring where feasible (a `GetShellCallback` whose `onShellDied` fires → `getShellAwait()` resumes exceptionally / `isRootGranted()` returns false; a timeout test for the never-returns case). Where the static `Shell.getShell` path resists unit testing, rely on the timeout guarantee + device verification.
+- On-device (maintainer): privilege probe resolves on rooted **and** non-rooted devices (never hangs); `ThorRootService`-backed root ops (suspend, clear data, uninstall) still work post-move; extensions/other root paths unaffected.
+
+## Suggested PR split (for the plan)
+- **1a:** MainShell fix (small, contained, `:suCore` only).
+- **1b:** `ThorRootService` → `:app` move (the boundary refactor).
+- **1c:** coroutines dep + Apache-2.0 LICENSE (trivial).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ agp = "9.4.0-alpha05"
 biometric = "1.4.0-alpha02"
 datastorePreferences = "1.2.1"
 kotlin = "2.4.10"
+kotlinxCoroutines = "1.10.2"
 coreKtx = "1.19.0"
 junit = "4.13.2"
 room = "2.8.4"
@@ -69,6 +70,7 @@ room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 #Kotlin
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 #Lottie
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version.ref = "lottieCompose" }
 #Shizuku

--- a/suCore/LICENSE
+++ b/suCore/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/suCore/README.md
+++ b/suCore/README.md
@@ -68,4 +68,4 @@ Odin's design principles and IPC daemon architecture are adapted from the except
 
 ### License Compatibility
 - The original design from `libsu` is licensed under the Apache License 2.0. All modifications and structural enhancements comply with Apache-2.0 requirements.
-- Odin, as part of the Thor project, is licensed under the **GNU General Public License v3.0 (GPL-3.0)**.
+- Odin is licensed under the **Apache License 2.0** (see [`LICENSE`](LICENSE)), inspired by [`libsu`](https://github.com/topjohnwu/libsu) (also Apache-2.0); credit to the original authors.

--- a/suCore/build.gradle.kts
+++ b/suCore/build.gradle.kts
@@ -33,4 +33,5 @@ android {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+    implementation(libs.kotlinx.coroutines.android)
 }

--- a/suCore/src/main/java/com/valhalla/superuser/Shell.kt
+++ b/suCore/src/main/java/com/valhalla/superuser/Shell.kt
@@ -438,6 +438,13 @@ abstract class Shell : Closeable {
          * @param shell the `Shell` obtained in the asynchronous operation.
          */
         fun onShell(shell: Shell)
+
+        /**
+         * Called when the shell could NOT be created (hard init failure). Default no-op keeps this
+         * source- and binary-compatible; callers that await a shell (e.g. getShellAwait) should
+         * override it to fail fast instead of suspending forever.
+         */
+        fun onShellDied(error: Throwable?) {}
     }
 
     /**

--- a/suCore/src/main/java/com/valhalla/superuser/internal/MainShell.kt
+++ b/suCore/src/main/java/com/valhalla/superuser/internal/MainShell.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import com.valhalla.superuser.NoShellException
 import com.valhalla.superuser.Shell
 import com.valhalla.superuser.Shell.GetShellCallback
+import kotlinx.coroutines.CancellationException
 import java.io.InputStream
 import java.util.concurrent.Executor
 
@@ -58,18 +59,13 @@ object MainShell {
                 try {
                     returnShell(get(), executor, callback)
                 } catch (e: Exception) {
-                    // Shell creation failed. Log it and keep the worker thread from dying
-                    // uncaught (catch all Exceptions, not just NoShellException).
-                    //
-                    // NOTE: GetShellCallback.onShell(Shell) only accepts a NON-null Shell, so
-                    // there is no in-file way to hand a terminal failure back to callers here.
-                    // Awaiting coroutines that rely on the callback (e.g. getShellAwait() ->
-                    // isRootGranted()) will still suspend forever on a hard failure. Fully
-                    // unblocking them requires an API-level change outside this file: add an
-                    // onFailure()/onShellDied() channel to Shell.GetShellCallback, or have
-                    // getShellAwait() resume its continuation with an exception / apply a
-                    // timeout. See needsFollowUp.
+                    // Shell creation failed. Log it, keep the worker thread alive (catch-all), AND
+                    // signal the terminal failure to the callback via the same executor path
+                    // returnShell uses — so awaiting callers fail fast instead of suspending forever.
                     Utils.ex(e)
+                    if (e is CancellationException) throw e
+                    if (executor == null) callback.onShellDied(e)
+                    else executor.execute { callback.onShellDied(e) }
                 }
             }
         }

--- a/suCore/src/main/java/com/valhalla/superuser/ipc/RootService.kt
+++ b/suCore/src/main/java/com/valhalla/superuser/ipc/RootService.kt
@@ -115,4 +115,18 @@ abstract class RootService : ContextWrapper(null) {
     fun stopSelf() {
         RootServiceServer.getInstance(this).selfStop(getComponentName())
     }
+
+    /**
+     * Enforce that the current Binder transaction comes from an authorized caller: root (0),
+     * the system server (1000), or the UID that started this RootService. Call from inside your
+     * AIDL stub methods. Throws [SecurityException] otherwise.
+     */
+    protected fun enforceCaller() {
+        val callingUid = android.os.Binder.getCallingUid()
+        val authorizedUid =
+            com.valhalla.superuser.internal.RootServiceServer.getInstanceOrNull()?.authorizedUid ?: -1
+        if (callingUid != 0 && callingUid != 1000 && callingUid != authorizedUid) {
+            throw SecurityException("Access denied: UID $callingUid is not authorized.")
+        }
+    }
 }

--- a/suCore/src/main/java/com/valhalla/superuser/ktx/ShellExtensions.kt
+++ b/suCore/src/main/java/com/valhalla/superuser/ktx/ShellExtensions.kt
@@ -1,11 +1,13 @@
 package com.valhalla.superuser.ktx
 
+import com.valhalla.superuser.NoShellException
 import com.valhalla.superuser.Shell
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Suspends until the Shell Job is complete and returns the result.
@@ -62,6 +64,14 @@ suspend fun getShellAwait(): Shell = suspendCancellableCoroutine { cont ->
         override fun onShell(shell: Shell) {
             if (cont.isActive) {
                 cont.resume(shell)
+            }
+        }
+
+        override fun onShellDied(error: Throwable?) {
+            if (cont.isActive) {
+                cont.resumeWithException(
+                    error ?: NoShellException("Root shell initialization failed")
+                )
             }
         }
     })

--- a/suCore/src/main/java/com/valhalla/superuser/ktx/ShellRepository.kt
+++ b/suCore/src/main/java/com/valhalla/superuser/ktx/ShellRepository.kt
@@ -23,8 +23,14 @@ class RealShellRepository : ShellRepository {
     // Either way this UI-gating probe resolves to false instead of suspending indefinitely.
     override suspend fun isRootGranted(): Boolean = withContext(Dispatchers.IO) {
         withTimeoutOrNull(SHELL_INIT_TIMEOUT_MS) {
-            runCatching { getShellAwait().isRoot }
-                .getOrElse { if (it is kotlin.coroutines.cancellation.CancellationException) throw it else false }
+            try {
+                getShellAwait().isRoot
+            } catch (e: Exception) {
+                // Rethrow cancellation so withTimeoutOrNull handles the timeout (and structured
+                // concurrency is preserved); any other failure resolves the probe to false.
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                false
+            }
         } ?: false
     }
 

--- a/suCore/src/main/java/com/valhalla/superuser/ktx/ShellRepository.kt
+++ b/suCore/src/main/java/com/valhalla/superuser/ktx/ShellRepository.kt
@@ -23,7 +23,8 @@ class RealShellRepository : ShellRepository {
     // Either way this UI-gating probe resolves to false instead of suspending indefinitely.
     override suspend fun isRootGranted(): Boolean = withContext(Dispatchers.IO) {
         withTimeoutOrNull(SHELL_INIT_TIMEOUT_MS) {
-            runCatching { getShellAwait().isRoot }.getOrDefault(false)
+            runCatching { getShellAwait().isRoot }
+                .getOrElse { if (it is kotlin.coroutines.cancellation.CancellationException) throw it else false }
         } ?: false
     }
 

--- a/suCore/src/main/java/com/valhalla/superuser/ktx/ShellRepository.kt
+++ b/suCore/src/main/java/com/valhalla/superuser/ktx/ShellRepository.kt
@@ -2,6 +2,7 @@ package com.valhalla.superuser.ktx
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
 
 /**
@@ -17,10 +18,13 @@ interface ShellRepository {
 
 class RealShellRepository : ShellRepository {
 
-    // Lazy check for root status that doesn't block the UI thread
+    // Lazy, bounded, failure-safe root check. A hard shell-init failure now resumes getShellAwait()
+    // exceptionally (via onShellDied); the timeout additionally covers a worker that never returns.
+    // Either way this UI-gating probe resolves to false instead of suspending indefinitely.
     override suspend fun isRootGranted(): Boolean = withContext(Dispatchers.IO) {
-        // Ensure we have a shell first
-        getShellAwait().isRoot
+        withTimeoutOrNull(SHELL_INIT_TIMEOUT_MS) {
+            runCatching { getShellAwait().isRoot }.getOrDefault(false)
+        } ?: false
     }
 
     override suspend fun runCommand(command: String): Result<List<String>> {
@@ -48,4 +52,9 @@ class RealShellRepository : ShellRepository {
                 Result.failure(e)
             }
         }
+
+    companion object {
+        // Upper bound for shell-init before the root probe gives up and reports "no root".
+        private const val SHELL_INIT_TIMEOUT_MS = 10_000L
+    }
 }


### PR DESCRIPTION
## Odin Phase 1 — prepare `:suCore` for Maven Central extraction

Phase 1 of publishing Thor's in-house libsu fork **Odin** (`:suCore`, `com.valhalla.superuser`) to Maven Central as `com.trinadhthatakula:odin`. This PR preps the module *in place* — no publishing yet (Phase 2/3). Built via subagent-driven SDD; spec + plan in `docs/superpowers/{specs,plans}/2026-07-21-odin-phase1-sucore-prep.*`.

### What's in this PR
- **MainShell shell-init hard-failure fix** (closes `docs/follow-ups/mainshell-shell-init-hard-failure.md`, the CodeRabbit Major deferred from #263). `getShellAwait()` → `isRootGranted()` could suspend forever on a hard shell-init failure. Added a default no-op `onShellDied(error: Throwable?)` to `Shell.GetShellCallback`, dispatched from `MainShell.get()`'s catch; `getShellAwait()` now resumes exceptionally, and `isRootGranted()` is bounded by a 10s `withTimeoutOrNull` + `getOrElse { rethrow CancellationException else false }` so it resolves to `false` instead of hanging.
- **Make Odin generic** — moved the Thor-specific `ThorRootService.kt` + `IThorRootService.aidl` out of `:suCore` into `:app` (`com.valhalla.thor.rootservice`). Added a reusable `protected fun RootService.enforceCaller()` to Odin's generic base (keeps the `internal` caller-UID enforcement inside the module); replaced hardcoded `com.valhalla.thor`/`.debug` strings with `BuildConfig.APPLICATION_ID`; updated `RootSystemGateway` + manifest. `grep com.valhalla.thor suCore/src` is now empty.
- **Self-containment prep** — declared the `kotlinx-coroutines-android` dependency in `:suCore` (was resolving only via ambient classpath); added a canonical Apache-2.0 `suCore/LICENSE`; flipped the README license note GPL-3.0 → Apache-2.0.

### Verification
- `assembleFossDebug` + `assembleStoreDebug` green.
- **On-device verified (maintainer), debug + release:** root probe resolves on rooted & non-rooted with no UI hang; root suspend / clear-data still work post-move ("Managed by Thor" shown).
- Each task passed an independent spec+quality review; final whole-branch review = ready to merge.

### Deferred to Phase 2 (extraction/publish) — intentional
- Switch the `:suCore` coroutines dep `implementation` → `api` at publish time (Odin's public API exposes `suspend` fns + `Shell.Job.asFlow(): Flow`).
- Apply the Kotlin plugin explicitly in-module, remove the empty `foss_release` build type, finalize `minSdk` — all safer in the standalone repo than inside Thor's AGP-9 monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
