### PR TITLE
Release: v1.93.0 (unpublished) — ownership marks + portable installer theme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,29 @@ contributions help keep the project alive and free for everyone.
 
 ## License
 
-This project is licensed under the GNU General Public License v3.0 (GPL-3.0).
+**Copyright © 2025–2026 Trinadh Thatakula.**
 
-- `libsu` is licensed under the Apache License 2.0. All modifications and usage in this project
-  comply with the Apache-2.0 requirements.
-- This project as a whole is distributed under the GNU General Public License v3.0 (GPL-3.0).
-- See the [LICENSE](LICENSE) file for full license text.
+Thor is free software: you can redistribute it and/or modify it under the terms of the **GNU
+General Public License as published by the Free Software Foundation — either version 3 of the
+License, or (at your option) any later version** (`GPL-3.0-or-later`). See the [LICENSE](LICENSE)
+file for the full text.
+
+- The project as a whole is distributed under the GNU General Public License v3.0 or later.
+- Portions derive from [`libsu`](https://github.com/topjohnwu/libsu) (Apache-2.0); all such use
+  complies with the Apache-2.0 requirements.
+- The **Thor name, logo, and icon are trademarks** of Trinadh Thatakula and are **not** licensed
+  under the GPL. See [TRADEMARK.md](TRADEMARK.md).
+
+### ⚠️ Official builds & unofficial forks
+
+Thor is **100% FOSS with no ads and no trackers**. Official, ad-free builds come **only** from
+[Google Play](https://play.google.com/store/apps/details?id=com.valhalla.thor),
+[IzzyOnDroid](https://apt.izzysoft.de/fdroid/index/apk/com.valhalla.thor),
+[Indus App Store](https://www.indusappstore.com/apps/productivity/thor/com.valhalla.thor/), and
+[GitHub Releases](https://github.com/trinadhthatakula/Thor/releases).
+
+The GPL guarantees your right to fork and modify Thor. However, an unofficial build that **injects
+ads or trackers, or bundles a proprietary ad SDK** (e.g. AdMob) is **not** the official Thor, is
+not endorsed, and — because it combines GPL-licensed code with proprietary components — is likely
+in violation of the GPL. Such builds must also **rename the app and change the icon** per
+[TRADEMARK.md](TRADEMARK.md). Please report them.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,54 @@
+# Thor Trademark & Branding Policy
+
+**Copyright © 2025–2026 Trinadh Thatakula.**
+
+Thor's source code is licensed under [`GPL-3.0-or-later`](LICENSE). This policy covers what the
+GPL deliberately does **not**: the project's **name, logo, and icon** — its brand identity.
+
+## What this policy protects
+
+The following are trademarks and brand assets of **Trinadh Thatakula** ("the maintainer") and are
+**not** licensed under the GPL:
+
+- The name **"Thor"** and **"Thor App Manager"** as used to identify this application.
+- The **Thor logo and launcher icon**, including `thor_drawn`, `thor_animated`, `thor_mono`,
+  `thor_drawn_foreground`, and all variants.
+- The visual identity used to present Thor on app stores and within the app's own UI.
+
+As expressly permitted by **GPL-3.0 §7(e)**, the license does **not** grant permission to use
+these names, trademarks, service marks, or logos.
+
+## What you may do (your GPL freedoms are unaffected)
+
+- Use, study, run, and modify the source for any purpose.
+- Distribute your own modified versions — **provided** you comply with the GPL: release the
+  complete corresponding source, preserve the copyright and license notices, and do **not**
+  combine the GPL-licensed code with proprietary components in a distributed binary.
+- Refer to Thor by name in **truthful, descriptive, non-endorsing** ways (e.g. "a fork of Thor",
+  "based on Thor").
+
+## What you may NOT do
+
+- Distribute a fork or rebuild **under the name "Thor" / "Thor App Manager"**, or using the Thor
+  **logo/icon**. A fork must ship under a **different name and a different icon**.
+- Present your build in a way that **implies it is the official Thor**, or is endorsed by,
+  affiliated with, or maintained by the maintainer.
+- Use the Thor name or logo on app-store listings, websites, or marketing for a fork.
+
+## Note on ads, trackers, and proprietary SDKs
+
+Thor is intentionally **ad-free and tracker-free FOSS**. The GPL does not, by itself, forbid a
+fork from adding ads — but two independent rules still bind such a build:
+
+1. **License:** bundling a **proprietary ad SDK** (e.g. Google AdMob / `play-services-ads`) into a
+   distributed build creates a combined work that **cannot** satisfy the GPL, and is a **license
+   violation** — independent of this trademark policy.
+2. **Trademark:** such a build may **not** use the Thor name or icon (this policy), and must still
+   publish its complete corresponding source (the GPL).
+
+## Contact
+
+To ask about permitted use, or to report misuse of the Thor name/logo or a GPL violation:
+
+- Repository: <https://github.com/trinadhthatakula/Thor>
+- Maintainer: Trinadh Thatakula

--- a/app/src/androidTest/java/com/valhalla/thor/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/ExampleInstrumentedTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/foss/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
+++ b/app/src/foss/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.settings
 
 import android.app.Activity

--- a/app/src/foss/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
+++ b/app/src/foss/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.settings
 
 import android.content.Intent

--- a/app/src/main/java/com/valhalla/thor/HomeActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/HomeActivity.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor
 
 import android.os.Bundle

--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor
 
 import android.app.Application

--- a/app/src/main/java/com/valhalla/thor/core/ThorShellConfig.kt
+++ b/app/src/main/java/com/valhalla/thor/core/ThorShellConfig.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.core
 
 import com.valhalla.superuser.Shell

--- a/app/src/main/java/com/valhalla/thor/data/Constants.kt
+++ b/app/src/main/java/com/valhalla/thor/data/Constants.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data
 
 const val ACTION_INSTALL_STATUS = "com.valhalla.thor.INSTALL_STATUS"

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.gateway
 
 import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.gateway
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.gateway
 
 import android.content.pm.PackageManager

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutContract.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutContract.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.launcher
 
 /** Pure contract shared between the shortcut publisher and the launch trampoline. */

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.launcher
 
 import android.app.PendingIntent

--- a/app/src/main/java/com/valhalla/thor/data/manager/ExtensionManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/ExtensionManager.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/manager/ExtensionTrust.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/ExtensionTrust.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import java.security.MessageDigest

--- a/app/src/main/java/com/valhalla/thor/data/manager/PendingInstallIntent.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/PendingInstallIntent.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import android.content.Intent

--- a/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import com.valhalla.thor.domain.model.PrivilegeState

--- a/app/src/main/java/com/valhalla/thor/data/manager/RoomExtensionDataStore.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/RoomExtensionDataStore.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import com.valhalla.thor.data.source.local.room.ExtensionDataDao

--- a/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import android.app.usage.StorageStatsManager

--- a/app/src/main/java/com/valhalla/thor/data/manager/ThorShellExecutor.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/ThorShellExecutor.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import com.valhalla.thor.domain.repository.SystemRepository

--- a/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import android.app.AppOpsManager

--- a/app/src/main/java/com/valhalla/thor/data/provider/ExtensionOpsProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/ExtensionOpsProvider.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.provider
 
 import android.content.ContentProvider

--- a/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/FreezerBridgeProvider.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.provider
 
 import android.content.ContentProvider

--- a/app/src/main/java/com/valhalla/thor/data/receivers/AutoReinstallReceiver.kt
+++ b/app/src/main/java/com/valhalla/thor/data/receivers/AutoReinstallReceiver.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.receivers
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/valhalla/thor/data/receivers/BootReceiver.kt
+++ b/app/src/main/java/com/valhalla/thor/data/receivers/BootReceiver.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.receivers
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/valhalla/thor/data/receivers/FreezerShortcutPinnedReceiver.kt
+++ b/app/src/main/java/com/valhalla/thor/data/receivers/FreezerShortcutPinnedReceiver.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.receivers
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/valhalla/thor/data/receivers/InstallReceiver.kt
+++ b/app/src/main/java/com/valhalla/thor/data/receivers/InstallReceiver.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.receivers
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppBundleBuilderImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppBundleBuilderImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import com.valhalla.thor.BuildConfig

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppBundleFileStoreImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppBundleFileStoreImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppInfoMapper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppInfoMapper.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.content.pm.ApplicationInfo

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import kotlinx.serialization.SerialName

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import java.io.File

--- a/app/src/main/java/com/valhalla/thor/data/repository/FreezerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/FreezerRepositoryImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import com.valhalla.thor.data.source.local.room.FreezerDao

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/repository/StoreRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/StoreRepositoryImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import android.os.SystemClock

--- a/app/src/main/java/com/valhalla/thor/data/security/BiometricHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/security/BiometricHelper.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.security
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.service
 
 import android.app.KeyguardManager

--- a/app/src/main/java/com/valhalla/thor/data/source/local/UadHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/UadHelper.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.dhizuku
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuReflector.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.dhizuku
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDao.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.room
 
 import androidx.room.Dao

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDatabase.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDatabase.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.room
 
 import androidx.room.AutoMigration

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppEntity.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppEntity.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.room
 
 import androidx.room.Entity

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppTypeConverters.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppTypeConverters.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.room
 
 import androidx.room.TypeConverter

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/ExtensionDataDao.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/ExtensionDataDao.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.room
 
 import androidx.room.Dao

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/ExtensionDataEntity.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/ExtensionDataEntity.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.room
 
 import androidx.room.Entity

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/FreezerDao.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/FreezerDao.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.room
 
 import androidx.room.Dao

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/FreezerEntity.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/FreezerEntity.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.room
 
 import androidx.room.Entity

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/PackageManagerExt.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/PackageManagerExt.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.shizuku
 
 import android.content.pm.PackageInfo

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.shizuku
 
 import android.app.ActivityManager

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.shizuku
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuPackageInstallerUtils.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuPackageInstallerUtils.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.shizuku
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 @file:Suppress("unused")
 
 package com.valhalla.thor.data.source.local.shizuku

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Targets.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Targets.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.source.local.shizuku
 
 import android.os.Build

--- a/app/src/main/java/com/valhalla/thor/data/util/ApksMetadataGenerator.kt
+++ b/app/src/main/java/com/valhalla/thor/data/util/ApksMetadataGenerator.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.util
 
 import com.valhalla.thor.domain.model.AppInfo

--- a/app/src/main/java/com/valhalla/thor/data/util/PackageVerifier.kt
+++ b/app/src/main/java/com/valhalla/thor/data/util/PackageVerifier.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.util
 
 import android.content.pm.ApplicationInfo

--- a/app/src/main/java/com/valhalla/thor/di/Modules.kt
+++ b/app/src/main/java/com/valhalla/thor/di/Modules.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.di
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/domain/InstallState.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/InstallState.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain
 
 import com.valhalla.thor.domain.model.AppMetadata

--- a/app/src/main/java/com/valhalla/thor/domain/InstallerEventBus.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/InstallerEventBus.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain
 
 import kotlinx.coroutines.channels.BufferOverflow

--- a/app/src/main/java/com/valhalla/thor/domain/gateway/SystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/gateway/SystemGateway.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.gateway
 
 /**

--- a/app/src/main/java/com/valhalla/thor/domain/model/AnimationIntensity.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AnimationIntensity.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 enum class AnimationIntensity {

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppClickAction.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppClickAction.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 sealed interface AppClickAction {

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppInfo.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppInfo.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppInstallable.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppInstallable.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 data class AppInstallable(

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppListType.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppListType.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 enum class AppListType {

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppMetadata.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppMetadata.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 data class AppMetadata(

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppPermission.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppPermission.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 data class AppPermission(

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppSorting.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppSorting.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 /**

--- a/app/src/main/java/com/valhalla/thor/domain/model/DetailedAppInfo.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/DetailedAppInfo.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import androidx.compose.runtime.Immutable

--- a/app/src/main/java/com/valhalla/thor/domain/model/ExportTarget.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ExportTarget.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 /** Where an export should be written. */

--- a/app/src/main/java/com/valhalla/thor/domain/model/ExtensionCatalog.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ExtensionCatalog.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import kotlinx.serialization.Serializable

--- a/app/src/main/java/com/valhalla/thor/domain/model/ExtensionOpsGate.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ExtensionOpsGate.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 /** Package-name prefix every Thor extension shares. */

--- a/app/src/main/java/com/valhalla/thor/domain/model/FilterType.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FilterType.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 sealed interface FilterType {

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezerMode.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 /** What the Freezer does when it "freezes" an app. GH#239. */

--- a/app/src/main/java/com/valhalla/thor/domain/model/HistoryRecord.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/HistoryRecord.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import kotlinx.serialization.Serializable

--- a/app/src/main/java/com/valhalla/thor/domain/model/MultiAppAction.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/MultiAppAction.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 sealed interface MultiAppAction {

--- a/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeMode.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 enum class PrivilegeMode {

--- a/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeState.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 /**

--- a/app/src/main/java/com/valhalla/thor/domain/model/RestoreRequest.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/RestoreRequest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 /**

--- a/app/src/main/java/com/valhalla/thor/domain/model/SortBy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/SortBy.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import com.valhalla.thor.R

--- a/app/src/main/java/com/valhalla/thor/domain/model/ThemeMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ThemeMode.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 enum class ThemeMode {

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 data class UserPreferences(

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppAnalyzer.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppAnalyzer.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import android.net.Uri

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppBundleBuilder.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppBundleBuilder.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import com.valhalla.thor.domain.model.AppInfo

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppBundleFileStore.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppBundleFileStore.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import java.io.File

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import com.valhalla.thor.domain.model.AppInfo

--- a/app/src/main/java/com/valhalla/thor/domain/repository/FreezerRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/FreezerRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/valhalla/thor/domain/repository/InstallerRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/InstallerRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import android.net.Uri

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PermissionRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PermissionRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import com.valhalla.thor.domain.model.AppPermission

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import com.valhalla.thor.domain.model.AnimationIntensity

--- a/app/src/main/java/com/valhalla/thor/domain/repository/StoreRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/StoreRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 import android.net.Uri

--- a/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.repository
 
 interface SystemRepository {

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ExportAppUseCase.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.BuildConfig

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/GetAppDetailsUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/GetAppDetailsUseCase.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.domain.model.AppInfo

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/GetAppPermissionsUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/GetAppPermissionsUseCase.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.domain.model.AppPermission

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/GetInstalledAppsUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/GetInstalledAppsUseCase.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.domain.model.AppInfo

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ManageAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ManageAppUseCase.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.domain.model.restorePlanFor

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ShareAppUseCase.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.usecase
 
 import android.net.Uri

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/TogglePermissionUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/TogglePermissionUseCase.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.domain.repository.PermissionRepository

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.appList
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.appList
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.appList
 
 import android.widget.Toast

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.appList
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.appList
 
 import android.Manifest

--- a/app/src/main/java/com/valhalla/thor/presentation/common/ShizukuPermissionHandler.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/common/ShizukuPermissionHandler.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.common
 
 import android.content.pm.PackageManager

--- a/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionBrowseScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionBrowseScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.extension
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionBrowseViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionBrowseViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.extension
 
 import android.net.Uri

--- a/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionManagerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionManagerScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.extension
 
 import android.content.Intent

--- a/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionManagerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionManagerViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.extension
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.freezer
 
 import android.widget.Toast

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSelectToolBox.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSelectToolBox.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.freezer
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerSettingsSheet.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.freezer
 
 import androidx.compose.foundation.horizontalScroll

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.freezer
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/ManageFreezerSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/ManageFreezerSheet.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.freezer
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/home/AppDestinations.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/AppDestinations.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home
 
 import com.valhalla.thor.R

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home
 
 import androidx.activity.compose.rememberLauncherForActivityResult

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/AppDistributionChart.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/AppDistributionChart.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home.components
 
 import androidx.compose.animation.core.animateFloatAsState

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home.components
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/DashboardHeader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/DashboardHeader.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home.components
 
 import androidx.compose.animation.core.Animatable

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home.components
 
 /** The four Home action tiles, in bento order. */

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home.components
 
 import androidx.compose.animation.animateContentSize

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/SummaryStatRow.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/SummaryStatRow.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home.components
 
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/SupportCommunitySection.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/SupportCommunitySection.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home.components
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.installer
 
 import android.content.pm.PackageManager

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.installer
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstallerActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstallerActivity.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.installer
 
 import android.os.Bundle

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstallerActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstallerActivity.kt
@@ -7,12 +7,20 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.valhalla.thor.domain.model.ThemeMode
+import com.valhalla.thor.domain.model.UserPreferences
+import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.presentation.theme.ThorTheme
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class PortableInstallerActivity : ComponentActivity() {
 
     private val installerViewModel: InstallerViewModel by viewModel()
+    private val preferenceRepository: PreferenceRepository by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,7 +35,21 @@ class PortableInstallerActivity : ComponentActivity() {
             installerViewModel.resetState()
         }
         setContent {
-            ThorTheme {
+            val prefs by preferenceRepository.userPreferences
+                .collectAsStateWithLifecycle(initialValue = UserPreferences())
+
+            val systemDark = isSystemInDarkTheme()
+            val darkTheme = when (prefs.themeMode) {
+                ThemeMode.LIGHT -> false
+                ThemeMode.DARK -> true
+                ThemeMode.SYSTEM -> systemDark
+            }
+
+            ThorTheme(
+                darkTheme = darkTheme,
+                dynamicColor = prefs.useDynamicColor,
+                amoledMode = prefs.useAmoled,
+            ) {
                 PortableInstaller(
                     viewModel = installerViewModel,
                     onDismiss = {

--- a/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.launcher
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.main
 
 import android.content.Intent

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.main
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/navigation/ThorRoute.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/navigation/ThorRoute.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.navigation
 
 import androidx.navigation3.runtime.NavKey

--- a/app/src/main/java/com/valhalla/thor/presentation/permission/PermissionManagerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/permission/PermissionManagerScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.permission
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/valhalla/thor/presentation/permission/PermissionManagerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/permission/PermissionManagerViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.permission
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/permission/PermissionUiState.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/permission/PermissionUiState.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.permission
 
 import com.valhalla.thor.domain.model.AppPermission

--- a/app/src/main/java/com/valhalla/thor/presentation/security/AuthState.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/AuthState.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.security
 
 /**

--- a/app/src/main/java/com/valhalla/thor/presentation/security/BiometricPromptHandler.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/BiometricPromptHandler.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.security
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/presentation/security/BiometricScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/BiometricScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.security
 
 import androidx.compose.animation.core.RepeatMode

--- a/app/src/main/java/com/valhalla/thor/presentation/security/SecurityViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/SecurityViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.security
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/BillingProcessor.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/BillingProcessor.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.settings
 
 import android.app.Activity

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.settings
 
 import android.content.Intent

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.settings
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/valhalla/thor/presentation/theme/Color.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/theme/Color.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.theme
 
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/com/valhalla/thor/presentation/theme/Theme.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/theme/Theme.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.theme
 
 import android.os.Build

--- a/app/src/main/java/com/valhalla/thor/presentation/theme/Type.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/theme/Type.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.theme
 
 import androidx.compose.material3.Typography

--- a/app/src/main/java/com/valhalla/thor/presentation/tile/FreezerTileService.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/tile/FreezerTileService.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.tile
 
 import android.os.Build

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/AppIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/AppIconLoader.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.utils
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/ObserveAsEvents.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/ObserveAsEvents.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.utils
 
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/RecommendationColors.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/RecommendationColors.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.utils
 
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/UiUtils.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/UiUtils.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.utils
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AffirmationDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AffirmationDialog.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AnimateLottieRaw.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AnimateLottieRaw.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import android.content.res.Configuration

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoDialog.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.foundation.Image

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.activity.compose.BackHandler

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/FreezeLoggerDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/FreezeLoggerDialog.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/FreezerPromptSnackbar.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/FreezerPromptSnackbar.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.animation.AnimatedVisibility

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/MultiSelectToolBox.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/MultiSelectToolBox.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/SupportDeveloperBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/SupportDeveloperBottomSheet.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/TermLogger.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/TermLogger.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/ThankYouDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/ThankYouDialog.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.foundation.background

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/TypeWriterText.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/TypeWriterText.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.widgets
 
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
+++ b/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.rootservice
 
 import android.annotation.SuppressLint

--- a/app/src/main/java/com/valhalla/thor/util/LocaleManager.kt
+++ b/app/src/main/java/com/valhalla/thor/util/LocaleManager.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.util
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/util/Logger.kt
+++ b/app/src/main/java/com/valhalla/thor/util/Logger.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.util
 
 import com.valhalla.thor.BuildConfig

--- a/app/src/main/java/com/valhalla/thor/util/UiText.kt
+++ b/app/src/main/java/com/valhalla/thor/util/UiText.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.util
 
 import android.content.Context

--- a/app/src/main/java/com/valhalla/thor/util/UriExtensions.kt
+++ b/app/src/main/java/com/valhalla/thor/util/UriExtensions.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.util
 
 import android.content.Context

--- a/app/src/store/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
+++ b/app/src/store/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.settings
 
 import android.app.Activity

--- a/app/src/store/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
+++ b/app/src/store/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.settings
 
 import android.app.Activity

--- a/app/src/test/java/com/valhalla/thor/ExampleUnitTest.kt
+++ b/app/src/test/java/com/valhalla/thor/ExampleUnitTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/data/launcher/FreezerShortcutContractTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/launcher/FreezerShortcutContractTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.launcher
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/data/manager/ExtensionTrustTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/manager/ExtensionTrustTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.manager
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleZipTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleZipTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.data.repository
 
 import org.junit.After

--- a/app/src/test/java/com/valhalla/thor/domain/model/AppSortingTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/AppSortingTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/domain/model/ExportTargetTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/ExportTargetTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/domain/model/ExtensionOpsGateTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/ExtensionOpsGateTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/FreezerModeTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/PrivilegeResolverTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/valhalla/thor/domain/model/RestoreGateTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/RestoreGateTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.domain.model
 
 import org.junit.Assert.assertFalse

--- a/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.thor.presentation.home
 
 import com.valhalla.thor.presentation.home.components.HomeAction.CLEAR_CACHE

--- a/bypass/src/main/java/com/valhalla/bypass/Bypass.kt
+++ b/bypass/src/main/java/com/valhalla/bypass/Bypass.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.bypass
 
 import android.annotation.SuppressLint

--- a/bypass/src/main/java/com/valhalla/bypass/DexFieldLayout.kt
+++ b/bypass/src/main/java/com/valhalla/bypass/DexFieldLayout.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.bypass
 
 import android.os.SharedMemory

--- a/bypass/src/main/java/com/valhalla/bypass/Helper.kt
+++ b/bypass/src/main/java/com/valhalla/bypass/Helper.kt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 package com.valhalla.bypass
 
 import android.content.Context

--- a/release-notes/v1.93.0/github.md
+++ b/release-notes/v1.93.0/github.md
@@ -35,6 +35,9 @@ Thor's privileged core was completely re-engineered and then extracted into its 
 ### 🐛 App Suspend Fixed on Release Builds (#265)
 * Suspending / unsuspending apps silently failed on **release / Play** builds: R8 renamed bundled framework shadow classes, so the runtime calls hit the real framework classes and threw. The shadows were removed and the root-service daemon is kept intact, so **suspend works again on shipped builds** (`77ec023`).
 
+### 🎨 Portable Installer Follows Your Theme (#273)
+* Opening an APK from Files or another app now renders the installer in **your** chosen theme — dark / light mode, Material You dynamic color and AMOLED — instead of only the device night setting. `PortableInstallerActivity` was themed with defaults; it now reads your preferences like the rest of the app (`6bfb6ea`).
+
 ### 🔄 Auto Reinstall Apps (#251)
 * **One-click reinstall**: sync app metadata automatically and trigger install-time overrides directly from your app-manager view (`6e689e8`).
 * **Idempotency guarantee**: removed a redundant processing cache so reinstallations are seamless and idempotent (`df642fa`).
@@ -91,6 +94,7 @@ A full-codebase audit surfaced 66 issues; this release resolves them:
 ## 🛠 Commits Log (`v1.92.0...HEAD`)
 
 **Merged pull requests**
+* `663eaac` — #273 fix portable-installer theming (honor user theme / dynamic color / AMOLED)
 * `9f424ae` — #270 promote v1.92.3 to stable (dev → master)
 * `9b1e1f3` — #269 losslessly compact the long `VectorPath` drawables
 * `fbc8a8e` — #268 resolve Android lint + Qodana findings
@@ -111,6 +115,7 @@ A full-codebase audit surfaced 66 issues; this release resolves them:
 * `295aa79` (#253) / `ca6da96` (#252) / `fbd3d3c` (#250) / `eb83a4a` (#249) — Dependabot dependency bumps
 
 **Key commits**
+* `6bfb6ea` fix(installer): honor user theme, dynamic color & AMOLED in portable installer
 * `28fef5c` fix(root): propagate privileged-op failures across the `ThorRootService` Binder
 * `aacc18e` feat(odin): consume published Odin 1.0.0; delete `:suCore`; real shell exit codes
 * `77ec023` fix(app): fix release-only app suspend broken by R8

--- a/release-notes/v1.93.0/playstore.txt
+++ b/release-notes/v1.93.0/playstore.txt
@@ -6,6 +6,6 @@
 
 • 📦 Much smaller download, plus a big stability & memory-leak cleanup for a smoother app.
 
-• 📱 Landscape & foldable layout fixes.
+• 📱 Landscape & foldable fixes; installer now follows your app theme.
 
 • 🌍 Now translated into Arabic, Spanish, French and Chinese.

--- a/release-notes/v1.93.0/telegram.md
+++ b/release-notes/v1.93.0/telegram.md
@@ -12,6 +12,8 @@ Our entire recent dev cycle, consolidated into one big update.
 
 • 🛠️ **Suspend fixed** on release / Play builds.
 
+• 🎨 **Themed installer** — opening an APK from Files or another app now respects your dark mode, dynamic color & AMOLED settings.
+
 • 📦 **~48% smaller** direct-download APK (6.23 MB → 3.24 MB).
 
 • 🛡️ **Rock-solid** — a 66-finding stability, memory-leak & architecture audit means fewer crashes and no background ANRs.


### PR DESCRIPTION
Promotes `dev` → `master`. `versionCode` stays **1930** (v1.93.0) — this is **not** a bump. 1930 was never published (the release workflow was cancelled), so these changes fold into the same unpublished 1.93.0.

## What's included since the last master (PR #271)

### Ownership & licensing marks (PR #272)
- `README.md`: `Copyright © 2025–2026 Trinadh Thatakula`, explicit **GPL-3.0-or-later** grant wording, and an "Official builds & unofficial forks" section.
- `TRADEMARK.md`: reserves the Thor **name, logo, and icon** under GPL-3.0 §7(e) — code stays GPL, brand does not.
- **SPDX per-file headers** on all 186 first-party Kotlin sources (`:app` + `:bypass`). Purely additive (0 deletions), verbatim `LICENSE` untouched.

### Bug fix (PR #273)
- **Portable installer now honors the user's theme.** `PortableInstallerActivity` (external APK view/send entry point from Files & third-party apps) was themed with `ThorTheme` defaults, so it followed the device night mode and ignored the in-app `ThemeMode`, dynamic-color, and AMOLED settings. It now reads `PreferenceRepository` and passes `darkTheme`/`dynamicColor`/`amoledMode`, matching `HomeActivity`.

## Notes
- 188 files changed, +661 / −7 (headers dominate the count; logic delta is the single installer file).
- ⚠️ The existing `release-notes/v1.93.0/` changelog predates the installer fix — it does not yet mention it. Worth adding before re-publishing 1930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)