### PR TITLE
test(app-list): behaviour tests for the load/refresh timing, and the seam they needed

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -26,6 +26,7 @@ import com.valhalla.thor.data.receivers.FreezerShortcutPinnedReceiver
 import com.valhalla.thor.domain.model.BulkOp
 import com.valhalla.thor.domain.model.BulkResult
 import com.valhalla.thor.domain.model.FreezeState
+import com.valhalla.thor.domain.repository.AppShortcutController
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
@@ -37,13 +38,13 @@ import kotlinx.coroutines.launch
 import org.koin.core.annotation.Single
 
 /** Owns all launcher-shortcut plumbing for the Freezer feature. */
-@Single
+@Single(binds = [AppShortcutController::class])
 class FreezerShortcutManager(
     private val context: Context,
     private val freezerRepository: FreezerRepository,
     private val bulkFreezeRunner: BulkFreezeRunner,
     private val stateReader: AppFreezeStateReader,
-) {
+) : AppShortcutController {
     // App-scoped: bulk work must survive the (finishing) trampoline activity.
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -130,7 +131,7 @@ class FreezerShortcutManager(
     }
 
     /** Grey out a per-app shortcut (the ceiling — pinned icons can't be silently removed). */
-    fun disableAppShortcut(packageName: String) {
+    override fun disableAppShortcut(packageName: String) {
         ShortcutManagerCompat.disableShortcuts(
             context,
             listOf(FreezerShortcutContract.appShortcutId(packageName)),

--- a/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
@@ -7,6 +7,7 @@ import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.domain.model.PrivilegeState
 import com.valhalla.thor.domain.model.resolvePrivilegeMode
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.PrivilegeStateProvider
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.PrivilegeProbeTier
@@ -39,15 +40,15 @@ import rikka.shizuku.Shizuku
  * Shizuku listeners (they live for the app), so consumers created before a
  * first-launch grant still see it once granted.
  */
-@Single
+@Single(binds = [PrivilegeStateProvider::class])
 class PrivilegeManager(
     private val systemRepository: SystemRepository,
     private val preferenceRepository: PreferenceRepository
-) {
+) : PrivilegeStateProvider {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     private val _state = MutableStateFlow(PrivilegeState())
-    val state: StateFlow<PrivilegeState> = _state.asStateFlow()
+    override val state: StateFlow<PrivilegeState> = _state.asStateFlow()
 
     // Bumped to force a re-probe; StateFlow<Int> emits on every distinct value.
     private val refreshTrigger = MutableStateFlow(0)

--- a/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
@@ -9,6 +9,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Process
+import com.valhalla.thor.domain.repository.StorageStatsProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
@@ -18,14 +19,14 @@ import org.koin.core.annotation.Single
  * StorageStatsManager. Requires the GET_USAGE_STATS app-op for other packages
  * (see UsageAccessManager) — a per-package failure is skipped, never thrown.
  */
-@Single
-class StorageStatsHelper(private val context: Context) {
+@Single(binds = [StorageStatsProvider::class])
+class StorageStatsHelper(private val context: Context) : StorageStatsProvider {
 
     private val statsManager = context.getSystemService(StorageStatsManager::class.java)
     private val pm = context.packageManager
     private val user = Process.myUserHandle()
 
-    suspend fun installSizes(packages: List<String>): Map<String, Long> =
+    override suspend fun installSizes(packages: List<String>): Map<String, Long> =
         withContext(Dispatchers.IO) {
             val manager = statsManager ?: return@withContext emptyMap()
             // One Binder call for all ApplicationInfo instead of one per package.

--- a/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.Process
 import android.provider.Settings
 import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.domain.repository.UsageAccessGate
 import org.koin.core.annotation.Single
 
 /**
@@ -18,11 +19,11 @@ import org.koin.core.annotation.Single
  * StorageStatsManager. Tries a silent grant through the active privilege
  * gateway; always re-verifies; exposes the Settings deep-link for the fallback.
  */
-@Single
+@Single(binds = [UsageAccessGate::class])
 class UsageAccessManager(
     private val context: Context,
     private val systemRepository: SystemRepository
-) {
+) : UsageAccessGate {
     private val appOps = context.getSystemService(AppOpsManager::class.java)
     private val pkg = context.packageName
 
@@ -30,7 +31,7 @@ class UsageAccessManager(
     private var autoGrantAttempted = false
 
     @Suppress("DEPRECATION")
-    fun isGranted(): Boolean {
+    override fun isGranted(): Boolean {
         val ops = appOps ?: return false
         val mode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             ops.unsafeCheckOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, Process.myUid(), pkg)
@@ -41,7 +42,7 @@ class UsageAccessManager(
     }
 
     /** Best-effort silent grant via a privileged gateway; returns the verified result. */
-    suspend fun tryGrantViaPrivilege(): Boolean {
+    override suspend fun tryGrantViaPrivilege(): Boolean {
         if (isGranted()) return true
         // Harmless if no privilege is active (command just fails); may also be
         // blocked on newer Android — hence we re-verify rather than assume success.
@@ -54,7 +55,7 @@ class UsageAccessManager(
      * transient failure (e.g. the privilege gateway not fully ready yet) can still be
      * retried the next time this runs rather than being disabled for the whole process.
      */
-    suspend fun maybeAutoGrant() {
+    override suspend fun maybeAutoGrant() {
         if (autoGrantAttempted || isGranted()) return
         if (tryGrantViaPrivilege()) autoGrantAttempted = true
     }

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppShortcutController.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppShortcutController.kt
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+/**
+ * Domain port for the launcher-shortcut side effects an app action has to trigger. Narrow on
+ * purpose: the concrete `FreezerShortcutManager` also pins, syncs and re-renders shortcuts, all
+ * of which need `ShortcutManager` and a `Context`. Callers that only have to retire a shortcut
+ * when its app disappears take this instead.
+ */
+interface AppShortcutController {
+    /** Disable (and hide) any shortcut targeting [packageName] — it is gone or no longer launchable. */
+    fun disableAppShortcut(packageName: String)
+}

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PrivilegeStateProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PrivilegeStateProvider.kt
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+import com.valhalla.thor.domain.model.PrivilegeState
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Read-only view of the shared privilege probe. The concrete `PrivilegeManager` registers
+ * Shizuku binder listeners from its initializer, which is a live Android/Binder dependency;
+ * consumers that only *observe* the probe take this port instead, so they stay constructible
+ * off-device. Anything that needs to trigger a re-probe still depends on the manager itself.
+ */
+interface PrivilegeStateProvider {
+    /** Latest privilege availability. Emits `isReady = true` once the first probe lands. */
+    val state: StateFlow<PrivilegeState>
+}

--- a/app/src/main/java/com/valhalla/thor/domain/repository/StorageStatsProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/StorageStatsProvider.kt
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+/**
+ * Domain port for per-package install sizes. Keeps callers free of `StorageStatsManager`,
+ * `PackageManager` and `UserHandle` — the concrete impl lives in the data layer and resolves
+ * all three from a `Context`. Signatures use only String/primitives, no Android types.
+ */
+interface StorageStatsProvider {
+    /**
+     * Total install size (app + data + cache) per package. Packages whose stats cannot be
+     * read are omitted rather than reported as zero, so callers can keep a previous value.
+     */
+    suspend fun installSizes(packages: List<String>): Map<String, Long>
+}

--- a/app/src/main/java/com/valhalla/thor/domain/repository/UsageAccessGate.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/UsageAccessGate.kt
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+/**
+ * Domain port for the GET_USAGE_STATS app-op that [StorageStatsProvider] depends on. Covers
+ * only the check/grant half; the Settings deep-link stays on the concrete `UsageAccessManager`
+ * because it returns an `Intent`, which has no place in a domain signature.
+ */
+interface UsageAccessGate {
+    /** True when this process currently holds the Usage Access app-op. */
+    fun isGranted(): Boolean
+
+    /** Best-effort silent grant through the active privilege gateway; returns the *verified* result. */
+    suspend fun tryGrantViaPrivilege(): Boolean
+
+    /** One best-effort auto-grant per process, latched only after a grant actually succeeds. */
+    suspend fun maybeAutoGrant()
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -6,10 +6,6 @@ package com.valhalla.thor.presentation.appList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
-import com.valhalla.thor.data.launcher.FreezerShortcutManager
-import com.valhalla.thor.data.manager.PrivilegeManager
-import com.valhalla.thor.data.manager.StorageStatsHelper
-import com.valhalla.thor.data.manager.UsageAccessManager
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.FilterType
@@ -21,8 +17,12 @@ import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.model.freezeTier
 import com.valhalla.thor.domain.model.sortApps
 import com.valhalla.thor.domain.repository.AppRepository
+import com.valhalla.thor.domain.repository.AppShortcutController
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.PrivilegeStateProvider
+import com.valhalla.thor.domain.repository.StorageStatsProvider
+import com.valhalla.thor.domain.repository.UsageAccessGate
 import com.valhalla.thor.domain.usecase.FreezeAppUseCase
 import com.valhalla.thor.domain.usecase.GetAppDetailsUseCase
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
@@ -32,7 +32,7 @@ import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.util.UiTextException
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.channels.Channel
@@ -51,6 +51,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
+import org.koin.core.annotation.Named
 
 // ... AppListUiState remains same ...
 data class AppListUiState(
@@ -103,15 +104,20 @@ sealed interface AppListEvent {
 class AppListViewModel(
     private val getInstalledAppsUseCase: GetInstalledAppsUseCase,
     private val getAppDetailsUseCase: GetAppDetailsUseCase,
-    private val privilegeManager: PrivilegeManager,
+    private val privilege: PrivilegeStateProvider,
     private val manageAppUseCase: ManageAppUseCase,
     private val freezeAppUseCase: FreezeAppUseCase,
     private val preferenceRepository: PreferenceRepository,
     private val freezerRepository: FreezerRepository,
-    private val freezerShortcutManager: FreezerShortcutManager,
+    private val appShortcuts: AppShortcutController,
     private val appRepository: AppRepository,
-    private val storageStatsHelper: StorageStatsHelper,
-    private val usageAccessManager: UsageAccessManager
+    private val storageStats: StorageStatsProvider,
+    private val usageAccess: UsageAccessGate,
+    // Injected rather than hardcoded so a test can put every stage of this view model on one
+    // scheduler: the sort/filter pipeline below runs off-main, and a `Dispatchers.Default` baked
+    // in here would keep it on a real thread pool while the rest ran on virtual time.
+    @Named("default") private val defaultDispatcher: CoroutineDispatcher,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
 
     private var appsJob: Job? = null
@@ -128,7 +134,7 @@ class AppListViewModel(
     val events: Flow<AppListEvent> = _events.receiveAsFlow()
 
     // Combine raw app data with user preferences from DataStore
-    // OPTIMIZATION: flowOn(Dispatchers.Default) ensures sorting/filtering happens on background thread
+    // OPTIMIZATION: flowOn(defaultDispatcher) ensures sorting/filtering happens on background thread
     val uiState = combine(_rawState, preferenceRepository.userPreferences) { state, prefs ->
         val mergedState = state.copy(
             sortBy = prefs.appSortBy,
@@ -139,7 +145,7 @@ class AppListViewModel(
         )
         processList(mergedState)
     }
-        .flowOn(Dispatchers.Default) // Move computation off Main Thread
+        .flowOn(defaultDispatcher) // Move computation off Main Thread
         .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),
@@ -207,7 +213,7 @@ class AppListViewModel(
             // so a Shizuku grant reflects here without reloading the list.
             combine(
                 getInstalledAppsUseCase(),
-                privilegeManager.state
+                privilege.state
             ) { (user, system), priv ->
                 Triple(user, system, priv)
             }.catch { e ->
@@ -236,7 +242,7 @@ class AppListViewModel(
                     )
                 }
                 if (priv.hasAnyPrivilege) {
-                    launch { usageAccessManager.maybeAutoGrant() }
+                    launch { usageAccess.maybeAutoGrant() }
                 }
             }
         }
@@ -292,7 +298,7 @@ class AppListViewModel(
     private fun ensureInstallSizes() {
         sizeJob?.cancel()
         sizeJob = viewModelScope.launch {
-            if (!usageAccessManager.isGranted() && !usageAccessManager.tryGrantViaPrivilege()) {
+            if (!usageAccess.isGranted() && !usageAccess.tryGrantViaPrivilege()) {
                 _rawState.update { it.copy(needsUsageAccessPrompt = true) }
                 return@launch
             }
@@ -300,7 +306,7 @@ class AppListViewModel(
             try {
                 val packages = (_rawState.value.allUserApps + _rawState.value.allSystemApps)
                     .map { it.packageName }
-                val sizes = storageStatsHelper.installSizes(packages)
+                val sizes = storageStats.installSizes(packages)
                 _rawState.update { state ->
                     state.copy(
                         needsUsageAccessPrompt = false,
@@ -344,7 +350,7 @@ class AppListViewModel(
                 }
 
                 if (freeze) {
-                    val inFreezer = withContext(Dispatchers.IO) {
+                    val inFreezer = withContext(ioDispatcher) {
                         freezerRepository.contains(packageName)
                     }
                     if (!inFreezer) {
@@ -395,7 +401,7 @@ class AppListViewModel(
      * Unfreeze-all reaches it. Refusing here would strand a frozen app off the list it belongs on.
      */
     fun addToFreezer(packageName: String) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             freezerRepository.add(packageName)
             _events.send(
                 AppListEvent.ShowMessage(UiText.StringResource(R.string.added_to_freezer_success))
@@ -416,13 +422,13 @@ class AppListViewModel(
      * before the gate existed can always be taken back off.
      */
     fun toggleFreezerMembership(packageName: String) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             if (freezerRepository.contains(packageName)) {
                 freezerRepository.remove(packageName)
                 // Pinned launcher shortcuts can't be removed silently, only greyed out — leaving a
                 // live shortcut for an app no longer in the freezer would let it drive a freeze
                 // from the launcher.
-                freezerShortcutManager.disableAppShortcut(packageName)
+                appShortcuts.disableAppShortcut(packageName)
                 _events.send(
                     AppListEvent.ShowMessage(
                         UiText.PluralsResource(R.plurals.removed_from_freezer_success, 1)
@@ -455,7 +461,7 @@ class AppListViewModel(
     }
 
     fun performMultiAction(action: MultiAppAction) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             when (action) {
                 is MultiAppAction.Freeze -> {
                     // EXPERT apps go through unwarned here by design — a batch is not the place to

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -9,6 +9,7 @@ import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.FilterType
 import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.PrivilegeMode
+import com.valhalla.thor.domain.model.PrivilegeState
 import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
 import com.valhalla.thor.domain.model.ThemeMode
@@ -16,11 +17,16 @@ import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.repository.AppBundleBuilder
 import com.valhalla.thor.domain.repository.AppBundleFileStore
 import com.valhalla.thor.domain.repository.AppRepository
+import com.valhalla.thor.domain.repository.AppShortcutController
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.PrivilegeStateProvider
+import com.valhalla.thor.domain.repository.StorageStatsProvider
 import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.domain.repository.UsageAccessGate
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import java.io.File
@@ -281,6 +287,69 @@ class FakeAppBundleFileStore : AppBundleFileStore {
 
     private fun unsupported(): Nothing =
         throw UnsupportedOperationException("file store needs a device")
+}
+
+// The four ports below exist so a view model can be built without a Context. Each concrete
+// implementation resolves a system service (or registers Shizuku listeners) from its initializer,
+// which throws on a plain JVM — see the KDoc on each interface for what was left behind.
+
+/**
+ * A privilege probe a test can drive by hand: no Shizuku listeners, no probe coroutine, no Binder.
+ *
+ * Starts at the *cold-start* value — `isReady = false` — because that is the state every consumer
+ * has to survive, and a fake that started ready would hide the loader-gating rule entirely.
+ */
+class FakePrivilegeStateProvider(
+    initial: PrivilegeState = PrivilegeState()
+) : PrivilegeStateProvider {
+
+    private val _state = MutableStateFlow(initial)
+
+    override val state: StateFlow<PrivilegeState> = _state
+
+    /** Publish a new probe result, as the real manager does when a grant lands. */
+    fun emit(next: PrivilegeState) {
+        _state.value = next
+    }
+}
+
+/** Answers from a fixed table and records what it was asked, so "was a size scan run" is assertable. */
+class FakeStorageStatsProvider(
+    private val sizes: Map<String, Long> = emptyMap()
+) : StorageStatsProvider {
+
+    val queries = mutableListOf<List<String>>()
+
+    override suspend fun installSizes(packages: List<String>): Map<String, Long> {
+        queries += packages
+        // Mirrors the real one: an unreadable package is *absent*, not zero.
+        return sizes.filterKeys { it in packages }
+    }
+}
+
+/** Grant state is a plain flag a test can flip mid-run, matching how the app-op behaves. */
+class FakeUsageAccessGate(var granted: Boolean = true) : UsageAccessGate {
+
+    var autoGrantCalls = 0
+        private set
+
+    override fun isGranted(): Boolean = granted
+
+    override suspend fun tryGrantViaPrivilege(): Boolean = granted
+
+    override suspend fun maybeAutoGrant() {
+        autoGrantCalls++
+    }
+}
+
+/** Records the packages whose launcher shortcut was retired. */
+class FakeAppShortcutController : AppShortcutController {
+
+    val disabled = mutableListOf<String>()
+
+    override fun disableAppShortcut(packageName: String) {
+        disabled += packageName
+    }
 }
 
 /**

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import com.valhalla.thor.domain.model.AnimationIntensity
+import com.valhalla.thor.domain.model.UserPreferences
+import com.valhalla.thor.domain.usecase.FreezeAppUseCase
+import com.valhalla.thor.domain.usecase.GetAppDetailsUseCase
+import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
+import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.presentation.FakeAppRepository
+import com.valhalla.thor.presentation.FakeAppShortcutController
+import com.valhalla.thor.presentation.FakeFreezerRepository
+import com.valhalla.thor.presentation.FakePreferenceRepository
+import com.valhalla.thor.presentation.FakePrivilegeStateProvider
+import com.valhalla.thor.presentation.FakeStorageStatsProvider
+import com.valhalla.thor.presentation.FakeSystemRepository
+import com.valhalla.thor.presentation.FakeUsageAccessGate
+import com.valhalla.thor.presentation.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Behaviour tests for [AppListViewModel]'s **temporal** contract — the three rules from PR #278 that
+ * `TransitionSettleDelayTest` cannot reach, because that suite pins the constants and these are
+ * about who pays them and when.
+ *
+ * The rules under test:
+ *
+ * - a deliberate pull-to-refresh starts the package scan **immediately**; only navigation entry
+ *   pays `settleDelayFor(intensity)`, and it pays exactly that;
+ * - the pull-to-refresh indicator stays up for the whole `REFRESH_INDICATOR_MIN_VISIBLE` window;
+ * - a refresh arriving mid-hold **extends** the indicator rather than letting the cancelled hold
+ *   clear it at the original deadline — the subtlest line in that change;
+ * - relaunching the scan tears the previous collector down first, so two refreshes can never leave
+ *   two package scans running over each other.
+ *
+ * *How "the scan started" is observed:* `FakeAppRepository` hands out a `MutableStateFlow`, and its
+ * `subscriptionCount` goes to 1 exactly when the view model's `combine` reaches the repository and
+ * back to 0 when that collector is torn down. That is the real boundary — the point at which the
+ * production flow would register its package receivers and call `pm.getInstalledPackages` — rather
+ * than a flag the view model sets about itself.
+ *
+ * The dispatcher is **standard**, not unconfined (the rule's default): every assertion here is about
+ * an intermediate state at a known instant, so work must queue on the virtual clock rather than run
+ * eagerly at the call site. The same dispatcher is passed in for the view model's `default` and `io`
+ * dispatchers, which puts the sort/filter pipeline behind `uiState` on the same scheduler as the
+ * test body — otherwise it would run on a real thread pool and no `runCurrent()` would order it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppListViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private lateinit var appRepository: FakeAppRepository
+    private lateinit var system: FakeSystemRepository
+    private lateinit var freezer: FakeFreezerRepository
+    private lateinit var privilege: FakePrivilegeStateProvider
+
+    @Before
+    fun setUp() {
+        appRepository = FakeAppRepository()
+        system = FakeSystemRepository()
+        freezer = FakeFreezerRepository()
+        privilege = FakePrivilegeStateProvider()
+    }
+
+    /** Live collectors on the app list — 1 while a scan is running, 0 once it has been torn down. */
+    private fun scanCollectors(): Int = appRepository.apps.subscriptionCount.value
+
+    /**
+     * Builds the view model at [intensity] and keeps [AppListViewModel.uiState] hot.
+     *
+     * `uiState` is `stateIn(WhileSubscribed(5000))`: with no collector it stays pinned to the
+     * initial `AppListUiState()` and every indicator assertion below would pass for the wrong
+     * reason. Note the view model's `init` already fires `loadApps(deferForTransition = true)`, so
+     * every test starts with an entry load in flight — which is exactly the state a pull-to-refresh
+     * arrives in.
+     */
+    private fun TestScope.viewModel(
+        intensity: AnimationIntensity = AnimationIntensity.MEDIUM
+    ): AppListViewModel {
+        val prefs = FakePreferenceRepository(UserPreferences(animationIntensity = intensity))
+        val manageAppUseCase = ManageAppUseCase(system)
+        val vm = AppListViewModel(
+            getInstalledAppsUseCase = GetInstalledAppsUseCase(appRepository),
+            getAppDetailsUseCase = GetAppDetailsUseCase(appRepository),
+            privilege = privilege,
+            manageAppUseCase = manageAppUseCase,
+            freezeAppUseCase = FreezeAppUseCase(appRepository, manageAppUseCase),
+            preferenceRepository = prefs,
+            freezerRepository = freezer,
+            appShortcuts = FakeAppShortcutController(),
+            appRepository = appRepository,
+            storageStats = FakeStorageStatsProvider(),
+            usageAccess = FakeUsageAccessGate(),
+            defaultDispatcher = mainDispatcherRule.dispatcher,
+            ioDispatcher = mainDispatcherRule.dispatcher
+        )
+        backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.uiState.collect {} }
+        return vm
+    }
+
+    // --- Who pays the settle delay ---------------------------------------------------------
+
+    @Test
+    fun `a manual refresh starts the scan without advancing the clock`() = runTest {
+        // HIGH, so the entry load in `init` is parked on the longest delay there is. If the manual
+        // path paid any part of it, the scan below could not have started at t = 0.
+        val vm = viewModel(AnimationIntensity.HIGH)
+        runCurrent()
+        assertEquals("the entry load must still be waiting out its settle delay", 0, scanCollectors())
+
+        vm.loadApps()
+        runCurrent()
+
+        assertEquals("a pull-to-refresh must reach the scan at once", 1, scanCollectors())
+        assertEquals("no virtual time may have passed", 0L, currentTime)
+    }
+
+    @Test
+    fun `screen entry at LOW starts the scan immediately`() = runTest {
+        // LOW maps to Duration.ZERO, which delay() returns from without suspending, so the entry
+        // load behaves like the manual one: no wait at all.
+        viewModel(AnimationIntensity.LOW)
+        runCurrent()
+
+        assertEquals(1, scanCollectors())
+        assertEquals(0L, currentTime)
+    }
+
+    @Test
+    fun `screen entry at MEDIUM waits exactly 400ms before scanning`() = runTest {
+        viewModel(AnimationIntensity.MEDIUM)
+        runCurrent()
+        assertEquals(0, scanCollectors())
+
+        advanceTimeBy(399)
+        runCurrent()
+        assertEquals("the scan must not start early", 0, scanCollectors())
+
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals("the scan must start as soon as the delay is paid", 1, scanCollectors())
+    }
+
+    @Test
+    fun `screen entry at HIGH waits exactly 800ms before scanning`() = runTest {
+        viewModel(AnimationIntensity.HIGH)
+        runCurrent()
+        assertEquals(0, scanCollectors())
+
+        advanceTimeBy(799)
+        runCurrent()
+        assertEquals("the scan must not start early", 0, scanCollectors())
+
+        advanceTimeBy(1)
+        runCurrent()
+        assertEquals("the scan must start as soon as the delay is paid", 1, scanCollectors())
+    }
+
+    // --- The pull-to-refresh indicator -----------------------------------------------------
+
+    @Test
+    fun `the indicator stays up for the whole minimum-visible window`() = runTest {
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+
+        vm.loadApps()
+        runCurrent()
+        assertTrue("the flag is raised by the call, not by the timer", vm.uiState.value.isManualRefreshing)
+
+        advanceTimeBy(599)
+        runCurrent()
+        assertTrue("the indicator must not blink out early", vm.uiState.value.isManualRefreshing)
+
+        advanceTimeBy(1)
+        runCurrent()
+        assertFalse("the indicator must clear once the window is paid", vm.uiState.value.isManualRefreshing)
+    }
+
+    @Test
+    fun `a refresh mid-hold extends the indicator instead of clearing at the first deadline`() =
+        runTest {
+            val vm = viewModel(AnimationIntensity.LOW)
+            runCurrent()
+
+            vm.loadApps()
+            runCurrent()
+
+            advanceTimeBy(300)
+            runCurrent()
+            vm.loadApps() // second pull, 300 ms into the first hold
+            runCurrent()
+
+            advanceTimeBy(300)
+            runCurrent()
+            assertTrue(
+                "the first hold's deadline is now; a cancelled hold must never lower the flag",
+                vm.uiState.value.isManualRefreshing
+            )
+
+            advanceTimeBy(299)
+            runCurrent()
+            assertTrue("the second hold owns the window now", vm.uiState.value.isManualRefreshing)
+
+            advanceTimeBy(1)
+            runCurrent()
+            assertFalse(
+                "600 ms after the second pull, the indicator clears",
+                vm.uiState.value.isManualRefreshing
+            )
+            assertEquals(900L, currentTime)
+        }
+
+    @Test
+    fun `screen entry never raises the pull-to-refresh indicator`() = runTest {
+        // The indicator belongs to direct manipulation. Entry has its own loader (`isLoading`), and
+        // showing a pull-to-refresh spinner for a navigation the user did not pull would be a lie.
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+
+        assertFalse(vm.uiState.value.isManualRefreshing)
+
+        advanceTimeBy(1_000)
+        runCurrent()
+        assertFalse(vm.uiState.value.isManualRefreshing)
+    }
+
+    // --- Teardown ---------------------------------------------------------------------------
+
+    @Test
+    fun `a second load tears the previous scan down before starting the next`() = runTest {
+        // The view model half of the prompt-cancellation rule: `AppRepositoryImpl`'s per-package
+        // `ensureActive()` only helps if the collector is actually cancelled, and two live
+        // collectors would mean two package scans mutating the same cache at once.
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+        assertEquals(1, scanCollectors())
+
+        vm.loadApps()
+        runCurrent()
+
+        assertEquals("two live collectors means two overlapping package scans", 1, scanCollectors())
+    }
+}

--- a/docs/follow-ups/viewmodel-behavior-tests.md
+++ b/docs/follow-ups/viewmodel-behavior-tests.md
@@ -1,8 +1,12 @@
 # Follow-up: ViewModel behavior tests need `kotlinx-coroutines-test` + turbine
 
-**Status:** ✅ **Done.** `AppListViewModelTest` covers all five behaviours from *Sketch* §4 in 8
-tests, on virtual time, on branch `test/applist-viewmodel-behavior`. The dependencies had landed
-earlier on `chore/tier0-batch-1` and are also used by `MainViewModelTest` (24 tests) and
+**Status:** ✅ **Done, with one half-covered item named below.** `AppListViewModelTest` covers the
+four temporal behaviours from *Sketch* §4 in 8 tests on virtual time, on branch
+`test/applist-viewmodel-behavior`. The fifth — the cancelled-scan rule — is covered on the view
+model side only (the relaunch tears the previous collector down); its repository half, the
+`ensureActive()` in `AppRepositoryImpl`, is **out of reach from a JVM test** and is deliberately
+left to the instrumented story. See *Acceptance*. The dependencies had landed earlier on
+`chore/tier0-batch-1` and are also used by `MainViewModelTest` (24 tests) and
 `SecurityViewModelTest` (7).
 **Severity:** Minor (test-coverage gap; no runtime defect). **Effort:** small–medium.
 **Revised:** 2026-07-30 — twice: once when the dependencies landed, again when the tests were
@@ -114,8 +118,11 @@ Not a decision, just the shape:
 
 ## Acceptance
 
-- ✅ All five behaviors asserted under virtual time; no measurable wall-clock added to the suite
-  (the 8 tests run in ~0.2 s total; the suite went 209 → 217).
+- ✅ for four of the five, ⚠️ for the fifth. The four temporal behaviours are asserted under virtual
+  time; the cancelled-scan rule is asserted on the view model side and **not** on the repository
+  side (see the `ensureActive()` note below — the criterion as written cannot be met from
+  `testFossDebugUnitTest`). No measurable wall-clock added to the suite either way (the 8 tests run
+  in ~0.2 s total; the suite went 209 → 217).
 - **Mutation-checked**, the same way `REFRESH_INDICATOR_MIN_VISIBLE` was: deleting the
   `ensureActive()` call, or flipping the `deferForTransition` default, must make at least one test
   fail. A test that survives both mutations is not constraining the behavior it claims to.

--- a/docs/follow-ups/viewmodel-behavior-tests.md
+++ b/docs/follow-ups/viewmodel-behavior-tests.md
@@ -1,18 +1,22 @@
 # Follow-up: ViewModel behavior tests need `kotlinx-coroutines-test` + turbine
 
-**Status:** Partly done, **no longer blocked**. The two dependencies landed on `chore/tier0-batch-1`
-and were used: `MainViewModelTest` (24 tests) and `SecurityViewModelTest` (7) now cover those two
-view models behaviourally. `AppListViewModel` — the one this doc was actually written about — is
-still uncovered, and the four tests listed under *Sketch* §4 are still unwritten. What remains is
-writing them, not enabling them.
+**Status:** ✅ **Done.** `AppListViewModelTest` covers all five behaviours from *Sketch* §4 in 8
+tests, on virtual time, on branch `test/applist-viewmodel-behavior`. The dependencies had landed
+earlier on `chore/tier0-batch-1` and are also used by `MainViewModelTest` (24 tests) and
+`SecurityViewModelTest` (7).
 **Severity:** Minor (test-coverage gap; no runtime defect). **Effort:** small–medium.
-**Revised:** 2026-07-30, after the dependencies landed.
+**Revised:** 2026-07-30 — twice: once when the dependencies landed, again when the tests were
+written and the *"only unwritten tests"* claim below turned out to be wrong. See
+*What it actually took*.
 **Raised by:** an external model's review of PR #278 (2026-07-27), which noted that the PR's timing
 behavior is covered only by pure-function tests over the delay constants, not by tests of the
 ViewModel logic that consumes them. The observation is correct.
 
 Files: `app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt`,
+`app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt`,
 `app/src/test/java/com/valhalla/thor/presentation/appList/TransitionSettleDelayTest.kt`,
+`app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt`,
+`app/src/main/java/com/valhalla/thor/domain/repository/{PrivilegeStateProvider,StorageStatsProvider,UsageAccessGate,AppShortcutController}.kt`,
 `app/build.gradle.kts`, `gradle/libs.versions.toml`
 
 ## Problem
@@ -38,8 +42,42 @@ the original deadline. Those are precisely the regressions this PR could re-intr
 shared fakes live in `ViewModelTestDoubles.kt` next to it, and several suites already run on virtual
 time. `AppListViewModel`'s temporal behaviour is simply not among them yet.
 
-This is therefore no longer a missing-capability gap. It is unwritten tests, with the harness they
-need already sitting beside them.
+~~This is therefore no longer a missing-capability gap. It is unwritten tests, with the harness they
+need already sitting beside them.~~ Half right, and the wrong half was load-bearing — see below.
+
+## What it actually took
+
+The harness was there; the *view model* was not constructible. Four of `AppListViewModel`'s eleven
+collaborators were concrete Koin `@Single` classes bound to Android:
+
+| Collaborator | Why it could not be built on a plain JVM |
+|---|---|
+| `PrivilegeManager` | registers Shizuku binder/permission listeners from `init` |
+| `StorageStatsHelper` | `context.getSystemService(StorageStatsManager)` + `context.packageManager` in property initializers |
+| `UsageAccessManager` | `context.getSystemService(AppOpsManager)` in a property initializer |
+| `FreezerShortcutManager` | `Context` + `ShortcutManagerCompat` |
+
+`android.jar` methods throw `RuntimeException("Stub!")` in unit tests (this project does not set
+`testOptions.unitTests.isReturnDefaultValues`), and all four classes are `final`, so there was no
+subclass or stub-Context route either. That is why this view model — the one the doc was written
+about — stayed uncovered while two others got tested: **not** because nobody wrote the tests.
+
+The seam, kept deliberately additive:
+
+- four narrow ports in `domain/repository/` — `PrivilegeStateProvider` (just `state`),
+  `StorageStatsProvider`, `UsageAccessGate`, `AppShortcutController` (just `disableAppShortcut`) —
+  each covering only what `AppListViewModel` actually calls;
+- the four classes implement them and declare `@Single(binds = [...])`, which **adds** a bound type
+  without removing the concrete one, so the other seven call sites (`HomeViewModel`,
+  `FreezerViewModel`, `BulkFreezeRunner`, `FreezerTileService`, …) are untouched;
+- `AppListViewModel` takes the ports, plus `@Named("default")`/`@Named("io")` dispatchers instead of
+  hardcoded `Dispatchers.*` — the convention CLAUDE.md already states, and the thing that lets the
+  `flowOn` sort/filter pipeline behind `uiState` share the test's virtual clock rather than run on a
+  real thread pool;
+- fakes for the four ports live beside the existing ones in `ViewModelTestDoubles.kt`.
+
+**The generalisable bit:** "the harness exists" is not the same as "the subject is reachable".
+Before filing a test-coverage follow-up, try constructing the class.
 
 ## Sketch
 
@@ -76,7 +114,20 @@ Not a decision, just the shape:
 
 ## Acceptance
 
-- All five behaviors asserted under virtual time; no measurable wall-clock added to the suite.
+- ✅ All five behaviors asserted under virtual time; no measurable wall-clock added to the suite
+  (the 8 tests run in ~0.2 s total; the suite went 209 → 217).
 - **Mutation-checked**, the same way `REFRESH_INDICATOR_MIN_VISIBLE` was: deleting the
   `ensureActive()` call, or flipping the `deferForTransition` default, must make at least one test
   fail. A test that survives both mutations is not constraining the behavior it claims to.
+  - ✅ `deferForTransition = false` → `true`: **3 tests fail** (`a manual refresh starts the scan
+    without advancing the clock`, and both indicator tests — a deferred refresh never raises the
+    flag).
+  - ⚠️ `ensureActive()`: **not reachable from a JVM test, and the criterion as written cannot be
+    met.** It sits inside `AppRepositoryImpl.getAllApps()`'s `callbackFlow`, behind
+    `pm.getInstalledPackages`, a `BroadcastReceiver` and `context.resources` — the same wall this
+    doc's own premise tripped over. Only an instrumented test can delete-and-observe it.
+    What stands in for it is the view model half of the same rule: `a second load tears the previous
+    scan down before starting the next` asserts the repository flow has exactly one live collector
+    after a relaunch, and **deleting `appsJob?.cancel()` makes it fail**. `ensureActive()` only
+    matters because that cancel happens; this pins the half that is in reach. Closing the other half
+    belongs with the instrumented-test story, not here.


### PR DESCRIPTION
Closes the `viewmodel-behavior-tests` follow-up.

## Why this wasn't just "write the tests"

The follow-up doc asserted the gap was only unwritten tests, with the harness already in place. The harness was there; **`AppListViewModel` was not constructible on a plain JVM**. Four of its eleven collaborators are concrete Koin `@Single` classes that touch Android from their initializers:

| Collaborator | Blocker |
|---|---|
| `PrivilegeManager` | registers Shizuku binder/permission listeners in `init` |
| `StorageStatsHelper` | `getSystemService(StorageStatsManager)` + `packageManager` in property initializers |
| `UsageAccessManager` | `getSystemService(AppOpsManager)` in a property initializer |
| `FreezerShortcutManager` | `Context` + `ShortcutManagerCompat` |

`android.jar` throws `RuntimeException("Stub!")` in unit tests (this project doesn't set `isReturnDefaultValues`), and all four are `final`, so there was no subclass or stub-`Context` route. That is why this view model stayed uncovered while `MainViewModel` and `SecurityViewModel` got suites.

## The seam (commit 1) — additive, no behaviour change

- Four narrow ports in `domain/repository/`, each covering only what the view model calls: `PrivilegeStateProvider` (just `state`), `StorageStatsProvider`, `UsageAccessGate`, `AppShortcutController` (just `disableAppShortcut`).
- The implementations declare `@Single(binds = [...])`, which **adds** a bound type without removing the concrete one — the other seven call sites (`HomeViewModel`, `FreezerViewModel`, `BulkFreezeRunner`, `FreezerTileService`, `AppInfoDetailsViewModel`, `SettingsViewModel`, `AutoFreezeManager`) are untouched and keep injecting the class. Koin's compile-safety checks pass, which is this project's stated guarantee against a missing binding.
- `AppListViewModel` also takes `@Named("default")`/`@Named("io")` dispatchers instead of hardcoding `Dispatchers.*` — the convention CLAUDE.md already states, and what lets the `flowOn` sort/filter pipeline behind `uiState` share one scheduler with the test instead of running on a real thread pool. Same dispatchers at runtime.

## The tests (commit 2) — 8 tests, all five behaviours from the doc

- a pull-to-refresh reaches the scan at `t = 0`, while the entry load is still parked on its settle delay;
- entry pays exactly `settleDelayFor(intensity)` — 0 / 400 / 800 ms, asserted at the millisecond either side of each deadline;
- the indicator stays up for the whole 600 ms window, and entry never raises it at all;
- a refresh 300 ms into a hold **extends** the indicator to 900 ms rather than letting the cancelled hold clear it at 600 ms;
- relaunching the scan leaves exactly one live collector, so two pulls can't overlap two package scans.

"The scan started" is observed as a *subscription on the repository flow* — the point where production would register its package receivers and call `pm.getInstalledPackages` — rather than a flag the view model sets about itself.

## Mutation checks (the doc's acceptance bar)

| Mutation | Result |
|---|---|
| `deferForTransition` default `false` → `true` | ❌ **3 tests fail** |
| delete `appsJob?.cancel()` | ❌ **1 test fails** (teardown) |
| delete `ensureActive()` | **not reachable from a JVM test** — it lives inside `AppRepositoryImpl.getAllApps()`'s `callbackFlow`, behind `PackageManager`/`BroadcastReceiver`. Recorded in the doc rather than papered over; the view-model half of that rule is what the teardown test pins. |

## Verification

`./gradlew assembleFossDebug testFossDebugUnitTest lintFossDebug --rerun-tasks` → **BUILD SUCCESSFUL**, 99/99 tasks executed. Suite **209 → 217**, 0 failures, 0 skipped. Only pre-existing warnings (Koin plugin version notice, three elvis warnings in `ExtensionManager.kt`).

Not covered here: on-device behaviour is unchanged by construction, so no device pass was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app-management capabilities for shortcut control, privilege-state monitoring, storage-size retrieval, and usage-access handling.
* **Improvements**
  * Improved app-list loading, refreshing, freezer actions, and background task scheduling.
  * Added configurable dispatching to improve responsiveness and consistency.
* **Bug Fixes**
  * Prevented overlapping app scans by cancelling previous scans before starting new ones.
  * Refined refresh timing and indicator behavior across animation settings.
* **Tests**
  * Added comprehensive coverage for scanning delays, refresh behavior, cancellation, and indicator timing.
* **Documentation**
  * Updated behavior-testing documentation with current coverage and acceptance details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->