### PR TITLE
fix(shizu): retry an image URL once before calling it dead

### DIFF
--- a/.github/scripts/check-shizu-manifest.sh
+++ b/.github/scripts/check-shizu-manifest.sh
@@ -32,6 +32,21 @@ warn()    { printf '  WARN %s\n' "$*" >&2; warnings=$((warnings + 1)); }
 ok()      { printf '  ok   %s\n' "$*"; }
 section() { printf '\n== %s ==\n' "$*"; }
 
+# The manifest's twelve image URLs are fetched back to back from one address,
+# and raw.githubusercontent.com answers a burst like that with a 429 often
+# enough to have tripped this checker twice while it was being written. The
+# link check below already forgives 429; this one demands a 200, so give it one
+# retry. A transient refusal then passes on the second attempt, while a file
+# that is genuinely missing fails both and is still reported.
+image_code() {
+  _c="$(curl -sSL --max-time 25 -o /dev/null -w '%{http_code}' "$1")" || _c=000
+  if [ "$_c" != "200" ]; then
+    sleep 3
+    _c="$(curl -sSL --max-time 25 -o /dev/null -w '%{http_code}' "$1")" || _c=000
+  fi
+  printf '%s' "$_c"
+}
+
 need() {
   command -v "$1" >/dev/null 2>&1 || {
     printf 'missing required tool: %s\n' "$1" >&2
@@ -260,7 +275,7 @@ if [ "$NETWORK" -eq 1 ]; then
   # subshell, where every fail() would increment a copy of $failures that dies
   # with the subshell. URLs contain no whitespace, so word splitting is safe.
   for u in $(jq -r '[.icon_url, .banner_url, ((.screenshots // [])[])] | .[]' "$MANIFEST"); do
-    code="$(curl -sSL --max-time 25 -o /dev/null -w '%{http_code}' "$u")"
+    code="$(image_code "$u")"
     if [ "$code" = "200" ]; then ok "$code  ${u##*/}"; else fail "image not served: $code $u"; fi
   done
 


### PR DESCRIPTION
Follow-up to #282, same principle: the audit should fail on drift, not on the network having a bad second.

## What happened

While verifying #282 I saw the checker exit 1 twice, both times on the first run immediately after a `git push`, and never reproducibly — four consecutive runs after each were clean.

The cause is an asymmetry between two adjacent tiers. The image tier fetches twelve `raw.githubusercontent.com` URLs back to back from one address and requires a 200 from every one. The link tier three lines below already forgives 403 and 429, with a comment saying why:

> A 403 or 429 from a site with bot protection is not a dead link, and failing on it would make the weekly audit cry wolf until nobody reads it — which is the exact failure this audit exists to prevent.

That reasoning applies just as well to a burst of twelve requests at raw.githubusercontent.com, which rate-limits. The image tier just never got it.

The consequence is worse than a red run: a rate-limited audit files a tracking issue saying `image not served: 429 …/3.jpg`, which reads as "a screenshot went missing from master". Nothing is missing. A wrong diagnosis is more expensive than no alarm, because someone has to go disprove it.

## What changes

Each image URL gets one retry after a short pause. Nothing else moves — the required code is still exactly 200, and `download_url` is a single request rather than a burst, so it is left alone.

## Verified

- Reachable image: 200 on the first attempt, no retry spent.
- `…/does-not-exist.png`: 404 after both attempts, still `FAIL`.
- Unresolvable host: `000` after both attempts, still `FAIL`.
- Manifest mutated to point a screenshot at a missing file: `image not served: 404`, **exit 1**. A genuinely absent image is still caught.
- Clean manifest: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)