### PR TITLE
fix(freezer): rebuild pinned shortcut icons from the runner, not from one caller

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/freezer/BulkFreezeRunner.kt
+++ b/app/src/main/java/com/valhalla/thor/data/freezer/BulkFreezeRunner.kt
@@ -22,9 +22,13 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -74,6 +78,33 @@ class BulkFreezeRunner(
 
     /** Outcome of the last completed run, consumed once by whoever displays it. */
     val lastResult: StateFlow<BulkResult?> = _lastResult.asStateFlow()
+
+    // extraBufferCapacity + DROP_OLDEST so tryEmit never fails and never suspends the run: a
+    // slow subscriber (the icon rebuild decodes one bitmap per pinned app) must not be able to
+    // hold a batch open, and coalescing a burst down to "rebuild once more afterwards" is
+    // correct because every subscriber re-reads live state rather than the emitted value.
+    private val _completions = MutableSharedFlow<BulkOp>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /**
+     * Emits once per run that actually touched packages — the seam for side effects that must
+     * follow *any* bulk run, whichever surface started it.
+     *
+     * This exists because side effects bolted to one caller are unreachable from the other.
+     * The pinned-shortcut icon rebuild used to hang off `FreezerShortcutManager.runBulk`, so a
+     * freeze started from the QS tile — which calls [launch] directly, having no reason to know
+     * shortcuts exist — froze the apps and left every pinned icon in full colour. Device
+     * evidence: `dumpsys shortcut` showed the publisher's call count and stored icon bitmap
+     * unchanged across a tile freeze that did set `enabled=3`.
+     *
+     * Not emitted for a no-op run ([run] returned null: no privilege, or nothing to act on) —
+     * nothing changed, so nothing needs rebuilding. Not emitted for a cancelled run either;
+     * the conflicting op that replaced it emits its own completion, and subscribers rebuild
+     * from live state, so the later emission subsumes the lost one.
+     */
+    val completions: SharedFlow<BulkOp> = _completions.asSharedFlow()
 
     private val _runningOp = MutableStateFlow<BulkOp?>(null)
 
@@ -194,6 +225,11 @@ class BulkFreezeRunner(
                     // READY again. Stale either way — drop it.
                     _lastResult.value = if (op == BulkOp.FREEZE) result else null
                     if (result.total > 0) notifier.post(result)
+                    // Unconditional, unlike the two lines above: a completion is not a *report*
+                    // of the run, it is the fact that package state changed. It must not inherit
+                    // the tile's freeze-only rule (an unfreeze recolours icons too) nor the
+                    // notifier's permission gate (icons are not a notification).
+                    _completions.tryEmit(op)
                 }
             } catch (e: CancellationException) {
                 // B-2: CancellationException is an Exception in Kotlin; rethrowing here keeps

--- a/app/src/main/java/com/valhalla/thor/data/freezer/BulkFreezeRunner.kt
+++ b/app/src/main/java/com/valhalla/thor/data/freezer/BulkFreezeRunner.kt
@@ -79,11 +79,22 @@ class BulkFreezeRunner(
     /** Outcome of the last completed run, consumed once by whoever displays it. */
     val lastResult: StateFlow<BulkResult?> = _lastResult.asStateFlow()
 
+    // replay = 1 so a completion is not lost to a subscriber that has not attached yet.
+    // extraBufferCapacity alone only buffers for an *already-subscribed but slow* collector; with
+    // zero subscribers tryEmit still returns true and discards. FreezerShortcutManager subscribes
+    // from `scope.launch` in its init, which dispatches asynchronously, so there is a window —
+    // narrow, but the correctness of the icon rebuild should not rest on it losing a race.
+    //
+    // Replaying to a late subscriber is harmless here precisely because subscribers re-read live
+    // package state instead of trusting the emitted value: a replayed completion costs one extra
+    // idempotent rebuild, never a wrong icon.
+    //
     // extraBufferCapacity + DROP_OLDEST so tryEmit never fails and never suspends the run: a
     // slow subscriber (the icon rebuild decodes one bitmap per pinned app) must not be able to
     // hold a batch open, and coalescing a burst down to "rebuild once more afterwards" is
-    // correct because every subscriber re-reads live state rather than the emitted value.
+    // correct for the same reason.
     private val _completions = MutableSharedFlow<BulkOp>(
+        replay = 1,
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
@@ -224,12 +235,18 @@ class BulkFreezeRunner(
                     // unfrozen, so leaving it would show "Froze N apps" on a tile that is now
                     // READY again. Stale either way — drop it.
                     _lastResult.value = if (op == BulkOp.FREEZE) result else null
-                    if (result.total > 0) notifier.post(result)
-                    // Unconditional, unlike the two lines above: a completion is not a *report*
+                    // Unconditional, unlike the lines around it: a completion is not a *report*
                     // of the run, it is the fact that package state changed. It must not inherit
                     // the tile's freeze-only rule (an unfreeze recolours icons too) nor the
                     // notifier's permission gate (icons are not a notification).
+                    //
+                    // Ahead of notifier.post for the same reason: post() is a binder call into
+                    // NotificationManager and the outer catch would swallow anything it threw,
+                    // silently skipping the emission for a run whose packages are already
+                    // mutated. tryEmit cannot throw or suspend, so nothing is owed to ordering
+                    // the other way.
                     _completions.tryEmit(op)
+                    if (result.total > 0) notifier.post(result)
                 }
             } catch (e: CancellationException) {
                 // B-2: CancellationException is an Exception in Kotlin; rethrowing here keeps

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -55,6 +55,28 @@ class FreezerShortcutManager(
         const val LAUNCH_ACTIVITY = "com.valhalla.thor.presentation.launcher.FreezerLaunchActivity"
     }
 
+    init {
+        // Rebuild pinned icons off the runner's completions rather than off a call site.
+        //
+        // The QS tile calls BulkFreezeRunner.launch directly — correctly: a tile has no reason
+        // to know shortcuts exist — so a rebuild hung off runBulk was reachable from the
+        // launcher Freeze-all shortcut and from nowhere else. Apps froze from the tile and
+        // their pinned icons stayed full colour.
+        //
+        // The dependency direction is forced: this class already holds the runner, so it
+        // subscribes. The runner must not hold this class back (Koin cycle), which also keeps
+        // it free of any launcher concern.
+        //
+        // Startup is not a race. Koin builds this @Single as a constructor argument of
+        // AutoFreezeManager, and ThorApplication.onCreate calls autoFreezeManager
+        // .startObserving() synchronously — so the collector is running before onCreate
+        // returns, and Application.onCreate always completes before the framework binds
+        // FreezerTileService.
+        scope.launch {
+            bulkFreezeRunner.completions.collect { rebuildPinnedIcons() }
+        }
+    }
+
     fun isPinSupported(): Boolean =
         ShortcutManagerCompat.isRequestPinShortcutSupported(context)
 
@@ -119,67 +141,69 @@ class FreezerShortcutManager(
      * Bulk freeze/unfreeze every package in the freezer, off the finishing activity.
      *
      * Returns the run so the caller can await its [BulkResult] and report it. The icon rebuild
-     * is deliberately *not* part of that Deferred: it belongs to this manager's own
-     * process-lifetime scope, so a caller that finishes early never truncates it, and a caller
-     * that awaits does not wait on shortcut bookkeeping it does not care about.
+     * is deliberately *not* part of that Deferred: it hangs off the runner's completions (see
+     * the `init` block), so a caller that finishes early never truncates it, and a caller that
+     * awaits does not wait on shortcut bookkeeping it does not care about.
      */
-    fun runBulk(disable: Boolean): Deferred<BulkResult?> {
-        val op = if (disable) BulkOp.FREEZE else BulkOp.UNFREEZE
+    fun runBulk(disable: Boolean): Deferred<BulkResult?> =
         // Delegate so this shares the tile's candidate filter, Semaphore(5), deadline and
         // result reporting. It previously ran sequentially and discarded every Result.
-        val run = bulkFreezeRunner.launch(op)
-        scheduleIconRefresh(run)
-        return run
-    }
-
-    // The run this manager has already scheduled an icon refresh for, so repeated taps do not
-    // stack redundant rebuilds. Guarded by the instance monitor; see scheduleIconRefresh.
-    private var refreshScheduledFor: Deferred<BulkResult?>? = null
+        bulkFreezeRunner.launch(if (disable) BulkOp.FREEZE else BulkOp.UNFREEZE)
 
     /**
-     * Rebuild the pinned per-app shortcut icons once [run] settles — at most once per run.
-     *
-     * The dedupe is not cosmetic. `BulkFreezeRunner.launch` coalesces same-op taps onto one
-     * shared `Deferred`, and the bulk shortcut shows nothing for up to two seconds, so impatient
-     * re-taps are the expected case rather than the exotic one. Without the guard each tap
-     * queues another full rebuild: N concurrent icon decodes over every pinned package, for
-     * byte-identical output. That is the same hazard [pinAppShortcutSuspend] exists to avoid.
-     *
-     * Identity, not equality: a conflicting op returns a *different* Deferred and must get its
-     * own refresh, because it leaves the packages in the opposite state.
+     * Fire-and-forget rebuild of every pinned per-app icon, for a caller that runs its own
+     * batch instead of going through [BulkFreezeRunner] — currently only Settings'
+     * Unfreeze-all. Runs on this manager's process-lifetime scope, so a finishing caller
+     * cannot truncate it.
      */
-    @Synchronized
-    private fun scheduleIconRefresh(run: Deferred<BulkResult?>) {
-        if (refreshScheduledFor === run) return
-        refreshScheduledFor = run
-        scope.launch {
-            try {
-                // Icons follow app state, so wait for the run to settle before rebuilding them.
-                // join() rather than watching runningOp: a fast run can clear that before this
-                // coroutine is even dispatched, and we would then wait forever.
-                run.join()
-                val pinnedIds = pinnedShortcutIds()
-                val updated = freezerRepository.getAllPackageNames()
-                    .filter { FreezerShortcutContract.appShortcutId(it) in pinnedIds }
-                    .mapNotNull { pkg -> appLabel(pkg)?.let { buildAppShortcut(pkg, it) } }
-                if (updated.isNotEmpty()) {
-                    ShortcutManagerCompat.updateShortcuts(context, updated)
-                }
-            } catch (e: CancellationException) {
-                // Never swallow cancellation — it breaks cooperative coroutine cancellation.
-                throw e
-            } catch (e: Exception) {
-                // stateOf (called by buildAppShortcut) catches only NameNotFoundException;
-                // a binder-death RuntimeException would otherwise escape to Android's default
-                // uncaught handler and kill the process. Log and continue.
-                Logger.e("FreezerShortcut", "icon refresh after bulk run failed", e)
-            } finally {
-                // Release the slot under the same monitor, and only if it is still ours: a
-                // conflicting op may already have claimed it for its own run.
-                synchronized(this@FreezerShortcutManager) {
-                    if (refreshScheduledFor === run) refreshScheduledFor = null
-                }
+    fun refreshPinnedShortcutIcons() {
+        scope.launch { rebuildPinnedIcons() }
+    }
+
+    /**
+     * Repaint every pinned per-app shortcut from live freeze state.
+     *
+     * No dedupe needed: `BulkFreezeRunner.launch` coalesces same-op taps onto one run, one run
+     * emits one completion, and the completions buffer collapses a burst into a single trailing
+     * rebuild. So impatient re-taps — the expected case, since the bulk shortcut shows nothing
+     * for up to two seconds — cost one rebuild, not N concurrent icon decodes over every pinned
+     * package. Correctness under coalescing comes from reading live state here rather than
+     * trusting anything carried on the emission.
+     */
+    private suspend fun rebuildPinnedIcons() {
+        try {
+            val pinnedIds = pinnedShortcutIds()
+            val updated = freezerRepository.getAllPackageNames()
+                .filter { FreezerShortcutContract.appShortcutId(it) in pinnedIds }
+                .mapNotNull { pkg -> appLabel(pkg)?.let { buildAppShortcut(pkg, it) } }
+            if (updated.isNotEmpty()) {
+                pushShortcutUpdate(updated)
             }
+        } catch (e: CancellationException) {
+            // Never swallow cancellation — it breaks cooperative coroutine cancellation. This
+            // only arrives when the process-lifetime scope itself dies, so ending the
+            // completions collector with it is correct.
+            throw e
+        } catch (e: Exception) {
+            // stateOf (called by buildAppShortcut) catches only NameNotFoundException; a
+            // binder-death RuntimeException would otherwise escape to Android's default
+            // uncaught handler and kill the process — and would also terminate the collector
+            // for the rest of the process lifetime. Log and continue.
+            Logger.e("FreezerShortcut", "pinned icon rebuild failed", e)
+        }
+    }
+
+    // updateShortcuts reports failure by returning false, not by throwing. ShortcutManager
+    // rate-limits a *background* publisher (~10 accepted calls per 24h, the counter reset
+    // whenever the app has been in the foreground), and the tile path is background by
+    // definition. A dropped update is indistinguishable on screen from "we never called it",
+    // so log it rather than let the next report of this bug start from zero again.
+    private fun pushShortcutUpdate(shortcuts: List<ShortcutInfoCompat>) {
+        if (!ShortcutManagerCompat.updateShortcuts(context, shortcuts)) {
+            Logger.d(
+                "FreezerShortcut",
+                "updateShortcuts rejected ${shortcuts.size} pinned icon(s) — rate-limited?"
+            )
         }
     }
 
@@ -275,7 +299,7 @@ class FreezerShortcutManager(
     // Rebuild + push the current-state icon for a package's pinned shortcut (no-op if absent).
     private fun updateShortcutIcon(packageName: String) {
         val label = appLabel(packageName) ?: return
-        ShortcutManagerCompat.updateShortcuts(context, listOf(buildAppShortcut(packageName, label)))
+        pushShortcutUpdate(listOf(buildAppShortcut(packageName, label)))
     }
 
     private fun appLabel(packageName: String): String? = try {

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -67,11 +67,12 @@ class FreezerShortcutManager(
         // subscribes. The runner must not hold this class back (Koin cycle), which also keeps
         // it free of any launcher concern.
         //
-        // Startup is not a race. Koin builds this @Single as a constructor argument of
-        // AutoFreezeManager, and ThorApplication.onCreate calls autoFreezeManager
-        // .startObserving() synchronously — so the collector is running before onCreate
-        // returns, and Application.onCreate always completes before the framework binds
-        // FreezerTileService.
+        // Startup ordering gets this close: Koin builds this @Single as a constructor argument
+        // of AutoFreezeManager, ThorApplication.onCreate calls autoFreezeManager.startObserving()
+        // synchronously, and Application.onCreate always completes before the framework binds
+        // FreezerTileService. But `scope.launch` only *schedules* the collector, so subscription
+        // itself is not ordered against the first run — which is why `completions` carries
+        // replay = 1. A replayed completion just costs one extra rebuild from live state.
         scope.launch {
             bulkFreezeRunner.completions.collect { rebuildPinnedIcons() }
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -178,6 +178,11 @@ class SettingsViewModel(
                     async { manageAppUseCase.forceUnfreeze(pkg) }
                 }.awaitAll()
             }
+            // This is the one bulk path that does not go through BulkFreezeRunner, so it does
+            // not get the icon rebuild that hangs off the runner's completions. Ask for it
+            // explicitly or pinned shortcuts stay grey for apps this just restored.
+            freezerShortcutManager.refreshPinnedShortcutIcons()
+
             val failures = results.count { it.isFailure }
             val uiText = if (failures == 0) {
                 UiText.PluralsResource(R.plurals.unfrozen_count_success, pkgs.size)

--- a/docs/follow-ups/shortcut-match-flags-system-apps.md
+++ b/docs/follow-ups/shortcut-match-flags-system-apps.md
@@ -40,8 +40,9 @@ So every package that reaches these lookups is a user app with a pinned shortcut
 ## Fix them together, or not at all
 
 **`appLabel` currently masks `appIcon`.** `rebuildPinnedIcons` and `updateShortcutIcon` both
-short-circuit on `appLabel(pkg) ?: return`, so `appIcon` never runs for a package it would throw
-on. Patching `appLabel` alone un-masks it: `appIcon` throws, the catch returns
+short-circuit on `appLabel(pkg) ?: return`, so `appIcon` never runs for a package whose lookup
+would fail. Patching `appLabel` alone un-masks it: the `getApplicationIcon(pkg)` call inside
+`appIcon` throws, `appIcon`'s own `catch` swallows it and returns
 `IconCompat.createWithResource(context, R.drawable.frozen)`, and that vector is
 `android:tint="?attr/colorControlNormal"` — a theme attr that cannot resolve in the launcher's
 context, so it renders as the white/invisible blob `bulkIcon`'s own KDoc warns about. That turns

--- a/docs/follow-ups/shortcut-match-flags-system-apps.md
+++ b/docs/follow-ups/shortcut-match-flags-system-apps.md
@@ -1,0 +1,66 @@
+# Pinned-shortcut PackageManager lookups drop frozen system apps
+
+**Status:** filed, not fixed. Latent — unreachable while per-app pins stay user-apps-only.
+**Found:** 2026-07-29, during the root-cause sweep for the tile icon-refresh bug (PR #286).
+
+## The gap
+
+Two lookups in `FreezerShortcutManager` resolve a package without the match flags a frozen
+**system** app needs:
+
+| Site | Call | Missing |
+|---|---|---|
+| `appLabel` (`FreezerShortcutManager.kt:281`) | `getApplicationInfo(pkg, MATCH_DISABLED_COMPONENTS)` | `MATCH_UNINSTALLED_PACKAGES` |
+| `appIcon` (`FreezerShortcutManager.kt:293`) | `getApplicationIcon(pkg)` | everything — the `String` overload resolves via `getApplicationInfo(pkg, sDefaultFlags)`, and `sDefaultFlags` is `GET_SHARED_LIBRARY_FILES` |
+
+Thor freezes system apps with `pm uninstall --user N`, not `pm disable`, so a frozen system app
+is **not installed for the current user**. `PackageInfoUtils.generateApplicationInfo` →
+`checkUseInstalledOrHidden` → `PackageUserStateUtils.isAvailable` then returns false without
+`MATCH_UNINSTALLED_PACKAGES` / `MATCH_KNOWN_PACKAGES`, and `getApplicationInfo` throws
+`NameNotFoundException`.
+
+`AppFreezeStateReader.MATCH_FLAGS` is the correct reference pattern; these two sites predate it.
+
+User apps are unaffected. `getApplicationInfo` does **not** filter on the enabled setting —
+`ComputerEngine.getApplicationInfoInternalBody` carries the literal comment *"Note: isEnabledLP()
+does not apply here - always return info"* — so a `pm disable`d package still resolves with flags
+`0`. That is why `AutoFreezeManager.kt:122` works.
+
+## Why it is unreachable today
+
+Per-app pinned shortcuts are `!isSystem`-gated at every entry point:
+
+- `FreezerViewModel.kt:348` — `if (app.isSystem) return // v1: user apps only`
+- `FreezerViewModel.kt:361` — `.filter { !it.isSystem }` (pin-all)
+- `AppInfoDetailsScreen.kt:798`, `AppInfoDialog.kt:623` — `&& !appInfo.isSystem &&`
+
+and `rebuildPinnedIcons` pre-filters the watchlist by `in pinnedIds` before calling `appLabel`.
+So every package that reaches these lookups is a user app with a pinned shortcut.
+
+## Fix them together, or not at all
+
+**`appLabel` currently masks `appIcon`.** `rebuildPinnedIcons` and `updateShortcutIcon` both
+short-circuit on `appLabel(pkg) ?: return`, so `appIcon` never runs for a package it would throw
+on. Patching `appLabel` alone un-masks it: `appIcon` throws, the catch returns
+`IconCompat.createWithResource(context, R.drawable.frozen)`, and that vector is
+`android:tint="?attr/colorControlNormal"` — a theme attr that cannot resolve in the launcher's
+context, so it renders as the white/invisible blob `bulkIcon`'s own KDoc warns about. That turns
+"icon does not update" into "icon becomes a white square", which is worse.
+
+Suggested shape: resolve `ApplicationInfo` **once** with `AppFreezeStateReader.MATCH_FLAGS` and
+feed it to both `getApplicationLabel(ApplicationInfo)` and `getApplicationIcon(ApplicationInfo)`.
+One binder call instead of two, and no way for the two to disagree.
+
+## Trigger
+
+Lifting the "v1: user apps only" pin gate — which is exactly what the "should the tile be allowed
+to freeze system apps?" discussion would lead to. Do this first if that lands.
+
+## Same gap, elsewhere (scoped out)
+
+- `ExtensionOpsProvider.kt:113` — misreports a frozen **system** app as not-frozen to extensions.
+  Real, user-visible to extension authors, unrelated to shortcuts.
+- `FreezerLaunchActivity.kt:168` (`isSuspended`) — benign; the `||` at `:137` short-circuits so it
+  is only evaluated once `getLaunchIntentForPackage` has already resolved.
+- `AutoFreezeManager.kt:122` (flags `0`) — benign; a frozen system app throws, is logged
+  "not found, skipping", and skipping an already-frozen app is the desired outcome anyway.


### PR DESCRIPTION
Fixes item **9** of #284's device-verification list: *"pinned per-app shortcut icons still grey/ungrey after a bulk run"*. Reported failing on device — apps froze, icons stayed coloured.

## The bug

`FreezerTileService.onClick` is one line: `runner.launch(BulkOp.FREEZE)`. That is correct — a QS tile has no reason to know shortcuts exist. But the icon rebuild was bolted to `FreezerShortcutManager.runBulk`, whose only caller is the launcher trampoline. So the side effect was reachable from **one** of the runner's two callers and from nowhere else, and a tile freeze issued no `updateShortcuts` at all.

Reproduced on an emulator (API 37, Pixel Launcher, `dumpsys shortcut`):

| action | package | publisher `Calls:` | shortcut `timestamp` | stored bitmap |
|---|---|---|---|---|
| baseline | `enabled=1` | 0 | …731420 | 30044 B (colour) |
| **Freeze-all** shortcut | `enabled=3` | **1** | **…877330** | **22572 B (grey)** — repainted live |
| **Unfreeze-all** shortcut | `enabled=1` | 1 | …950576 | 30044 B (colour) |
| **QS tile** | `enabled=3` — freeze worked | **1 (unchanged)** | **unchanged** | **unchanged (colour)** |

That also rules out the launcher-side theories: `updateShortcuts` *does* mutate an already-pinned shortcut and Pixel Launcher repaints it with no relaunch; rate limiting was not in play (`Calls: 1` of 10); the shortcut was `disabledReason=[Not disabled]`; and the `FLAG_MATCH_PINNED` id matched byte-for-byte.

Not a regression from #284 — the pre-rework tile never touched `ShortcutManager` either. What the rework changed is that `BulkFreezeRunner` became the single owner of bulk freeze/unfreeze, which is what makes this gap structural and fixable in one place.

## The fix

`BulkFreezeRunner` publishes a `completions: SharedFlow<BulkOp>`; `FreezerShortcutManager` subscribes in its `init`. The dependency direction is forced by DI — the manager already injects the runner, so it observes, and the runner stays free of any launcher concern instead of acquiring a Koin cycle. No future caller can forget it.

Startup is not a race: Koin builds the manager as a constructor argument of `AutoFreezeManager`, and `ThorApplication.onCreate` calls `startObserving()` synchronously, so the collector is live before `onCreate` returns — and `Application.onCreate` always completes before the framework binds a `TileService`.

The per-run dedupe added in #284 goes away with `scheduleIconRefresh`: one run emits one completion, and the buffer (capacity 1, `DROP_OLDEST`) collapses a burst of impatient re-taps into one trailing rebuild. Correctness under that coalescing comes from the rebuild reading live state rather than anything carried on the emission.

## Two more from the same sweep

- **Settings → Unfreeze-all** is the one bulk path that does not go through the runner (its own `awaitAll` over `forceUnfreeze`), so it had the mirror symptom: icons stay **grey** after restoring. It now asks for the rebuild explicitly. Behaviour otherwise unchanged — same packages, same toast.
- **`updateShortcuts` returns `false`, it does not throw.** `ShortcutManager` rate-limits a *background* publisher (~10 accepted calls / 24 h, counter reset whenever the app has been foreground), and the tile path is background by definition. Both call sites discarded that boolean, so a dropped update was indistinguishable on screen from "we never called it". Both now route through `pushShortcutUpdate`, which logs the rejection.

## Left alone, deliberately

`appLabel` (`MATCH_DISABLED_COMPONENTS` only) and `appIcon` (`getApplicationIcon(String)`, no MATCH flags) both drop a system app frozen via `pm uninstall --user N`. Unreachable today — per-app pins are `!isSystem`-gated at four sites — but they go live the moment "v1: user apps only" is lifted, and **they must be fixed together**: patching `appLabel` alone un-masks `appIcon` and turns "no update" into a fallback snowflake glyph. Filed rather than fixed blind.

## Verification

- `testFossDebugUnitTest --rerun-tasks` — **141 tests, 0 failures**
- `lintFossRelease` — **0 errors**, only the 5 known intentional `VectorPath` warnings
- `assembleFossRelease` — green

**Device verification outstanding**, on root / Shizuku / Dhizuku:
1. Pin an app shortcut, freeze from the **QS tile** → icon goes grey ← the reported bug
2. Same app, unfreeze from the tile's watchlist path → icon returns to colour
3. Freeze-all / Unfreeze-all launcher shortcuts → unchanged from #284 (regression check)
4. Two rapid tile taps → one rebuild, not two
5. Settings → Unfreeze-all with a pinned frozen app → icon returns to colour
6. Auto-freeze (screen off) → per-app refresh still works

## Diagnosis method

Claude Opus 5, 7 agents, 656 k tokens: 4 competing hypotheses, each pipelined into two adversarial refuters (facts lens + symptom lens), killed only if both refuted. Three were refuted — one of them empirically on a connected device, which is what produced the table above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic refreshes for pinned app shortcut icons after bulk freeze and unfreeze operations.
  * Added a manual option to rebuild pinned shortcut icons using the latest freezer state.
  * Improved shortcut icon updates following individual app state changes.

* **Bug Fixes**
  * Improved reliability of shortcut icon refreshes during bulk operations.
  * Preserved cancellation handling while rebuilding shortcut icons.

* **Documentation**
  * Documented potential matching issues when resolving system app labels and icons for shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->