### PR TITLE
fix(shizu): do not fail the weekly audit when the schema host blocks the runner

### DIFF
--- a/.github/scripts/check-shizu-manifest.sh
+++ b/.github/scripts/check-shizu-manifest.sh
@@ -310,8 +310,8 @@ if [ "$NETWORK" -eq 1 ]; then
     # Unreachable is not drift. Failing the weekly run on a block we cannot lift
     # would leave the tracking issue permanently open, and an alarm that is
     # always on is an alarm nobody reads.
-    warn "could not fetch $UPSTREAM_SCHEMA_URL (HTTP $up_code)"
-    warn "the live schema was NOT compared — run this checker off a CI runner to cover that"
+    warn "could not fetch $UPSTREAM_SCHEMA_URL (HTTP $up_code) — the live schema was NOT compared"
+    printf '       (run this checker off a CI runner to cover it)\n' >&2
   elif ! jq -e . "$tmp/upstream.json" >/dev/null 2>&1; then
     warn "upstream schema fetch returned non-JSON (captive portal?) — the live schema was NOT compared"
   else

--- a/.github/scripts/check-shizu-manifest.sh
+++ b/.github/scripts/check-shizu-manifest.sh
@@ -26,7 +26,9 @@ case "${1:-}" in
 esac
 
 failures=0
+warnings=0
 fail()    { printf '  FAIL %s\n' "$*" >&2; failures=$((failures + 1)); }
+warn()    { printf '  WARN %s\n' "$*" >&2; warnings=$((warnings + 1)); }
 ok()      { printf '  ok   %s\n' "$*"; }
 section() { printf '\n== %s ==\n' "$*"; }
 
@@ -291,31 +293,50 @@ if [ "$NETWORK" -eq 1 ]; then
   fi
 
   section "upstream schema"
-  if curl -fsSL --max-time 25 "$UPSTREAM_SCHEMA_URL" -o "$tmp/upstream.json"; then
-    if ! jq -e . "$tmp/upstream.json" >/dev/null 2>&1; then
-      fail "upstream schema fetch returned non-JSON (captive portal?) — treat as a fetch failure, not a manifest failure"
-    else
-      if check-jsonschema --schemafile "$tmp/upstream.json" "$MANIFEST" >/dev/null 2>&1; then
-        ok "manifest validates against the LIVE schema"
-      else
-        fail "manifest does NOT validate against the live schema — the store is rejecting this file right now"
-        check-jsonschema --schemafile "$tmp/upstream.json" "$MANIFEST" >&2
-      fi
-      if diff -u "$SCHEMA" "$tmp/upstream.json" > "$tmp/schema.diff"; then
-        ok "vendored schema is identical to upstream"
-      else
-        fail "vendored schema differs from upstream — review and re-vendor:"
-        cat "$tmp/schema.diff" >&2
-      fi
-    fi
+  # docshizu.siwane.xyz sits behind bot protection that 403s datacenter address
+  # ranges. A GitHub Actions runner is in that range; an ordinary connection is
+  # not, so this tier passes locally and 403s in CI. Try a browser UA before
+  # concluding anything — it costs one request and tells us whether the block is
+  # keyed on the agent or on the address.
+  up_code=""
+  for ua in 'thor-shizu-audit/1' \
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36'; do
+    up_code="$(curl -sSL --max-time 25 -A "$ua" -o "$tmp/upstream.json" \
+                    -w '%{http_code}' "$UPSTREAM_SCHEMA_URL" 2>/dev/null)" || true
+    [ -n "$up_code" ] || up_code=000
+    [ "$up_code" = "200" ] && break
+  done
+  if [ "$up_code" != "200" ]; then
+    # Unreachable is not drift. Failing the weekly run on a block we cannot lift
+    # would leave the tracking issue permanently open, and an alarm that is
+    # always on is an alarm nobody reads.
+    warn "could not fetch $UPSTREAM_SCHEMA_URL (HTTP $up_code)"
+    warn "the live schema was NOT compared — run this checker off a CI runner to cover that"
+  elif ! jq -e . "$tmp/upstream.json" >/dev/null 2>&1; then
+    warn "upstream schema fetch returned non-JSON (captive portal?) — the live schema was NOT compared"
   else
-    fail "could not fetch $UPSTREAM_SCHEMA_URL"
+    if check-jsonschema --schemafile "$tmp/upstream.json" "$MANIFEST" >/dev/null 2>&1; then
+      ok "manifest validates against the LIVE schema"
+    else
+      fail "manifest does NOT validate against the live schema — the store is rejecting this file right now"
+      check-jsonschema --schemafile "$tmp/upstream.json" "$MANIFEST" >&2
+    fi
+    if diff -u "$SCHEMA" "$tmp/upstream.json" > "$tmp/schema.diff"; then
+      ok "vendored schema is identical to upstream"
+    else
+      fail "vendored schema differs from upstream — review and re-vendor:"
+      cat "$tmp/schema.diff" >&2
+    fi
   fi
 fi
 
 printf '\n'
 if [ "$failures" -eq 0 ]; then
-  printf 'shizu_store.json: all checks passed\n'
+  if [ "$warnings" -eq 0 ]; then
+    printf 'shizu_store.json: all checks passed\n'
+  else
+    printf 'shizu_store.json: all checks passed, %d skipped (see WARN above)\n' "$warnings"
+  fi
   exit 0
 fi
 printf 'shizu_store.json: %d check(s) failed\n' "$failures" >&2


### PR DESCRIPTION
The first weekly [Shizu store audit](https://github.com/trinadhthatakula/Thor/actions/runs/30283799702) went red, filed #281, and was right to do both — the mechanism works. But the thing it caught is not something we can fix.

## What failed

Exactly one check, the last one: fetching the upstream schema from `docshizu.siwane.xyz` returned **403** to the runner. Everything else passed — schema validation, all six locales, copy matching fastlane, the twelve image URLs, the four link URLs, `download_url` resolving to the foss artifact, the changelog against `release-notes/v1.93.0/`.

The same URL returns 200 from an ordinary connection with any user agent, including the audit's own. The host sits behind bot protection keyed on the address range, and GitHub runners are in it. [This branch's run](https://github.com/trinadhthatakula/Thor/actions/runs/30284809817) confirms it: retrying with a Chrome user agent is refused too, so the block is on the address, not on us.

## What changes

An unreachable host is not drift. Left as-is, the weekly run is red forever and #281 reopens every Monday for something no commit can resolve — and an alarm that is always on is an alarm nobody reads, which is the failure this audit exists to prevent, reached from the other side.

So the tier now retries once with a browser user agent and, if that is refused too, **warns instead of failing** — naming the HTTP code and stating plainly that the live schema was not compared. Warnings are counted and reported in the summary line (`all checks passed, 2 skipped`) so a green run still says what it skipped.

A schema that *is* fetched and *does* differ still fails, unchanged. The comparison is not abandoned, only moved off the runner: it works from any normal connection, which is where release prep runs the checker anyway.

## Verified

- Happy path locally: fetches, validates against the live schema, vendored copy identical — exit 0.
- Unreachable upstream (mutated URL): two WARNs, `all checks passed, 2 skipped` — **exit 0**.
- Vendored schema tampered while upstream is reachable: `vendored schema differs from upstream` — **exit 1**. Drift still fails.
- On a runner: WARN, run green, and the workflow **auto-closed #281**.

That last point exercised the whole safety net end to end — red, issue filed, fixed, green, issue closed — which is better proof than a first-try pass would have been.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest checks when the upstream schema is temporarily unavailable or blocked.
  * Validation now distinguishes warnings from failures and reports both clearly.
  * Live schema comparisons continue when valid schema data is available, while non-JSON or unreachable responses produce warnings instead of immediate failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->