### PR TITLE
fix(installer): honor user theme, dynamic color & AMOLED in portable installer

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstallerActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstallerActivity.kt
@@ -7,12 +7,20 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.valhalla.thor.domain.model.ThemeMode
+import com.valhalla.thor.domain.model.UserPreferences
+import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.presentation.theme.ThorTheme
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class PortableInstallerActivity : ComponentActivity() {
 
     private val installerViewModel: InstallerViewModel by viewModel()
+    private val preferenceRepository: PreferenceRepository by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,7 +35,21 @@ class PortableInstallerActivity : ComponentActivity() {
             installerViewModel.resetState()
         }
         setContent {
-            ThorTheme {
+            val prefs by preferenceRepository.userPreferences
+                .collectAsStateWithLifecycle(initialValue = UserPreferences())
+
+            val systemDark = isSystemInDarkTheme()
+            val darkTheme = when (prefs.themeMode) {
+                ThemeMode.LIGHT -> false
+                ThemeMode.DARK -> true
+                ThemeMode.SYSTEM -> systemDark
+            }
+
+            ThorTheme(
+                darkTheme = darkTheme,
+                dynamicColor = prefs.useDynamicColor,
+                amoledMode = prefs.useAmoled,
+            ) {
                 PortableInstaller(
                     viewModel = installerViewModel,
                     onDismiss = {


### PR DESCRIPTION
## Problem

A tester reported that launching the **portable installer** from Files or a third-party app ignores the user's dark-mode and dynamic-color settings.

## Root cause

`PortableInstallerActivity` — the entry point for external APK view/send intents — called `ThorTheme { }` with **all defaults**:
- `darkTheme = isSystemInDarkTheme()` → follows the **device** night mode, not the in-app `ThemeMode`
- `dynamicColor = false` (hard-coded) → ignores the user's Material You preference
- `amoledMode = true` (hard-coded) → ignores the user's AMOLED preference

So the installer sheet never matched the rest of the app when opened from outside Thor.

## Fix

Mirror the pattern `HomeActivity` already uses:
- inject `PreferenceRepository`
- collect `userPreferences`
- derive `darkTheme` from `prefs.themeMode` (`LIGHT`/`DARK`/`SYSTEM`)
- pass `dynamicColor = prefs.useDynamicColor` and `amoledMode = prefs.useAmoled` into `ThorTheme`

External launches now theme identically to the main app.

## Scope / verification

- Single-file change. `HomeActivity` was the only other `ThorTheme` call site and was already correct; `FreezerLaunchActivity` renders no theme.
- No version bump — rides on the unpublished `versionCode 1930`.
- `:app:compileFossDebugKotlin` — **BUILD SUCCESSFUL** (only pre-existing, unrelated warnings).
- Suggested device check: open an APK from Files with Dark + dynamic color enabled and confirm the installer sheet matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)