### PR TITLE
fix(freezer): stop the tile and Freeze-all bypassing the unsafe-app block

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/freezer/AppFreezeStateReader.kt
+++ b/app/src/main/java/com/valhalla/thor/data/freezer/AppFreezeStateReader.kt
@@ -5,7 +5,11 @@ package com.valhalla.thor.data.freezer
 
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import com.valhalla.thor.data.source.local.UadSnapshot
+import com.valhalla.thor.domain.model.FreezeCandidate
 import com.valhalla.thor.domain.model.FreezeState
+import com.valhalla.thor.domain.model.FreezeTier
+import com.valhalla.thor.domain.model.freezeTierOf
 import com.valhalla.thor.domain.model.isFrozen
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
@@ -23,7 +27,19 @@ import org.koin.core.annotation.Single
 class AppFreezeStateReader(
     private val packageManager: PackageManager,
 ) {
-    fun stateOf(packageName: String): FreezeState = try {
+    /** Live freeze state only, for callers with no freeze decision to make. */
+    fun stateOf(packageName: String): FreezeState =
+        candidateOf(packageName, UadSnapshot.UNFILTERED).state
+
+    /**
+     * Live freeze state *and* the freeze-policy verdict, from one [ApplicationInfo] read.
+     *
+     * [uad] is passed in rather than resolved here so a bulk run classifies its whole watchlist
+     * against one snapshot: `UadHelper` is not injected into this class on purpose, which keeps
+     * a per-package `uadMap` touch — and the ~1.6 MB JSON parse hiding behind the first one —
+     * off a loop that already costs one binder call per entry.
+     */
+    fun candidateOf(packageName: String, uad: UadSnapshot): FreezeCandidate = try {
         val info = packageManager.getApplicationInfo(packageName, MATCH_FLAGS)
         // MATCH_UNINSTALLED_PACKAGES is not optional. Thor freezes *system* apps with
         // `pm uninstall --user N`, not `pm disable`, so a frozen system app is not installed
@@ -34,12 +50,25 @@ class AppFreezeStateReader(
         // back looking ACTIVE instead of FROZEN.
         val enabled = info.enabled && (info.flags and ApplicationInfo.FLAG_INSTALLED) != 0
         val suspended = (info.flags and ApplicationInfo.FLAG_SUSPENDED) != 0
-        if (isFrozen(enabled, suspended)) FreezeState.FROZEN else FreezeState.ACTIVE
+        // FLAG_SYSTEM alone, never OR'd with FLAG_UPDATED_SYSTEM_APP — that is what isSystem
+        // means everywhere else in Thor (AppInfoMapper, RootSystemGateway.setAppDisabled), and
+        // a tier computed from a different definition than the one the freeze itself uses would
+        // block and unblock inconsistent sets of apps.
+        val isSystem = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+        val tier = freezeTierOf(
+            isSystem = isSystem,
+            bloatRecommendation = uad.recommendationFor(packageName),
+            isUadLoadFailed = uad.loadFailed,
+        )
+        FreezeCandidate(
+            state = if (isFrozen(enabled, suspended)) FreezeState.FROZEN else FreezeState.ACTIVE,
+            blockedFromFreeze = tier == FreezeTier.BLOCKED,
+        )
     } catch (_: PackageManager.NameNotFoundException) {
         // Unnamed: "no such package for this user" is the expected answer here, not an error.
-        FreezeState.ABSENT
+        ABSENT
     } catch (e: CancellationException) {
-        // CancellationException is an Exception in Kotlin. stateOf runs inside the runner's
+        // CancellationException is an Exception in Kotlin. candidateOf runs inside the runner's
         // coroutines, so the broad catch below would otherwise turn a cancelled sweep into a
         // watchlist of ABSENT packages — silently, and looking exactly like success.
         throw e
@@ -51,11 +80,17 @@ class AppFreezeStateReader(
         // :app to catch what escapes. Unreadable is treated as ABSENT: a bulk run skips the
         // package rather than acting on a state it could not confirm.
         Logger.e("AppFreezeStateReader", "could not read freeze state for $packageName", e)
-        FreezeState.ABSENT
+        ABSENT
     }
 
     private companion object {
         const val MATCH_FLAGS =
             PackageManager.MATCH_UNINSTALLED_PACKAGES or PackageManager.MATCH_DISABLED_COMPONENTS
+
+        // blockedFromFreeze = true, not the data class default: every path that produces ABSENT
+        // is one where we could not read the app at all, so we also could not have classified
+        // it. ABSENT already excludes the package from both ops, but leaving the verdict at
+        // "not blocked" would quietly re-enable freezing if the state test ever moved.
+        val ABSENT = FreezeCandidate(FreezeState.ABSENT, blockedFromFreeze = true)
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/freezer/BulkFreezeRunner.kt
+++ b/app/src/main/java/com/valhalla/thor/data/freezer/BulkFreezeRunner.kt
@@ -4,6 +4,8 @@
 package com.valhalla.thor.data.freezer
 
 import com.valhalla.thor.data.manager.PrivilegeManager
+import com.valhalla.thor.data.source.local.UadHelper
+import com.valhalla.thor.data.source.local.UadSnapshot
 import com.valhalla.thor.domain.model.BulkAction
 import com.valhalla.thor.domain.model.BulkOp
 import com.valhalla.thor.domain.model.BulkResult
@@ -56,6 +58,7 @@ class BulkFreezeRunner(
     private val preferenceRepository: PreferenceRepository,
     private val privilegeManager: PrivilegeManager,
     private val stateReader: AppFreezeStateReader,
+    private val uadHelper: UadHelper,
     private val notifier: BulkResultNotifier,
     @Named("io") private val io: CoroutineDispatcher,
 ) {
@@ -148,10 +151,32 @@ class BulkFreezeRunner(
      */
     suspend fun refreshFreezableCount() {
         withContext(io) {
-            val watchlist = freezerRepository.getAllPackageNames()
-            _freezableCount.value =
-                freezableCandidates(watchlist, BulkOp.FREEZE, stateReader::stateOf).size
+            _freezableCount.value = targetsFor(BulkOp.FREEZE).size
         }
+    }
+
+    /**
+     * The packages [op] would act on right now — the one place either surface asks that.
+     *
+     * Shared by [refreshFreezableCount] and [run] because a count derived differently from the
+     * batch it describes is a tile that lies: it would offer "Freeze 3" and then freeze two, or
+     * sit READY over a watchlist with nothing left it is allowed to touch.
+     *
+     * The [UadSnapshot] is taken once per call, not per package. FREEZE gets a real one so the
+     * blocked tier — unsafe system apps, and every system app when the UAD list will not load —
+     * is excluded exactly as `MainViewModel.performCountedFreeze`, `AutoFreezeManager` and the
+     * in-app freeze dialog exclude it; before this, the tile was the one bulk path that would
+     * happily freeze what the dialog refuses to render a confirm button for.
+     *
+     * UNFREEZE gets [UadSnapshot.UNFILTERED] on purpose. Unfreezing is how a user escapes a bad
+     * freeze, so it must never be gated on the same list: if `uad_lists.json` failed to load,
+     * a filtered unfreeze would classify every system app as blocked and strand them frozen.
+     */
+    private suspend fun targetsFor(op: BulkOp): List<String> {
+        val watchlist = freezerRepository.getAllPackageNames()
+        if (watchlist.isEmpty()) return emptyList()
+        val uad = if (op == BulkOp.FREEZE) uadHelper.snapshot() else UadSnapshot.UNFILTERED
+        return freezableCandidates(watchlist, op) { stateReader.candidateOf(it, uad) }
     }
 
     /**
@@ -335,8 +360,7 @@ class BulkFreezeRunner(
         // having awaited anything.
         if (!privilegeManager.state.first { it.isReady }.hasAnyPrivilege) return null
 
-        val watchlist = freezerRepository.getAllPackageNames()
-        val targets = freezableCandidates(watchlist, op, stateReader::stateOf)
+        val targets = targetsFor(op)
         if (targets.isEmpty()) return null
 
         // Resolved once per run, not per package: the mode cannot change mid-batch, and the

--- a/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
@@ -111,9 +111,19 @@ class AutoFreezeManager(
                         scope.launch {
                             semaphore.withPermit {
                                 try {
+                                    // Fail closed on an unresolved tier. getAppDetails swallows
+                                    // every Exception and returns null (AppRepositoryImpl.kt:245),
+                                    // so null means "could not classify" — a transient binder
+                                    // failure looks identical to an absent package. Freezing on
+                                    // an unknown tier is how an Unsafe system app reaches
+                                    // `pm uninstall --user`. Skipping costs one cycle; the next
+                                    // screen-off re-reads the whole Freezer list anyway.
                                     val detailedApp = appRepository.getAppDetails(pkg)
-                                    if (detailedApp != null && detailedApp.freezeTier == FreezeTier.BLOCKED) {
-                                        Logger.d("AutoFreezeManager", "Skipping auto-freeze for UNSAFE system app: $pkg")
+                                    if (detailedApp == null || detailedApp.freezeTier == FreezeTier.BLOCKED) {
+                                        Logger.d(
+                                            "AutoFreezeManager",
+                                            "Skipping auto-freeze, tier blocked or unresolved: $pkg"
+                                        )
                                         return@launch
                                     }
                                     val appInfo = pm.getApplicationInfo(pkg, 0)

--- a/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
@@ -10,7 +10,9 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import com.valhalla.thor.domain.model.FreezeTier
 import com.valhalla.thor.domain.model.FreezerMode
+import com.valhalla.thor.domain.model.freezeTier
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
@@ -110,14 +112,9 @@ class AutoFreezeManager(
                             semaphore.withPermit {
                                 try {
                                     val detailedApp = appRepository.getAppDetails(pkg)
-                                    if (detailedApp != null) {
-                                        val isSystem = detailedApp.isSystem
-                                        val isUadFailed = isSystem && detailedApp.isUadLoadFailed
-                                        val isUnsafe = isSystem && detailedApp.bloatRecommendation?.lowercase() == "unsafe"
-                                        if (isSystem && (isUadFailed || isUnsafe)) {
-                                            Logger.d("AutoFreezeManager", "Skipping auto-freeze for UNSAFE system app: $pkg")
-                                            return@launch
-                                        }
+                                    if (detailedApp != null && detailedApp.freezeTier == FreezeTier.BLOCKED) {
+                                        Logger.d("AutoFreezeManager", "Skipping auto-freeze for UNSAFE system app: $pkg")
+                                        return@launch
                                     }
                                     val appInfo = pm.getApplicationInfo(pkg, 0)
                                     val alreadySuspended = (appInfo.flags and ApplicationInfo.FLAG_SUSPENDED) != 0

--- a/app/src/main/java/com/valhalla/thor/data/source/local/UadHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/UadHelper.kt
@@ -14,6 +14,37 @@ data class UadEntry(
     val removal: String
 )
 
+/**
+ * One consistent read of [UadHelper] — the recommendation map plus whether the list behind it
+ * failed to load — taken together so a caller cannot mix a fresh map with a stale flag.
+ *
+ * That mix is not hypothetical. [UadHelper.didLoadFail] is assigned only inside the lazy load
+ * that the `uadMap` getter triggers, so on a cold instance the flag reads `false` until the map
+ * has been touched at least once. Code that consults the flag first therefore concludes "the
+ * list loaded fine" no matter what — and the safety rule it guards ("no UAD data means treat
+ * every system app as blocked") fails *open*, which is the exact direction it must never fail.
+ * [UadHelper.snapshot] reads the map first; taking the pair through this type is what stops the
+ * order being re-derived, and re-derived wrongly, at each call site.
+ */
+class UadSnapshot internal constructor(
+    private val entries: Map<String, UadEntry>,
+    val loadFailed: Boolean,
+) {
+    /** UAD's removal recommendation for [packageName] ("Unsafe", "Expert", …), or null. */
+    fun recommendationFor(packageName: String): String? = entries[packageName]?.removal
+
+    companion object {
+        /**
+         * A snapshot that classifies nothing, for paths where the tier is irrelevant by design
+         * — unfreezing, and the plain state read behind `AppFreezeStateReader.stateOf`.
+         *
+         * Deliberately NOT a default parameter value anywhere: on a freeze path this would
+         * silently disable the block, so every use has to be written out and justified.
+         */
+        val UNFILTERED = UadSnapshot(emptyMap(), loadFailed = false)
+    }
+}
+
 @Single
 class UadHelper(
     private val context: Context,
@@ -36,6 +67,19 @@ class UadHelper(
                 cachedMap ?: buildUadMap().also { cachedMap = it }
             }
         }
+
+    /**
+     * The map and [didLoadFail] as one value — see [UadSnapshot] for why they must travel
+     * together.
+     *
+     * The `uadMap` read has to come first: it is what forces the lazy load that assigns
+     * [didLoadFail], so reading the flag first would observe the pre-load default. Cheap after
+     * the first call (the map is cached), so a per-run snapshot is fine.
+     */
+    fun snapshot(): UadSnapshot {
+        val entries = uadMap
+        return UadSnapshot(entries, didLoadFail)
+    }
 
     fun invalidateCache() {
         // Lock-free by design: this is called from a main-thread BroadcastReceiver on

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+/**
+ * How dangerous it is to freeze a package, derived from its UAD (Universal Android Debloater)
+ * recommendation.
+ *
+ * Only system apps have a tier. Freezing a user app is always reversible with `pm enable`, so
+ * there is nothing to warn about; system apps are frozen with `pm uninstall --user`, and the
+ * ones the UAD list marks unsafe can leave the device unable to boot, place calls, or reach the
+ * network.
+ */
+enum class FreezeTier {
+    /** No warning: a user app, or a system app UAD considers safe to remove. */
+    NORMAL,
+
+    /** Warn loudly, then let the user through — UAD's "Expert" tier. */
+    EXPERT,
+
+    /** Never freeze, whatever the surface. UAD's "Unsafe" tier, or no usable UAD data at all. */
+    BLOCKED,
+}
+
+/**
+ * The tier for one package.
+ *
+ * [isUadLoadFailed] outranks the recommendation on purpose: with no list loaded every system app
+ * would read as unclassified, and "unclassified" must fail *closed*. That is the same reasoning
+ * the freeze dialogs and the batch paths already use — this function exists so the rule has one
+ * home instead of being retyped at each of them, which is how the QS tile ended up freezing what
+ * the in-app dialog refuses to.
+ */
+fun freezeTierOf(
+    isSystem: Boolean,
+    bloatRecommendation: String?,
+    isUadLoadFailed: Boolean,
+): FreezeTier = when {
+    !isSystem -> FreezeTier.NORMAL
+    isUadLoadFailed -> FreezeTier.BLOCKED
+    // .lowercase() is load-bearing: uad_lists.json stores the recommendation capitalised
+    // ("Unsafe", "Expert"), so comparing against a lowercase literal without it matches nothing
+    // and the gate degrades into a silent no-op that looks exactly like "nothing was risky".
+    else -> when (bloatRecommendation?.lowercase()) {
+        "unsafe" -> FreezeTier.BLOCKED
+        "expert" -> FreezeTier.EXPERT
+        else -> FreezeTier.NORMAL
+    }
+}
+
+/** [freezeTierOf] for an app we already hold. */
+val AppInfo.freezeTier: FreezeTier
+    get() = freezeTierOf(isSystem, bloatRecommendation, isUadLoadFailed)

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezeState.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezeState.kt
@@ -7,21 +7,46 @@ package com.valhalla.thor.domain.model
 enum class FreezeState { FROZEN, ACTIVE, ABSENT }
 
 /**
+ * Everything a bulk run needs to know about one package: where it is now, and whether policy
+ * lets us freeze it at all.
+ *
+ * Both halves come from a single read so they cannot disagree. Asking for [state] and
+ * [blockedFromFreeze] separately would mean a second PackageManager binder call per watchlist
+ * entry on every QS shade open, and a window in which the two answers describe different
+ * instants.
+ */
+data class FreezeCandidate(
+    val state: FreezeState,
+    /**
+     * True when [FreezeTier.BLOCKED] applies — an unsafe system app, or any system app while the
+     * UAD list is unreadable. Freeze-only: it says nothing about unfreezing, which is always
+     * allowed and is in fact the way *out* of a bad state.
+     */
+    val blockedFromFreeze: Boolean = false,
+)
+
+/**
  * The packages a bulk [op] would actually act on, in watchlist order.
  *
  * This is the fix for the tile counting watchlist rows: the freezer watchlist is invariant
  * under freeze/unfreeze, so only the live per-app state can tell us whether there is
  * anything left to do. [FreezeState.ABSENT] packages are skipped but deliberately left in
  * the watchlist — pruning them is out of scope.
+ *
+ * Written as two explicit branches rather than one `wanted` state plus a shared filter so the
+ * asymmetry is structural: [BulkOp.FREEZE] honours [FreezeCandidate.blockedFromFreeze],
+ * [BulkOp.UNFREEZE] must not. A blocked app that somehow got frozen has to stay unfreezable,
+ * or the block would trap it.
  */
 fun freezableCandidates(
     watchlist: List<String>,
     op: BulkOp,
-    stateOf: (String) -> FreezeState,
-): List<String> {
-    val wanted = when (op) {
-        BulkOp.FREEZE -> FreezeState.ACTIVE
-        BulkOp.UNFREEZE -> FreezeState.FROZEN
+    candidateOf: (String) -> FreezeCandidate,
+): List<String> = when (op) {
+    BulkOp.FREEZE -> watchlist.filter {
+        val candidate = candidateOf(it)
+        candidate.state == FreezeState.ACTIVE && !candidate.blockedFromFreeze
     }
-    return watchlist.filter { stateOf(it) == wanted }
+
+    BulkOp.UNFREEZE -> watchlist.filter { candidateOf(it).state == FreezeState.FROZEN }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -11,7 +11,9 @@ import com.valhalla.thor.data.launcher.FreezerShortcutManager
 import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
+import com.valhalla.thor.domain.model.FreezeTier
 import com.valhalla.thor.domain.model.FreezerMode
+import com.valhalla.thor.domain.model.freezeTier
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
@@ -188,6 +190,17 @@ class FreezerViewModel(
     fun toggleManaged(packageName: String, add: Boolean) {
         viewModelScope.launch(Dispatchers.IO) {
             if (add) {
+                // The blocked tier, enforced here and not only in the sheet that calls this.
+                // Adding does two things — it freezes the app now, and it enlists it in every
+                // later bulk run — so a surface that forgot to ask would hand the QS tile and
+                // the launcher shortcuts a target the in-app dialog refuses to even offer a
+                // confirm button for. The sheet still asks first; this is the backstop.
+                val app = _uiState.value.allInstalledApps
+                    .firstOrNull { it.packageName == packageName }
+                if (app != null && app.freezeTier == FreezeTier.BLOCKED) {
+                    emitToast(UiText.StringResource(R.string.error_unsafe_skipped))
+                    return@launch
+                }
                 val freezeResult = if (_uiState.value.freezerMode == FreezerMode.SUSPEND)
                     manageAppUseCase.setAppSuspended(packageName, true)
                 else manageAppUseCase.setAppDisabled(packageName, true)

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -195,9 +195,16 @@ class FreezerViewModel(
                 // later bulk run — so a surface that forgot to ask would hand the QS tile and
                 // the launcher shortcuts a target the in-app dialog refuses to even offer a
                 // confirm button for. The sheet still asks first; this is the backstop.
+                //
+                // A miss fails closed. allInstalledApps is a snapshot of the last full rescan,
+                // so between the tap and this coroutine a refresh can drop the entry — and the
+                // very next statement freezes. Treating "not found" as "not blocked" would let
+                // an unclassified system app through on exactly the timing where we know least
+                // about it. error_unsafe_skipped covers both readings: it says UNSAFE / safety
+                // check failed.
                 val app = _uiState.value.allInstalledApps
                     .firstOrNull { it.packageName == packageName }
-                if (app != null && app.freezeTier == FreezeTier.BLOCKED) {
+                if (app == null || app.freezeTier == FreezeTier.BLOCKED) {
                     emitToast(UiText.StringResource(R.string.error_unsafe_skipped))
                     return@launch
                 }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/ManageFreezerSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/ManageFreezerSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -32,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -46,15 +48,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
+import com.valhalla.thor.domain.model.FreezeTier
+import com.valhalla.thor.domain.model.freezeTier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import com.valhalla.asgard.components.ConnectedButtonGroup
 import com.valhalla.asgard.components.ConnectedButtonGroupItem
+import com.valhalla.asgard.components.StatusChip
+import com.valhalla.thor.presentation.utils.getBloatRecommendationColors
 import com.valhalla.thor.presentation.widgets.AppIcon
 import com.valhalla.thor.presentation.widgets.AppSearchBar
 import kotlinx.coroutines.launch
@@ -70,6 +77,11 @@ fun ManageFreezerSheet(
     onDismiss: () -> Unit
 ) {
     var selectedType by rememberSaveable { mutableStateOf(AppListType.USER) }
+
+    // The app awaiting a blocked/expert confirmation, or null. Plain remember rather than
+    // rememberSaveable: AppInfo is not Saveable, and a dialog that survives process death would
+    // outlive the list it was raised from anyway — losing it on rotation is the safe direction.
+    var pendingApp by remember { mutableStateOf<AppInfo?>(null) }
 
     val filtered = remember(allApps, searchQuery, selectedType) {
         val typeFiltered = allApps.filter { it.isSystem == (selectedType == AppListType.SYSTEM) }
@@ -148,11 +160,101 @@ fun ManageFreezerSheet(
                 FreezerManageItem(
                     app = app,
                     inFreezer = inFreezer,
-                    onClick = { onToggle(app.packageName, !inFreezer) }
+                    onClick = {
+                        // Ask once, here, rather than on every later freeze. A watchlist entry
+                        // is a standing instruction: the QS tile and the launcher Freeze-all
+                        // shortcut act on it with no UI at all, so add time is the last moment
+                        // a warning can reach the user. Removal is never gated — unfreezing is
+                        // the way out of a bad state.
+                        val tier = app.freezeTier
+                        if (!inFreezer && tier != FreezeTier.NORMAL) pendingApp = app
+                        else onToggle(app.packageName, !inFreezer)
+                    }
                 )
             }
         }
     }
+
+    pendingApp?.let { app ->
+        FreezeTierDialog(
+            app = app,
+            onConfirm = {
+                onToggle(app.packageName, true)
+                pendingApp = null
+            },
+            onDismiss = { pendingApp = null }
+        )
+    }
+}
+
+/**
+ * The blocked / expert confirmation for adding a system app to the Freezer.
+ *
+ * Mirrors the freeze confirmation in AppInfoDialog, and deliberately so: blocked apps get no
+ * confirm button at all, expert apps get a red "Freeze anyway". [FreezerViewModel.toggleManaged]
+ * repeats the blocked check because a dialog is advice, not enforcement.
+ */
+@Composable
+private fun FreezeTierDialog(
+    app: AppInfo,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val tier = app.freezeTier
+    val isBlocked = tier == FreezeTier.BLOCKED
+    // Blocked splits two ways for the body text only: no usable UAD data at all vs. an app the
+    // list names as unsafe. The verdict is identical either way.
+    val isUadFailed = app.isUadLoadFailed
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = stringResource(
+                    if (isBlocked) R.string.freeze_blocked else R.string.freeze_expert_warning
+                ),
+                color = MaterialTheme.colorScheme.error
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                if (!isUadFailed) {
+                    app.bloatRecommendation?.let { rec ->
+                        val (color, textColor) = getBloatRecommendationColors(rec)
+                        StatusChip(text = rec, containerColor = color, contentColor = textColor)
+                        Spacer(Modifier.height(12.dp))
+                    }
+                }
+                Text(
+                    text = stringResource(
+                        when {
+                            isUadFailed -> R.string.uad_load_failed_freeze_desc
+                            isBlocked -> R.string.freeze_unsafe_desc
+                            else -> R.string.freeze_expert_desc
+                        }
+                    ),
+                    textAlign = TextAlign.Center
+                )
+            }
+        },
+        confirmButton = {
+            if (!isBlocked) {
+                TextButton(onClick = onConfirm) {
+                    Text(
+                        text = stringResource(R.string.freeze_anyway),
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(if (isBlocked) R.string.close else R.string.no))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -9,7 +9,9 @@ import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
+import com.valhalla.thor.domain.model.FreezeTier
 import com.valhalla.thor.domain.model.MultiAppAction
+import com.valhalla.thor.domain.model.freezeTier
 import com.valhalla.thor.domain.model.isActive
 import com.valhalla.thor.domain.model.isFrozen
 import com.valhalla.thor.domain.model.UserPreferences
@@ -516,10 +518,7 @@ class MainViewModel(
         val targets = if (isFreeze) {
             // Only freeze ACTIVE apps: skip unsafe/UAD system apps AND anything already frozen
             // (disabled or suspended) so we never stack disable+suspend into a mixed state.
-            apps.filter { app ->
-                app.isActive && !(app.isSystem && (app.isUadLoadFailed ||
-                    app.bloatRecommendation?.lowercase() == "unsafe"))
-            }
+            apps.filter { it.isActive && it.freezeTier != FreezeTier.BLOCKED }
         } else {
             apps
         }

--- a/app/src/test/java/com/valhalla/thor/domain/model/FreezeStateTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/FreezeStateTest.kt
@@ -16,13 +16,15 @@ class FreezeStateTest {
         "com.gone" to FreezeState.ABSENT,
     )
     private val watchlist = states.keys.toList()
-    private val stateOf: (String) -> FreezeState = { states[it] ?: FreezeState.ABSENT }
+    private val candidateOf: (String) -> FreezeCandidate = {
+        FreezeCandidate(states[it] ?: FreezeState.ABSENT)
+    }
 
     @Test
     fun `freeze targets only active apps`() {
         assertEquals(
             listOf("com.active.one", "com.active.two"),
-            freezableCandidates(watchlist, BulkOp.FREEZE, stateOf)
+            freezableCandidates(watchlist, BulkOp.FREEZE, candidateOf)
         )
     }
 
@@ -30,14 +32,14 @@ class FreezeStateTest {
     fun `unfreeze targets only frozen apps`() {
         assertEquals(
             listOf("com.frozen.one"),
-            freezableCandidates(watchlist, BulkOp.UNFREEZE, stateOf)
+            freezableCandidates(watchlist, BulkOp.UNFREEZE, candidateOf)
         )
     }
 
     @Test
     fun `uninstalled packages are never candidates`() {
-        val all = freezableCandidates(watchlist, BulkOp.FREEZE, stateOf) +
-                freezableCandidates(watchlist, BulkOp.UNFREEZE, stateOf)
+        val all = freezableCandidates(watchlist, BulkOp.FREEZE, candidateOf) +
+                freezableCandidates(watchlist, BulkOp.UNFREEZE, candidateOf)
         assertEquals(emptyList<String>(), all.filter { it == "com.gone" })
     }
 
@@ -48,7 +50,7 @@ class FreezeStateTest {
         val allFrozen = listOf("a", "b", "c")
         assertEquals(
             emptyList<String>(),
-            freezableCandidates(allFrozen, BulkOp.FREEZE) { FreezeState.FROZEN }
+            freezableCandidates(allFrozen, BulkOp.FREEZE) { FreezeCandidate(FreezeState.FROZEN) }
         )
     }
 
@@ -56,7 +58,7 @@ class FreezeStateTest {
     fun `an empty watchlist yields no candidates`() {
         assertEquals(
             emptyList<String>(),
-            freezableCandidates(emptyList(), BulkOp.FREEZE, stateOf)
+            freezableCandidates(emptyList(), BulkOp.FREEZE, candidateOf)
         )
     }
 
@@ -65,7 +67,150 @@ class FreezeStateTest {
         val reversed = listOf("com.active.two", "com.active.one")
         assertEquals(
             listOf("com.active.two", "com.active.one"),
-            freezableCandidates(reversed, BulkOp.FREEZE, stateOf)
+            freezableCandidates(reversed, BulkOp.FREEZE, candidateOf)
+        )
+    }
+
+    // --- blocked tier ---------------------------------------------------------------------
+    //
+    // The QS tile and the launcher Freeze-all shortcut act on the watchlist with no dialog in
+    // front of them, so this filter is the only thing standing between a stored watchlist entry
+    // and a `pm uninstall --user` on a package the in-app dialog refuses to freeze at all.
+
+    private fun blocked(state: FreezeState) = FreezeCandidate(state, blockedFromFreeze = true)
+
+    @Test
+    fun `a blocked active app is not a freeze candidate`() {
+        assertEquals(
+            emptyList<String>(),
+            freezableCandidates(listOf("com.unsafe"), BulkOp.FREEZE) { blocked(FreezeState.ACTIVE) }
+        )
+    }
+
+    @Test
+    fun `a blocked frozen app is still an unfreeze candidate`() {
+        // The asymmetry that makes the block safe. An app can be in the watchlist frozen from
+        // before it was ever classified (or from a Thor version without this filter); gating
+        // unfreeze on the same predicate would trap it frozen with no in-app way out.
+        assertEquals(
+            listOf("com.unsafe"),
+            freezableCandidates(listOf("com.unsafe"), BulkOp.UNFREEZE) {
+                blocked(FreezeState.FROZEN)
+            }
+        )
+    }
+
+    @Test
+    fun `blocked apps are dropped but their neighbours survive`() {
+        val mixed = listOf("com.ok.one", "com.unsafe", "com.ok.two")
+        assertEquals(
+            listOf("com.ok.one", "com.ok.two"),
+            freezableCandidates(mixed, BulkOp.FREEZE) {
+                if (it == "com.unsafe") blocked(FreezeState.ACTIVE)
+                else FreezeCandidate(FreezeState.ACTIVE)
+            }
+        )
+    }
+
+    @Test
+    fun `an all-blocked watchlist yields no freeze candidates`() {
+        // What the tile has to paint INACTIVE. A count taken any other way would advertise
+        // "Freeze 3" over a batch that then froze nothing.
+        assertEquals(
+            emptyList<String>(),
+            freezableCandidates(listOf("a", "b", "c"), BulkOp.FREEZE) { blocked(FreezeState.ACTIVE) }
+        )
+    }
+
+    @Test
+    fun `blockedFromFreeze defaults to false`() {
+        // Guards the default: flipping it would silently empty every freeze batch.
+        assertEquals(false, FreezeCandidate(FreezeState.ACTIVE).blockedFromFreeze)
+    }
+}
+
+/** The freeze-risk tier shared by the tile, the bulk paths and the in-app dialogs. */
+class FreezePolicyTest {
+
+    @Test
+    fun `user apps are never blocked whatever the recommendation says`() {
+        // bloatRecommendation is meaningless for a user app, and freezing one is reversible
+        // with pm enable — so a stale UAD row must not gate it.
+        assertEquals(
+            FreezeTier.NORMAL,
+            freezeTierOf(isSystem = false, bloatRecommendation = "Unsafe", isUadLoadFailed = false)
+        )
+    }
+
+    @Test
+    fun `user apps are not blocked by a failed UAD load either`() {
+        assertEquals(
+            FreezeTier.NORMAL,
+            freezeTierOf(isSystem = false, bloatRecommendation = null, isUadLoadFailed = true)
+        )
+    }
+
+    @Test
+    fun `an unsafe system app is blocked`() {
+        // Capitalised exactly as uad_lists.json stores it. A comparison that forgets
+        // .lowercase() matches nothing here and the whole gate becomes a silent no-op that
+        // still passes every other test in this class.
+        assertEquals(
+            FreezeTier.BLOCKED,
+            freezeTierOf(isSystem = true, bloatRecommendation = "Unsafe", isUadLoadFailed = false)
+        )
+    }
+
+    @Test
+    fun `an expert system app warns but is not blocked`() {
+        assertEquals(
+            FreezeTier.EXPERT,
+            freezeTierOf(isSystem = true, bloatRecommendation = "Expert", isUadLoadFailed = false)
+        )
+    }
+
+    @Test
+    fun `a recommended system app is normal`() {
+        assertEquals(
+            FreezeTier.NORMAL,
+            freezeTierOf(
+                isSystem = true,
+                bloatRecommendation = "Recommended",
+                isUadLoadFailed = false
+            )
+        )
+    }
+
+    @Test
+    fun `an unclassified system app is normal`() {
+        // Present in the list but with no removal advice, or absent from it entirely: Thor has
+        // always allowed these, and blocking them would take most of the system list away.
+        assertEquals(
+            FreezeTier.NORMAL,
+            freezeTierOf(isSystem = true, bloatRecommendation = null, isUadLoadFailed = false)
+        )
+    }
+
+    @Test
+    fun `a failed UAD load blocks every system app`() {
+        // Fail closed: with no list we cannot tell a safe system app from a bootloop.
+        assertEquals(
+            FreezeTier.BLOCKED,
+            freezeTierOf(isSystem = true, bloatRecommendation = null, isUadLoadFailed = true)
+        )
+    }
+
+    @Test
+    fun `a failed UAD load outranks a benign recommendation`() {
+        // The recommendation string cannot be trusted when the load that produced it failed —
+        // it is whatever a partially-populated or stale map happened to hold.
+        assertEquals(
+            FreezeTier.BLOCKED,
+            freezeTierOf(
+                isSystem = true,
+                bloatRecommendation = "Recommended",
+                isUadLoadFailed = true
+            )
         )
     }
 }


### PR DESCRIPTION
## The bug

The QS tile and the launcher Freeze-all shortcut were the only freeze surfaces in Thor with **no risk-tier gate**.

Six other sites already refuse to freeze a system app that the UAD list marks `Unsafe` — or *any* system app when the list fails to load — and the in-app dialog for such an app doesn't even render a confirm button. But `BulkFreezeRunner` acted on the raw watchlist, so a package the app itself flatly refuses to touch could still be `pm uninstall --user`-ed by a single tap on the tile.

## The fix

**One gate, one place.** New `domain/model/FreezePolicy.kt`:

```kotlin
enum class FreezeTier { NORMAL, EXPERT, BLOCKED }
fun freezeTierOf(isSystem: Boolean, bloatRecommendation: String?, isUadLoadFailed: Boolean): FreezeTier
val AppInfo.freezeTier: FreezeTier
```

Both pre-existing hand-rolled copies of that predicate — `MainViewModel.performCountedFreeze` and `AutoFreezeManager` — are migrated onto it. They were byte-identical to each other and to the six dialog sites; the drift risk between copies is what let this slip through in the first place.

**The count cannot lie.** `BulkFreezeRunner.targetsFor(op)` is shared by `run()` and `refreshFreezableCount()`, so the number the tile advertises is computed by the same filter as the batch it then runs.

**Unfreeze is deliberately ungated.** `UNFREEZE` passes `UadSnapshot.UNFILTERED`. Applying the same predicate to unfreeze would strand system apps frozen whenever the UAD list fails to load — the one state with no in-app way out. `FreezeStateTest` pins this asymmetry.

**Ordering trap closed.** `UadHelper.snapshot()` exists because `didLoadFail` is only assigned *inside* the lazy `loadUadList()`; reading the flag before touching `uadMap` returns a stale `false` and the safety rule fails **open**. `snapshot()` takes the map first, forcing the load, then reads the flag.

**Warn at add time, not per-tap.** A watchlist entry is a standing instruction the tile obeys with no UI in front of it, so `ManageFreezerSheet` now confirms when an app is *added*: BLOCKED gets no confirm button, EXPERT gets a red "Freeze anyway", removal is never gated. `FreezerViewModel.toggleManaged` repeats the blocked check as enforcement behind that advisory dialog.

**Zero new strings** — all eight resources already ship in all five locales.

## Deliberate non-changes

- `AppRepositoryImpl.kt:101-102` / `:239-243` already read `uadMap` then `didLoadFail` by hand in the correct order. Left un-migrated to `snapshot()`: hot path, zero behaviour change to gain.
- `MainViewModel`'s `MultiAppAction.Uninstall` gate — uninstall is a different operation with its own policy.
- The `AppInfoDialog` / `AppInfoDetailsScreen` tier dialogs keep their existing inline predicates; converging those is a larger UI refactor and out of scope here.

## Verification

- **Unit tests: 154 pass, 0 failures, 0 skipped** (`--rerun-tasks`; a bare run reports UP-TO-DATE and silently skips). `FreezePolicyTest` (8 cases) pins the load-bearing `.lowercase()` using the capitalised `"Unsafe"` / `"Expert"` literals that `uad_lists.json` actually stores — a comparison that drops `.lowercase()` matches nothing and the gate becomes a silent no-op. `FreezeStateTest` (11 cases) pins the FREEZE-honours-blocked / UNFREEZE-ignores-blocked asymmetry.
- **Builds:** `assembleFossDebug` + `assembleFossRelease` + `assembleStoreRelease` all green.
- **Lint:** `lintFossRelease` + `lintStoreRelease` — only the 5 pre-existing intentional `VectorPath` warnings, nothing new.
- **Adversarial review:** 4 disjoint lenses (safety-gate, regression, concurrency/lifecycle, correctness-tests), each finding handed to an independent refuter. 11 findings raised, **11 refuted, 0 confirmed.**

## Review gate

`git grep -n "UNFILTERED" app/src/main/java` must return **exactly 2 real usages** — `AppFreezeStateReader.kt:32` and `BulkFreezeRunner.kt:178` — plus the declaration and one KDoc mention. A third usage means someone handed `UNFILTERED` to a freeze path, which silently disables the block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced risk-based freeze tiers (normal, expert, blocked) to improve safety decisions.
  * Added a tier-aware confirmation flow when adding apps to the freezer.
  * Updated bulk-freeze eligibility to use the new tier rules.

* **Bug Fixes**
  * Blocked apps are excluded from freeze selections while still remaining eligible for unfreezing.
  * Auto-freeze on screen-off now skips apps with unresolved safety tier data or blocked tier.

* **Tests**
  * Expanded coverage for tier assignment and blocked-candidate filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->