### PR TITLE
fix(installer): gate downgrade detection on a known versionCode + surface the codes

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -177,8 +177,9 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
         val versionName = manifest?.versionName?.takeIf { it.isNotBlank() }
             ?: apkmInfo?.versionName?.takeIf { it.isNotBlank() }
             ?: "Unknown"
-        // 0 when neither sidecar declares a usable code. Consumers must gate on that (see
-        // isVersionDowngrade) — a bundle whose sidecar carries a version *name* in version_code
+        // Null when neither sidecar declares a usable code. This is the ONLY path that can produce
+        // an unknown version code — there is no APK to parse here — and consumers must gate on it
+        // (see isVersionDowngrade): a bundle whose sidecar carries a version *name* in version_code
         // used to land here as 0 and read as a downgrade against every installed app.
         val versionCode = resolveSidecarVersionCode(manifest, apkmInfo)
         val icon = iconBytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
@@ -235,20 +236,23 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
      *
      * Keyed by packageName AND [versionCode]: Coil keys its File memory cache by the path only
      * (addLastModifiedToFileCacheKey defaults false), so a fixed per-package path would serve a
-     * STALE icon after a version bump — a distinct path per version busts that. Written to a unique
-     * temp file then atomically renamed, so two concurrent same-(pkg,version) analyses can never
-     * expose a partial/corrupt PNG to Coil (either the old complete file or the new one).
+     * STALE icon after a version bump — a distinct path per version busts that. A null (unknown)
+     * version code gets its own `_unknown` key rather than sharing the `_0` slot with a real APK
+     * that legitimately declares version code 0. Written to a unique temp file then atomically
+     * renamed, so two concurrent same-(pkg,version) analyses can never expose a partial/corrupt
+     * PNG to Coil (either the old complete file or the new one).
      *
      * Best-effort: any decode/IO failure yields a null path (never crashes parsing). This cache
      * file is intentionally NOT deleted in analyze()'s finally — the UI reads it after analyze()
      * returns; it lives in cacheDir so the OS can reclaim it.
      */
-    private fun persistIcon(bitmap: Bitmap?, packageName: String, versionCode: Long): String? {
+    private fun persistIcon(bitmap: Bitmap?, packageName: String, versionCode: Long?): String? {
         if (bitmap == null) return null
         return runCatching {
             val iconDir = File(context.cacheDir, "installer_icons").apply { mkdirs() }
-            val dest = File(iconDir, "${packageName}_$versionCode.png")
-            val tmp = File(iconDir, "${packageName}_$versionCode.${java.util.UUID.randomUUID()}.png.tmp")
+            val key = "${packageName}_${versionCode ?: "unknown"}"
+            val dest = File(iconDir, "$key.png")
+            val tmp = File(iconDir, "$key.${java.util.UUID.randomUUID()}.png.tmp")
             try {
                 FileOutputStream(tmp).use { out ->
                     bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -177,7 +177,10 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
         val versionName = manifest?.versionName?.takeIf { it.isNotBlank() }
             ?: apkmInfo?.versionName?.takeIf { it.isNotBlank() }
             ?: "Unknown"
-        val versionCode = (manifest?.versionCode ?: apkmInfo?.versionCode)?.toLongOrNull() ?: 0L
+        // 0 when neither sidecar declares a usable code. Consumers must gate on that (see
+        // isVersionDowngrade) — a bundle whose sidecar carries a version *name* in version_code
+        // used to land here as 0 and read as a downgrade against every installed app.
+        val versionCode = resolveSidecarVersionCode(manifest, apkmInfo)
         val icon = iconBytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
         return AppMetadata(
             label = label,

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
@@ -106,15 +106,19 @@ fun parseApkmInfo(jsonText: String): ApkmInfo? = try {
  * a junk `manifest.json` value can never shadow a good `info.json` one; the sibling version *name*
  * resolution already works this way. Surrounding whitespace is tolerated.
  *
- * Returns `0` for "unknown" — the same convention `CatalogEntry.versionCode` uses. Callers must
- * never treat `0` as authoritative; in particular it must not be compared against an installed
- * app's version code, because `0` loses every such comparison and would report a downgrade for
- * any installed app no matter how new the picked file is.
+ * Returns null for "unknown", which callers must never compare against an installed app's version
+ * code: any number we substituted would lose that comparison and report a downgrade for every
+ * installed app, no matter how new the picked file is. See `isVersionDowngrade`.
+ *
+ * A sidecar `0` is treated as unknown too, unlike a `0` parsed out of a real APK manifest (which is
+ * a legal, authoritative version code). These fields are free text written by third-party
+ * repackers, where `0` is indistinguishable from an unset placeholder — and treating it as known
+ * would let a junk `manifest.json` value shadow a good `info.json` one, which the per-source
+ * fallthrough below exists to prevent.
  */
-fun resolveSidecarVersionCode(manifest: XapkManifestInfo?, apkmInfo: ApkmInfo?): Long =
+fun resolveSidecarVersionCode(manifest: XapkManifestInfo?, apkmInfo: ApkmInfo?): Long? =
     sidecarVersionCode(manifest?.versionCode)
         ?: sidecarVersionCode(apkmInfo?.versionCode)
-        ?: 0L
 
 /** One sidecar field as a usable version code, or null when blank, non-numeric or non-positive. */
 private fun sidecarVersionCode(raw: String?): Long? =

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
@@ -97,6 +97,29 @@ fun parseApkmInfo(jsonText: String): ApkmInfo? = try {
     null
 }
 
+/**
+ * Resolve a bundle's version code from its sidecar JSON, best source first.
+ *
+ * Sidecar version codes are typed `String?` because real producers write them either as a JSON
+ * number or as a string. Some also write a version *name* into the field (`"4.3.0"`), leave it
+ * blank, or omit it — none of which is a version code. Each source is therefore tried in turn, so
+ * a junk `manifest.json` value can never shadow a good `info.json` one; the sibling version *name*
+ * resolution already works this way. Surrounding whitespace is tolerated.
+ *
+ * Returns `0` for "unknown" — the same convention `CatalogEntry.versionCode` uses. Callers must
+ * never treat `0` as authoritative; in particular it must not be compared against an installed
+ * app's version code, because `0` loses every such comparison and would report a downgrade for
+ * any installed app no matter how new the picked file is.
+ */
+fun resolveSidecarVersionCode(manifest: XapkManifestInfo?, apkmInfo: ApkmInfo?): Long =
+    sidecarVersionCode(manifest?.versionCode)
+        ?: sidecarVersionCode(apkmInfo?.versionCode)
+        ?: 0L
+
+/** One sidecar field as a usable version code, or null when blank, non-numeric or non-positive. */
+private fun sidecarVersionCode(raw: String?): Long? =
+    raw?.trim()?.toLongOrNull()?.takeIf { it > 0L }
+
 /** File extensions that unambiguously denote a bundle container (never a single APK). */
 private val BUNDLE_EXTENSIONS = setOf("xapk", "apkm", "apks", "apkp")
 

--- a/app/src/main/java/com/valhalla/thor/domain/InstallState.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/InstallState.kt
@@ -27,16 +27,11 @@ sealed interface InstallState {
         val oldVersionCode: Long? = null
     ) : InstallState {
 
-        @Suppress("unused")
-        fun getVersionInfo(): String {
-            return if (isUpdate) {
-                "Update available: ${meta.version} (current: $oldVersion)"
-            } else if (isDowngrade) {
-                "Downgrade detected: ${meta.version} (current: $oldVersion)"
-            } else {
-                "Ready to install version ${meta.version}"
-            }
-        }
+        // getVersionInfo() lived here: dead code (@Suppress("unused"), no call sites) that
+        // rendered the verdict from version NAMES only, and tested isUpdate before isDowngrade —
+        // a downgrade is always also an update, so its downgrade branch was unreachable and it
+        // reported "Update available: 1.2.5.1 (current: 1.2.4.7)" for precisely the case this
+        // class now exists to explain. Deleted rather than fixed; nothing called it.
 
         fun getActionButtonText(): com.valhalla.thor.util.UiText {
             return when {

--- a/app/src/main/java/com/valhalla/thor/domain/InstallState.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/InstallState.kt
@@ -12,11 +12,19 @@ sealed interface InstallState {
     data object Idle : InstallState
     data object Parsing : InstallState
 
+    /**
+     * @param oldVersion the installed app's version *name*, or null when nothing is installed.
+     * @param oldVersionCode the installed app's version *code* — the value [isDowngrade] is
+     *   actually decided on. Carried so the UI can show it: version names routinely disagree with
+     *   version codes, and without the codes on screen a correct downgrade verdict is impossible
+     *   for a user to distinguish from a bug.
+     */
     data class ReadyToInstall(
         val meta: AppMetadata,
         val isUpdate: Boolean,
         val isDowngrade: Boolean = false,
-        val oldVersion: String? = null
+        val oldVersion: String? = null,
+        val oldVersionCode: Long? = null
     ) : InstallState {
 
         @Suppress("unused")

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppMetadata.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppMetadata.kt
@@ -3,11 +3,18 @@
 
 package com.valhalla.thor.domain.model
 
+/**
+ * @param versionCode the file's Android version code, or null when it could not be read at all.
+ *   Null is *unknown*, which is not the same as `0`: a real APK whose manifest omits
+ *   `android:versionCode` parses as `0`, and Android compares that value numerically like any
+ *   other — installing it over a positive code is a genuine downgrade. Only the sidecar-only
+ *   fallback, which has no APK to parse, can produce null. See [isVersionDowngrade].
+ */
 data class AppMetadata(
     val label: String,
     val packageName: String,
     val version: String,
-    val versionCode: Long,
+    val versionCode: Long?,
     val iconPath: String?,
     val permissions: List<String> = emptyList()
 )

--- a/app/src/main/java/com/valhalla/thor/domain/model/VersionCompare.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/VersionCompare.kt
@@ -6,15 +6,17 @@ package com.valhalla.thor.domain.model
 /**
  * True iff [newVersionCode] is a *known* version code strictly older than [installedVersionCode].
  *
- * A non-positive [newVersionCode] means "unknown" — the analyzer could not read a usable version
- * code out of the picked file — and must never be reported as a downgrade. `0` loses every
- * comparison, so treating it as authoritative would flag an install over *any* installed app as a
- * downgrade, however new the file actually is. Same `0 = unknown` convention as
- * [CatalogEntry.versionCode].
+ * A null [newVersionCode] means "unknown" — the analyzer could not read a version code out of the
+ * picked file at all — and must never be reported as a downgrade, because an unknown would
+ * otherwise have to be represented by some number, and any number we picked would lose against
+ * something. Unknown is deliberately *not* encoded as `0`: `0` is a legal Android version code (the
+ * platform parser defaults a manifest with no `android:versionCode` to zero) and Android compares
+ * it numerically like any other, so installing a genuine `0` over a positive code IS a downgrade
+ * and has to be reported as one.
  *
  * Version *names* are deliberately not consulted: Android sequences updates by version code alone,
  * so a file may carry a newer-looking name (`1.2.5.1` over `1.2.4.7`) and still be a real
  * downgrade. Callers should surface both codes so that verdict is explainable to the user.
  */
-fun isVersionDowngrade(newVersionCode: Long, installedVersionCode: Long): Boolean =
-    newVersionCode > 0L && newVersionCode < installedVersionCode
+fun isVersionDowngrade(newVersionCode: Long?, installedVersionCode: Long): Boolean =
+    newVersionCode != null && newVersionCode < installedVersionCode

--- a/app/src/main/java/com/valhalla/thor/domain/model/VersionCompare.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/VersionCompare.kt
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+/**
+ * True iff [newVersionCode] is a *known* version code strictly older than [installedVersionCode].
+ *
+ * A non-positive [newVersionCode] means "unknown" — the analyzer could not read a usable version
+ * code out of the picked file — and must never be reported as a downgrade. `0` loses every
+ * comparison, so treating it as authoritative would flag an install over *any* installed app as a
+ * downgrade, however new the file actually is. Same `0 = unknown` convention as
+ * [CatalogEntry.versionCode].
+ *
+ * Version *names* are deliberately not consulted: Android sequences updates by version code alone,
+ * so a file may carry a newer-looking name (`1.2.5.1` over `1.2.4.7`) and still be a real
+ * downgrade. Callers should surface both codes so that verdict is explainable to the user.
+ */
+fun isVersionDowngrade(newVersionCode: Long, installedVersionCode: Long): Boolean =
+    newVersionCode > 0L && newVersionCode < installedVersionCode

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -106,11 +106,12 @@ class InstallerViewModel(
                         existing?.let { PackageInfoCompat.getLongVersionCode(it) }
 
                     isUpdateOperation = existing != null
-                    // Gated on a KNOWN version code: the analyzer yields 0 when it could not read
-                    // one out of the file, and 0 would otherwise lose against every installed app.
+                    // isVersionDowngrade itself gates on a KNOWN version code: the analyzer yields
+                    // null when it could not read one out of the file, and any number we
+                    // substituted would lose against every installed app.
                     isDowngrade = installedVersionCode != null &&
                         isVersionDowngrade(meta.versionCode, installedVersionCode)
-                    versionCodeUnknown = installedVersionCode != null && meta.versionCode <= 0L
+                    versionCodeUnknown = installedVersionCode != null && meta.versionCode == null
 
                     eventBus.emit(
                         InstallState.ReadyToInstall(

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.domain.InstallState
 import com.valhalla.thor.domain.InstallerEventBus
+import com.valhalla.thor.domain.model.isVersionDowngrade
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.domain.repository.InstallMode
 import com.valhalla.thor.domain.repository.InstallerRepository
@@ -94,17 +95,22 @@ class InstallerViewModel(
                         }.getOrNull()
                     }
 
+                    val installedVersionCode =
+                        existing?.let { PackageInfoCompat.getLongVersionCode(it) }
+
                     isUpdateOperation = existing != null
-                    isDowngrade = if (existing != null) {
-                        meta.versionCode < PackageInfoCompat.getLongVersionCode(existing)
-                    } else false
+                    // Gated on a KNOWN version code: the analyzer yields 0 when it could not read
+                    // one out of the file, and 0 would otherwise lose against every installed app.
+                    isDowngrade = installedVersionCode != null &&
+                        isVersionDowngrade(meta.versionCode, installedVersionCode)
 
                     eventBus.emit(
                         InstallState.ReadyToInstall(
                             meta = meta,
                             isUpdate = isUpdateOperation,
                             isDowngrade = isDowngrade,
-                            oldVersion = existing?.versionName
+                            oldVersion = existing?.versionName,
+                            oldVersionCode = installedVersionCode
                         )
                     )
                 },

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -49,6 +49,13 @@ class InstallerViewModel(
     private var isUpdateOperation: Boolean = false
     private var isDowngrade: Boolean = false
 
+    // True when there IS something installed but we could not read a version code out of the
+    // picked file, so we can neither prove nor rule out a downgrade. Distinct from isDowngrade:
+    // that one is a verdict (it drives the warning and the NORMAL-mode veto) and must only be
+    // true when we can prove one. This one only ever widens the install *permission* — see
+    // startInstallation().
+    private var versionCodeUnknown: Boolean = false
+
     // True once THIS ViewModel has driven a parse/install on the shared @Single bus. Only an
     // owning VM may reset the bus in onCleared(), so tearing down a non-owning installer screen
     // (e.g. one that merely observed the bus) can't clobber a terminal Success / ReadyToInstall
@@ -103,6 +110,7 @@ class InstallerViewModel(
                     // one out of the file, and 0 would otherwise lose against every installed app.
                     isDowngrade = installedVersionCode != null &&
                         isVersionDowngrade(meta.versionCode, installedVersionCode)
+                    versionCodeUnknown = installedVersionCode != null && meta.versionCode <= 0L
 
                     eventBus.emit(
                         InstallState.ReadyToInstall(
@@ -154,8 +162,18 @@ class InstallerViewModel(
             return
         }
 
+        // The downgrade *permission* is deliberately wider than the downgrade *verdict*. It ends up
+        // as `pm install -d` / setRequestDowngrade(true), which is permissive-only — a no-op when
+        // the install turns out not to be a downgrade — so it is also the right flag when we could
+        // not read a version code at all: withholding it would let the OS reject the install with
+        // an opaque INSTALL_FAILED_VERSION_DOWNGRADE the user cannot override. Widened only on a
+        // privileged path; in NORMAL mode the flag needs a privilege we do not have, so it would
+        // buy nothing and merely put a reflective setRequestDowngrade call on the unprivileged
+        // happy path for the first time.
+        val allowDowngrade = isDowngrade || (versionCodeUnknown && mode != InstallMode.NORMAL)
+
         viewModelScope.launch {
-            repository.installPackage(uri, mode, isDowngrade)
+            repository.installPackage(uri, mode, allowDowngrade)
         }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
@@ -367,6 +367,11 @@ fun PortableInstaller(
                                 } else {
                                     meta.version
                                 },
+                                // Appending the code made this line ~10 characters longer. Both
+                                // children of this Row are unweighted, so at a large font scale on
+                                // a narrow screen it would wrap mid-token beside a centred prefix.
+                                // fill = false keeps the Row centred while bounding this child.
+                                modifier = Modifier.weight(1f, fill = false),
                                 style = MaterialTheme.typography.bodyMedium,
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.primary
@@ -396,16 +401,19 @@ fun PortableInstaller(
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurface
                                 )
-                                // Apps whose versionCode scheme drops a component (e.g. name
-                                // 1.2.4.7 -> code 1002007, name 1.2.5.1 -> code 1002001) look like
-                                // an upgrade by name while genuinely downgrading by code. Spell the
-                                // numbers out, or this reads as a Thor bug.
+                                // A version NAME can move forward while the version CODE moves
+                                // back: an app only has to hand-maintain its code and slip (Omni
+                                // Browser shipped name 1.2.4.7 as code 27, then name 1.2.5.1 as
+                                // code 25). Android sequences updates by code alone, so spell the
+                                // two numbers out; otherwise a correct verdict reads as a Thor
+                                // bug — which is exactly how this got reported. Passed as strings
+                                // on purpose: see the comment on install_downgrade_code_explainer.
                                 s.oldVersionCode?.let { installedCode ->
                                     Text(
                                         text = stringResource(
                                             R.string.install_downgrade_code_explainer,
-                                            meta.versionCode,
-                                            installedCode
+                                            meta.versionCode.toString(),
+                                            installedCode.toString()
                                         ),
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
@@ -335,11 +335,12 @@ fun PortableInstaller(
                                     fontWeight = FontWeight.Bold,
                                     color = MaterialTheme.colorScheme.primary
                                 )
-                                // 0 means the analyzer could not read a version code out of the
-                                // file (see isVersionDowngrade) — showing "(0)" would be a lie.
-                                if (meta.versionCode > 0L) {
+                                // Null means the analyzer could not read a version code out of the
+                                // file (see isVersionDowngrade) — there is no number to show. A
+                                // real code of 0 is NOT that case and is shown like any other.
+                                meta.versionCode?.let { code ->
                                     Text(
-                                        text = "(${meta.versionCode})",
+                                        text = "($code)",
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant
                                     )
@@ -362,11 +363,9 @@ fun PortableInstaller(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                             Text(
-                                text = if (meta.versionCode > 0L) {
-                                    "${meta.version} (${meta.versionCode})"
-                                } else {
-                                    meta.version
-                                },
+                                text = meta.versionCode
+                                    ?.let { "${meta.version} ($it)" }
+                                    ?: meta.version,
                                 // Appending the code made this line ~10 characters longer. Both
                                 // children of this Row are unweighted, so at a large font scale on
                                 // a narrow screen it would wrap mid-token beside a centred prefix.
@@ -408,11 +407,15 @@ fun PortableInstaller(
                                 // two numbers out; otherwise a correct verdict reads as a Thor
                                 // bug — which is exactly how this got reported. Passed as strings
                                 // on purpose: see the comment on install_downgrade_code_explainer.
-                                s.oldVersionCode?.let { installedCode ->
+                                // Both codes are non-null whenever isDowngrade is true; the checks
+                                // are here so the branch can never render the word "null".
+                                val newCode = meta.versionCode
+                                val installedCode = s.oldVersionCode
+                                if (newCode != null && installedCode != null) {
                                     Text(
                                         text = stringResource(
                                             R.string.install_downgrade_code_explainer,
-                                            meta.versionCode.toString(),
+                                            newCode.toString(),
                                             installedCode.toString()
                                         ),
                                         style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
@@ -306,6 +306,16 @@ fun PortableInstaller(
                                     style = MaterialTheme.typography.bodyMedium,
                                     fontWeight = FontWeight.Medium
                                 )
+                                // The version CODE is what the update/downgrade verdict is made
+                                // on; names routinely disagree with it. Without this on screen a
+                                // correct downgrade call is indistinguishable from a bug.
+                                s.oldVersionCode?.let { code ->
+                                    Text(
+                                        text = "($code)",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                             Icon(
                                 painter = painterResource(R.drawable.open_in_new),
@@ -325,6 +335,15 @@ fun PortableInstaller(
                                     fontWeight = FontWeight.Bold,
                                     color = MaterialTheme.colorScheme.primary
                                 )
+                                // 0 means the analyzer could not read a version code out of the
+                                // file (see isVersionDowngrade) — showing "(0)" would be a lie.
+                                if (meta.versionCode > 0L) {
+                                    Text(
+                                        text = "(${meta.versionCode})",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
                     } else {
@@ -343,7 +362,11 @@ fun PortableInstaller(
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                             Text(
-                                text = "${meta.version} (${meta.versionCode})",
+                                text = if (meta.versionCode > 0L) {
+                                    "${meta.version} (${meta.versionCode})"
+                                } else {
+                                    meta.version
+                                },
                                 style = MaterialTheme.typography.bodyMedium,
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.primary
@@ -367,11 +390,28 @@ fun PortableInstaller(
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.error
                             )
-                            Text(
-                                text = stringResource(R.string.install_downgrade_warning),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(R.string.install_downgrade_warning),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                // Apps whose versionCode scheme drops a component (e.g. name
+                                // 1.2.4.7 -> code 1002007, name 1.2.5.1 -> code 1002001) look like
+                                // an upgrade by name while genuinely downgrading by code. Spell the
+                                // numbers out, or this reads as a Thor bug.
+                                s.oldVersionCode?.let { installedCode ->
+                                    Text(
+                                        text = stringResource(
+                                            R.string.install_downgrade_code_explainer,
+                                            meta.versionCode,
+                                            installedCode
+                                        ),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
                         }
                     } else if (s.isUpdate) {
                         Row(

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -338,7 +338,7 @@
     <string name="title_thor_installer">مثبت Thor</string>
     <string name="install_analyzing">جاري تحليل الحزمة…</string>
     <string name="install_downgrade_warning">سيؤدي هذا إلى خفض إصدار التطبيق.</string>
-    <string name="install_downgrade_code_explainer">رمز الإصدار %1$d أقل من المثبَّت %2$d. يرتّب Android التحديثات حسب رمز الإصدار لا حسب اسم الإصدار، لذا قد يبدو التطبيق أحدث وهو في الواقع خفض للإصدار.</string>
+    <string name="install_downgrade_code_explainer">رمز الإصدار %1$s أقل من المثبَّت %2$s. يرتّب Android التحديثات حسب رمز الإصدار لا حسب اسم الإصدار، لذا قد يبدو التطبيق أحدث وهو في الواقع خفض للإصدار.</string>
     <string name="install_update_warning">سيؤدي هذا إلى تحديث التطبيق الحالي.</string>
     <plurals name="install_permissions">
         <item quantity="zero">لا تطلب هذه الحزمة أي أذونات. %2$s</item>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -338,6 +338,7 @@
     <string name="title_thor_installer">مثبت Thor</string>
     <string name="install_analyzing">جاري تحليل الحزمة…</string>
     <string name="install_downgrade_warning">سيؤدي هذا إلى خفض إصدار التطبيق.</string>
+    <string name="install_downgrade_code_explainer">رمز الإصدار %1$d أقل من المثبَّت %2$d. يرتّب Android التحديثات حسب رمز الإصدار لا حسب اسم الإصدار، لذا قد يبدو التطبيق أحدث وهو في الواقع خفض للإصدار.</string>
     <string name="install_update_warning">سيؤدي هذا إلى تحديث التطبيق الحالي.</string>
     <plurals name="install_permissions">
         <item quantity="zero">لا تطلب هذه الحزمة أي أذونات. %2$s</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -308,6 +308,7 @@
     <string name="title_thor_installer">Instalador Thor</string>
     <string name="install_analyzing">Analizando paquete…</string>
     <string name="install_downgrade_warning">Esto degradará la aplicación.</string>
+    <string name="install_downgrade_code_explainer">El código de versión %1$d es inferior al instalado %2$d. Android ordena las actualizaciones por código de versión, no por nombre de versión: una aplicación puede parecer más reciente y aun así ser una degradación.</string>
     <string name="install_update_warning">Esto actualizará la aplicación existente.</string>
     <plurals name="install_permissions">
         <item quantity="one">Este paquete solicita %1$d permiso. %2$s</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -308,7 +308,7 @@
     <string name="title_thor_installer">Instalador Thor</string>
     <string name="install_analyzing">Analizando paquete…</string>
     <string name="install_downgrade_warning">Esto degradará la aplicación.</string>
-    <string name="install_downgrade_code_explainer">El código de versión %1$d es inferior al instalado %2$d. Android ordena las actualizaciones por código de versión, no por nombre de versión: una aplicación puede parecer más reciente y aun así ser una degradación.</string>
+    <string name="install_downgrade_code_explainer">El código de versión %1$s es inferior al instalado %2$s. Android ordena las actualizaciones por código de versión, no por nombre de versión: una aplicación puede parecer más reciente y aun así ser una degradación.</string>
     <string name="install_update_warning">Esto actualizará la aplicación existente.</string>
     <plurals name="install_permissions">
         <item quantity="one">Este paquete solicita %1$d permiso. %2$s</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -308,6 +308,7 @@
     <string name="title_thor_installer">Installateur Thor</string>
     <string name="install_analyzing">Analyse du paquet…</string>
     <string name="install_downgrade_warning">Cela va dégrader l\'application.</string>
+    <string name="install_downgrade_code_explainer">Le code de version %1$d est inférieur au %2$d installé. Android ordonne les mises à jour par code de version, et non par nom de version : une application peut sembler plus récente tout en étant une rétrogradation.</string>
     <string name="install_update_warning">Cela va mettre à jour l\'application existante.</string>
     <plurals name="install_permissions">
         <item quantity="one">Ce paquet demande %1$d autorisation. %2$s</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -308,7 +308,7 @@
     <string name="title_thor_installer">Installateur Thor</string>
     <string name="install_analyzing">Analyse du paquet…</string>
     <string name="install_downgrade_warning">Cela va dégrader l\'application.</string>
-    <string name="install_downgrade_code_explainer">Le code de version %1$d est inférieur au %2$d installé. Android ordonne les mises à jour par code de version, et non par nom de version : une application peut sembler plus récente tout en étant une rétrogradation.</string>
+    <string name="install_downgrade_code_explainer">Le code de version %1$s est inférieur au %2$s installé. Android ordonne les mises à jour par code de version, et non par nom de version : une application peut sembler plus récente tout en étant une rétrogradation.</string>
     <string name="install_update_warning">Cela va mettre à jour l\'application existante.</string>
     <plurals name="install_permissions">
         <item quantity="one">Ce paquet demande %1$d autorisation. %2$s</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -301,7 +301,7 @@
     <string name="title_thor_installer">Thor 安装器</string>
     <string name="install_analyzing">正在解析包…</string>
     <string name="install_downgrade_warning">这将降级该应用。</string>
-    <string name="install_downgrade_code_explainer">版本号 %1$d 低于已安装的 %2$d。Android 按版本号（versionCode）而非版本名称排序更新，因此应用看起来较新仍可能是降级。</string>
+    <string name="install_downgrade_code_explainer">版本号 %1$s 低于已安装的 %2$s。Android 按版本号（versionCode）而非版本名称排序更新，因此应用看起来较新仍可能是降级。</string>
     <string name="install_update_warning">这将更新现有应用。</string>
     <plurals name="install_permissions">
         <item quantity="other">此包请求 %1$d 个权限。%2$s</item>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -301,6 +301,7 @@
     <string name="title_thor_installer">Thor 安装器</string>
     <string name="install_analyzing">正在解析包…</string>
     <string name="install_downgrade_warning">这将降级该应用。</string>
+    <string name="install_downgrade_code_explainer">版本号 %1$d 低于已安装的 %2$d。Android 按版本号（versionCode）而非版本名称排序更新，因此应用看起来较新仍可能是降级。</string>
     <string name="install_update_warning">这将更新现有应用。</string>
     <plurals name="install_permissions">
         <item quantity="other">此包请求 %1$d 个权限。%2$s</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,7 +386,12 @@
     <string name="title_thor_installer">Thor Installer</string>
     <string name="install_analyzing">Analyzing Package…</string>
     <string name="install_downgrade_warning">This will downgrade the app.</string>
-    <string name="install_downgrade_code_explainer">Version code %1$d is lower than the installed %2$d. Android orders updates by version code, not by version name — an app can look newer and still be a downgrade.</string>
+    <!-- %1$s and %2$s are version codes. They are deliberately %s, not %d: %d is localised by
+         java.util.Formatter (Arabic-Indic digits under ar-EG, for example), and these same two
+         numbers are rendered elsewhere on this screen by plain Kotlin interpolation, which is
+         always ASCII. A version code is an opaque identifier the user compares against a store
+         listing or adb output, so keep it ASCII and keep it consistent. -->
+    <string name="install_downgrade_code_explainer">Version code %1$s is lower than the installed %2$s. Android orders updates by version code, not by version name — an app can look newer and still be a downgrade.</string>
     <string name="install_update_warning">This will update the existing app.</string>
     <plurals name="install_permissions">
         <item quantity="one">This package requests %1$d permission. %2$s</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,6 +386,7 @@
     <string name="title_thor_installer">Thor Installer</string>
     <string name="install_analyzing">Analyzing Package…</string>
     <string name="install_downgrade_warning">This will downgrade the app.</string>
+    <string name="install_downgrade_code_explainer">Version code %1$d is lower than the installed %2$d. Android orders updates by version code, not by version name — an app can look newer and still be a downgrade.</string>
     <string name="install_update_warning">This will update the existing app.</string>
     <plurals name="install_permissions">
         <item quantity="one">This package requests %1$d permission. %2$s</item>

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
@@ -403,6 +403,57 @@ class BundleAnalysisTest {
         assertTrue(resolveBundleInstallSet(entries, null, null).isEmpty())
     }
 
+    // --- sidecar version-code resolution ---
+
+    @Test
+    fun sidecarVersionCode_blankManifestValueDoesNotShadowApkmValue() {
+        // The elvis used to test only for null, so a present-but-blank manifest value won the
+        // chain and collapsed to 0 — even with a perfectly good info.json code alongside it.
+        val manifest = parseXapkManifest("""{"package_name":"com.example.app","version_code":""}""")
+        val apkm = parseApkmInfo("""{"pname":"com.example.app","versioncode":"30271"}""")
+        assertEquals(30271L, resolveSidecarVersionCode(manifest, apkm))
+    }
+
+    @Test
+    fun sidecarVersionCode_versionNameInCodeFieldFallsThroughToApkm() {
+        // Some producers write a version NAME into version_code. That is not a version code, so it
+        // must not win the chain — this is the one place the "we compare version names" hypothesis
+        // was literally true.
+        val manifest =
+            parseXapkManifest("""{"package_name":"com.example.app","version_code":"4.3.0"}""")
+        val apkm = parseApkmInfo("""{"pname":"com.example.app","versioncode":"4300"}""")
+        assertEquals(4300L, resolveSidecarVersionCode(manifest, apkm))
+    }
+
+    @Test
+    fun sidecarVersionCode_numericManifestValueStillWins() {
+        // Guard the GH#159 string-from-number contract end to end.
+        val manifest =
+            parseXapkManifest("""{"package_name":"com.example.app","version_code":12345}""")
+        assertEquals(12345L, resolveSidecarVersionCode(manifest, null))
+    }
+
+    @Test
+    fun sidecarVersionCode_toleratesSurroundingWhitespace() {
+        val manifest =
+            parseXapkManifest("""{"package_name":"com.example.app","version_code":" 12345 "}""")
+        assertEquals(12345L, resolveSidecarVersionCode(manifest, null))
+    }
+
+    @Test
+    fun sidecarVersionCode_absentInBothSidecarsIsUnknown() {
+        // 0 = unknown. isVersionDowngrade() gates on this; it is NOT an authoritative version code.
+        assertEquals(0L, resolveSidecarVersionCode(parseXapkManifest("""{"package_name":"x"}"""), null))
+        assertEquals(0L, resolveSidecarVersionCode(null, null))
+    }
+
+    @Test
+    fun sidecarVersionCode_nonPositiveValuesAreUnknown() {
+        val manifest = parseXapkManifest("""{"package_name":"x","version_code":"0"}""")
+        val apkm = parseApkmInfo("""{"pname":"x","versioncode":"-7"}""")
+        assertEquals(0L, resolveSidecarVersionCode(manifest, apkm))
+    }
+
     @Test
     fun resolveBundleInstallSet_doesNotAppendForeignStandaloneApk() {
         // A complete manifest plus a stray standalone top-level APK (e.g. a

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
@@ -442,28 +442,39 @@ class BundleAnalysisTest {
 
     @Test
     fun sidecarVersionCode_absentInBothSidecarsIsUnknown() {
-        // 0 = unknown. isVersionDowngrade() gates on this; it is NOT an authoritative version code.
-        assertEquals(0L, resolveSidecarVersionCode(parseXapkManifest("""{"package_name":"x"}"""), null))
-        assertEquals(0L, resolveSidecarVersionCode(null, null))
+        // null = unknown, NOT 0: `0` is a legal version code that a real APK manifest can declare,
+        // and isVersionDowngrade() compares it like any other number. Unknown has to be its own
+        // value so an unreadable sidecar can't masquerade as "version zero" and lose every compare.
+        assertNull(resolveSidecarVersionCode(parseXapkManifest("""{"package_name":"x"}"""), null))
+        assertNull(resolveSidecarVersionCode(null, null))
     }
 
     @Test
     fun sidecarVersionCode_nonPositiveValuesAreUnknown() {
-        // A lone negative value, so the `> 0` filter is what is under test. With a "0" in the
-        // manifest slot the chain would already answer 0 for the wrong reason and the filter could
-        // be deleted without failing anything.
-        assertEquals(
-            0L,
+        // Sidecar fields are free text from third-party repackers, so `0` there is treated as an
+        // unset placeholder — deliberately unlike a `0` parsed out of a real APK manifest. A lone
+        // negative value pins the `> 0` filter itself: with a "0" in the manifest slot the chain
+        // would answer null for the wrong reason and the filter could be deleted for free.
+        assertNull(
             resolveSidecarVersionCode(
                 parseXapkManifest("""{"package_name":"x","version_code":"-7"}"""),
                 null
             )
         )
-        assertEquals(0L, resolveSidecarVersionCode(null, parseApkmInfo("""{"pname":"x","versioncode":"-7"}""")))
+        assertNull(resolveSidecarVersionCode(null, parseApkmInfo("""{"pname":"x","versioncode":"-7"}""")))
         // Both slots non-positive: neither may win.
         val manifest = parseXapkManifest("""{"package_name":"x","version_code":"0"}""")
         val apkm = parseApkmInfo("""{"pname":"x","versioncode":"-7"}""")
-        assertEquals(0L, resolveSidecarVersionCode(manifest, apkm))
+        assertNull(resolveSidecarVersionCode(manifest, apkm))
+    }
+
+    @Test
+    fun sidecarVersionCode_zeroDoesNotShadowAGoodSiblingValue() {
+        // The per-source `> 0` filter is what makes the fallthrough work: a "0" in manifest.json
+        // must not win the chain when info.json carries a real code alongside it.
+        val manifest = parseXapkManifest("""{"package_name":"x","version_code":"0"}""")
+        val apkm = parseApkmInfo("""{"pname":"x","versioncode":"30271"}""")
+        assertEquals(30271L, resolveSidecarVersionCode(manifest, apkm))
     }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleAnalysisTest.kt
@@ -449,6 +449,18 @@ class BundleAnalysisTest {
 
     @Test
     fun sidecarVersionCode_nonPositiveValuesAreUnknown() {
+        // A lone negative value, so the `> 0` filter is what is under test. With a "0" in the
+        // manifest slot the chain would already answer 0 for the wrong reason and the filter could
+        // be deleted without failing anything.
+        assertEquals(
+            0L,
+            resolveSidecarVersionCode(
+                parseXapkManifest("""{"package_name":"x","version_code":"-7"}"""),
+                null
+            )
+        )
+        assertEquals(0L, resolveSidecarVersionCode(null, parseApkmInfo("""{"pname":"x","versioncode":"-7"}""")))
+        // Both slots non-positive: neither may win.
         val manifest = parseXapkManifest("""{"package_name":"x","version_code":"0"}""")
         val apkm = parseApkmInfo("""{"pname":"x","versioncode":"-7"}""")
         assertEquals(0L, resolveSidecarVersionCode(manifest, apkm))

--- a/app/src/test/java/com/valhalla/thor/domain/model/VersionCompareTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/VersionCompareTest.kt
@@ -31,7 +31,10 @@ class VersionCompareTest {
     }
 
     @Test
-    fun unknownVersionCodeIsNotADowngradeEvenAgainstAFreshInstall() {
+    fun unknownOnBothSidesIsNotADowngrade() {
+        // Not the fresh-install case — the caller short-circuits on `existing == null` before it
+        // ever gets here. This is "installed app also reports 0", e.g. an APK that never declared
+        // a version code at all.
         assertFalse(isVersionDowngrade(newVersionCode = 0L, installedVersionCode = 0L))
     }
 
@@ -53,20 +56,39 @@ class VersionCompareTest {
 
     @Test
     fun versionCodeMajorIsRespected() {
-        // longVersionCode packs versionCodeMajor into the high 32 bits. Both operands must stay
-        // Long: truncating to Int here is what made an earlier revision mis-detect downgrades.
-        val installed = (1L shl 32) or 1L
-        val newer = (1L shl 32) or 5L
-        assertFalse(isVersionDowngrade(newVersionCode = newer, installedVersionCode = installed))
-        assertTrue(isVersionDowngrade(newVersionCode = installed, installedVersionCode = newer))
+        // longVersionCode packs versionCodeMajor into the HIGH 32 bits, so both operands must stay
+        // Long. The operands are picked so an Int-truncating implementation INVERTS the verdict:
+        // (1L shl 32) truncates to 0, so a truncating compare asks "5 < 0" and answers false where
+        // the truth is "5 < 4294967296" — a downgrade. Operands that survive truncation (e.g.
+        // 0x1_00000001 vs 0x1_00000005, which truncate to 1 and 5 and keep their order) would pin
+        // nothing at all.
+        val installedWithMajor = 1L shl 32 // versionCodeMajor = 1, versionCode = 0
+        assertTrue(
+            isVersionDowngrade(newVersionCode = 5L, installedVersionCode = installedWithMajor)
+        )
+        // Converse: bumping versionCodeMajor is an upgrade, not a downgrade.
+        assertFalse(
+            isVersionDowngrade(newVersionCode = installedWithMajor, installedVersionCode = 5L)
+        )
     }
 
     @Test
     fun newerLookingVersionNameWithLowerCodeIsStillADowngrade() {
-        // The com.rebelroot.omni report. Its scheme encodes major/minor/build and DROPS the third
-        // component: 1.2.4.7 -> 1002007, 1.2.5.1 -> 1002001. The name reads as an upgrade while the
-        // code goes backwards, and Android sequences updates by code alone — so Thor is right to
-        // call this a downgrade. Pinned so nobody "fixes" it by comparing version names.
-        assertTrue(isVersionDowngrade(newVersionCode = 1002001L, installedVersionCode = 1002007L))
+        // Pinned so nobody "fixes" the com.rebelroot.omni report by comparing version NAMES.
+        //
+        // Real numbers, read out of github.com/REBEL-ROOT/omni-browser at the two release tags the
+        // reporter named — this is not reverse-engineered:
+        //
+        //   v1.2.4.6  versionName "1.2.4.6"  versionCode 26
+        //   v1.2.4.7  versionName "1.2.4.7"  versionCode 27   <- installed
+        //   v1.2.5.1  versionName "1.2.5.1"  versionCode 25   <- picked
+        //   1.2.6.0   versionName "1.2.6"    versionCode 25
+        //
+        // Their versionCode is hand-maintained and simply went backwards. Android sequences
+        // updates by code alone, so 25 over 27 is a downgrade and the platform installer refuses
+        // it too — Thor is not wrong here, the upstream app is. (Their v1.2.3.4 also shipped
+        // versionCode 1002004 from a scheme they abandoned, which is why a 1002005-style code
+        // shows up in old listings of this app.)
+        assertTrue(isVersionDowngrade(newVersionCode = 25L, installedVersionCode = 27L))
     }
 }

--- a/app/src/test/java/com/valhalla/thor/domain/model/VersionCompareTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/VersionCompareTest.kt
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure tests for the installer's downgrade predicate.
+ *
+ * Context: a community report of "the Portable Installer treats an upgrade as a downgrade". The
+ * comparison itself was already versionCode-based and correct; what was missing was the
+ * "unknown version code" gate — the analyzer yields 0 when it cannot read a code out of the picked
+ * file, and 0 loses against every installed app, so an unreadable file read as a downgrade of
+ * whatever was installed.
+ */
+class VersionCompareTest {
+
+    @Test
+    fun unknownVersionCodeIsNeverADowngrade() {
+        // The regression this guards: 0 is "analyzer could not read a code", not "version zero".
+        // Ungated, `0 < 4210` is true and EVERY installed app looks downgraded.
+        assertFalse(isVersionDowngrade(newVersionCode = 0L, installedVersionCode = 4210L))
+    }
+
+    @Test
+    fun negativeVersionCodeIsTreatedAsUnknown() {
+        assertFalse(isVersionDowngrade(newVersionCode = -1L, installedVersionCode = 4210L))
+    }
+
+    @Test
+    fun unknownVersionCodeIsNotADowngradeEvenAgainstAFreshInstall() {
+        assertFalse(isVersionDowngrade(newVersionCode = 0L, installedVersionCode = 0L))
+    }
+
+    @Test
+    fun strictlyLowerKnownCodeIsADowngrade() {
+        assertTrue(isVersionDowngrade(newVersionCode = 4200L, installedVersionCode = 4210L))
+    }
+
+    @Test
+    fun equalCodeIsNotADowngrade() {
+        // Android permits same-versionCode reinstall; only a strictly lower code is a downgrade.
+        assertFalse(isVersionDowngrade(newVersionCode = 4210L, installedVersionCode = 4210L))
+    }
+
+    @Test
+    fun higherCodeIsNotADowngrade() {
+        assertFalse(isVersionDowngrade(newVersionCode = 4300L, installedVersionCode = 4210L))
+    }
+
+    @Test
+    fun versionCodeMajorIsRespected() {
+        // longVersionCode packs versionCodeMajor into the high 32 bits. Both operands must stay
+        // Long: truncating to Int here is what made an earlier revision mis-detect downgrades.
+        val installed = (1L shl 32) or 1L
+        val newer = (1L shl 32) or 5L
+        assertFalse(isVersionDowngrade(newVersionCode = newer, installedVersionCode = installed))
+        assertTrue(isVersionDowngrade(newVersionCode = installed, installedVersionCode = newer))
+    }
+
+    @Test
+    fun newerLookingVersionNameWithLowerCodeIsStillADowngrade() {
+        // The com.rebelroot.omni report. Its scheme encodes major/minor/build and DROPS the third
+        // component: 1.2.4.7 -> 1002007, 1.2.5.1 -> 1002001. The name reads as an upgrade while the
+        // code goes backwards, and Android sequences updates by code alone — so Thor is right to
+        // call this a downgrade. Pinned so nobody "fixes" it by comparing version names.
+        assertTrue(isVersionDowngrade(newVersionCode = 1002001L, installedVersionCode = 1002007L))
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/VersionCompareTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/VersionCompareTest.kt
@@ -12,29 +12,40 @@ import org.junit.Test
  *
  * Context: a community report of "the Portable Installer treats an upgrade as a downgrade". The
  * comparison itself was already versionCode-based and correct; what was missing was the
- * "unknown version code" gate — the analyzer yields 0 when it cannot read a code out of the picked
- * file, and 0 loses against every installed app, so an unreadable file read as a downgrade of
- * whatever was installed.
+ * "unknown version code" gate — the analyzer yields null when it cannot read a code out of the
+ * picked file, and any number substituted for it loses against every installed app, so an
+ * unreadable file read as a downgrade of whatever was installed.
  */
 class VersionCompareTest {
 
     @Test
     fun unknownVersionCodeIsNeverADowngrade() {
-        // The regression this guards: 0 is "analyzer could not read a code", not "version zero".
-        // Ungated, `0 < 4210` is true and EVERY installed app looks downgraded.
-        assertFalse(isVersionDowngrade(newVersionCode = 0L, installedVersionCode = 4210L))
+        // The regression this guards: "analyzer could not read a code" is null, and ungated it
+        // would have to be some number — whereupon EVERY installed app looks downgraded.
+        assertFalse(isVersionDowngrade(newVersionCode = null, installedVersionCode = 4210L))
     }
 
     @Test
-    fun negativeVersionCodeIsTreatedAsUnknown() {
-        assertFalse(isVersionDowngrade(newVersionCode = -1L, installedVersionCode = 4210L))
+    fun realVersionCodeZeroIsStillCompared() {
+        // The counterpart to the test above, and the reason unknown is null rather than 0: the
+        // platform's APK parser defaults a manifest with no `android:versionCode` to zero, and
+        // Android sequences that value numerically like any other. Installing it over 4210 is a
+        // genuine downgrade the OS will refuse, so Thor has to warn instead of silently passing it
+        // off as "unknown, probably fine".
+        assertTrue(isVersionDowngrade(newVersionCode = 0L, installedVersionCode = 4210L))
     }
 
     @Test
-    fun unknownOnBothSidesIsNotADowngrade() {
+    fun unknownAgainstAZeroInstallIsNotADowngrade() {
         // Not the fresh-install case — the caller short-circuits on `existing == null` before it
-        // ever gets here. This is "installed app also reports 0", e.g. an APK that never declared
-        // a version code at all.
+        // ever gets here. This is "unreadable file over an installed app that declared no version
+        // code at all", where there is nothing to compare and nothing to warn about.
+        assertFalse(isVersionDowngrade(newVersionCode = null, installedVersionCode = 0L))
+    }
+
+    @Test
+    fun zeroOverZeroIsNotADowngrade() {
+        // Two version-code-less APKs: equal, so a reinstall rather than a downgrade.
         assertFalse(isVersionDowngrade(newVersionCode = 0L, installedVersionCode = 0L))
     }
 


### PR DESCRIPTION
## The report

Community report via Telegram (screenshot only): *"the Portable Installer considers an upgrade as a downgrade."*
`com.rebelroot.omni` — installed `1.2.4.7`, picked `1.2.5.1`, plain `.apk`.

## Verdict: for that app, Thor is right — but it had no way to say so

The starting hypothesis was that we compare version **names**. We don't. The decision is
`Long`-vs-`Long` on `versionCode` (`InstallerViewModel.kt`), and the only lexicographic
version-name comparison in the repo is `SortBy.VERSION_NAME` (`AppSorting.kt:17`), which feeds the
app-list sorter and never reaches the installer.

Omni's `versionCode` is hand-maintained and **went backwards**. From
[REBEL-ROOT/omni-browser](https://github.com/REBEL-ROOT/omni-browser) `app/build.gradle.kts` at each
release tag:

| tag | versionName | versionCode |
|---|---|---|
| v1.2.4.6 | 1.2.4.6 | 26 |
| **v1.2.4.7** | 1.2.4.7 | **27** ← installed |
| **v1.2.5.1** | 1.2.5.1 | **25** ← picked |
| 1.2.6.0 | 1.2.6 | 25 |

The name reads as an upgrade while the code goes backwards. Android sequences updates by code
alone, so this is a genuine downgrade — the stock installer refuses it too. That's an upstream
versioning defect in Omni, and anyone on 1.2.4.7 is currently stuck: 1.2.6 also ships code 25.

> An earlier revision of this PR claimed a "drops the third name component" encoding
> (1.2.4.7 → 1002007, 1.2.5.1 → 1002001), reverse-engineered from one online sample. That was
> wrong — see `6e974ca`. Their v1.2.3.4 did ship `versionCode = 1002004` from a scheme they
> abandoned one release later, which is where such codes in old listings come from. The verdict
> was right; the reasoning wasn't.

## What *was* broken

**1. `AppAnalyzerImpl.kt:180` — sidecar version code collapsed to `0`.**
```kotlin
val versionCode = (manifest?.versionCode ?: apkmInfo?.versionCode)?.toLongOrNull() ?: 0L
```
Both sidecar fields are `String?`. Any non-numeric value — a version **name** written into
`version_code`, a blank, padding, an absent key — became `0`. And the elvis tested only `null`, so a
blank `manifest.json` value shadowed a perfectly good `info.json` one. This is the one place the
version-name hypothesis was literally true. Extracted to `resolveSidecarVersionCode()`, which tries
each source in turn, trims, and rejects non-positive values.

**2. `0` was then treated as authoritative.** It loses against every installed app, so a file whose
code couldn't be read reported a downgrade of whatever was installed, however new it actually was —
and in NORMAL mode that's a hard refusal with `error_downgrade_privilege`, no override. Added the
pure domain predicate `isVersionDowngrade()`, which treats a non-positive code as *unknown* and
never a downgrade. Same `0 = unknown` convention the extension store already uses
(`ExtensionCatalog.versionCode`); the installer was the outlier.

**3. The panel showed version names only** — the codes the verdict is made on appeared nowhere, so
a correct downgrade call was indistinguishable from a bug. That's precisely how this got reported.
`ReadyToInstall` now carries `oldVersionCode`; both codes render under their names, and the
downgrade warning spells the comparison out. Codes are suppressed when unknown rather than shown
as `(0)`.

## Tests

Pure JUnit4, no new test dependencies:
- `VersionCompareTest` (new, 8) — unknown/negative gate, equality, `versionCodeMajor` packing, and
  pins the Omni case (25 over 27) so nobody "fixes" it by comparing names.
- `BundleAnalysisTest` (+6, 24→30) — blank / version-name / padded / absent / non-positive sidecar codes.

Verified **red-before-green**: a throwaway test ran the pre-fix expressions and confirmed they
really did yield `0` for blank, version-name and padded inputs (and that `0 < 4210` is true), then
was deleted.

## Verification

- 93 unit tests pass, 0 failures.
- `assembleFossDebug` + `lintFossDebug` green — only the 5 pre-existing intentional `VectorPath` warnings.
- Explainer string added in all 5 maintained locales (en/ar/es/fr/zh-rCN).
- No `versionCode` bump — this repo bumps only in `chore(release)` commits.

## Not verified

**No on-device run.** The UI change (version-code lines + the explainer `Column`) is compile- and
lint-verified only; nobody has looked at the rendered layout, including in landscape/narrow widths.
Root cause #1's trigger path (a bundle whose inner APKs won't parse) has no fixture either — it is
covered at the pure-function seam, not end to end.

## Review round 1 — `6e974ca`

Three reviewers, three lenses. Full write-up in the [review comment](https://github.com/trinadhthatakula/Thor/pull/276#issuecomment-5085484758). Headline: `isDowngrade` was doing double duty as both the verdict *and* the `pm install -d` permission flag, so the unknown-code gate in `ee8c40b` silently dropped `-d` and turned a previously-succeeding privileged install into a hard `INSTALL_FAILED_VERSION_DOWNGRADE`. Split into verdict vs. permission. Also: two tests that pinned nothing, `%d` → `%s` for Arabic digit shaping, an overflow guard, and the deletion of dead names-only `getVersionInfo()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

