### PR TITLE
fix(build): align :vm-runtime to Java 21 so the IDE stops rewriting .idea

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -3,4 +3,11 @@
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel target="21" />
   </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="Thor.vm-runtime" options="--patch-module jdk.unsupported=$PROJECT_DIR$/vm-runtime/src/main/java" />
+      <module name="Thor.vm-runtime.main" options="--patch-module jdk.unsupported=$PROJECT_DIR$/vm-runtime/src/main/java" />
+      <module name="Thor.vm-runtime.test" options="--patch-module jdk.unsupported=$PROJECT_DIR$/vm-runtime/src/main/java" />
+    </option>
+  </component>
 </project>

--- a/vm-runtime/build.gradle.kts
+++ b/vm-runtime/build.gradle.kts
@@ -2,7 +2,24 @@ plugins {
     `java-library`
 }
 
+// Must match `:app` and `:bypass` (both 21). The IDE derives ONE project-wide language level and
+// bytecode target from the Gradle model, so a module that disagrees drags the whole project down to
+// its level and rewrites `.idea/compiler.xml` and `.idea/misc.xml` on every sync — which is why
+// hand-editing those files back to 21 never held. Nothing here ships: `:bypass` takes this module as
+// `compileOnly`, so these stubs only satisfy the compiler for symbols ART already provides.
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+// `sun.misc` belongs to the JDK's `jdk.unsupported` module, and from -source 9 onwards javac refuses
+// to compile a source file into a package a system module already owns. At -source 8 that check does
+// not run, which is the only reason this module ever compiled at 1.8. `--patch-module` is the
+// sanctioned way to say "these sources patch that module" — it is what lets the shadow stub keep its
+// required `sun.misc.Unsafe` name. Android's android.jar does not ship `sun.misc.Unsafe`, so `:bypass`
+// still resolves the symbol from here and not from the JDK.
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.addAll(
+        listOf("--patch-module", "jdk.unsupported=${projectDir.resolve("src/main/java")}")
+    )
 }


### PR DESCRIPTION
Fixes the recurring `.idea/compiler.xml` → 1.8 and `.idea/misc.xml` → lost `default="true"` churn, at the cause rather than at the file.

## Why hand-editing never held

Three earlier commits — `c42075e8`, `5ab0fa80`, `c64416c9` — edited `misc.xml` back by hand, and each one came undone. Those two files are IDE **outputs**: they're recomputed from the Gradle model on every sync, so editing them fixes the symptom for exactly as long as it takes to sync again.

## The cause

`:vm-runtime` pinned `source/targetCompatibility` to `VERSION_1_8`, while `:app` and `:bypass` are both 21. IntelliJ derives **one** project-wide language level and **one** bytecode target, so the lowest module wins — the project got dragged to 1.8, and because that level no longer matched the IDE default for the JDK, `default="true"` was dropped too. Two symptoms, one cause.

## What the fix ran into

The bump doesn't compile on its own:

```text
sun/misc/Unsafe.java:1: error: package exists in another module: jdk.unsupported
```

`sun.misc` is owned by the JDK's `jdk.unsupported` module, and from `-source 9` javac refuses to compile into a package a system module already owns. That check simply doesn't run at `-source 8` — **the 1.8 pin was load-bearing by accident, not by design**, which is worth knowing before anyone tries this again.

`--patch-module jdk.unsupported=<srcDir>` is the sanctioned way to say "these sources patch that module", and it lets the shadow stub keep the `sun.misc.Unsafe` name it must have. `android.jar` doesn't ship `sun.misc.Unsafe`, so `:bypass` still resolves the symbol from here and not from the JDK.

## The `.idea/compiler.xml` hunk is deliberate

It's the IDE mirroring that compiler argument out of the Gradle model — it needs it to build `:vm-runtime` itself. Leaving it uncommitted would just swap the churn this PR removes for fresh churn of the same kind. It uses `$PROJECT_DIR$`, so it's machine-independent.

## Nothing shipped changes

`:bypass` consumes this module as `compileOnly`. The two stubs (`dalvik.system.VMRuntime`, `sun.misc.Unsafe`) exist only to give the compiler symbols ART provides at runtime, and are never packaged into any APK.

## Verification

| Check | Result |
|---|---|
| `:vm-runtime:build` + `:bypass:assembleRelease` | pass (Kotlin recompiled, stub still resolves) |
| Stub bytecode | major **65** (Java 21), was 52 |
| `vm-runtime.jar` contents | unchanged — same two classes |
| `assembleFossRelease` | pass |
| `:app:testFossDebugUnitTest --rerun-tasks` | **376 tests, 0 failures** |
| Post-sync `.idea/misc.xml` | byte-identical to HEAD — `JDK_21`, `default="true"` |
| Post-sync `.idea/compiler.xml` | keeps `target="21"` |

## Left alone

`app/baselineprofile/` still pins Java 11, but it's deliberately absent from `settings.gradle.kts`, so it never enters the Gradle model and can't affect the derived level.

Also noticed, not changed here: no Java toolchain is pinned anywhere in the build, and `misc.xml` records `corretto-21` while `CLAUDE.md` mandates Zulu 21. Both are separate calls to make.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime module to compile with Java 21.
  * Improved module compilation configuration for compatibility with Java 21 tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->