### PR TITLE
docs(release-notes): correct three factual errors in the v1.93.1 notes

### DIFF
--- a/release-notes/v1.93.1/github.md
+++ b/release-notes/v1.93.1/github.md
@@ -6,17 +6,17 @@ freezer's Quick Settings tile, pinned shortcuts and bulk engine substantially re
 sheet unified into a single surface, and a batch of security and correctness fixes that includes an
 **escape hatch for an app lock that could previously lock you out permanently**.
 
-> **Not** in this release, despite what an earlier draft of these notes said: **app backup**.
-> Exporting installable bundles is not a backup — no app *data* is captured, and there is no restore
-> path. #51 stays open, and the word is deliberately absent below.
+> **Not in this release: app backup.** Exporting installable bundles is not a backup — no app *data*
+> is captured, and there is no restore path. #51 stays open, and the word is deliberately absent
+> below.
 
-> 215 commits and 21 merged pull requests since **v1.93.0**.
+> 219 commits and 22 merged pull requests since **v1.93.0**.
 
 ---
 
 ## ✨ Highlights
 
-* 🧊 **Freeze Profiles** — named groups of apps you can freeze or unfreeze in one tap (#295, closes #55a).
+* 🧊 **Freeze Profiles** — named groups of apps you can freeze or unfreeze in one tap (#295, the profiles half of #55).
 * 💾 **Bulk export** — save a whole selection of apps to a folder in one run (#293).
 * 📦 **`.xapk` export** — the third bundle format, with a picker (#293, completes #164).
 * 🔎 **Filter the app list by permission** (#294, closes #285).
@@ -29,7 +29,10 @@ sheet unified into a single surface, and a batch of security and correctness fix
 
 ## What's Changed
 
-### 🧊 Freeze Profiles (#295 — closes #55a)
+### 🧊 Freeze Profiles (#295 — the profiles half of #55)
+#55 asks for two things: freeze **profiles** and a **process manager**. Profiles ship here; the
+process manager does not, so **#55 stays open**.
+
 Named groups of apps, frozen or unfrozen as a set, saved in two new Room tables via
 `@AutoMigration(5→6)` (new tables only, schema export committed).
 * **The feature**: `freeze_profiles` + `freeze_profile_apps`, a `FreezeProfileRepository`, a profiles
@@ -64,9 +67,9 @@ Export stops being one-app-at-a-time.
   bundle is named after the app rather than after the word `"null"` (`c79bcbda`), and the index name
   is stamped to the millisecond so two runs in the same second can't collide (`8aae224a`).
 * ⚠️ **This is not a backup, and is deliberately not described as one.** It captures installable
-  bundles, **not app data**, and there is **no restore path** — `RestoreRequest` exists as a domain
-  model but is wired to no UI. #51 ("App + data backup") stays **open**; the data half needs root and
-  a restore flow, and neither is in this release.
+  bundles, **not app data**, and there is **no restore path at all** — nothing in the codebase reads
+  an exported bundle back. #51 ("App + data backup") stays **open**; the data half needs root and a
+  restore flow, and neither is in this release.
 
 ### 📦 `.xapk` Export (#293 — completes #164)
 * `.xapk` joins `.apk` and `.apks` as an export format, with a format picker in the export sheet
@@ -217,7 +220,7 @@ bulk freeze engine were rebuilt around one runner and one state reader.
 ## 🛠 Commits Log (`v1.93.0...HEAD`)
 
 **Merged pull requests**
-* `2a503959` — #295 freeze profiles (#55a)
+* `2a503959` — #295 freeze profiles (#55, profiles half)
 * `4e35e0b4` — #294 filter the app list by permission (#285)
 * `1f35400b` — #299 keep the watchlist prompt flag off the backup
 * `5eb19981` — #300 shortcut match flags for frozen system apps
@@ -240,7 +243,7 @@ bulk freeze engine were rebuilt around one runner and one state reader.
 * `e10aebef` — #275 Dependabot maven group
 
 **Key commits**
-* `f2a19d87` feat(freezer): named freeze profiles (#55a)
+* `f2a19d87` feat(freezer): named freeze profiles (#55, profiles half)
 * `81f4215d` feat(app-list): filter the app list by permission (#285)
 * `0ef42564` feat: export a whole selection of apps in one run, with a written index
 * `77bfc027` feat(export): offer `.xapk` as an export format (#164)

--- a/release-notes/v1.93.1/github.md
+++ b/release-notes/v1.93.1/github.md
@@ -6,11 +6,11 @@ freezer's Quick Settings tile, pinned shortcuts and bulk engine substantially re
 sheet unified into a single surface, and a batch of security and correctness fixes that includes an
 **escape hatch for an app lock that could previously lock you out permanently**.
 
-> **Not in this release: app backup.** Exporting installable bundles is not a backup — no app *data*
-> is captured, and there is no restore path. #51 stays open, and the word is deliberately absent
-> below.
+> **Not in this release: app-data backup.** Exporting installable bundles is not a backup — no app
+> *data* is captured, and there is no restore path. #51 stays **open**. Where "backup" does appear
+> below it means either Android's own cloud backup or an explicit statement that export is *not* one.
 
-> 219 commits and 22 merged pull requests since **v1.93.0**.
+*219 commits and 22 merged pull requests since **v1.93.0**.*
 
 ---
 
@@ -30,8 +30,8 @@ sheet unified into a single surface, and a batch of security and correctness fix
 ## What's Changed
 
 ### 🧊 Freeze Profiles (#295 — the profiles half of #55)
-#55 asks for two things: freeze **profiles** and a **process manager**. Profiles ship here; the
-process manager does not, so **#55 stays open**.
+Issue #55 asks for two things: freeze **profiles** and a **process manager**. Profiles ship here;
+the process manager does not, so **#55 stays open**.
 
 Named groups of apps, frozen or unfrozen as a set, saved in two new Room tables via
 `@AutoMigration(5→6)` (new tables only, schema export committed).
@@ -220,6 +220,7 @@ bulk freeze engine were rebuilt around one runner and one state reader.
 ## 🛠 Commits Log (`v1.93.0...HEAD`)
 
 **Merged pull requests**
+* `b1f270e8` — #301 bump to 1931, v1.93.1 release notes, Shizu changelog sync
 * `2a503959` — #295 freeze profiles (#55, profiles half)
 * `4e35e0b4` — #294 filter the app list by permission (#285)
 * `1f35400b` — #299 keep the watchlist prompt flag off the backup

--- a/release-notes/v1.93.1/telegram.md
+++ b/release-notes/v1.93.1/telegram.md
@@ -20,4 +20,4 @@
 
 • 🔒 App lock can no longer lock you out.
 
-🌍 Now in Arabic, Spanish, French and Chinese.
+🌍 Every new string ships in Arabic, Spanish, French and Chinese.

--- a/release-notes/v1.93.1/telegram.md
+++ b/release-notes/v1.93.1/telegram.md
@@ -1,29 +1,23 @@
-🚀 **Thor v1.93.1 — freeze profiles, bulk export and a much steadier freezer!**
+🚀 **Freeze profiles, bulk export and a much steadier freezer!**
 
-**What's New:**
+**New:**
 
-• 🧊 **Freeze Profiles** — save named groups of apps ("Work", "Games") and freeze or unfreeze the whole set in one tap.
+• 🧊 **Freeze Profiles** — save named groups of apps, freeze or unfreeze the set in one tap.
 
-• 💾 **Bulk export** — select any number of apps and save them all to a folder in one run, with a cancellable progress bar and a list of what was written.
+• 💾 **Bulk export** — save any number of apps to a folder in one cancellable run.
 
-• 📦 **`.xapk` export** — now offered alongside `.apk` and `.apks`, with a format picker.
+• 📦 **.xapk export**, alongside .apk and .apks.
 
-• 🔎 **Filter by permission** — see every app that can reach your Camera, Mic or Location, with chips named by Android itself, in your language.
+• 🔎 **Filter by permission** — see what can reach your Camera, Mic or Location.
 
-• 📱 **One app-info sheet** — the tabbed details now live inside the sheet, so there's no second screen to jump to.
+• 📱 **One app-info sheet**, with the full details built in.
 
 **Fixed:**
 
-• 🧊 **Big freezer rework** — the Quick Settings tile now shows what's really happening, pinned shortcuts refresh their icons, and a bulk run that fails says so instead of "nothing to do".
+• 🧊 Big freezer rework — the tile tells the truth and shortcuts refresh.
 
-• 🛡️ **Blocked apps stay blocked** — the tile, Freeze-all and the watchlist all respect the safety tier now, not just the single-app buttons.
+• 🛡️ Blocked apps stay blocked on every surface.
 
-• 🔒 **App lock can't lock you out** — if too many failed attempts hard-lock your biometrics, there's a way back in. It also won't switch on where it could never work.
+• 🔒 App lock can no longer lock you out.
 
-• 🔐 **Your settings backup is private** — the app cache and internal state are excluded from cloud backup and device transfer.
-
-• 📥 **Installer** — downgrades are detected properly, and huge version codes no longer get truncated.
-
-• 🔄 **App list** — pull-to-refresh stays readable, and the scan respects cancellation.
-
-🌍 Every new string ships in Arabic, Spanish, French and Chinese (Simplified).
+🌍 Now in Arabic, Spanish, French and Chinese.


### PR DESCRIPTION
Corrections to the v1.93.1 release notes, found by auditing the `dev` → `master` diff before opening the release PR. **Notes only** — no code, strings, or version metadata.

## Three factual errors

**1. `RestoreRequest` is not a domain model.**

The notes claimed the export feature has no restore path because "`RestoreRequest` exists as a domain model but is wired to no UI". `RestoreRequest.kt` does exist, but it declares no type of that name — it holds `mayRestore()`, the Stormbringer launcher gate that decides whether a frozen app may be woken when its icon is tapped. That is the *freezer's* sense of "restore", not backup/restore, so it was the wrong evidence for the wrong feature.

The conclusion is unchanged, and actually stronger: nothing in the codebase reads an exported bundle back at all.

**2. The headline counts were wrong.**

`release-notes/README.md` sets the baseline as the last release tag. `v1.93.0..dev` is **219 commits / 22 merged PRs**, not 215 / 21. 215 matched no range I can construct; 21 was the `master..dev` PR count, a different baseline than the sentence claims.

**3. `#55a` is not an issue.**

#55 is *"Process manager support and profiles for freezing apps"*. Only the profiles half shipped, so "closes #55a" was wrong twice over — the ref doesn't exist, and the issue isn't closed by this work. Now stated as "the profiles half of #55", with a line making explicit that **#55 stays open** because the process manager did not ship.

## Also: the Telegram broadcast would have posted nothing

`telegram.md` is trimmed from **1632 → 676** UTF-16 units.

Both `telegram-release.yml:146` and `dev-check.yml:221` pass the notes as a `sendDocument` **caption**, which Telegram caps at **1024** units. With the workflow's header (`telegram-release.yml:130`) and the GitHub-link footer, v1.93.1's caption came to **1645** — Telegram rejects an oversized caption outright rather than truncating. The request has no `--fail` and its output is discarded, so the step would have gone **green having posted nothing**.

Now **816** units including header and footer.

⚠️ **This is pre-existing, not a regression.** v1.93.0's caption would have been **1148** — also over. Worth checking whether that broadcast actually landed. Hardening the workflow (fail on non-OK response, or truncate) is left out of this PR as separate work.

## Verification

- `.github/scripts/check-shizu-manifest.sh` → **all checks passed**. `playstore.txt` is untouched (447 chars, cap 500), so `shizu_store.json` stays in sync.
- Every remaining commit hash in `github.md` was left as-is; the audit sampled them against `git log` and found no mismatches.
- Full caption length re-measured against the actual workflow header and footer strings, not estimated.

## Audit scope, for the record

This came out of a 5-dimension pre-release audit (Room migration safety, notes accuracy, CI gates, security/dependency delta, version consistency) with adversarial verification of each finding. **Migration safety, security/deps, and version consistency returned zero findings** — the `@AutoMigration(5→6)` is new-tables-only with the schema export committed, and no blockers were found for the release itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub release notes to clarify backup availability, profile freezing, and bulk export limitations.
  * Refined commit and pull request descriptions for improved accuracy.
  * Reworked Telegram release notes with clearer “What’s New” and “Fixed” sections.
  * Simplified descriptions of export, filtering, app information, and localization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->