### PR TITLE
chore: keep website copy drafts out of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ CLAUDE.md
 /docs/enforcement
 # Generated audit reports — large, regenerable, and never worth committing
 /docs/audit
+# Website copy drafts — the published source of truth is the site itself, not this repo
+/docs/site-content


### PR DESCRIPTION
## What

Adds `/docs/site-content` to `.gitignore`, next to `/docs/enforcement` and `/docs/audit`.

## Why

`docs/site-content/` holds the working drafts of the pages for `thor.trinadhthatakula.com` — features, FAQ, privacy policy, extensions policy, and the new build-an-extension guide. They are review material, not a deliverable.

Once the site ships, **the site's own source is the thing that has to be correct**. A second copy in this repo would drift out of sync and then get quoted back as if it were current — which is worse than not having it, particularly for a privacy policy.

The state they were in — untracked but not ignored — is the worst of the two options. The files were one `git add -A` away from landing in a commit nobody meant to write. Ignoring them makes "local" actually mean local.

## Test plan

- `git check-ignore -v docs/site-content/faq.md` → matches `.gitignore:42`
- `git status --short` → clean
- No build impact; `.gitignore` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude generated audit and site content files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->