### PR TITLE
fix(freezer): removing an app from the watchlist always restores it

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -102,7 +102,7 @@ class FreezerShortcutManager(
 
     /** Update an already-pinned per-app shortcut so its icon reflects the app's current state.
      *  No-op if no such shortcut exists. Call after any freeze/unfreeze of the package. */
-    fun refreshAppShortcut(packageName: String) {
+    override fun refreshAppShortcut(packageName: String) {
         scope.launch { updateShortcutIcon(packageName) }
     }
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppShortcutController.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppShortcutController.kt
@@ -12,4 +12,10 @@ package com.valhalla.thor.domain.repository
 interface AppShortcutController {
     /** Disable (and hide) any shortcut targeting [packageName] — it is gone or no longer launchable. */
     fun disableAppShortcut(packageName: String)
+
+    /**
+     * Re-render an already-pinned shortcut for [packageName] so its icon matches the app's current
+     * frozen/active state. No-op when nothing is pinned. Call after any freeze or unfreeze.
+     */
+    fun refreshAppShortcut(packageName: String)
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -6,19 +6,19 @@ package com.valhalla.thor.presentation.appList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.R
-import com.valhalla.thor.data.launcher.FreezerShortcutManager
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.FreezeTier
 import com.valhalla.thor.domain.model.freezeTier
 import com.valhalla.thor.presentation.freezer.FreezerPrompt
 import com.valhalla.thor.domain.repository.AppRepository
+import com.valhalla.thor.domain.repository.AppShortcutController
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.FreezeAppUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.util.UiTextException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
+import org.koin.core.annotation.Named
 
 data class AppInfoDetailsUiState(
     val isLoading: Boolean = true,
@@ -48,7 +49,15 @@ class AppInfoDetailsViewModel(
     private val manageAppUseCase: ManageAppUseCase,
     private val freezeAppUseCase: FreezeAppUseCase,
     private val freezerRepository: FreezerRepository,
-    private val freezerShortcutManager: FreezerShortcutManager
+    // The narrow port, not the concrete FreezerShortcutManager: this screen only retires and
+    // re-renders a single app's shortcut, and the manager needs a Context, so depending on the
+    // class put the whole view model out of reach of a JVM test. Same dependency AppListViewModel
+    // already takes.
+    private val appShortcuts: AppShortcutController,
+    // Injected rather than a baked-in Dispatchers.IO, so a test can put this work on its own
+    // scheduler — otherwise every action below escapes the test dispatcher and nothing here is
+    // deterministically assertable.
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AppInfoDetailsUiState())
@@ -73,7 +82,7 @@ class AppInfoDetailsViewModel(
             // potentially slow root check; run them off the Main thread. Each probe is an
             // independent round-trip, so launch them concurrently and let their latency
             // overlap (alongside the freezer lookup) instead of stacking sequentially.
-            val (probes, inFreezer) = withContext(Dispatchers.IO) {
+            val (probes, inFreezer) = withContext(ioDispatcher) {
                 val rootProbe = async { systemRepository.isRootAvailable() }
                 val shizukuProbe = async { systemRepository.isShizukuAvailable() }
                 val dhizukuProbe = async { systemRepository.isDhizukuAvailable() }
@@ -120,7 +129,7 @@ class AppInfoDetailsViewModel(
     // viewModelScope coroutine, so launching again was redundant and could let concurrent refreshes
     // complete out of order. Called directly => it serializes within the caller's coroutine.
     private suspend fun refreshDetails(packageName: String) {
-        val inFreezer = withContext(Dispatchers.IO) { freezerRepository.contains(packageName) }
+        val inFreezer = withContext(ioDispatcher) { freezerRepository.contains(packageName) }
         val details = appRepository.getDetailedAppInfo(packageName)
         if (details != null) {
             _uiState.update {
@@ -140,8 +149,8 @@ class AppInfoDetailsViewModel(
             val result = if (freeze) freezeAppUseCase(packageName)
             else manageAppUseCase.setAppDisabled(packageName, false)
             result.onSuccess {
-                freezerShortcutManager.refreshAppShortcut(packageName)
-                val inFreezer = withContext(Dispatchers.IO) { freezerRepository.contains(packageName) }
+                appShortcuts.refreshAppShortcut(packageName)
+                val inFreezer = withContext(ioDispatcher) { freezerRepository.contains(packageName) }
                 if (freeze && !inFreezer) {
                     // Don't auto-add — prompt the user to add it to the Freezer instead.
                     _uiState.update { it.copy(freezerPrompt = FreezerPrompt(packageName, appName)) }
@@ -223,7 +232,7 @@ class AppInfoDetailsViewModel(
      */
     fun addToFreezer(packageName: String) {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) { freezerRepository.add(packageName) }
+            withContext(ioDispatcher) { freezerRepository.add(packageName) }
             _uiState.update { it.copy(freezerPrompt = null, isInFreezer = true) }
             refreshDetails(packageName)
         }
@@ -234,12 +243,25 @@ class AppInfoDetailsViewModel(
     }
 
     fun addOrRemoveFromFreezer(packageName: String) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             val currentlyIn = freezerRepository.contains(packageName)
             if (currentlyIn) {
                 freezerRepository.remove(packageName)
-                freezerShortcutManager.disableAppShortcut(packageName)
+                appShortcuts.disableAppShortcut(packageName)
                 _uiState.update { it.copy(isInFreezer = false) }
+                // Removing always restores, the same as FreezerViewModel.removeFromFreezer and
+                // AppListViewModel.toggleFreezerMembership. Leaving the app frozen here would strand
+                // it: the freezer screen no longer lists it, so the only route back is the
+                // import-already-disabled flow. forceUnfreeze covers the case where details haven't
+                // loaded — both of its halves are no-ops on an already-active app.
+                val app = _uiState.value.detailedInfo?.appInfo
+                (if (app != null) manageAppUseCase.restoreApp(packageName, app.enabled, app.isSuspended)
+                else manageAppUseCase.forceUnfreeze(packageName))
+                    .onFailure { e ->
+                        _events.send(UiText.StringResource(R.string.error_format, e.message ?: ""))
+                        return@launch
+                    }
+                refreshDetails(packageName)
                 _events.send(UiText.PluralsResource(R.plurals.removed_from_freezer_success, 1))
             } else {
                 // Same BLOCKED gate as FreezerViewModel.toggleManaged and

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -246,14 +246,16 @@ class AppInfoDetailsViewModel(
         viewModelScope.launch(ioDispatcher) {
             val currentlyIn = freezerRepository.contains(packageName)
             if (currentlyIn) {
-                freezerRepository.remove(packageName)
-                appShortcuts.disableAppShortcut(packageName)
-                _uiState.update { it.copy(isInFreezer = false) }
                 // Removing always restores, the same as FreezerViewModel.removeFromFreezer and
                 // AppListViewModel.toggleFreezerMembership. Leaving the app frozen here would strand
                 // it: the freezer screen no longer lists it, so the only route back is the
                 // import-already-disabled flow. forceUnfreeze covers the case where details haven't
                 // loaded — both of its halves are no-ops on an already-active app.
+                //
+                // Restore first, drop the watchlist row second. The privileged call is the only step
+                // that can fail, and the Room delete is durable — do it first and a failed restore
+                // leaves a frozen app with no watchlist entry to retry from, which is the exact
+                // stranding this method exists to prevent.
                 val app = _uiState.value.detailedInfo?.appInfo
                 (if (app != null) manageAppUseCase.restoreApp(packageName, app.enabled, app.isSuspended)
                 else manageAppUseCase.forceUnfreeze(packageName))
@@ -261,6 +263,11 @@ class AppInfoDetailsViewModel(
                         _events.send(UiText.StringResource(R.string.error_format, e.message ?: ""))
                         return@launch
                     }
+                freezerRepository.remove(packageName)
+                appShortcuts.disableAppShortcut(packageName)
+                // refreshDetails re-reads membership, but only when details are loaded — set it here
+                // too so the toggle also flips before the first load lands.
+                _uiState.update { it.copy(isInFreezer = false) }
                 refreshDetails(packageName)
                 _events.send(UiText.PluralsResource(R.plurals.removed_from_freezer_success, 1))
             } else {

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -520,16 +520,14 @@ class AppListViewModel(
     fun toggleFreezerMembership(packageName: String) {
         viewModelScope.launch(ioDispatcher) {
             if (freezerRepository.contains(packageName)) {
-                freezerRepository.remove(packageName)
-                // Pinned launcher shortcuts can't be removed silently, only greyed out — leaving a
-                // live shortcut for an app no longer in the freezer would let it drive a freeze
-                // from the launcher.
-                appShortcuts.disableAppShortcut(packageName)
-                // Restore before reporting success. Resolved against _rawState for the same reason
-                // the add path is: a search or filter that hides the app must not decide its fate.
-                // When it can't be resolved, forceUnfreeze does both halves unconditionally — an
-                // unsuspend on a non-suspended app and an enable on an enabled one are no-ops, so
-                // the fallback is safe rather than merely tolerable.
+                // Restore before dropping the row, and before reporting success. The privileged call
+                // is the only step that can fail and the Room delete is durable, so removing first
+                // would leave a failed restore holding a frozen app with no watchlist entry to retry
+                // from — the exact stranding this method exists to prevent. Resolved against
+                // _rawState for the same reason the add path is: a search or filter that hides the
+                // app must not decide its fate. When it can't be resolved, forceUnfreeze does both
+                // halves unconditionally — an unsuspend on a non-suspended app and an enable on an
+                // enabled one are no-ops, so the fallback is safe rather than merely tolerable.
                 val app = (_rawState.value.allUserApps + _rawState.value.allSystemApps)
                     .firstOrNull { it.packageName == packageName }
                 val restored =
@@ -543,6 +541,11 @@ class AppListViewModel(
                     )
                     return@launch
                 }
+                freezerRepository.remove(packageName)
+                // Pinned launcher shortcuts can't be removed silently, only greyed out — leaving a
+                // live shortcut for an app no longer in the freezer would let it drive a freeze
+                // from the launcher.
+                appShortcuts.disableAppShortcut(packageName)
                 // Same optimistic local patch freezeApp does, so the row stops reading as frozen
                 // without waiting for a full rescan.
                 _rawState.update { state ->

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -501,8 +501,13 @@ class AppListViewModel(
     }
 
     /**
-     * Freezer watchlist membership, not freeze state — this adds/removes the app from the set the
-     * freezer screen and the bulk freeze paths operate on; it never disables anything itself.
+     * Freezer watchlist membership. Adding never freezes; **removing always restores**, so an app
+     * can never be left frozen but untracked.
+     *
+     * That asymmetry is deliberate and matches [FreezerViewModel.removeFromFreezer]: leaving a
+     * removed app frozen strands it somewhere the freezer screen no longer lists, and the user's
+     * only route back is the import-already-disabled flow. Every surface that can take an app off
+     * the watchlist has to restore it, or the answer depends on which screen you tapped.
      *
      * Reads `contains()` rather than [AppListUiState.freezerPackageNames] so the decision is made
      * against the database at the moment of the tap, not against a state snapshot the observer may
@@ -520,6 +525,36 @@ class AppListViewModel(
                 // live shortcut for an app no longer in the freezer would let it drive a freeze
                 // from the launcher.
                 appShortcuts.disableAppShortcut(packageName)
+                // Restore before reporting success. Resolved against _rawState for the same reason
+                // the add path is: a search or filter that hides the app must not decide its fate.
+                // When it can't be resolved, forceUnfreeze does both halves unconditionally — an
+                // unsuspend on a non-suspended app and an enable on an enabled one are no-ops, so
+                // the fallback is safe rather than merely tolerable.
+                val app = (_rawState.value.allUserApps + _rawState.value.allSystemApps)
+                    .firstOrNull { it.packageName == packageName }
+                val restored =
+                    if (app != null) manageAppUseCase.restoreApp(packageName, app.enabled, app.isSuspended)
+                    else manageAppUseCase.forceUnfreeze(packageName)
+                restored.onFailure { e ->
+                    _events.send(
+                        AppListEvent.ShowMessage(
+                            UiText.StringResource(R.string.error_format, e.message ?: "")
+                        )
+                    )
+                    return@launch
+                }
+                // Same optimistic local patch freezeApp does, so the row stops reading as frozen
+                // without waiting for a full rescan.
+                _rawState.update { state ->
+                    fun restore(list: List<AppInfo>) = list.map {
+                        if (it.packageName == packageName) it.copy(enabled = true, isSuspended = false)
+                        else it
+                    }
+                    state.copy(
+                        allUserApps = restore(state.allUserApps),
+                        allSystemApps = restore(state.allSystemApps)
+                    )
+                }
                 _events.send(
                     AppListEvent.ShowMessage(
                         UiText.PluralsResource(R.plurals.removed_from_freezer_success, 1)

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -120,12 +120,20 @@ class FakeAppRepository(initialApps: List<AppInfo> = emptyList()) : AppRepositor
     val apps = MutableStateFlow(initialApps)
     val installSizeWrites = mutableListOf<Map<String, Long>>()
 
+    /**
+     * Detail-screen answers, by package. Empty by default, so `getDetailedAppInfo` keeps returning
+     * null — which is itself a state under test: the details screen has to behave sanely before its
+     * first load lands, not only after.
+     */
+    val details = mutableMapOf<String, DetailedAppInfo>()
+
     override fun getAllApps(): Flow<List<AppInfo>> = apps
 
     override suspend fun getAppDetails(packageName: String): AppInfo? =
         apps.value.firstOrNull { it.packageName == packageName }
 
-    override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? = null
+    override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? =
+        details[packageName]
 
     override suspend fun getApkDetails(apkPath: String): AppInfo? = null
 
@@ -385,13 +393,18 @@ class FakePermissionRepository(
     override suspend fun isPrivilegeActive(): Boolean = true
 }
 
-/** Records the packages whose launcher shortcut was retired. */
+/** Records the packages whose launcher shortcut was retired, and those merely re-rendered. */
 class FakeAppShortcutController : AppShortcutController {
 
     val disabled = mutableListOf<String>()
+    val refreshed = mutableListOf<String>()
 
     override fun disableAppShortcut(packageName: String) {
         disabled += packageName
+    }
+
+    override fun refreshAppShortcut(packageName: String) {
+        refreshed += packageName
     }
 }
 

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModelTest.kt
@@ -144,6 +144,18 @@ class AppInfoDetailsViewModelTest {
             "a failed thaw must not report itself as a successful removal",
             seen.single() is UiText.StringResource
         )
+        // The watchlist row is the only route back to a frozen app: the freezer screen lists it,
+        // and Unfreeze-all reaches it from there. Dropping the row on a failed thaw would leave the
+        // app frozen with nothing pointing at it, so the removal has to be all-or-nothing.
+        assertTrue("a failed thaw must keep the watchlist entry", freezer.contains("a"))
+        assertTrue(
+            "and the toggle must still read as tracked",
+            vm.uiState.value.isInFreezer
+        )
+        assertTrue(
+            "the launcher shortcut outlives a failed removal too",
+            shortcuts.disabled.isEmpty()
+        )
     }
 
     /**

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModelTest.kt
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import com.valhalla.thor.domain.model.DetailedAppInfo
+import com.valhalla.thor.domain.usecase.FreezeAppUseCase
+import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.presentation.FakeAppRepository
+import com.valhalla.thor.presentation.FakeAppShortcutController
+import com.valhalla.thor.presentation.FakeFreezerRepository
+import com.valhalla.thor.presentation.FakeSystemRepository
+import com.valhalla.thor.presentation.MainDispatcherRule
+import com.valhalla.thor.presentation.userApp
+import com.valhalla.thor.util.UiText
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The app-info sheet's half of the freezer-watchlist contract.
+ *
+ * One rule is under test, and it is the asymmetric one: **adding never freezes, removing always
+ * restores.** Three surfaces can take an app off the watchlist — [FreezerViewModel.removeFromFreezer],
+ * [AppListViewModel.toggleFreezerMembership] and [AppInfoDetailsViewModel.addOrRemoveFromFreezer] —
+ * and if they disagree, whether your app comes back depends on which screen you happened to tap.
+ * Leaving it frozen strands it: the freezer screen no longer lists it, so the only route back is the
+ * import-already-disabled flow.
+ *
+ * `FakeSystemRepository` records the privileged calls in order, which is the whole assertion here —
+ * "did `setAppSuspended` and `setAppDisabled` actually get reached for this package" is exactly what
+ * a restore means at the privilege boundary, and a mixed disabled-*and*-suspended app needs both.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppInfoDetailsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    private lateinit var appRepository: FakeAppRepository
+    private lateinit var system: FakeSystemRepository
+    private lateinit var freezer: FakeFreezerRepository
+    private lateinit var shortcuts: FakeAppShortcutController
+
+    @Before
+    fun setUp() {
+        appRepository = FakeAppRepository()
+        system = FakeSystemRepository()
+        freezer = FakeFreezerRepository()
+        shortcuts = FakeAppShortcutController()
+    }
+
+    private fun viewModel(): AppInfoDetailsViewModel {
+        val manageAppUseCase = ManageAppUseCase(system)
+        return AppInfoDetailsViewModel(
+            appRepository = appRepository,
+            systemRepository = system,
+            manageAppUseCase = manageAppUseCase,
+            freezeAppUseCase = FreezeAppUseCase(appRepository, manageAppUseCase),
+            freezerRepository = freezer,
+            appShortcuts = shortcuts,
+            ioDispatcher = mainDispatcherRule.dispatcher
+        )
+    }
+
+    /** Collects one-off events for the duration of the test, as the screen does. */
+    private fun TestScope.events(vm: AppInfoDetailsViewModel): List<UiText> {
+        val seen = mutableListOf<UiText>()
+        backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.events.collect { seen += it } }
+        return seen
+    }
+
+    /** Publishes [app] as the loaded detail, so the restore resolves against real state. */
+    private fun loaded(app: com.valhalla.thor.domain.model.AppInfo) {
+        appRepository.apps.value = listOf(app)
+        appRepository.details[app.packageName] = DetailedAppInfo(appInfo = app)
+    }
+
+    @Test
+    fun `removing a disabled and suspended app undoes both halves`() = runTest {
+        loaded(userApp("a", enabled = false, isSuspended = true))
+        freezer.add("a")
+        val vm = viewModel()
+        vm.loadAppDetails("a")
+        runCurrent()
+
+        vm.addOrRemoveFromFreezer("a")
+        runCurrent()
+
+        assertEquals(
+            "a removal has to unsuspend and re-enable, not just drop the row",
+            listOf("setAppSuspended:a:false", "setAppDisabled:a:false"),
+            system.calls
+        )
+        assertFalse("the app is off the watchlist", freezer.contains("a"))
+        assertFalse("and the sheet stops showing it as tracked", vm.uiState.value.isInFreezer)
+    }
+
+    /**
+     * The fallback path. `restoreApp` needs the app's current state to know which halves to undo;
+     * before the first detail load there is none, so the code falls through to `forceUnfreeze`,
+     * which does both unconditionally. That is safe rather than merely tolerable: unsuspending a
+     * non-suspended app and enabling an enabled one are both no-ops at the privilege layer.
+     */
+    @Test
+    fun `removing before details load still restores, unconditionally`() = runTest {
+        freezer.add("a")
+        val vm = viewModel() // no loadAppDetails — detailedInfo is null
+
+        vm.addOrRemoveFromFreezer("a")
+        runCurrent()
+
+        assertEquals(
+            listOf("setAppSuspended:a:false", "setAppDisabled:a:false"),
+            system.calls
+        )
+        assertFalse(freezer.contains("a"))
+    }
+
+    @Test
+    fun `a failed restore is reported instead of the removal message`() = runTest {
+        loaded(userApp("a", enabled = false))
+        freezer.add("a")
+        system.failWith("setAppDisabled:a:false", IllegalStateException("shell died"))
+        val vm = viewModel()
+        val seen = events(vm)
+        vm.loadAppDetails("a")
+        runCurrent()
+
+        vm.addOrRemoveFromFreezer("a")
+        runCurrent()
+
+        assertEquals("exactly one event, and it is not the success", 1, seen.size)
+        assertTrue(
+            "a failed thaw must not report itself as a successful removal",
+            seen.single() is UiText.StringResource
+        )
+    }
+
+    /**
+     * The other half of the asymmetry. Adding is a bookkeeping change only — it must never reach the
+     * privilege layer, or opening the sheet and tapping "track this" would silently freeze the app.
+     */
+    @Test
+    fun `adding to the watchlist freezes nothing`() = runTest {
+        loaded(userApp("a"))
+        val vm = viewModel()
+        vm.loadAppDetails("a")
+        runCurrent()
+
+        vm.addOrRemoveFromFreezer("a")
+        runCurrent()
+
+        assertTrue("no privileged call belongs on the add path", system.calls.isEmpty())
+        assertTrue(freezer.contains("a"))
+    }
+
+    /**
+     * A pinned launcher shortcut outlives the watchlist entry — Android won't let an app delete a
+     * shortcut the user pinned, so the ceiling is greying it out. If that were skipped, the home
+     * screen would keep a live-looking icon for an app Thor no longer tracks.
+     */
+    @Test
+    fun `removal retires the launcher shortcut`() = runTest {
+        loaded(userApp("a", enabled = false))
+        freezer.add("a")
+        val vm = viewModel()
+        vm.loadAppDetails("a")
+        runCurrent()
+
+        vm.addOrRemoveFromFreezer("a")
+        runCurrent()
+
+        assertEquals(listOf("a"), shortcuts.disabled)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
@@ -350,4 +350,85 @@ class AppListViewModelTest {
         assertFalse("a failure ends the wait too", vm.uiState.value.isLoadingPermissions)
         assertTrue("the stale index is dropped, not kept", vm.uiState.value.permissionIndex.isEmpty)
     }
+
+    // --- Leaving the watchlist ------------------------------------------------------------------
+
+    /**
+     * Taking an app off the watchlist has to restore it. It is the asymmetric half of the toggle —
+     * adding never freezes — and the reason is that this surface is the *only* one that can drop an
+     * app the freezer screen then stops listing. Leave it frozen and the app is stranded: invisible
+     * in the launcher, absent from the freezer, recoverable only through import-already-disabled.
+     *
+     * Asserted against the recorded privilege calls rather than the resulting state, because the
+     * bug this pins was that no privileged call happened at all.
+     */
+    @Test
+    fun `removing a suspended app from the watchlist unsuspends and enables it`() = runTest {
+        freezer.add("a")
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+        appRepository.apps.value = listOf(userApp("a", enabled = false, isSuspended = true))
+        runCurrent()
+        system.calls.clear()
+
+        vm.toggleFreezerMembership("a")
+        runCurrent()
+
+        assertEquals(
+            "both halves of the mixed disabled+suspended state have to be undone",
+            listOf("setAppSuspended:a:false", "setAppDisabled:a:false"),
+            system.calls
+        )
+        assertFalse("and it leaves the watchlist", freezer.contains("a"))
+    }
+
+    /**
+     * The optimistic patch matters as much as the privileged call: without it the row keeps reading
+     * as frozen until the next full rescan, which is exactly long enough for someone to tap it again.
+     */
+    @Test
+    fun `the row stops reading as frozen without waiting for a rescan`() = runTest {
+        freezer.add("a")
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+        appRepository.apps.value = listOf(userApp("a", enabled = false, isSuspended = true))
+        runCurrent()
+
+        vm.toggleFreezerMembership("a")
+        runCurrent()
+
+        val app = vm.uiState.value.allUserApps.first { it.packageName == "a" }
+        assertTrue("enabled again", app.enabled)
+        assertFalse("and not suspended", app.isSuspended)
+    }
+
+    /**
+     * A failed restore must not read as success. The app is still frozen at this point, so a
+     * "removed from freezer" toast would be a lie told at the worst moment — the watchlist entry is
+     * already gone, so the freezer screen can no longer offer a way back.
+     */
+    @Test
+    fun `a failed restore is reported instead of the removal message`() = runTest {
+        freezer.add("a")
+        val vm = viewModel(AnimationIntensity.LOW)
+        val events = mutableListOf<AppListEvent>()
+        backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.events.collect { events += it } }
+        runCurrent()
+        appRepository.apps.value = listOf(userApp("a", enabled = false))
+        runCurrent()
+        events.clear()
+        system.failWith("setAppDisabled:a:false", IllegalStateException("no privilege"))
+
+        vm.toggleFreezerMembership("a")
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                AppListEvent.ShowMessage(
+                    UiText.StringResource(R.string.error_format, "no privilege")
+                )
+            ),
+            events
+        )
+    }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
@@ -403,9 +403,10 @@ class AppListViewModelTest {
     }
 
     /**
-     * A failed restore must not read as success. The app is still frozen at this point, so a
-     * "removed from freezer" toast would be a lie told at the worst moment — the watchlist entry is
-     * already gone, so the freezer screen can no longer offer a way back.
+     * A failed restore must not read as success, and must not half-apply. The app is still frozen at
+     * this point, so a "removed from freezer" toast would be a lie — and dropping the watchlist entry
+     * anyway would make it an expensive one, since the freezer screen is what offers the way back.
+     * Removal is all-or-nothing: restore first, drop the row only once it worked.
      */
     @Test
     fun `a failed restore is reported instead of the removal message`() = runTest {
@@ -429,6 +430,10 @@ class AppListViewModelTest {
                 )
             ),
             events
+        )
+        assertTrue(
+            "the watchlist entry is the only route back to a still-frozen app",
+            freezer.contains("a")
         )
     }
 }


### PR DESCRIPTION
## The bug

Taking an app off the Freezer watchlist is supposed to thaw it first, so it can never end up frozen but no longer tracked. Three surfaces can remove an app from the watchlist, and only one of them actually did.

| Surface | Removes from watchlist | Restores the app |
|---|---|---|
| `FreezerViewModel.removeFromFreezer` / `toggleManaged` | yes | **yes** |
| `AppListViewModel.toggleFreezerMembership` | yes | **no** |
| `AppInfoDetailsViewModel.addOrRemoveFromFreezer` | yes | **no** |

On the two broken paths the watchlist row was dropped, the launcher shortcut was greyed out, and a success message was shown — while the app stayed disabled or suspended. That strands it: the Freezer screen no longer lists the app, so the user's only route back is the import-already-disabled flow. Which answer you got depended on which screen you happened to tap.

## The fix

Both paths now restore before reporting success:

- **`restoreApp(pkg, enabled, isSuspended)`** when the `AppInfo` is resolvable, so an app that is *both* disabled and suspended has both halves undone (the mixed state from #239).
- **`forceUnfreeze(pkg)`** when it is not — before the app-info sheet's first detail load, or when a search/filter has hidden the row in the app list. Both of its halves are no-ops on an already-active app, so the fallback is safe rather than merely tolerable.
- A **failed thaw surfaces the error** instead of the removal message. Previously a dead shell still reported "removed".

`AppListViewModel` also patches its local state optimistically, exactly as `freezeApp` already does, so the row stops reading as frozen without waiting for a full rescan.

Resolution is against `_rawState`, not the filtered list, for the same reason the add path is: a search or filter that hides the app must not decide its fate.

**The add path is deliberately unchanged.** The asymmetry is the point — adding never freezes, removing always restores — and the KDoc now says so at both sites.

## Testability changes

The app-info sheet could not be constructed in a JVM test at all, so the second half of the fix would have shipped unverified. Two narrow changes:

- `AppShortcutController` gains `refreshAppShortcut`, and `AppInfoDetailsViewModel` takes that port instead of the concrete `FreezerShortcutManager`, which needs a `Context`. `AppListViewModel` already depended on the interface, so this makes the two consistent rather than introducing a new pattern.
- That view model's five hardcoded `Dispatchers.IO` uses become an injected `@Named("io")` dispatcher, per the rule in `CLAUDE.md`. Without it the work escapes the test scheduler and nothing is deterministically assertable.

`FakeAppRepository` gained a settable `details` map (defaulting to empty, so `getDetailedAppInfo` still returns null — itself a state under test).

## Tests

Eight new regression tests. **Each was verified to fail against the pre-fix code**, not merely to pass against the new code:

`AppListViewModelTest` (3)
- `removing a suspended app from the watchlist unsuspends and enables it` — was `expected:<[setAppSuspended:a:false, setAppDisabled:a:false]> but was:<[]>`
- `the row stops reading as frozen without waiting for a rescan` — was `AssertionError: enabled again`
- `a failed restore is reported instead of the removal message` — previously got the removal `PluralsResource`

`AppInfoDetailsViewModelTest` (5, new file)
- `removing a disabled and suspended app undoes both halves`
- `removing before details load still restores, unconditionally`
- `a failed restore is reported instead of the removal message`
- `adding to the watchlist freezes nothing` — pins the other half of the asymmetry
- `removal retires the launcher shortcut`

Full suite: **384 tests, 0 failures, 0 skipped** (`:app:testFossDebugUnitTest --rerun-tasks`).

## Note

This also unblocks a FAQ answer for the website, which currently carries a "don't publish this until the code matches" gate on exactly this behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removing an app from the freezer watchlist now restores its previous enabled or suspended state.
  - Failed restorations display an error instead of reporting success.
  - App status updates immediately after removal, without waiting for a rescan.
  - Launcher shortcuts are disabled and refreshed when apps are removed or their freezer state changes.

- **Tests**
  - Added coverage for restoration, error handling, shortcut updates, and immediate status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->