### PR TITLE
feat(support): offer GitHub Sponsors alongside Patreon and PayPal

### DIFF
--- a/app/src/foss/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
+++ b/app/src/foss/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
@@ -19,13 +19,32 @@ fun SupportDeveloperHelper(
 ) {
     val context = LocalContext.current
 
+    val sponsorsTitle = stringResource(R.string.sponsor_github_title)
+    val sponsorsDesc = stringResource(R.string.sponsor_github_desc)
     val patreonTitle = stringResource(R.string.become_patreon_title)
     val patreonDesc = stringResource(R.string.become_patreon_desc)
     val paypalTitle = stringResource(R.string.donate_paypal_title)
     val paypalDesc = stringResource(R.string.donate_paypal_desc)
 
-    val actions = remember(patreonTitle, patreonDesc, paypalTitle, paypalDesc) {
+    val actions = remember(
+        sponsorsTitle, sponsorsDesc, patreonTitle, patreonDesc, paypalTitle, paypalDesc
+    ) {
         listOf(
+            // First deliberately: lowest fees of the three, and it sits beside the source, which is
+            // where a FOSS user already is.
+            SupportAction(
+                iconRes = R.drawable.brand_github,
+                title = sponsorsTitle,
+                description = sponsorsDesc,
+                onClick = {
+                    val intent = Intent(
+                        Intent.ACTION_VIEW,
+                        "https://github.com/sponsors/trinadhthatakula".toUri()
+                    )
+                    runCatching { context.startActivity(intent) }
+                    onDismiss()
+                }
+            ),
             SupportAction(
                 iconRes = R.drawable.brand_patreon,
                 title = patreonTitle,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -430,6 +430,8 @@
     <string name="support_developer">دعم المطور</string>
     <string name="support_developer_desc">دعم التطوير المستمر لـ Thor</string>
     <string name="support_developer_desc_detailed">Thor مفتوح المصدر وخالٍ تمامًا من الإعلانات. إذا كان مفيدًا لك، يرجى التفكير في دعم عملي:</string>
+    <string name="sponsor_github_title">الرعاية عبر GitHub</string>
+    <string name="sponsor_github_desc">تبرع لمرة واحدة أو شهريًا، بجانب الشيفرة المصدرية مباشرة</string>
     <string name="become_patreon_title">كن داعمًا على Patreon</string>
     <string name="become_patreon_desc">دعم التطوير المستمر باشتراك شهري</string>
     <string name="donate_paypal_title">التبرع عبر PayPal</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -396,6 +396,8 @@
     <string name="support_developer">Apoyar al desarrollador</string>
     <string name="support_developer_desc">Apoya el desarrollo continuo de Thor</string>
     <string name="support_developer_desc_detailed">Thor es de código abierto y completamente libre de anuncios. Si te ha sido útil, considera apoyar mi trabajo:</string>
+    <string name="sponsor_github_title">Patrocinar en GitHub</string>
+    <string name="sponsor_github_desc">Puntual o mensual, justo al lado del código</string>
     <string name="become_patreon_title">Hacerse Patreon</string>
     <string name="become_patreon_desc">Apoya el desarrollo continuo con una suscripción mensual</string>
     <string name="donate_paypal_title">Donar a través de PayPal</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -396,6 +396,8 @@
     <string name="support_developer">Soutenir le développeur</string>
     <string name="support_developer_desc">Soutenir le développement continu de Thor</string>
     <string name="support_developer_desc_detailed">Thor est open source et complètement sans publicité. S\'il vous a été utile, merci de considérer de soutenir mon travail :</string>
+    <string name="sponsor_github_title">Sponsoriser sur GitHub</string>
+    <string name="sponsor_github_desc">Ponctuel ou mensuel, au plus près du code</string>
     <string name="become_patreon_title">Devenir Patreon</string>
     <string name="become_patreon_desc">Soutenir le développement continu avec un abonnement mensuel</string>
     <string name="donate_paypal_title">Faire un don via PayPal</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -388,6 +388,8 @@
     <string name="support_developer">支持开发者</string>
     <string name="support_developer_desc">支持 Thor 的持续开发</string>
     <string name="support_developer_desc_detailed">Thor 是开源且完全无广告的。如果它对您有所帮助，请考虑支持我的工作：</string>
+    <string name="sponsor_github_title">在 GitHub 上赞助</string>
+    <string name="sponsor_github_desc">一次性或按月赞助，就在代码旁边</string>
     <string name="become_patreon_title">成为 Patreon 赞助者</string>
     <string name="become_patreon_desc">通过按月订阅支持持续开发</string>
     <string name="donate_paypal_title">通过 PayPal 捐赠</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -511,6 +511,8 @@
     <string name="support_developer">Support Developer</string>
     <string name="support_developer_desc">Support ongoing development of Thor</string>
     <string name="support_developer_desc_detailed">Thor is open source and completely ad-free. If it has been helpful to you, please consider supporting my work:</string>
+    <string name="sponsor_github_title">Sponsor on GitHub</string>
+    <string name="sponsor_github_desc">One-off or monthly, right next to the code</string>
     <string name="become_patreon_title">Become a Patreon</string>
     <string name="become_patreon_desc">Support ongoing development with a monthly subscription</string>
     <string name="donate_paypal_title">Donate via PayPal</string>

--- a/app/src/store/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
+++ b/app/src/store/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
@@ -43,15 +43,33 @@ fun SupportDeveloperHelper(
 
     var pendingChangeProductId by remember { mutableStateOf<String?>(null) }
 
-    // "Direct" tab — Patreon + PayPal. Always available, including in the store build.
-    // Resolve strings via stringResource (configuration-aware) in composable scope, then pass them
-    // into remember as keys so the list recomputes on locale/config change.
+    // "Direct" tab — GitHub Sponsors + Patreon + PayPal. Always available, including in the store
+    // build. Resolve strings via stringResource (configuration-aware) in composable scope, then pass
+    // them into remember as keys so the list recomputes on locale/config change.
+    val sponsorsTitle = stringResource(R.string.sponsor_github_title)
+    val sponsorsDesc = stringResource(R.string.sponsor_github_desc)
     val patreonTitle = stringResource(R.string.become_patreon_title)
     val patreonDesc = stringResource(R.string.become_patreon_desc)
     val paypalTitle = stringResource(R.string.donate_paypal_title)
     val paypalDesc = stringResource(R.string.donate_paypal_desc)
-    val directActions = remember(patreonTitle, patreonDesc, paypalTitle, paypalDesc) {
+    val directActions = remember(
+        sponsorsTitle, sponsorsDesc, patreonTitle, patreonDesc, paypalTitle, paypalDesc
+    ) {
         listOf(
+            // First deliberately: lowest fees of the three, and it sits beside the source.
+            SupportAction(
+                iconRes = R.drawable.brand_github,
+                title = sponsorsTitle,
+                description = sponsorsDesc,
+                onClick = {
+                    val intent = Intent(
+                        Intent.ACTION_VIEW,
+                        "https://github.com/sponsors/trinadhthatakula".toUri()
+                    )
+                    runCatching { context.startActivity(intent) }
+                    onDismiss()
+                }
+            ),
             SupportAction(
                 iconRes = R.drawable.brand_patreon,
                 title = patreonTitle,


### PR DESCRIPTION
`.github/FUNDING.yml` declares five funding routes; the app offered two. The one missing route that matters is **GitHub Sponsors** — lowest fees of the set, and it sits next to the source, which is where a FOSS user already is.

Added to both helpers, **first in the list** in each:

| Build | Before | After |
|---|---|---|
| `foss` | Patreon, PayPal | **GitHub Sponsors**, Patreon, PayPal |
| `store` ("Direct" tab) | Patreon, PayPal | **GitHub Sponsors**, Patreon, PayPal |

The Play Store tab is untouched.

**Three is deliberate.** Ko-fi and Buy Me a Coffee stay off the in-app sheet. The website can afford to list every route; a bottom sheet the user opened to do one thing cannot, and five near-identical rows makes the choice harder rather than more generous. `FUNDING.yml` still declares all five, so the GitHub sidebar covers the rest.

## Strings

`sponsor_github_title` / `sponsor_github_desc` added in **all five locales** (`values`, `-ar`, `-es`, `-fr`, `-zh-rCN`) — a missing one fails the lint build, not just the translation. `brand_github.xml` already existed, so no new drawable.

## Testing

- `assembleFossDebug` — BUILD SUCCESSFUL
- `assembleStoreDebug` — BUILD SUCCESSFUL
- `lintStoreRelease` — BUILD SUCCESSFUL, no `MissingTranslation`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Sponsors as a direct support option alongside Patreon and PayPal.
  * Selecting GitHub Sponsors opens the sponsorship page and closes the support panel.
* **Localization**
  * Added GitHub Sponsors title and description translations in Arabic, Spanish, French, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->