### PR TITLE
fix(freezer): freeze system apps by disabling them, not by uninstalling

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -88,10 +88,12 @@ for the presentation layer.
 - **Advanced Insights**: Installer source (resolved from package labels, not hardcoded), split APK
   indicators, version codes, SDK targets, `isSuspended`, `isDebuggable`.
 - **System App Support**: Uninstall or freeze system apps (requires any privilege mode). A freeze
-  disables the package and keeps its data; it removes the package for the current user only where
-  disabling is unavailable — Shizuku on Android 16+, and Dhizuku, whose gateway is not yet
+  disables the package and keeps its data; it removes the package for the current user
+  (`pm uninstall -k`, so the data directories survive) only where the platform actually *refused*
+  the disable — an OEM restriction, not an Android version, plus Dhizuku, whose gateway is not yet
   converted. `domain/model/FreezePolicy.kt` owns that rule; every reader of freeze state must
-  handle both, since devices carry system apps frozen the old way.
+  handle both, since devices carry system apps frozen the old way, when the fallback ran first,
+  unconditionally, and without `-k`.
 - **Security**: Biometric/device-credential lock for app access. Per-session authentication state.
 - **App Metadata Caching**: Room DB cache for `AppInfo`, invalidated via `lastUpdateTime`.
 - **Preferences** (`UserPreferences`): theme, AMOLED, dynamic color, biometric lock, sort/filter

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -87,7 +87,11 @@ for the presentation layer.
   with multi-user support.
 - **Advanced Insights**: Installer source (resolved from package labels, not hardcoded), split APK
   indicators, version codes, SDK targets, `isSuspended`, `isDebuggable`.
-- **System App Support**: Uninstall or freeze system apps (requires any privilege mode).
+- **System App Support**: Uninstall or freeze system apps (requires any privilege mode). A freeze
+  disables the package and keeps its data; it removes the package for the current user only where
+  disabling is unavailable — Shizuku on Android 16+, and Dhizuku, whose gateway is not yet
+  converted. `domain/model/FreezePolicy.kt` owns that rule; every reader of freeze state must
+  handle both, since devices carry system apps frozen the old way.
 - **Security**: Biometric/device-credential lock for app access. Per-session authentication state.
 - **App Metadata Caching**: Room DB cache for `AppInfo`, invalidated via `lastUpdateTime`.
 - **Preferences** (`UserPreferences`): theme, AMOLED, dynamic color, biometric lock, sort/filter

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -88,11 +88,16 @@ for the presentation layer.
 - **Advanced Insights**: Installer source (resolved from package labels, not hardcoded), split APK
   indicators, version codes, SDK targets, `isSuspended`, `isDebuggable`.
 - **System App Support**: Uninstall or freeze system apps (requires any privilege mode). A freeze
-  disables the package and keeps its data; it removes the package for the current user
-  (`pm uninstall -k`, so the data directories survive) only where the platform actually *refused*
-  the disable — an OEM restriction, not an Android version, plus Dhizuku, whose gateway is not yet
-  converted. `domain/model/FreezePolicy.kt` owns that rule; every reader of freeze state must
-  handle both, since devices carry system apps frozen the old way, when the fallback ran first,
+  disables the package and keeps its data. Only where the platform actually *refused* the disable
+  does it fall back to `pm uninstall -k --user N` — a **per-user removal, not a real uninstall**:
+  the APK stays on the read-only partition, the package record survives, and `-k` keeps both the
+  data directories and the runtime permission grants, so `pm install-existing --user N` restores
+  the app intact. That refusal is an OEM restriction, not an Android version. Dhizuku is the one
+  exception still on the old path: its gateway is not yet converted, so it removes for the current
+  user unconditionally and without `-k`. Note the fallback is unavailable to Shizuku at shell uid
+  on API 37, which answers it with `only root can delete system app for a particular user`.
+  `domain/model/FreezePolicy.kt` owns the rule; every reader of freeze state must handle both
+  mechanics, since devices carry system apps frozen the old way, when the removal ran first,
   unconditionally, and without `-k`.
 - **Security**: Biometric/device-credential lock for app access. Per-session authentication state.
 - **App Metadata Caching**: Room DB cache for `AppInfo`, invalidated via `lastUpdateTime`.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 - **Extension Manager** — an in-app catalog of optional add-ons, each signature-verified and SHA-256 checked before install
 - **Redesigned Home** — an adaptive bento grid with one-tap access to the Extension Manager
 - **Universal Android Debloater (UAD) Integration** — safety recommendation chips (Recommended, Advanced, Expert, Unsafe) dynamically shown for system packages
-- **Safe System App Debloating & Freezing** — uninstalls system apps for the current user (`pm uninstall --user`) and restores them (`pm install-existing`) to support modern Android versions safely
+- **Safe System App Debloating & Freezing** — freezes a system app by disabling it (`pm disable`), which keeps its data, and only removes it for the current user (`pm uninstall --user`, which does not) where the platform allows nothing else: Shizuku on Android 16+, and Dhizuku. Unfreezing undoes either mechanic (`pm install-existing`, then `pm enable`)
 - **Adaptive UI Layouts** — vertical navigation rail for tablets/foldables, optimized viewport layouts, and split landscape detail screens
 - **Safety Gating** — blocks freezing of system apps marked as **Unsafe** by UAD to prevent bootloops, and warns on **Expert** packages
 - Root Support

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 - **Extension Manager** — an in-app catalog of optional add-ons, each signature-verified and SHA-256 checked before install
 - **Redesigned Home** — an adaptive bento grid with one-tap access to the Extension Manager
 - **Universal Android Debloater (UAD) Integration** — safety recommendation chips (Recommended, Advanced, Expert, Unsafe) dynamically shown for system packages
-- **Safe System App Debloating & Freezing** — freezes a system app by disabling it (`pm disable`), which keeps its data, and only removes it for the current user (`pm uninstall --user`, which does not) where the platform allows nothing else: Shizuku on Android 16+, and Dhizuku. Unfreezing undoes either mechanic (`pm install-existing`, then `pm enable`)
+- **Safe System App Debloating & Freezing** — freezes a system app by disabling it (`pm disable`), which keeps its data, and only removes it for the current user (`pm uninstall -k --user`, which keeps the data too) where the device itself refuses to disable system packages — some OEM builds do, whatever the Android version — plus Dhizuku, whose gateway is not yet converted. Unfreezing undoes either mechanic (`pm install-existing`, then `pm enable`)
 - **Adaptive UI Layouts** — vertical navigation rail for tablets/foldables, optimized viewport layouts, and split landscape detail screens
 - **Safety Gating** — blocks freezing of system apps marked as **Unsafe** by UAD to prevent bootloops, and warns on **Expert** packages
 - Root Support

--- a/app/src/main/java/com/valhalla/thor/data/freezer/AppFreezeStateReader.kt
+++ b/app/src/main/java/com/valhalla/thor/data/freezer/AppFreezeStateReader.kt
@@ -45,7 +45,7 @@ class AppFreezeStateReader(
         val info = packageManager.getApplicationInfo(packageName, MATCH_FLAGS)
         // MATCH_UNINSTALLED_PACKAGES is not optional. A *system* app is frozen with `pm disable`
         // where that works and with `pm uninstall --user N` where it does not — the gated
-        // destructive fallback (`destructiveFreezeFallbackAllowed`), plus every package the
+        // destructive fallback (`uninstallFreezeFallbackAllowed`), plus every package the
         // uninstall-only builds froze and that is still frozen today. A package in that second
         // state is not installed for this user, so the lookup throws NameNotFoundException without
         // the flag — the app then reads ABSENT and freezableCandidates drops it, which silently
@@ -103,7 +103,7 @@ class AppFreezeStateReader(
          * Both mechanics are live, and neither flag can be dropped. `pm disable` is now what
          * freezes a system app wherever the platform permits it, and `pm uninstall --user N` is
          * what freezes one where it does not — the gated destructive fallback, see
-         * `destructiveFreezeFallbackAllowed`. Even if that gate closed everywhere tomorrow,
+         * `uninstallFreezeFallbackAllowed`. Even if that gate closed everywhere tomorrow,
          * MATCH_UNINSTALLED_PACKAGES would stay load-bearing: devices carry system apps that the
          * uninstall-only builds froze, and they read as ABSENT without it, which is precisely how
          * `Unfreeze all` would lose the packages that most need unfreezing.

--- a/app/src/main/java/com/valhalla/thor/data/freezer/AppFreezeStateReader.kt
+++ b/app/src/main/java/com/valhalla/thor/data/freezer/AppFreezeStateReader.kt
@@ -21,7 +21,9 @@ import org.koin.core.annotation.Single
  *
  * [MATCH_FLAGS] covers both of Thor's freeze mechanics — MATCH_DISABLED_COMPONENTS for a
  * disabled package, MATCH_UNINSTALLED_PACKAGES for a system package uninstalled for the user —
- * and FLAG_SUSPENDED (API 24+) catches the suspend-mode case.
+ * and FLAG_SUSPENDED (API 24+) catches the suspend-mode case. Both mechanics are live: a system
+ * app is frozen with `pm disable` where the platform allows it and with `pm uninstall --user N`
+ * where it does not, and packages frozen the second way by earlier builds are still out there.
  */
 @Single
 class AppFreezeStateReader(
@@ -41,13 +43,17 @@ class AppFreezeStateReader(
      */
     fun candidateOf(packageName: String, uad: UadSnapshot): FreezeCandidate = try {
         val info = packageManager.getApplicationInfo(packageName, MATCH_FLAGS)
-        // MATCH_UNINSTALLED_PACKAGES is not optional. Thor freezes *system* apps with
-        // `pm uninstall --user N`, not `pm disable`, so a frozen system app is not installed
-        // for this user and the lookup throws NameNotFoundException without it — the app then
-        // reads ABSENT and freezableCandidates drops it, which silently emptied the
-        // Unfreeze-all target list. FLAG_INSTALLED then has to be folded into `enabled`, the
-        // same way AppInfoMapper and AppRepositoryImpl already do it, or the package comes
-        // back looking ACTIVE instead of FROZEN.
+        // MATCH_UNINSTALLED_PACKAGES is not optional. A *system* app is frozen with `pm disable`
+        // where that works and with `pm uninstall --user N` where it does not — the gated
+        // destructive fallback (`destructiveFreezeFallbackAllowed`), plus every package the
+        // uninstall-only builds froze and that is still frozen today. A package in that second
+        // state is not installed for this user, so the lookup throws NameNotFoundException without
+        // the flag — the app then reads ABSENT and freezableCandidates drops it, which silently
+        // emptied the Unfreeze-all target list. FLAG_INSTALLED then has to be folded into
+        // `enabled`, the same way AppInfoMapper and AppRepositoryImpl already do it, or the
+        // package comes back looking ACTIVE instead of FROZEN. One conjunction, one mechanic each:
+        // `info.enabled` is what catches the `pm disable` half (that package *is* installed),
+        // FLAG_INSTALLED is what catches the uninstall half (that package reports enabled == true).
         val enabled = info.enabled && (info.flags and ApplicationInfo.FLAG_INSTALLED) != 0
         val suspended = (info.flags and ApplicationInfo.FLAG_SUSPENDED) != 0
         // FLAG_SYSTEM alone, never OR'd with FLAG_UPDATED_SYSTEM_APP — that is what isSystem
@@ -88,10 +94,19 @@ class AppFreezeStateReader(
          * The query flags any lookup of a possibly-frozen package needs, and the one definition of
          * them.
          *
-         * MATCH_UNINSTALLED_PACKAGES for a *system* app frozen with `pm uninstall --user N`, whose
-         * lookup throws `NameNotFoundException` without it; MATCH_DISABLED_COMPONENTS for a user
-         * app frozen with `pm disable`, which is belt-and-braces rather than load-bearing —
-         * `getApplicationInfo` does not filter on the enabled setting.
+         * MATCH_UNINSTALLED_PACKAGES for a package frozen with `pm uninstall --user N`, whose
+         * lookup throws `NameNotFoundException` without it; MATCH_DISABLED_COMPONENTS for one
+         * frozen with `pm disable`, which is belt-and-braces rather than load-bearing —
+         * `getApplicationInfo` does not filter on the *application's* enabled setting, so a
+         * disabled package resolves either way.
+         *
+         * Both mechanics are live, and neither flag can be dropped. `pm disable` is now what
+         * freezes a system app wherever the platform permits it, and `pm uninstall --user N` is
+         * what freezes one where it does not — the gated destructive fallback, see
+         * `destructiveFreezeFallbackAllowed`. Even if that gate closed everywhere tomorrow,
+         * MATCH_UNINSTALLED_PACKAGES would stay load-bearing: devices carry system apps that the
+         * uninstall-only builds froze, and they read as ABSENT without it, which is precisely how
+         * `Unfreeze all` would lose the packages that most need unfreezing.
          *
          * Public because the *copies* are what went wrong. `ExtensionOpsProvider` reported a frozen
          * system app as not-frozen to extensions until it grew its own pair, and

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -15,6 +15,7 @@ import com.valhalla.thor.rootservice.IThorRootService
 import com.valhalla.superuser.ktx.ShellRepository
 import com.valhalla.superuser.ktx.ShellResult
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.destructiveFreezeFallbackAllowed
@@ -312,9 +313,9 @@ class RootSystemGateway(
      * Rung 1 → (gated) rung 2 of the system-app freeze, with a state re-read between them.
      *
      * Rung 1 (`pm disable`) preserves the app's data; rung 2 (`pm uninstall --user`) deletes it, and
-     * is only reached when [destructiveFreezeFallbackAllowed] says this privilege/version pair has
-     * no other way to freeze a system app — which for root is never. Nothing here trusts a shell
-     * exit code: the rung that "succeeded" is the one the platform agrees changed the package state.
+     * is only reached when [destructiveFreezeFallbackAllowed] says this privilege mode has no other
+     * way to freeze a system app — which for root is never. Nothing here trusts a shell exit code:
+     * the rung that "succeeded" is the one the platform agrees changed the package state.
      */
     private suspend fun freezeSystemApp(
         packageName: String,
@@ -330,7 +331,10 @@ class RootSystemGateway(
         }
 
         // --- Rung 1: pm disable. Keeps the package installed for the user, so its data survives.
-        runCommand("pm disable --user $currentUser $escapedPackage")
+        // The result is kept rather than discarded because the gate below turns on *why* a rung
+        // failed: runCommand folds stderr into the exception message, which is where a
+        // PackageManagerService SecurityException lands.
+        val disableResult = runCommand("pm disable --user $currentUser $escapedPackage")
         when (readEffectivelyEnabled(packageName)) {
             false -> {
                 Logger.i(
@@ -360,15 +364,21 @@ class RootSystemGateway(
 
         // --- Rung 2: pm uninstall --user. DESTROYS the app's data; `pm install-existing` brings the
         // package back factory-fresh. Gated, not merely last: the policy — not this gateway — owns
-        // the question of whether a privilege/version pair has any other way to freeze a system app.
+        // the question of whether a privilege mode has any other way to freeze a system app.
         // Passing PrivilegeMode.ROOT literally is correct rather than lazy: this class *is* the root
         // implementation, and reading the user's configured mode here would let a fallback chain
-        // that landed on root apply Shizuku's escalation rules. Under root the gate answers false on
-        // every release, so the rung below is unreachable today and the failure is surfaced instead.
+        // that landed on root apply Shizuku's escalation rules. Under root the gate answers false
+        // whatever the refusal flag says — every refusal observed in the wild, AOSP's own and
+        // Xiaomi's alike, keys on the shell uid (2000), and root is uid 0 — so the rung below is
+        // unreachable today and the failure is surfaced instead. The flag is still computed and
+        // passed honestly rather than hardcoded to false, so the two gateways call the gate the
+        // same way and a future decision to let root escalate is a change in the policy, not here.
         if (!destructiveFreezeFallbackAllowed(
                 isSystem = true,
                 privilegeMode = PrivilegeMode.ROOT,
-                sdkInt = android.os.Build.VERSION.SDK_INT,
+                disableRefusedByPolicy = isPolicyRefusal(
+                    disableResult.exceptionOrNull()?.message
+                ),
             )
         ) {
             val refused = java.io.IOException(

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -403,8 +403,8 @@ class RootSystemGateway(
             Logger.w(
                 "RootSystemGateway",
                 "freeze $packageName: rung 1 `pm disable` had no effect; fell back to rung 2 " +
-                    "`pm uninstall -k --user $currentUser` — the app's data directories survive, " +
-                    "but its per-user permission grants are expected not to"
+                    "`pm uninstall -k --user $currentUser` — the app's data directories and its " +
+                    "runtime permission grants both survive the round trip"
             )
             return Result.success(Unit)
         }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -16,6 +16,8 @@ import com.valhalla.superuser.ktx.ShellRepository
 import com.valhalla.superuser.ktx.ShellResult
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.domain.gateway.SystemGateway
+import com.valhalla.thor.domain.model.PrivilegeMode
+import com.valhalla.thor.domain.model.destructiveFreezeFallbackAllowed
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.Dispatchers
@@ -220,6 +222,36 @@ class RootSystemGateway(
         return@withContext Result.failure(Exception("Root clear app data failed. Shell command and AIDL both failed."))
     }
 
+    /**
+     * Freeze ([isDisabled] = true) or unfreeze a package.
+     *
+     * **User apps** keep the single `pm disable` / `pm enable` rung they always had, with the
+     * unprivileged `setApplicationEnabledSetting` as a last resort. It works; it is untouched.
+     *
+     * **System apps** run a two-rung chain, in this order — the order matters because the two rungs
+     * have wildly different consequences for the user's data:
+     *
+     *  1. `pm disable` — the *data-preserving* rung, and the whole reason this chain exists. The
+     *     package stays installed for the user, so app data, accounts and permissions all survive
+     *     and unfreezing hands the app back exactly as it was. With root this should almost always
+     *     be the rung that takes; it was simply never tried before.
+     *  2. `pm uninstall --user N` — the historical rung, kept but **gated behind
+     *     [destructiveFreezeFallbackAllowed]**, which answers `false` for [PrivilegeMode.ROOT] on
+     *     every release: root can disable any package, so a refusal to disable is a real failure
+     *     worth surfacing, not a platform gap worth working around by deleting the user's data.
+     *     Under root this rung is therefore unreachable today and a failed rung 1 returns
+     *     `Result.failure`. The code stays because the gate — not this gateway — owns that decision,
+     *     and a device check could legitimately flip the root branch later.
+     *
+     * Unfreeze has to undo **both** mechanics, in the order install-existing → enable. Devices in
+     * the field carry apps frozen by the uninstall-only builds and must still thaw after this ships;
+     * and a single freeze can even leave a package *both* disabled (rung 1 took but was not observed
+     * to) *and* uninstalled (rung 2 ran anyway). `pm install-existing` restores the per-user
+     * installed bit but does not clear a disabled enabled-setting, so `pm enable` has to follow it.
+     *
+     * Every rung is verified by **re-reading `ApplicationInfo`**, never by the shell exit code: `pm`
+     * happily prints Success for a no-op and returns non-zero from commands that did take effect.
+     */
     override suspend fun setAppDisabled(packageName: String, isDisabled: Boolean): Result<Unit> {
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
@@ -227,26 +259,20 @@ class RootSystemGateway(
         val appInfo = getApplicationInfoCompat(packageName)
         val isSystem = appInfo != null && (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_SYSTEM) != 0
         val escapedPackage = packageName.escapeForShell()
-        val currentUser = getCurrentUserId()
 
-        val shellResult = if (isSystem) {
-            if (isDisabled) {
-                runCommand("pm uninstall --user $currentUser $escapedPackage")
+        if (isSystem) {
+            // Only the system path needs a user id, so the `am get-current-user` round trip stays
+            // off the user-app path entirely.
+            val currentUser = getCurrentUserId()
+            return if (isDisabled) {
+                freezeSystemApp(packageName, escapedPackage, currentUser)
             } else {
-                @Suppress("SENSELESS_COMPARISON")
-                if (appInfo != null) {
-                    val currentInstalled = (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0
-                    val currentEnabled = appInfo.enabled && currentInstalled
-                    if (currentInstalled && !currentEnabled) {
-                        runCommand("pm enable $escapedPackage")
-                    }
-                }
-                runCommand("pm install-existing --user $currentUser $escapedPackage")
+                unfreezeSystemApp(packageName, escapedPackage, currentUser)
             }
-        } else {
-            val state = if (isDisabled) "disable" else "enable"
-            runCommand("pm $state $escapedPackage")
         }
+
+        val state = if (isDisabled) "disable" else "enable"
+        val shellResult = runCommand("pm $state $escapedPackage")
 
         if (shellResult.isSuccess) return shellResult
 
@@ -258,29 +284,214 @@ class RootSystemGateway(
             if (currentDisabled == isDisabled) return Result.success(Unit)
         }
 
-        // Try unprivileged API as fallback (only for non-system apps)
-        if (!isSystem) {
-            val newState = if (isDisabled) {
-                android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED
-            } else {
-                android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-            }
-            val unprivilegedResult = runCatching {
-                context.packageManager.setApplicationEnabledSetting(packageName, newState, 0)
-            }
-            if (unprivilegedResult.isSuccess) {
-                val postAppInfo = getApplicationInfoCompat(packageName)
-                if (postAppInfo != null) {
-                    val postInstalled = (postAppInfo.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0
-                    val postEnabled = postAppInfo.enabled && postInstalled
-                    val postDisabled = !postEnabled
-                    if (postDisabled == isDisabled) return Result.success(Unit)
-                }
+        // Try unprivileged API as fallback. Still "only for non-system apps" — that used to be an
+        // `if (!isSystem)` here; system apps now return above, before this point, so the guard is
+        // the early return rather than a second test of the same flag.
+        val newState = if (isDisabled) {
+            android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        } else {
+            android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        }
+        val unprivilegedResult = runCatching {
+            context.packageManager.setApplicationEnabledSetting(packageName, newState, 0)
+        }
+        if (unprivilegedResult.isSuccess) {
+            val postAppInfo = getApplicationInfoCompat(packageName)
+            if (postAppInfo != null) {
+                val postInstalled = (postAppInfo.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0
+                val postEnabled = postAppInfo.enabled && postInstalled
+                val postDisabled = !postEnabled
+                if (postDisabled == isDisabled) return Result.success(Unit)
             }
         }
 
         return Result.failure(Exception("Root setAppDisabled failed."))
     }
+
+    /**
+     * Rung 1 → (gated) rung 2 of the system-app freeze, with a state re-read between them.
+     *
+     * Rung 1 (`pm disable`) preserves the app's data; rung 2 (`pm uninstall --user`) deletes it, and
+     * is only reached when [destructiveFreezeFallbackAllowed] says this privilege/version pair has
+     * no other way to freeze a system app — which for root is never. Nothing here trusts a shell
+     * exit code: the rung that "succeeded" is the one the platform agrees changed the package state.
+     */
+    private suspend fun freezeSystemApp(
+        packageName: String,
+        escapedPackage: String,
+        currentUser: String,
+    ): Result<Unit> {
+        // Already frozen — by us, by an older build, or by another tool. Short-circuit before any
+        // rung runs: re-freezing a package that is merely disabled must never walk down into the
+        // destructive rung just because the first command reported nothing to do.
+        if (readEffectivelyEnabled(packageName) == false) {
+            Logger.i("RootSystemGateway", "freeze $packageName: already frozen, no rung run")
+            return Result.success(Unit)
+        }
+
+        // --- Rung 1: pm disable. Keeps the package installed for the user, so its data survives.
+        runCommand("pm disable --user $currentUser $escapedPackage")
+        when (readEffectivelyEnabled(packageName)) {
+            false -> {
+                Logger.i(
+                    "RootSystemGateway",
+                    "freeze $packageName: rung 1 `pm disable --user $currentUser` took effect — app data preserved"
+                )
+                return Result.success(Unit)
+            }
+
+            null -> {
+                // The package resolved a moment ago (isSystem was derived from it) and `pm disable`
+                // cannot make it unresolvable — getApplicationInfoCompat carries
+                // MATCH_UNINSTALLED_PACKAGES, and a disabled application is still returned. So this
+                // is a failed *read*, not a known state, and the next rung deletes user data. Fail
+                // closed: a retry re-reads and, if rung 1 actually landed, short-circuits above.
+                val e = java.io.IOException(
+                    "Root freeze of $packageName: `pm disable --user $currentUser` ran but the package " +
+                        "state could no longer be read, so `pm uninstall --user $currentUser` was NOT " +
+                        "attempted — it would destroy app data on a state we cannot confirm."
+                )
+                Logger.e("RootSystemGateway", e.message.orEmpty(), e)
+                return Result.failure(e)
+            }
+
+            true -> Unit // Rung 1 did not take. Consider the destructive rung — see the gate below.
+        }
+
+        // --- Rung 2: pm uninstall --user. DESTROYS the app's data; `pm install-existing` brings the
+        // package back factory-fresh. Gated, not merely last: the policy — not this gateway — owns
+        // the question of whether a privilege/version pair has any other way to freeze a system app.
+        // Passing PrivilegeMode.ROOT literally is correct rather than lazy: this class *is* the root
+        // implementation, and reading the user's configured mode here would let a fallback chain
+        // that landed on root apply Shizuku's escalation rules. Under root the gate answers false on
+        // every release, so the rung below is unreachable today and the failure is surfaced instead.
+        if (!destructiveFreezeFallbackAllowed(
+                isSystem = true,
+                privilegeMode = PrivilegeMode.ROOT,
+                sdkInt = android.os.Build.VERSION.SDK_INT,
+            )
+        ) {
+            val refused = java.io.IOException(
+                "Root freeze of $packageName failed: `pm disable --user $currentUser` did not take " +
+                    "effect and the package is still enabled. Root can disable any package, so this is " +
+                    "a real refusal rather than a platform limit — the destructive " +
+                    "`pm uninstall --user $currentUser` fallback is not permitted here, and the app's " +
+                    "data was left intact."
+            )
+            Logger.e("RootSystemGateway", refused.message.orEmpty(), refused)
+            return Result.failure(refused)
+        }
+
+        runCommand("pm uninstall --user $currentUser $escapedPackage")
+        // Nothing is left to try, so anything but "definitely still enabled" is the state we asked
+        // for: a null read can now only mean the package is no longer resolvable for this user,
+        // which is precisely what `pm uninstall --user` produces.
+        if (readEffectivelyEnabled(packageName) != true) {
+            Logger.w(
+                "RootSystemGateway",
+                "freeze $packageName: rung 1 `pm disable` had no effect; fell back to rung 2 " +
+                    "`pm uninstall --user $currentUser` — the app's DATA WAS DESTROYED and unfreezing " +
+                    "will restore it factory-fresh"
+            )
+            return Result.success(Unit)
+        }
+
+        val failure = java.io.IOException(
+            "Root freeze of $packageName failed: neither `pm disable --user $currentUser` nor " +
+                "`pm uninstall --user $currentUser` changed the package's state."
+        )
+        Logger.e("RootSystemGateway", failure.message.orEmpty(), failure)
+        return Result.failure(failure)
+    }
+
+    /**
+     * Undoes *either* freeze mechanic, install-existing first and enable second.
+     *
+     * The two are not alternatives to choose between — a package can need both, because a freeze
+     * that escalated to the destructive rung on top of a `pm disable` that had already landed is
+     * left disabled *and* uninstalled-for-user. Root no longer produces that state, but it is asked
+     * to undo states it did not create: everything the uninstall-only builds froze, and anything
+     * Shizuku froze on Android 16+ where the gate still permits escalation. So this walks the state
+     * machine ([RootFreezeChain.unfreezeStep]) instead of branching once: not installed → restore
+     * it; installed but disabled → enable it; installed and enabled → done.
+     */
+    private suspend fun unfreezeSystemApp(
+        packageName: String,
+        escapedPackage: String,
+        currentUser: String,
+    ): Result<Unit> {
+        val tried = mutableListOf<String>()
+
+        fun unreadable(): Result<Unit> {
+            val e = java.io.IOException(
+                "Root unfreeze of $packageName failed: the package could not be read back" +
+                    (if (tried.isEmpty()) "." else " after ${tried.joinToString(", ") { "`$it`" }}.")
+            )
+            Logger.e("RootSystemGateway", e.message.orEmpty(), e)
+            return Result.failure(e)
+        }
+
+        var step = readUnfreezeStep(packageName) ?: return unreadable()
+
+        // --- Rung 1: the app was frozen by uninstalling it for this user (every build before the
+        // `pm disable` rung existed, plus any package that still falls back to it). FLAG_INSTALLED
+        // is clear, so put the package back for the user first.
+        if (step == RootFreezeChain.UnfreezeStep.INSTALL_EXISTING) {
+            runCommand("pm install-existing --user $currentUser $escapedPackage")
+            tried += "pm install-existing --user $currentUser"
+            step = readUnfreezeStep(packageName) ?: return unreadable()
+        }
+
+        // --- Rung 2: the app is installed but disabled — either frozen with `pm disable`, or just
+        // restored above with its old disabled enabled-setting intact. install-existing does not
+        // clear that setting, which is why this runs *after* rung 1 rather than instead of it.
+        if (step == RootFreezeChain.UnfreezeStep.ENABLE) {
+            runCommand("pm enable --user $currentUser $escapedPackage")
+            tried += "pm enable --user $currentUser"
+            step = readUnfreezeStep(packageName) ?: return unreadable()
+        }
+
+        // --- Rung 3: verify the end state is installed *and* enabled, from the platform's answer.
+        if (step == RootFreezeChain.UnfreezeStep.VERIFIED) {
+            Logger.i(
+                "RootSystemGateway",
+                "unfreeze $packageName: installed and enabled" +
+                    (if (tried.isEmpty()) " already, no rung run"
+                    else " via ${tried.joinToString(", ") { "`$it`" }}")
+            )
+            return Result.success(Unit)
+        }
+
+        val failure = java.io.IOException(
+            "Root unfreeze of $packageName failed: still ${
+                when (step) {
+                    RootFreezeChain.UnfreezeStep.INSTALL_EXISTING -> "not installed for user $currentUser"
+                    else -> "disabled"
+                }
+            } after ${tried.joinToString(", ") { "`$it`" }.ifBlank { "no command" }}."
+        )
+        Logger.e("RootSystemGateway", failure.message.orEmpty(), failure)
+        return Result.failure(failure)
+    }
+
+    /**
+     * The app's effective enabled state as the platform reports it *now*, or `null` when the package
+     * could not be resolved at all.
+     *
+     * `null` is deliberately distinct from `false`. The freeze chain's second rung deletes user data,
+     * so "I could not read it" must never collapse into either "not frozen yet" (→ delete) or
+     * "frozen" (→ report a success that never happened).
+     */
+    private fun readEffectivelyEnabled(packageName: String): Boolean? =
+        getApplicationInfoCompat(packageName)?.let {
+            RootFreezeChain.isEffectivelyEnabled(it.enabled, it.flags)
+        }
+
+    /** The next unfreeze rung for the package's live state, or `null` if it cannot be read. */
+    private fun readUnfreezeStep(packageName: String): RootFreezeChain.UnfreezeStep? =
+        getApplicationInfoCompat(packageName)?.let {
+            RootFreezeChain.unfreezeStep(it.enabled, it.flags)
+        }
 
     override suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit> = withContext(Dispatchers.IO) {
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
@@ -653,5 +864,57 @@ class RootSystemGateway(
         } else {
             "0"
         }
+    }
+}
+
+/**
+ * The state arithmetic behind the system-app freeze chain, taken as `(enabled, flags)` so it stays a
+ * plain JVM unit under test: a `PackageManager` cannot be faked in a unit test, and *which rung the
+ * chain picks* — one of which deletes the user's data — is the half worth pinning. Same shape as
+ * [com.valhalla.thor.data.provider.isFrozenAppInfo], which exists for the same reason.
+ *
+ * Namespaced in an object rather than left as top-level functions: `com.valhalla.thor.data.gateway`
+ * holds three gateways that all reason about these same flags, and a top-level `isEffectivelyEnabled`
+ * here would be a redeclaration the moment the next one wants the same name.
+ */
+object RootFreezeChain {
+
+    /**
+     * Thor's one definition of "this app is up and running", the fold
+     * `AppFreezeStateReader.candidateOf` applies and that `AppInfoMapper` and `AppRepositoryImpl`
+     * repeat: FLAG_INSTALLED is not optional once MATCH_UNINSTALLED_PACKAGES is in the query flags,
+     * because the lookup then *succeeds* for a package uninstalled for this user and reports
+     * `enabled == true`.
+     */
+    fun isEffectivelyEnabled(enabled: Boolean, flags: Int): Boolean =
+        enabled && (flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0
+
+    /** The rungs of an unfreeze, in the order they have to be attempted. */
+    enum class UnfreezeStep {
+        /** Not installed for this user — frozen with `pm uninstall --user N`. */
+        INSTALL_EXISTING,
+
+        /** Installed but disabled — frozen with `pm disable`, or just restored by rung 1. */
+        ENABLE,
+
+        /** Installed *and* enabled: nothing left to do. */
+        VERIFIED,
+    }
+
+    /**
+     * The next rung for a package in state `(enabled, flags)`.
+     *
+     * Installed-ness is tested first on purpose. A package can be both uninstalled-for-user *and*
+     * disabled: any freeze that escalated to the destructive rung on top of a `pm disable` that had
+     * already landed — an older build, or Shizuku on Android 16+ where the gate still permits it,
+     * both of which root may be the privilege asked to undo. `pm enable` on a package that is not
+     * installed for the user does not bring it back, while
+     * `pm install-existing` on a disabled package does not enable it. Only install → enable clears
+     * both; the caller re-reads between the two, so this being called twice is the normal path.
+     */
+    fun unfreezeStep(enabled: Boolean, flags: Int): UnfreezeStep = when {
+        (flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) == 0 -> UnfreezeStep.INSTALL_EXISTING
+        !enabled -> UnfreezeStep.ENABLE
+        else -> UnfreezeStep.VERIFIED
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -18,7 +18,7 @@ import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
-import com.valhalla.thor.domain.model.destructiveFreezeFallbackAllowed
+import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.Dispatchers
@@ -237,7 +237,7 @@ class RootSystemGateway(
      *     and unfreezing hands the app back exactly as it was. With root this should almost always
      *     be the rung that takes; it was simply never tried before.
      *  2. `pm uninstall --user N` — the historical rung, kept but **gated behind
-     *     [destructiveFreezeFallbackAllowed]**, which answers `false` for [PrivilegeMode.ROOT] on
+     *     [uninstallFreezeFallbackAllowed]**, which answers `false` for [PrivilegeMode.ROOT] on
      *     every release: root can disable any package, so a refusal to disable is a real failure
      *     worth surfacing, not a platform gap worth working around by deleting the user's data.
      *     Under root this rung is therefore unreachable today and a failed rung 1 returns
@@ -313,7 +313,7 @@ class RootSystemGateway(
      * Rung 1 → (gated) rung 2 of the system-app freeze, with a state re-read between them.
      *
      * Rung 1 (`pm disable`) preserves the app's data; rung 2 (`pm uninstall --user`) deletes it, and
-     * is only reached when [destructiveFreezeFallbackAllowed] says this privilege mode has no other
+     * is only reached when [uninstallFreezeFallbackAllowed] says this privilege mode has no other
      * way to freeze a system app — which for root is never. Nothing here trusts a shell exit code:
      * the rung that "succeeded" is the one the platform agrees changed the package state.
      */
@@ -373,7 +373,7 @@ class RootSystemGateway(
         // unreachable today and the failure is surfaced instead. The flag is still computed and
         // passed honestly rather than hardcoded to false, so the two gateways call the gate the
         // same way and a future decision to let root escalate is a change in the policy, not here.
-        if (!destructiveFreezeFallbackAllowed(
+        if (!uninstallFreezeFallbackAllowed(
                 isSystem = true,
                 privilegeMode = PrivilegeMode.ROOT,
                 disableRefusedByPolicy = isPolicyRefusal(
@@ -384,15 +384,18 @@ class RootSystemGateway(
             val refused = java.io.IOException(
                 "Root freeze of $packageName failed: `pm disable --user $currentUser` did not take " +
                     "effect and the package is still enabled. Root can disable any package, so this is " +
-                    "a real refusal rather than a platform limit — the destructive " +
-                    "`pm uninstall --user $currentUser` fallback is not permitted here, and the app's " +
-                    "data was left intact."
+                    "a real refusal rather than a platform limit — the `pm uninstall -k --user " +
+                    "$currentUser` fallback is not permitted here, and the package was left installed."
             )
             Logger.e("RootSystemGateway", refused.message.orEmpty(), refused)
             return Result.failure(refused)
         }
 
-        runCommand("pm uninstall --user $currentUser $escapedPackage")
+        // `-k` (DELETE_KEEP_DATA) is not optional here: without it this line deletes
+        // /data/user/N/<pkg> and an unfreeze returns the app factory-fresh, which is the bug this
+        // whole change exists to remove. With it, the data directories keep the same inodes across
+        // uninstall → install-existing (measured).
+        runCommand("pm uninstall -k --user $currentUser $escapedPackage")
         // Nothing is left to try, so anything but "definitely still enabled" is the state we asked
         // for: a null read can now only mean the package is no longer resolvable for this user,
         // which is precisely what `pm uninstall --user` produces.
@@ -400,15 +403,15 @@ class RootSystemGateway(
             Logger.w(
                 "RootSystemGateway",
                 "freeze $packageName: rung 1 `pm disable` had no effect; fell back to rung 2 " +
-                    "`pm uninstall --user $currentUser` — the app's DATA WAS DESTROYED and unfreezing " +
-                    "will restore it factory-fresh"
+                    "`pm uninstall -k --user $currentUser` — the app's data directories survive, " +
+                    "but its per-user permission grants are expected not to"
             )
             return Result.success(Unit)
         }
 
         val failure = java.io.IOException(
             "Root freeze of $packageName failed: neither `pm disable --user $currentUser` nor " +
-                "`pm uninstall --user $currentUser` changed the package's state."
+                "`pm uninstall -k --user $currentUser` changed the package's state."
         )
         Logger.e("RootSystemGateway", failure.message.orEmpty(), failure)
         return Result.failure(failure)
@@ -418,10 +421,10 @@ class RootSystemGateway(
      * Undoes *either* freeze mechanic, install-existing first and enable second.
      *
      * The two are not alternatives to choose between — a package can need both, because a freeze
-     * that escalated to the destructive rung on top of a `pm disable` that had already landed is
+     * that escalated to the uninstall rung on top of a `pm disable` that had already landed is
      * left disabled *and* uninstalled-for-user. Root no longer produces that state, but it is asked
      * to undo states it did not create: everything the uninstall-only builds froze, and anything
-     * Shizuku froze on Android 16+ where the gate still permits escalation. So this walks the state
+     * Shizuku froze on a device that refuses to disable system packages. So this walks the state
      * machine ([RootFreezeChain.unfreezeStep]) instead of branching once: not installed → restore
      * it; installed but disabled → enable it; installed and enabled → done.
      */
@@ -915,9 +918,9 @@ object RootFreezeChain {
      * The next rung for a package in state `(enabled, flags)`.
      *
      * Installed-ness is tested first on purpose. A package can be both uninstalled-for-user *and*
-     * disabled: any freeze that escalated to the destructive rung on top of a `pm disable` that had
-     * already landed — an older build, or Shizuku on Android 16+ where the gate still permits it,
-     * both of which root may be the privilege asked to undo. `pm enable` on a package that is not
+     * disabled: any freeze that escalated to the uninstall rung on top of a `pm disable` that had
+     * already landed — an older build, or Shizuku on a device that refuses to disable system
+     * packages, both of which root may be the privilege asked to undo. `pm enable` on a package that is not
      * installed for the user does not bring it back, while
      * `pm install-existing` on a disabled package does not enable it. Only install → enable clears
      * both; the caller re-reads between the two, so this being called twice is the normal path.

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -5,7 +5,6 @@ package com.valhalla.thor.data.gateway
 
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import android.os.Build
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.source.local.shizuku.EnableRungOrder
 import com.valhalla.thor.data.source.local.shizuku.ShizukuReflector
@@ -101,9 +100,16 @@ class ShizukuSystemGateway(
      * deleted its data" actually happened.
      */
     private suspend fun freezeSystemApp(packageName: String): Result<Unit> {
-        // Rungs 1 + 2. setAppEnabled already re-reads ApplicationInfo after each rung and returns
-        // true only when the package really is disabled, so an exit code alone never satisfies it.
-        if (reflector.setAppEnabled(packageName, false, EnableRungOrder.REFLECTION_FIRST)) {
+        // Rungs 1 + 2. setAppEnabledDetailed already re-reads ApplicationInfo after each rung and
+        // reports success only when the package really is disabled, so an exit code alone never
+        // satisfies it. The detailed variant is used because rung 3 below turns on *why* this
+        // failed, not merely that it did.
+        val disable = reflector.setAppEnabledDetailed(
+            packageName,
+            false,
+            EnableRungOrder.REFLECTION_FIRST,
+        )
+        if (disable.succeeded) {
             Logger.d(
                 "ShizukuSystemGateway",
                 "freeze($packageName): disabled in place; app data kept"
@@ -111,25 +117,28 @@ class ShizukuSystemGateway(
             return Result.success(Unit)
         }
 
-        // Rung 3, gated. The shared predicate is consulted rather than an inline SDK_INT check so
-        // both gateways move together if device testing puts the boundary somewhere else. isSystem
-        // is true by construction here — freezeSystemApp is only reached from the isSystem branch —
-        // but it is passed explicitly so the gate, not this call site, owns the whole rule.
+        // Rung 3, gated on the platform having actually refused — not on the Android version.
+        // A stock AOSP API 36 emulator disables system apps from the shell uid without complaint,
+        // so a version test would destroy data on every device that never needed this rung, while
+        // still missing the OEM builds (Xiaomi HyperOS, reported on Android 14) that do. isSystem
+        // is true by construction here, but it is passed explicitly so the gate — not this call
+        // site — owns the whole rule.
         if (!destructiveFreezeFallbackAllowed(
                 isSystem = true,
                 privilegeMode = PrivilegeMode.SHIZUKU,
-                sdkInt = Build.VERSION.SDK_INT
+                disableRefusedByPolicy = disable.refusedByPolicy,
             )
         ) {
             Logger.e(
                 "ShizukuSystemGateway",
                 "freeze($packageName): reflection and `pm disable-user` both left the package " +
-                    "enabled, and uninstall-for-user is not permitted on this release — failing " +
-                    "rather than destroying the app's data"
+                    "enabled, and nothing refused us — this is a failure to report, not a platform " +
+                    "limit to work around, so the app's data was left intact"
             )
             return Result.failure(
                 Exception(
-                    "Shizuku could not disable the system app $packageName, and freezing it by " +
+                    "Shizuku could not disable the system app $packageName. Nothing refused the " +
+                        "request, so this is not a device restriction, and freezing it by " +
                         "uninstalling it for this user would delete its data. Refusing."
                 )
             )

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -10,7 +10,7 @@ import com.valhalla.thor.data.source.local.shizuku.EnableRungOrder
 import com.valhalla.thor.data.source.local.shizuku.ShizukuReflector
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
-import com.valhalla.thor.domain.model.destructiveFreezeFallbackAllowed
+import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -83,7 +83,7 @@ class ShizukuSystemGateway(
      *
      *  1. **Bypass reflection** straight at `IPackageManager.setApplicationEnabledSetting`.
      *  2. **Shell** — `pm disable-user --user N <pkg>`.
-     *  3. **Uninstall for this user** — only where [destructiveFreezeFallbackAllowed] permits it.
+     *  3. **Uninstall for this user** — only where [uninstallFreezeFallbackAllowed] permits it.
      *
      * Rungs 1 and 2 both live inside `Shizuku.setAppDisabled` so the reflection block has
      * exactly one copy in the codebase; [EnableRungOrder.REFLECTION_FIRST] flips its default order
@@ -91,13 +91,13 @@ class ShizukuSystemGateway(
      * simply re-enables it. Neither is version-gated — Shizuku users on Android 15 and below freeze
      * system apps exactly as before, they just do it without ever reaching rung 3.
      *
-     * Rung 3 is not reversible. `pm uninstall --user N` carries no `-k`, so the app's data is
-     * deleted and an unfreeze brings it back factory-fresh. It ran *first* and *unconditionally*
-     * before this change, which is why freezing a preinstalled app silently cost the user their
-     * data. It now runs only on the one combination where disabling a system app is reported to be
-     * unavailable — Shizuku on Android 16+ — and everywhere else a failure to disable stays a
-     * failure. The log lines exist so a bug report can say which of "we disabled it" and "we
-     * deleted its data" actually happened.
+     * Rung 3 removes the package for this user. It ran *first* and *unconditionally* before this
+     * change, and without `-k`, which is why freezing a preinstalled app silently cost the user
+     * their data. It now carries `-k` ([ShizukuReflector.freezeSystemAppForUser]) so the data
+     * directories survive, and it is reached only where the platform actually refused to disable —
+     * everywhere else a failure to disable stays a failure. It is still last: it is the only rung
+     * that changes what the app looks like to the rest of the system (`FLAG_INSTALLED` clears), and
+     * the per-user permission grants are expected not to survive the round trip.
      */
     private suspend fun freezeSystemApp(packageName: String): Result<Unit> {
         // Rungs 1 + 2. setAppEnabledDetailed already re-reads ApplicationInfo after each rung and
@@ -123,7 +123,7 @@ class ShizukuSystemGateway(
         // still missing the OEM builds (Xiaomi HyperOS, reported on Android 14) that do. isSystem
         // is true by construction here, but it is passed explicitly so the gate — not this call
         // site — owns the whole rule.
-        if (!destructiveFreezeFallbackAllowed(
+        if (!uninstallFreezeFallbackAllowed(
                 isSystem = true,
                 privilegeMode = PrivilegeMode.SHIZUKU,
                 disableRefusedByPolicy = disable.refusedByPolicy,
@@ -133,31 +133,31 @@ class ShizukuSystemGateway(
                 "ShizukuSystemGateway",
                 "freeze($packageName): reflection and `pm disable-user` both left the package " +
                     "enabled, and nothing refused us — this is a failure to report, not a platform " +
-                    "limit to work around, so the app's data was left intact"
+                    "limit to work around"
             )
             return Result.failure(
                 Exception(
                     "Shizuku could not disable the system app $packageName. Nothing refused the " +
-                        "request, so this is not a device restriction, and freezing it by " +
-                        "uninstalling it for this user would delete its data. Refusing."
+                        "request, so this is not a device restriction — reporting the failure " +
+                        "rather than removing the app for this user."
                 )
             )
         }
 
         Logger.w(
             "ShizukuSystemGateway",
-            "freeze($packageName): reflection and `pm disable-user` both left the package enabled; " +
-                "falling back to uninstall-for-user, which DELETES this app's data"
+            "freeze($packageName): this device refuses to let the shell uid disable system " +
+                "packages; falling back to `pm uninstall -k --user N`, which keeps the app's data"
         )
-        val reported = runCancellableAction { reflector.uninstallApp(packageName) }
-        // Verify by re-reading rather than trusting uninstallApp's own verdict: its shell rung
-        // reports `pm`'s exit code and its reflection rung reports a PackageInstaller broadcast,
-        // and neither is the same question as "is this package still installed for me".
+        val reported = runCancellableAction { reflector.freezeSystemAppForUser(packageName) }
+        // Verify by re-reading rather than trusting the shell's exit code: `pm` is not a reliable
+        // narrator of whether the package is still installed for this user.
         return if (isFrozen(packageName)) {
             Logger.w(
                 "ShizukuSystemGateway",
-                "freeze($packageName): frozen by uninstall-for-user — its data is gone, and an " +
-                    "unfreeze will reinstall it factory-fresh"
+                "freeze($packageName): frozen by uninstall-for-user with -k — the data directories " +
+                    "survive, but per-user permission grants are expected not to, so the app may " +
+                    "re-prompt after an unfreeze"
             )
             Result.success(Unit)
         } else {
@@ -184,7 +184,7 @@ class ShizukuSystemGateway(
      * test `AppFreezeStateReader.candidateOf` applies, so "unfrozen" here means what "not frozen"
      * means everywhere else.
      *
-     * [destructiveFreezeFallbackAllowed] is deliberately **not** consulted anywhere below. It is a
+     * [uninstallFreezeFallbackAllowed] is deliberately **not** consulted anywhere below. It is a
      * freeze-only gate; an Android 15 device that was frozen by the old unconditional-uninstall
      * build is carrying a state this build would now refuse to create, and it still has to be able
      * to unfreeze it. Gating the thaw on the same predicate would strand exactly those users.

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -96,8 +96,12 @@ class ShizukuSystemGateway(
      * their data. It now carries `-k` ([ShizukuReflector.freezeSystemAppForUser]) so the data
      * directories survive, and it is reached only where the platform actually refused to disable —
      * everywhere else a failure to disable stays a failure. It is still last: it is the only rung
-     * that changes what the app looks like to the rest of the system (`FLAG_INSTALLED` clears), and
-     * the per-user permission grants are expected not to survive the round trip.
+     * that changes what the app looks like to the rest of the system (`FLAG_INSTALLED` clears).
+     *
+     * Rung 3 is also **unavailable at shell uid on API 37**: `pm uninstall -k --user N` on a system
+     * app returns `Failure [only root can delete system app for a particular user]` on Android 17,
+     * where the identical command succeeds on API 36. The package is left untouched, so the chain
+     * ends in an honest failure rather than a wrong state.
      */
     private suspend fun freezeSystemApp(packageName: String): Result<Unit> {
         // Rungs 1 + 2. setAppEnabledDetailed already re-reads ApplicationInfo after each rung and
@@ -155,9 +159,8 @@ class ShizukuSystemGateway(
         return if (isFrozen(packageName)) {
             Logger.w(
                 "ShizukuSystemGateway",
-                "freeze($packageName): frozen by uninstall-for-user with -k — the data directories " +
-                    "survive, but per-user permission grants are expected not to, so the app may " +
-                    "re-prompt after an unfreeze"
+                "freeze($packageName): frozen by uninstall-for-user with -k — data directories and " +
+                    "runtime permission grants both survive the round trip (measured on API 36)"
             )
             Result.success(Unit)
         } else {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -3,10 +3,16 @@
 
 package com.valhalla.thor.data.gateway
 
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.os.Build
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.data.source.local.shizuku.EnableRungOrder
 import com.valhalla.thor.data.source.local.shizuku.ShizukuReflector
 import com.valhalla.thor.domain.gateway.SystemGateway
+import com.valhalla.thor.domain.model.PrivilegeMode
+import com.valhalla.thor.domain.model.destructiveFreezeFallbackAllowed
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
@@ -58,23 +64,184 @@ class ShizukuSystemGateway(
     }
 
     override suspend fun setAppDisabled(packageName: String, isDisabled: Boolean): Result<Unit> {
+        // FLAG_SYSTEM alone, never OR'd with FLAG_UPDATED_SYSTEM_APP — ShizukuReflector.isSystemApp
+        // is written that way, matching AppInfoMapper, AppFreezeStateReader.candidateOf and
+        // RootSystemGateway.setAppDisabled. The destructive-fallback gate below is keyed on this
+        // same answer, so a second definition of "system" here would gate a different set of apps
+        // than the one the freeze itself acts on.
         val isSystem = reflector.isSystemApp(packageName)
         return if (isSystem) {
-            if (isDisabled) {
-                runAction { reflector.uninstallApp(packageName) }
-            } else {
-                val appInfo = reflector.getApplicationInfoOrNull(packageName)
-                val isInstalled = appInfo?.let { (it.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0 } ?: false
-                val isAppDisabled = appInfo?.enabled == false
-                if (isAppDisabled && isInstalled) {
-                    reflector.setAppEnabled(packageName, true)
-                }
-                runAction { reflector.reinstallExistingApp(packageName) }
-            }
+            if (isDisabled) freezeSystemApp(packageName) else unfreezeSystemApp(packageName)
         } else {
+            // Unchanged, and deliberately so: a user app is disabled with `pm disable --user N`
+            // shell-first, which works and is cheaper than a binder reflection round trip.
             runAction { reflector.setAppEnabled(packageName, !isDisabled) }
         }
     }
+
+    /**
+     * Freeze a *preinstalled* app, least destructive rung first:
+     *
+     *  1. **Bypass reflection** straight at `IPackageManager.setApplicationEnabledSetting`.
+     *  2. **Shell** — `pm disable-user --user N <pkg>`.
+     *  3. **Uninstall for this user** — only where [destructiveFreezeFallbackAllowed] permits it.
+     *
+     * Rungs 1 and 2 both live inside `Shizuku.setAppDisabled` so the reflection block has
+     * exactly one copy in the codebase; [EnableRungOrder.REFLECTION_FIRST] flips its default order
+     * for this path only. Both are genuinely reversible: the package keeps its data and unfreezing
+     * simply re-enables it. Neither is version-gated — Shizuku users on Android 15 and below freeze
+     * system apps exactly as before, they just do it without ever reaching rung 3.
+     *
+     * Rung 3 is not reversible. `pm uninstall --user N` carries no `-k`, so the app's data is
+     * deleted and an unfreeze brings it back factory-fresh. It ran *first* and *unconditionally*
+     * before this change, which is why freezing a preinstalled app silently cost the user their
+     * data. It now runs only on the one combination where disabling a system app is reported to be
+     * unavailable — Shizuku on Android 16+ — and everywhere else a failure to disable stays a
+     * failure. The log lines exist so a bug report can say which of "we disabled it" and "we
+     * deleted its data" actually happened.
+     */
+    private suspend fun freezeSystemApp(packageName: String): Result<Unit> {
+        // Rungs 1 + 2. setAppEnabled already re-reads ApplicationInfo after each rung and returns
+        // true only when the package really is disabled, so an exit code alone never satisfies it.
+        if (reflector.setAppEnabled(packageName, false, EnableRungOrder.REFLECTION_FIRST)) {
+            Logger.d(
+                "ShizukuSystemGateway",
+                "freeze($packageName): disabled in place; app data kept"
+            )
+            return Result.success(Unit)
+        }
+
+        // Rung 3, gated. The shared predicate is consulted rather than an inline SDK_INT check so
+        // both gateways move together if device testing puts the boundary somewhere else. isSystem
+        // is true by construction here — freezeSystemApp is only reached from the isSystem branch —
+        // but it is passed explicitly so the gate, not this call site, owns the whole rule.
+        if (!destructiveFreezeFallbackAllowed(
+                isSystem = true,
+                privilegeMode = PrivilegeMode.SHIZUKU,
+                sdkInt = Build.VERSION.SDK_INT
+            )
+        ) {
+            Logger.e(
+                "ShizukuSystemGateway",
+                "freeze($packageName): reflection and `pm disable-user` both left the package " +
+                    "enabled, and uninstall-for-user is not permitted on this release — failing " +
+                    "rather than destroying the app's data"
+            )
+            return Result.failure(
+                Exception(
+                    "Shizuku could not disable the system app $packageName, and freezing it by " +
+                        "uninstalling it for this user would delete its data. Refusing."
+                )
+            )
+        }
+
+        Logger.w(
+            "ShizukuSystemGateway",
+            "freeze($packageName): reflection and `pm disable-user` both left the package enabled; " +
+                "falling back to uninstall-for-user, which DELETES this app's data"
+        )
+        val reported = runCancellableAction { reflector.uninstallApp(packageName) }
+        // Verify by re-reading rather than trusting uninstallApp's own verdict: its shell rung
+        // reports `pm`'s exit code and its reflection rung reports a PackageInstaller broadcast,
+        // and neither is the same question as "is this package still installed for me".
+        return if (isFrozen(packageName)) {
+            Logger.w(
+                "ShizukuSystemGateway",
+                "freeze($packageName): frozen by uninstall-for-user — its data is gone, and an " +
+                    "unfreeze will reinstall it factory-fresh"
+            )
+            Result.success(Unit)
+        } else {
+            reported.fold(
+                onSuccess = {
+                    Result.failure(Exception("Shizuku: uninstall reported success but $packageName is still active."))
+                },
+                onFailure = { Result.failure(it) }
+            )
+        }
+    }
+
+    /**
+     * Unfreeze a *preinstalled* app, handling both mechanics that could have frozen it.
+     *
+     * A device in the field can be carrying either shape:
+     *  - **uninstalled for this user** — FLAG_INSTALLED is clear while `enabled` stays `true`.
+     *    Every build before this one produced this shape for *every* system app on *every* release;
+     *    this build still produces it, but only through the gated rung 3 above;
+     *  - **disabled** (rungs 1 and 2 above) — FLAG_INSTALLED is set while `enabled` is `false`.
+     *
+     * So: reinstall only when the package is actually missing, re-read, then enable only when it is
+     * actually disabled, and finally verify the end state is installed **and** enabled — the same
+     * test `AppFreezeStateReader.candidateOf` applies, so "unfrozen" here means what "not frozen"
+     * means everywhere else.
+     *
+     * [destructiveFreezeFallbackAllowed] is deliberately **not** consulted anywhere below. It is a
+     * freeze-only gate; an Android 15 device that was frozen by the old unconditional-uninstall
+     * build is carrying a state this build would now refuse to create, and it still has to be able
+     * to unfreeze it. Gating the thaw on the same predicate would strand exactly those users.
+     */
+    private suspend fun unfreezeSystemApp(packageName: String): Result<Unit> {
+        // Step 1 — not installed for this user? Bring it back.
+        if (!isInstalledForUser(packageName)) {
+            // Called directly rather than through runAction: reinstallExistingApp awaits a
+            // PackageInstaller broadcast and must stay cancellable (see runCancellableAction).
+            val reported = runCancellableAction { reflector.reinstallExistingApp(packageName) }
+            Logger.d(
+                "ShizukuSystemGateway",
+                "unfreeze($packageName): install-existing reported success=${reported.isSuccess}"
+            )
+            // Deliberately not returning here on either outcome. install-existing can report
+            // failure and still have landed, and it restores the package with whatever enabled
+            // state it had when it went away — so it can succeed and leave the app disabled. Only
+            // the re-read below decides.
+        }
+
+        // Step 2 — re-read. Installed now, but disabled?
+        val afterInstall = reflector.getApplicationInfoOrNull(packageName)
+        if (afterInstall != null &&
+            (afterInstall.flags and ApplicationInfo.FLAG_INSTALLED) != 0 &&
+            !afterInstall.enabled
+        ) {
+            val enabled = reflector.setAppEnabled(packageName, true)
+            Logger.d(
+                "ShizukuSystemGateway",
+                "unfreeze($packageName): re-enable reported $enabled"
+            )
+        }
+
+        // Step 3 — verify the END state, not any single rung's report.
+        val end = reflector.getApplicationInfoOrNull(packageName)
+        val installed = end != null && (end.flags and ApplicationInfo.FLAG_INSTALLED) != 0
+        return if (installed && end.enabled) {
+            Logger.d("ShizukuSystemGateway", "unfreeze($packageName): package is installed and enabled")
+            Result.success(Unit)
+        } else {
+            Result.failure(
+                Exception(
+                    "Shizuku: $packageName is still frozen after unfreeze " +
+                        "(installed=$installed, enabled=${end?.enabled})"
+                )
+            )
+        }
+    }
+
+    /**
+     * Is the package installed for the user Thor runs as?
+     *
+     * The reflector's lookup already carries MATCH_UNINSTALLED_PACKAGES, which is what lets a
+     * package uninstalled-for-user resolve here at all instead of throwing. It does *not* carry
+     * MATCH_DISABLED_COMPONENTS and does not need to: `getApplicationInfo` never filters on the
+     * enabled setting (`AppFreezeStateReader.MATCH_FLAGS` documents the same), so a disabled
+     * package resolves either way — hence no change to a default the other callers share.
+     */
+    private fun isInstalledForUser(packageName: String): Boolean =
+        reflector.getApplicationInfoOrNull(packageName)
+            ?.let { (it.flags and ApplicationInfo.FLAG_INSTALLED) != 0 } ?: false
+
+    /** The canonical freeze test, matching `AppFreezeStateReader.candidateOf`. */
+    private fun isFrozen(packageName: String): Boolean =
+        reflector.getApplicationInfoOrNull(packageName)
+            ?.let { !(it.enabled && (it.flags and ApplicationInfo.FLAG_INSTALLED) != 0) } ?: true
 
     override suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit> {
         return runAction { reflector.setAppSuspended(packageName, isSuspended) }
@@ -220,6 +387,28 @@ class ShizukuSystemGateway(
         return try {
             if (action()) Result.success(Unit)
             else Result.failure(Exception("Action failed. This may happen if reflection is blocked or shell lacks permissions."))
+        } catch (e: Exception) {
+            Logger.e("ShizukuSystemGateway", "Action execution failed", e)
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * [runAction] for the two genuinely suspending rungs, without its cancellation flaw.
+     *
+     * `CancellationException` IS an `Exception` in Kotlin, so [runAction]'s `catch (e: Exception)`
+     * turns a cancelled action into an ordinary `Result.failure` and the caller carries on as if
+     * the operation had merely failed. That matters exactly here: `uninstallApp` polls with
+     * `delay()` and `reinstallExistingApp` awaits a PackageInstaller broadcast, both under a
+     * ViewModel scope that can die mid-freeze. Rethrowing lets the coroutine unwind cleanly, the
+     * same discipline `ShizukuReflector` keeps at its own reflection call sites.
+     */
+    private suspend inline fun runCancellableAction(action: suspend () -> Boolean): Result<Unit> {
+        return try {
+            if (action()) Result.success(Unit)
+            else Result.failure(Exception("Action failed. This may happen if reflection is blocked or shell lacks permissions."))
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Logger.e("ShizukuSystemGateway", "Action execution failed", e)
             Result.failure(e)

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -328,7 +328,7 @@ class FreezerShortcutManager(
      *
      * [AppFreezeStateReader.MATCH_FLAGS] rather than MATCH_DISABLED_COMPONENTS alone: a system app
      * frozen by removal for the current user — the mechanic
-     * `FreezePolicy.destructiveFreezeFallbackAllowed` still permits, and the one every system app
+     * `FreezePolicy.uninstallFreezeFallbackAllowed` still permits, and the one every system app
      * frozen before Thor preferred disabling is already in — is not installed for this user, and
      * the lookup throws `NameNotFoundException` without MATCH_UNINSTALLED_PACKAGES. Unreachable
      * while per-app pins are gated to user apps, which is exactly what makes it worth fixing before

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -326,8 +326,10 @@ class FreezerShortcutManager(
     /**
      * One `ApplicationInfo` read, with the flags a *frozen* package needs.
      *
-     * [AppFreezeStateReader.MATCH_FLAGS] rather than MATCH_DISABLED_COMPONENTS alone: Thor freezes
-     * a system app with `pm uninstall --user N`, so that package is not installed for this user and
+     * [AppFreezeStateReader.MATCH_FLAGS] rather than MATCH_DISABLED_COMPONENTS alone: a system app
+     * frozen by removal for the current user — the mechanic
+     * `FreezePolicy.destructiveFreezeFallbackAllowed` still permits, and the one every system app
+     * frozen before Thor preferred disabling is already in — is not installed for this user, and
      * the lookup throws `NameNotFoundException` without MATCH_UNINSTALLED_PACKAGES. Unreachable
      * while per-app pins are gated to user apps, which is exactly what makes it worth fixing before
      * that gate moves rather than after.

--- a/app/src/main/java/com/valhalla/thor/data/provider/ExtensionOpsProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/ExtensionOpsProvider.kt
@@ -17,6 +17,7 @@ import com.valhalla.thor.data.manager.ExtensionManager
 import com.valhalla.thor.domain.model.isAuthorizedExtensionCaller
 import com.valhalla.thor.domain.model.isFrozen
 import com.valhalla.thor.domain.model.opTargets
+import com.valhalla.thor.domain.usecase.FreezeAppUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.TimeoutCancellationException
@@ -35,9 +36,15 @@ import org.koin.core.component.inject
  * Security (mirrors [FreezerBridgeProvider]): the caller is UID-attested via getCallingPackage() and must
  * be a pinned-signer extension; the privileged work runs under Thor's OWN identity
  * (Binder.clearCallingIdentity()); Thor's own package and the caller are never operated on.
+ *
+ * Attestation is not the whole story, though: a *legitimately* pinned extension still supplies an
+ * arbitrary package list, so freezes additionally go through [FreezeAppUseCase], which refuses a
+ * `FreezeTier.BLOCKED` package. Being a trusted caller buys the right to ask, not the right to
+ * freeze something that stops the device booting.
  */
 class ExtensionOpsProvider : ContentProvider(), KoinComponent {
     private val manageAppUseCase: ManageAppUseCase by inject()
+    private val freezeAppUseCase: FreezeAppUseCase by inject()
     private val extensionManager: ExtensionManager by inject()
 
     private enum class Op { FREEZE, UNFREEZE, TOGGLE }
@@ -88,7 +95,21 @@ class ExtensionOpsProvider : ContentProvider(), KoinComponent {
                     } else op
                     targets.count { pkg ->
                         when (effective) {
-                            Op.FREEZE -> manageAppUseCase.setAppDisabled(pkg, true)
+                            // FreezeAppUseCase, not the raw ManageAppUseCase primitive: it resolves
+                            // the package's FreezeTier and refuses a BLOCKED one. Its KDoc names
+                            // "an extension trigger" as exactly the caller it exists to backstop,
+                            // and this provider was the one such caller still going around it — an
+                            // extension's package list is attacker-chosen relative to the user, and
+                            // freezing an Unsafe system app can disable something the device needs
+                            // to boot. The batch paths skip this gate because they classify their
+                            // whole target list against one shared snapshot first; an extension
+                            // does no such filtering, so that exemption does not apply here.
+                            //
+                            // Default mode (FreezerMode.FREEZE) is deliberate and preserves the
+                            // disable-only rule above — it maps to setAppDisabled, never suspend.
+                            Op.FREEZE -> freezeAppUseCase(pkg)
+                            // Unfreeze stays ungated on purpose: it is the way *out* of a bad
+                            // freeze, so a block that caught it would trap the app it protects.
                             Op.UNFREEZE -> manageAppUseCase.forceUnfreeze(pkg)
                             Op.TOGGLE -> Result.failure(IllegalStateException()) // resolved above
                         }.isSuccess

--- a/app/src/main/java/com/valhalla/thor/data/provider/ExtensionOpsProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/ExtensionOpsProvider.kt
@@ -113,7 +113,7 @@ class ExtensionOpsProvider : ContentProvider(), KoinComponent {
      * True if any of [pkgs] is currently frozen — disabled, uninstalled for this user, or suspended.
      *
      * MATCH_DISABLED_COMPONENTS alone only saw the disabled half of a freeze. A system app frozen
-     * by removal for the current user — what `FreezePolicy.destructiveFreezeFallbackAllowed` still
+     * by removal for the current user — what `FreezePolicy.uninstallFreezeFallbackAllowed` still
      * permits, and what every system app frozen before Thor preferred disabling is already in — is
      * not installed for this user, so the lookup threw NameNotFoundException: an all-system-app
      * target list read as *not* frozen, and `toggle` then re-froze apps that were already frozen

--- a/app/src/main/java/com/valhalla/thor/data/provider/ExtensionOpsProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/provider/ExtensionOpsProvider.kt
@@ -112,11 +112,13 @@ class ExtensionOpsProvider : ContentProvider(), KoinComponent {
     /**
      * True if any of [pkgs] is currently frozen — disabled, uninstalled for this user, or suspended.
      *
-     * MATCH_DISABLED_COMPONENTS alone only saw the `pm disable` half of a freeze. A system app is
-     * frozen with `pm uninstall --user N`, so it is not installed for this user and the lookup threw
-     * NameNotFoundException: an all-system-app target list read as *not* frozen, and `toggle` then
-     * re-froze apps that were already frozen instead of thawing them. A package still missing under
-     * [AppFreezeStateReader.MATCH_FLAGS] genuinely is not there, so it stays "not frozen".
+     * MATCH_DISABLED_COMPONENTS alone only saw the disabled half of a freeze. A system app frozen
+     * by removal for the current user — what `FreezePolicy.destructiveFreezeFallbackAllowed` still
+     * permits, and what every system app frozen before Thor preferred disabling is already in — is
+     * not installed for this user, so the lookup threw NameNotFoundException: an all-system-app
+     * target list read as *not* frozen, and `toggle` then re-froze apps that were already frozen
+     * instead of thawing them. A package still missing under [AppFreezeStateReader.MATCH_FLAGS]
+     * genuinely is not there, so it stays "not frozen".
      */
     private fun anyFrozen(pm: PackageManager, pkgs: List<String>): Boolean = pkgs.any { pkg ->
         runCatching {

--- a/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
@@ -85,7 +85,7 @@ class PermissionRepositoryImpl(
      * One pass over every installed package, bucketing them by runtime-permission group.
      *
      * The match flags mirror `AppRepositoryImpl`'s sweep, and that is not optional. A *system* app
-     * frozen by removal for the current user — what `FreezePolicy.destructiveFreezeFallbackAllowed`
+     * frozen by removal for the current user — what `FreezePolicy.uninstallFreezeFallbackAllowed`
      * still permits, and what every system app frozen before Thor preferred disabling is already
      * in — is not installed for this user, and a default `getInstalledPackages` drops it. The
      * disabled mechanic needs no flag of its own here, which is exactly why the pair must stay

--- a/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
@@ -84,9 +84,12 @@ class PermissionRepositoryImpl(
     /**
      * One pass over every installed package, bucketing them by runtime-permission group.
      *
-     * The match flags mirror `AppRepositoryImpl`'s sweep, and that is not optional. Thor freezes
-     * *system* apps with `pm uninstall --user N`, so a frozen system app is not installed for this
-     * user and a default `getInstalledPackages` drops it. The app list keeps those rows — showing
+     * The match flags mirror `AppRepositoryImpl`'s sweep, and that is not optional. A *system* app
+     * frozen by removal for the current user — what `FreezePolicy.destructiveFreezeFallbackAllowed`
+     * still permits, and what every system app frozen before Thor preferred disabling is already
+     * in — is not installed for this user, and a default `getInstalledPackages` drops it. The
+     * disabled mechanic needs no flag of its own here, which is exactly why the pair must stay
+     * whole: the half that is doing the work is the invisible one. The app list keeps those rows — showing
      * them is a headline Thor capability — and `filterApps` intersects the list with this index, so
      * two different package universes would make every frozen app silently fall out of every chip.
      *

--- a/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
@@ -115,8 +115,10 @@ class AutoFreezeManager(
                                     // every Exception and returns null (AppRepositoryImpl.kt:245),
                                     // so null means "could not classify" — a transient binder
                                     // failure looks identical to an absent package. Freezing on
-                                    // an unknown tier is how an Unsafe system app reaches
-                                    // `pm uninstall --user`. Skipping costs one cycle; the next
+                                    // an unknown tier is how an Unsafe system app gets frozen at
+                                    // all — disabled, or removed for this user where disabling is
+                                    // not available (FreezePolicy.kt) — and neither is something
+                                    // the next boot forgives. Skipping costs one cycle; the next
                                     // screen-off re-reads the whole Freezer list anyway.
                                     val detailedApp = appRepository.getAppDetails(pkg)
                                     if (detailedApp == null || detailedApp.freezeTier == FreezeTier.BLOCKED) {
@@ -126,6 +128,16 @@ class AutoFreezeManager(
                                         )
                                         return@launch
                                     }
+                                    // Flags `0` is deliberate, and both freeze mechanics land on
+                                    // "skip" through it. A system app removed for this user throws
+                                    // NameNotFoundException and is caught below; a package disabled
+                                    // in place resolves — getApplicationInfo does not filter on the
+                                    // enabled setting — and is skipped by the `appInfo.enabled`
+                                    // test. Do *not* widen this to AppFreezeStateReader.MATCH_FLAGS
+                                    // without folding FLAG_INSTALLED into `enabled` as that class
+                                    // does: under MATCH_UNINSTALLED_PACKAGES a package uninstalled
+                                    // for this user comes back `enabled == true`, and auto-freeze
+                                    // would start acting on apps it can already see are frozen.
                                     val appInfo = pm.getApplicationInfo(pkg, 0)
                                     val alreadySuspended = (appInfo.flags and ApplicationInfo.FLAG_SUSPENDED) != 0
                                     // Only act on ACTIVE apps (enabled & not suspended) so auto-freeze

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -18,6 +18,73 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 import com.valhalla.thor.util.Logger
 
+/**
+ * Which privileged rung `Shizuku.setAppDisabled` tries first. (Plain text, not a KDoc link: the
+ * explicit `rikka.shizuku.Shizuku` import at the top of this file outranks the same-named object
+ * declared below it, so `[Shizuku]` here would point at the wrong class.)
+ *
+ * [SHELL_FIRST] is the historical order and stays the default. For an ordinary user app
+ * `pm disable --user N` is the cheapest thing that works, and that is not the path that broke.
+ *
+ * [REFLECTION_FIRST] exists for *preinstalled* apps. Both rungs end up inside the same
+ * `PackageManagerService.setEnabledSetting`, but they do not arrive there identically: the shell
+ * rung pays for a `newProcess` + `pm` round trip and can only report `pm`'s exit code, and `pm` is
+ * ordinary userspace that an OEM is free to modify or lock down, whereas the reflection rung calls
+ * `IPackageManager` straight through the Shizuku binder and names its target state
+ * (`COMPONENT_ENABLED_STATE_DISABLED_USER`) and its caller ("com.android.shell") explicitly rather
+ * than inheriting whatever this device's `pm` chose. Flipping the order costs nothing when both
+ * work and gives the direct call the first attempt when one of them does not.
+ */
+enum class EnableRungOrder { SHELL_FIRST, REFLECTION_FIRST }
+
+/** One privileged attempt, plus the label that names it in the log line when it is the one that stuck. */
+internal class EnableRung(val label: String, val attempt: () -> Boolean)
+
+internal const val RUNG_REFLECTION = "IPackageManager reflection"
+internal const val RUNG_SHELL = "pm shell"
+internal const val RUNG_UNPRIVILEGED = "unprivileged PackageManager"
+
+/**
+ * Runs [rungs] in order and returns the label of the first one after which [verify] reports the
+ * state has actually changed — or null if none of them moved it.
+ *
+ * Each rung's own return value is deliberately ignored. `pm` exits 0 for a disable that
+ * `PackageManagerService` refused, and a `Bypass.invoke` that threw nothing has still proven
+ * nothing, so the post-read is the only evidence that counts. It is equally deliberate that a rung
+ * reporting *failure* is still verified before moving on: `Shizuku.execute` returns -1 whenever it
+ * cannot read an exit code at all (null binder, timeout), and that is not the same as "the state
+ * did not change".
+ *
+ * Pure on purpose — no Android types, no logging — so the ordering and the short-circuit rule are
+ * reachable from a plain JVM unit test. The caller does the logging.
+ */
+internal fun firstRungThatSticks(rungs: List<EnableRung>, verify: () -> Boolean): String? {
+    for (rung in rungs) {
+        rung.attempt()
+        if (verify()) return rung.label
+    }
+    return null
+}
+
+/**
+ * The rung order itself, as a pure function so the one decision this change is actually about is
+ * reachable from a test.
+ *
+ * [unprivileged] is always last and is never reordered: it is the only rung that cannot possibly
+ * outrank a privileged one (Thor holds no `CHANGE_COMPONENT_ENABLED_STATE`, so for any package but
+ * its own it can only throw), and putting it anywhere else would spend a `SecurityException` before
+ * trying something that works.
+ */
+internal fun orderRungs(
+    rungOrder: EnableRungOrder,
+    shell: EnableRung,
+    reflection: EnableRung,
+    unprivileged: EnableRung,
+): List<EnableRung> = when (rungOrder) {
+    EnableRungOrder.SHELL_FIRST -> listOf(shell, reflection, unprivileged)
+    EnableRungOrder.REFLECTION_FIRST -> listOf(reflection, shell, unprivileged)
+}
+
 object Shizuku {
 
     /**
@@ -88,69 +155,153 @@ object Shizuku {
         return pkgs.isAppStopped(packageName)
     }
 
-    fun setAppDisabled(context: Context, packageName: String, disabled: Boolean): Boolean {
+    /**
+     * Enable/disable a package for the current user, trying every mechanism Shizuku can reach.
+     *
+     * [rungOrder] chooses which privileged rung goes first; see [EnableRungOrder]. The default is
+     * the historical shell-first order, so existing callers are untouched — only the preinstalled-app
+     * freeze path in `ShizukuSystemGateway` asks for [EnableRungOrder.REFLECTION_FIRST].
+     *
+     * Every rung is verified by re-reading `ApplicationInfo`, never by its own exit code; see
+     * [firstRungThatSticks]. Returns true only when the package really is in the requested state.
+     */
+    fun setAppDisabled(
+        context: Context,
+        packageName: String,
+        disabled: Boolean,
+        rungOrder: EnableRungOrder = EnableRungOrder.SHELL_FIRST
+    ): Boolean {
         val pkgs = Packages(context)
         pkgs.getApplicationInfoOrNull(packageName) ?: return false
         val userId = pkgs.myUserId
+        // Escaped for the shell rung only; the reflection rung passes the raw name over binder.
+        val escapedPackage = packageName.escapeForShell()
 
-        // 1. Try shell first
-        val command = if (disabled) {
-            "pm disable-user --user $userId $packageName"
-        } else {
-            "pm enable --user $userId $packageName"
-        }
-        val result = execute(command)
-        if (result.first == 0 && pkgs.isAppDisabled(packageName) == disabled) {
-            return true
-        }
+        // The canonical freeze test, the same one AppFreezeStateReader.candidateOf uses: a package
+        // is "not disabled" only when it is BOTH enabled AND installed for this user. `enabled` on
+        // its own — which is all this function used to check, via Packages.isAppDisabled — is wrong
+        // in the direction that matters here. The gateway's last-resort `pm uninstall --user N`
+        // clears FLAG_INSTALLED and leaves `enabled` true, so an app frozen by an older build reads
+        // back as "not disabled" and an unfreeze could never be verified as complete.
+        //
+        // MATCH_UNINSTALLED_PACKAGES (the Packages default) is what makes such a package readable
+        // at all. MATCH_DISABLED_COMPONENTS is deliberately NOT added: getApplicationInfo does not
+        // filter on the enabled setting, which AppFreezeStateReader.MATCH_FLAGS documents for the
+        // same reason, so it would buy nothing here while changing a default other callers share.
+        fun isDisabledNow(): Boolean = pkgs.getApplicationInfoOrNull(packageName)?.let {
+            !(it.enabled && (it.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0)
+        } ?: true // stopped resolving entirely: gone is at least as disabled as disabled
 
-        // 2. Fallback to Bypass reflection
-        val reflectionResult = runCatching {
-            val pm = asInterface("android.content.pm.IPackageManager", "package")
-            val newState = when {
-                !disabled -> android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-                isRoot -> android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED
-                else -> android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER
+        val shellRung = EnableRung(RUNG_SHELL) {
+            val command = if (disabled) {
+                "pm disable-user --user $userId $escapedPackage"
+            } else {
+                "pm enable --user $userId $escapedPackage"
             }
-            val caller = if (isRoot) context.packageName else "com.android.shell"
-            Bypass.invoke<Any?>(
-                pm.javaClass,
-                pm,
-                "setApplicationEnabledSetting",
-                arrayOf(
-                    String::class.java,
-                    Int::class.javaPrimitiveType!!,
-                    Int::class.javaPrimitiveType!!,
-                    Int::class.javaPrimitiveType!!,
-                    String::class.java
-                ),
-                packageName,
-                newState,
-                0,
-                userId,
-                caller
+            execute(command).first == 0
+        }
+
+        val reflectionRung = EnableRung(RUNG_REFLECTION) {
+            runCatching {
+                setApplicationEnabledSettingViaBypass(context, packageName, disabled, userId)
+                true
+            }.getOrElse { e ->
+                // Logged rather than swallowed (it used to be a bare getOrDefault(false)): when
+                // this rung is the one that is supposed to work, its SecurityException/
+                // NoSuchMethodException is the single most useful line in a bug report.
+                Logger.e(
+                    "Shizuku",
+                    "setApplicationEnabledSetting reflection failed for $packageName (disabled=$disabled)",
+                    e
+                )
+                false
+            }
+        }
+
+        // Always last, and barely a rung: Thor holds no CHANGE_COMPONENT_ENABLED_STATE (see
+        // AndroidManifest.xml), so for any package but its own this throws SecurityException and is
+        // swallowed. It stays because it is free on the rare device that does grant it, and because
+        // reaching it at all still buys one more post-read before we give up.
+        val unprivilegedRung = EnableRung(RUNG_UNPRIVILEGED) {
+            val newState = if (disabled) {
+                android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+            } else {
+                android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            }
+            runCatching {
+                context.packageManager.setApplicationEnabledSetting(packageName, newState, 0)
+            }.isSuccess
+        }
+
+        val ordered = orderRungs(rungOrder, shellRung, reflectionRung, unprivilegedRung)
+
+        val winner = firstRungThatSticks(ordered) { isDisabledNow() == disabled }
+        return if (winner != null) {
+            Logger.d(
+                "Shizuku",
+                "setAppDisabled($packageName, disabled=$disabled): $winner changed the state"
             )
             true
-        }.getOrDefault(false)
-
-        if (reflectionResult && pkgs.isAppDisabled(packageName) == disabled) {
-            return true
-        }
-
-        // 3. Unprivileged fallback (re-query PM to observe post-mutation state)
-        if (pkgs.isAppDisabled(packageName) == disabled) {
-            return true
-        }
-        val newState = if (disabled) {
-            android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED
         } else {
-            android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            Logger.e(
+                "Shizuku",
+                "setAppDisabled($packageName, disabled=$disabled): all rungs ran " +
+                    "(${ordered.joinToString { it.label }}) and the state did not change"
+            )
+            false
         }
-        runCatching {
-            context.packageManager.setApplicationEnabledSetting(packageName, newState, 0)
-        }
+    }
 
-        return pkgs.isAppDisabled(packageName) == disabled
+    /**
+     * The one and only copy of the `IPackageManager.setApplicationEnabledSetting` reflection.
+     *
+     * Both conditionals are load-bearing and must not be "simplified":
+     *
+     * - **newState.** `COMPONENT_ENABLED_STATE_DISABLED` (2) is the framework's "an admin turned
+     *   this off" state; `COMPONENT_ENABLED_STATE_DISABLED_USER` (3) is "the user turned this off",
+     *   and it is the state a shell-uid caller is allowed to set on somebody else's package — it is
+     *   also exactly what `pm disable-user` sets. A root Shizuku runs as uid 0 and may use the
+     *   stronger one.
+     * - **caller.** `PackageManagerService` validates the callingPackage argument against the
+     *   calling uid and throws SecurityException when the name does not belong to it. The call
+     *   arrives with the *Shizuku process's* uid: 2000 under the ordinary shell-uid Shizuku, whose
+     *   package is "com.android.shell", and 0 under a root Shizuku, which owns no package at all —
+     *   hence Thor's own name there.
+     *
+     * Returns Unit and throws on failure rather than returning a boolean: "the reflection did not
+     * blow up" is not evidence that the state moved, and a boolean here would invite a caller to
+     * treat it as one instead of doing the post-read.
+     */
+    private fun setApplicationEnabledSettingViaBypass(
+        context: Context,
+        packageName: String,
+        disabled: Boolean,
+        userId: Int
+    ) {
+        val pm = asInterface("android.content.pm.IPackageManager", "package")
+        val newState = when {
+            !disabled -> android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            isRoot -> android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+            else -> android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER
+        }
+        val caller = if (isRoot) context.packageName else "com.android.shell"
+        Bypass.invoke<Any?>(
+            pm.javaClass,
+            pm,
+            "setApplicationEnabledSetting",
+            arrayOf(
+                String::class.java,
+                Int::class.javaPrimitiveType!!,
+                Int::class.javaPrimitiveType!!,
+                Int::class.javaPrimitiveType!!,
+                String::class.java
+            ),
+            packageName,
+            newState,
+            0,
+            userId,
+            caller
+        )
     }
 
     // Hidden-API reflection (SuspendDialogInfo) is intentional: it is the core privilege mechanism,

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -41,9 +41,9 @@ enum class EnableRungOrder { SHELL_FIRST, REFLECTION_FIRST }
  * The outcome of a privileged enable/disable attempt.
  *
  * [refusedByPolicy] is the field that exists for exactly one caller: the preinstalled-app freeze,
- * whose fallback is `pm uninstall --user N` and therefore costs the user their data. It separates
- * "this device refuses to disable system packages" — an OEM restriction there is no way around —
- * from "that did not work just now", which is a bug report, not a licence to delete anything.
+ * whose fallback removes the package for the current user. It separates "this device refuses to
+ * disable system packages" — an OEM restriction there is no way around — from "that did not work
+ * just now", which is a bug report, not a licence to change mechanic behind the user's back.
  *
  * It is only ever meaningful when [succeeded] is false.
  */
@@ -63,7 +63,7 @@ internal enum class RungResult {
     /**
      * `PackageManagerService` **refused**. This is the one outcome that means "this device will
      * not let us do this", as opposed to "that did not work just now", and it is what
-     * `destructiveFreezeFallbackAllowed` keys the destructive fallback on.
+     * `uninstallFreezeFallbackAllowed` keys the uninstall-for-user fallback on.
      */
     REFUSED_BY_POLICY,
 }
@@ -117,7 +117,7 @@ internal data class ChainOutcome(val winner: String?, val refusedByPolicy: Boole
  *
  * A rung's claim to have been *refused* is the one thing that is carried out, because it is the
  * only outcome that distinguishes "this device will not do this" from "that did not work just
- * now" — and the caller spends that distinction on whether it may destroy the user's data.
+ * now" — and the caller spends that distinction on whether it may switch freeze mechanic.
  * [refusedByPolicy][ChainOutcome.refusedByPolicy] is sticky across rungs: a refusal from the
  * reflection rung still counts when a later rung merely fails, since the refusal is a fact about
  * the device either way.
@@ -670,6 +670,37 @@ object Shizuku {
         } catch (_: Exception) {
             false
         }
+    }
+
+    /**
+     * Removes a **preinstalled** app for the current user *without* deleting its data — the last
+     * rung of the system-app freeze, and deliberately not the same function as [uninstallApp].
+     *
+     * `-k` sets `DELETE_KEEP_DATA`, which leaves `/data/user/N/<pkg>` and `/data/user_de/N/<pkg>`
+     * in place instead of having `installd` destroy them. Measured on the HyperOS device that
+     * refuses to disable system packages at all: `pm uninstall -k --user 0` then
+     * `pm install-existing --user 0` returned the app with **byte-identical `ceDataInode` and
+     * `deDataInode`**. For a system app the data survives indefinitely — the package record never
+     * goes away, because the APK is still on the read-only partition and `pm uninstall --user` only
+     * clears `PackageUserState.installed` for one user.
+     *
+     * Known caveat, not yet measured: runtime permission grants and app-ops are per-user package
+     * state and are likely reset by the removal and *not* restored by `pm install-existing`, so the
+     * app may come back having to ask for its permissions again. That is a prompt, not data loss.
+     *
+     * The adb client's scary "there is no way to remove the remaining data" warning about `-k` is
+     * about orphaned data left behind by a *full* uninstall of a user app. It does not apply here,
+     * and it did not appear on the device.
+     *
+     * Kept separate from [uninstallApp] on purpose: adding `-k` there would silently make the
+     * user-facing "uninstall this app" feature leave data behind on every app it removes.
+     */
+    fun freezeSystemAppForUser(packageName: String): Boolean = try {
+        val currentUser = getCurrentUserId()
+        execute("pm uninstall -k --user $currentUser ${packageName.escapeForShell()}").first == 0
+    } catch (e: Exception) {
+        Logger.e("Shizuku", "freezeSystemAppForUser($packageName) failed", e)
+        false
     }
 
     fun reinstallApp(packageName: String): Boolean {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -37,33 +37,101 @@ import com.valhalla.thor.util.Logger
  */
 enum class EnableRungOrder { SHELL_FIRST, REFLECTION_FIRST }
 
+/**
+ * The outcome of a privileged enable/disable attempt.
+ *
+ * [refusedByPolicy] is the field that exists for exactly one caller: the preinstalled-app freeze,
+ * whose fallback is `pm uninstall --user N` and therefore costs the user their data. It separates
+ * "this device refuses to disable system packages" — an OEM restriction there is no way around —
+ * from "that did not work just now", which is a bug report, not a licence to delete anything.
+ *
+ * It is only ever meaningful when [succeeded] is false.
+ */
+data class DisableOutcome(val succeeded: Boolean, val refusedByPolicy: Boolean)
+
+/**
+ * What a rung reported about *itself*. Only [REFUSED_BY_POLICY] ever changes a decision; whether a
+ * rung believes it succeeded is not evidence of anything (see [firstRungThatSticks]).
+ */
+internal enum class RungResult {
+    /** The rung ran without complaint. Proves nothing on its own — the post-read decides. */
+    RAN,
+
+    /** The rung failed in a way that carries no information: non-zero exit, timeout, null binder. */
+    FAILED,
+
+    /**
+     * `PackageManagerService` **refused**. This is the one outcome that means "this device will
+     * not let us do this", as opposed to "that did not work just now", and it is what
+     * `destructiveFreezeFallbackAllowed` keys the destructive fallback on.
+     */
+    REFUSED_BY_POLICY,
+}
+
+/**
+ * Did this failure come from the platform refusing, rather than from anything transient?
+ *
+ * Matches both refusals Thor can actually meet: AOSP's own
+ * `SecurityException("Shell cannot change component state for <pkg> to 2")` and Xiaomi's vendor
+ * `SecurityException("Cannot disable system packages.")` out of `PackageManagerServiceImpl`. The
+ * shell rung only ever sees these as text on stderr, so text is what this reads.
+ */
+internal fun isPolicyRefusal(text: String?): Boolean =
+    text != null && text.contains("SecurityException", ignoreCase = true)
+
+/** As [isPolicyRefusal], for a rung that threw instead of printing. Walks the whole cause chain. */
+internal fun isPolicyRefusal(error: Throwable?): Boolean {
+    var e = error
+    var hops = 0
+    while (e != null && hops++ < 10) {
+        if (e is SecurityException) return true
+        if (e.javaClass.name.endsWith("SecurityException")) return true
+        e = e.cause
+    }
+    return false
+}
+
 /** One privileged attempt, plus the label that names it in the log line when it is the one that stuck. */
-internal class EnableRung(val label: String, val attempt: () -> Boolean)
+internal class EnableRung(val label: String, val attempt: () -> RungResult)
 
 internal const val RUNG_REFLECTION = "IPackageManager reflection"
 internal const val RUNG_SHELL = "pm shell"
 internal const val RUNG_UNPRIVILEGED = "unprivileged PackageManager"
 
 /**
- * Runs [rungs] in order and returns the label of the first one after which [verify] reports the
- * state has actually changed — or null if none of them moved it.
+ * The result of running the whole chain: which rung (if any) actually moved the state, and whether
+ * anything along the way was refused by the platform rather than merely failing.
+ */
+internal data class ChainOutcome(val winner: String?, val refusedByPolicy: Boolean)
+
+/**
+ * Runs [rungs] in order and reports the first one after which [verify] says the state has actually
+ * changed — or a null winner if none of them moved it.
  *
- * Each rung's own return value is deliberately ignored. `pm` exits 0 for a disable that
+ * A rung's claim to have *succeeded* is deliberately ignored. `pm` exits 0 for a disable that
  * `PackageManagerService` refused, and a `Bypass.invoke` that threw nothing has still proven
  * nothing, so the post-read is the only evidence that counts. It is equally deliberate that a rung
- * reporting *failure* is still verified before moving on: `Shizuku.execute` returns -1 whenever it
+ * reporting failure is still verified before moving on: `Shizuku.execute` returns -1 whenever it
  * cannot read an exit code at all (null binder, timeout), and that is not the same as "the state
  * did not change".
  *
- * Pure on purpose — no Android types, no logging — so the ordering and the short-circuit rule are
- * reachable from a plain JVM unit test. The caller does the logging.
+ * A rung's claim to have been *refused* is the one thing that is carried out, because it is the
+ * only outcome that distinguishes "this device will not do this" from "that did not work just
+ * now" — and the caller spends that distinction on whether it may destroy the user's data.
+ * [refusedByPolicy][ChainOutcome.refusedByPolicy] is sticky across rungs: a refusal from the
+ * reflection rung still counts when a later rung merely fails, since the refusal is a fact about
+ * the device either way.
+ *
+ * Pure on purpose — no Android types, no logging — so the ordering, the short-circuit and the
+ * refusal bookkeeping are all reachable from a plain JVM unit test. The caller does the logging.
  */
-internal fun firstRungThatSticks(rungs: List<EnableRung>, verify: () -> Boolean): String? {
+internal fun firstRungThatSticks(rungs: List<EnableRung>, verify: () -> Boolean): ChainOutcome {
+    var refused = false
     for (rung in rungs) {
-        rung.attempt()
-        if (verify()) return rung.label
+        if (rung.attempt() == RungResult.REFUSED_BY_POLICY) refused = true
+        if (verify()) return ChainOutcome(rung.label, refused)
     }
-    return null
+    return ChainOutcome(null, refused)
 }
 
 /**
@@ -170,9 +238,24 @@ object Shizuku {
         packageName: String,
         disabled: Boolean,
         rungOrder: EnableRungOrder = EnableRungOrder.SHELL_FIRST
-    ): Boolean {
+    ): Boolean = setAppDisabledDetailed(context, packageName, disabled, rungOrder).succeeded
+
+    /**
+     * [setAppDisabled], plus *why* it failed when it did.
+     *
+     * Only the preinstalled-app freeze needs this. It is the one caller whose next move depends on
+     * the difference between "the platform refused" and "that did not work", because its next move
+     * is `pm uninstall --user N` and that deletes the user's data.
+     */
+    fun setAppDisabledDetailed(
+        context: Context,
+        packageName: String,
+        disabled: Boolean,
+        rungOrder: EnableRungOrder = EnableRungOrder.SHELL_FIRST
+    ): DisableOutcome {
         val pkgs = Packages(context)
-        pkgs.getApplicationInfoOrNull(packageName) ?: return false
+        pkgs.getApplicationInfoOrNull(packageName)
+            ?: return DisableOutcome(succeeded = false, refusedByPolicy = false)
         val userId = pkgs.myUserId
         // Escaped for the shell rung only; the reflection rung passes the raw name over binder.
         val escapedPackage = packageName.escapeForShell()
@@ -192,19 +275,31 @@ object Shizuku {
             !(it.enabled && (it.flags and android.content.pm.ApplicationInfo.FLAG_INSTALLED) != 0)
         } ?: true // stopped resolving entirely: gone is at least as disabled as disabled
 
+        // `pm disable-user` (COMPONENT_ENABLED_STATE_DISABLED_USER) and not `pm disable`: since
+        // API 25 and still on 37, a shell-uid caller may only move a whole package between DEFAULT,
+        // ENABLED and DISABLED_USER, so `pm disable` throws SecurityException on every release.
+        // Verified on an AOSP API 36 emulator: `pm disable` → "Shell cannot change component state
+        // for null to 2"; `pm disable-user` → exit 0, enabled=3, installed=true.
         val shellRung = EnableRung(RUNG_SHELL) {
             val command = if (disabled) {
                 "pm disable-user --user $userId $escapedPackage"
             } else {
                 "pm enable --user $userId $escapedPackage"
             }
-            execute(command).first == 0
+            val (code, output) = execute(command)
+            when {
+                code == 0 -> RungResult.RAN
+                // `pm` reports a refusal by printing the SecurityException and exiting non-zero,
+                // so the exit code alone cannot tell a refusal from a timeout.
+                isPolicyRefusal(output) -> RungResult.REFUSED_BY_POLICY
+                else -> RungResult.FAILED
+            }
         }
 
         val reflectionRung = EnableRung(RUNG_REFLECTION) {
             runCatching {
                 setApplicationEnabledSettingViaBypass(context, packageName, disabled, userId)
-                true
+                RungResult.RAN
             }.getOrElse { e ->
                 // Logged rather than swallowed (it used to be a bare getOrDefault(false)): when
                 // this rung is the one that is supposed to work, its SecurityException/
@@ -214,7 +309,9 @@ object Shizuku {
                     "setApplicationEnabledSetting reflection failed for $packageName (disabled=$disabled)",
                     e
                 )
-                false
+                // Bypass.invoke reflects, so the platform's SecurityException arrives wrapped in an
+                // InvocationTargetException — hence the cause walk rather than an `is` check.
+                if (isPolicyRefusal(e)) RungResult.REFUSED_BY_POLICY else RungResult.FAILED
             }
         }
 
@@ -230,25 +327,31 @@ object Shizuku {
             }
             runCatching {
                 context.packageManager.setApplicationEnabledSetting(packageName, newState, 0)
-            }.isSuccess
+                RungResult.RAN
+            // FAILED and never REFUSED_BY_POLICY, however loudly this throws. Thor holds no
+            // CHANGE_COMPONENT_ENABLED_STATE, so for any package but its own this rung throws
+            // SecurityException on *every* device — reporting that as a policy refusal would hand
+            // the destructive fallback a permanent green light and undo the whole gate.
+            }.getOrElse { RungResult.FAILED }
         }
 
         val ordered = orderRungs(rungOrder, shellRung, reflectionRung, unprivilegedRung)
 
-        val winner = firstRungThatSticks(ordered) { isDisabledNow() == disabled }
-        return if (winner != null) {
+        val outcome = firstRungThatSticks(ordered) { isDisabledNow() == disabled }
+        return if (outcome.winner != null) {
             Logger.d(
                 "Shizuku",
-                "setAppDisabled($packageName, disabled=$disabled): $winner changed the state"
+                "setAppDisabled($packageName, disabled=$disabled): ${outcome.winner} changed the state"
             )
-            true
+            DisableOutcome(succeeded = true, refusedByPolicy = false)
         } else {
             Logger.e(
                 "Shizuku",
                 "setAppDisabled($packageName, disabled=$disabled): all rungs ran " +
-                    "(${ordered.joinToString { it.label }}) and the state did not change"
+                    "(${ordered.joinToString { it.label }}) and the state did not change" +
+                    if (outcome.refusedByPolicy) " — the platform REFUSED (SecurityException)" else ""
             )
-            false
+            DisableOutcome(succeeded = false, refusedByPolicy = outcome.refusedByPolicy)
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -684,9 +684,24 @@ object Shizuku {
      * goes away, because the APK is still on the read-only partition and `pm uninstall --user` only
      * clears `PackageUserState.installed` for one user.
      *
-     * Known caveat, not yet measured: runtime permission grants and app-ops are per-user package
-     * state and are likely reset by the removal and *not* restored by `pm install-existing`, so the
-     * app may come back having to ask for its permissions again. That is a prompt, not data loss.
+     * **Runtime permission grants survive too.** This was previously documented here as a likely
+     * cost — "the app may come back having to ask for its permissions again" — and that guess was
+     * wrong. Measured on a stock AOSP API 36 emulator at uid 2000: `pm grant` a revocable runtime
+     * permission, round-trip through `pm uninstall -k` / `pm install-existing`, and the permission
+     * returns `granted=true` with its flags unchanged. `-k` retains the whole `PackageUserState`,
+     * not just the data directories.
+     *
+     * **This rung does not exist at shell uid on API 37.** Measured on an Android 17 emulator
+     * (`CP31.260623.005`), the identical command that succeeds on API 36 fails:
+     * ```
+     * pm uninstall -k --user 0 com.android.egg
+     *   API 36 -> Success, exit 0
+     *   API 37 -> Failure [only root can delete system app for a particular user], exit 1
+     * ```
+     * The package is left untouched, so the caller sees an honest failure rather than a wrong
+     * state. On Android 17 a Shizuku running at uid 2000 therefore ends the chain at "could not
+     * disable" instead of escalating; a Shizuku started as root (uid 0) is unaffected. This is a
+     * platform restriction, not something to work around — do not add a rung below it.
      *
      * The adb client's scary "there is no way to remove the remaining data" warning about `-k` is
      * about orphaned data left behind by a *full* uninstall of a user app. It does not apply here,

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
@@ -140,6 +140,17 @@ class ShizukuReflector(
     fun setAppSuspended(packageName: String, suspended: Boolean): Boolean =
         Shizuku.setAppSuspended(context, packageName, suspended)
 
+    /**
+     * The last rung of the system-app freeze: remove for this user, **keep the data**.
+     *
+     * Shell-only, with no reflection fallback, and that is the point. The `PackageInstaller`
+     * fallback in [uninstallApp] cannot express `DELETE_KEEP_DATA` from here, so falling back to it
+     * would silently turn a data-preserving freeze into a data-destroying one — precisely the bug
+     * this whole change exists to remove. If the shell rung cannot do it, the freeze fails.
+     */
+    fun freezeSystemAppForUser(packageName: String): Boolean =
+        Shizuku.freezeSystemAppForUser(packageName)
+
     suspend fun uninstallApp(packageName: String, resetToFactory: Boolean = false): Boolean {
         // 1. Try shell first
         val shellResult = runCatching {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
@@ -63,9 +63,18 @@ class ShizukuReflector(
         }
     }
 
-    fun setAppEnabled(packageName: String, enabled: Boolean): Boolean {
+    /**
+     * [rungOrder] is passed straight through to [Shizuku.setAppDisabled] and defaults to the
+     * historical shell-first order, so every existing call site keeps its behaviour. Only the
+     * preinstalled-app freeze in `ShizukuSystemGateway` asks for [EnableRungOrder.REFLECTION_FIRST].
+     */
+    fun setAppEnabled(
+        packageName: String,
+        enabled: Boolean,
+        rungOrder: EnableRungOrder = EnableRungOrder.SHELL_FIRST
+    ): Boolean {
         return try {
-            Shizuku.setAppDisabled(context, packageName, !enabled)
+            Shizuku.setAppDisabled(context, packageName, !enabled, rungOrder)
         } catch (e: Exception) {
             if (BuildConfig.DEBUG)
                 Logger.e("ShizukuReflector", "setAppEnabled failed", e)

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
@@ -72,13 +72,27 @@ class ShizukuReflector(
         packageName: String,
         enabled: Boolean,
         rungOrder: EnableRungOrder = EnableRungOrder.SHELL_FIRST
-    ): Boolean {
+    ): Boolean = setAppEnabledDetailed(packageName, enabled, rungOrder).succeeded
+
+    /**
+     * [setAppEnabled], plus whether the platform *refused* rather than merely failed.
+     *
+     * A thrown exception is reported as `refusedByPolicy = false`: everything that reaches this
+     * catch got past the per-rung handling inside [Shizuku.setAppDisabledDetailed], so it is a
+     * Shizuku-binder or reflection-plumbing problem rather than `PackageManagerService` saying no.
+     * Guessing "refused" here would let a dead binder authorise deleting an app's data.
+     */
+    fun setAppEnabledDetailed(
+        packageName: String,
+        enabled: Boolean,
+        rungOrder: EnableRungOrder = EnableRungOrder.SHELL_FIRST
+    ): DisableOutcome {
         return try {
-            Shizuku.setAppDisabled(context, packageName, !enabled, rungOrder)
+            Shizuku.setAppDisabledDetailed(context, packageName, !enabled, rungOrder)
         } catch (e: Exception) {
             if (BuildConfig.DEBUG)
                 Logger.e("ShizukuReflector", "setAppEnabled failed", e)
-            false
+            DisableOutcome(succeeded = false, refusedByPolicy = false)
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezeImport.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezeImport.kt
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+/**
+ * The apps the Freezer's "you have disabled apps that aren't in the Freezer — import them?" prompt
+ * should offer, in scan order.
+ *
+ * Pure list logic, extracted out of `FreezerScreen` for one reason: the rule was wrong for a month
+ * and nothing noticed, because a filter written inline inside a Composable has nowhere to be tested
+ * from. `freezableCandidates` is the same shape and the same lesson.
+ *
+ * Four conditions, none of them redundant:
+ *
+ * **`!enabled`** — the app is frozen. Note that [AppInfo.enabled] is not the platform's
+ * `ApplicationInfo.enabled`: `AppInfoMapper` and `AppRepositoryImpl` both fold `FLAG_INSTALLED`
+ * into it, so this is true for a `pm disable`d package *and* for one removed with
+ * `pm uninstall --user N`. That is why the next condition exists.
+ *
+ * **`isInstalled`** — narrows the offer to [FreezeMechanic.DISABLE], the mechanic Thor now prefers
+ * everywhere the platform allows it. A package in the [FreezeMechanic.UNINSTALL] state is not
+ * offered, and deliberately so: nothing in a `PackageManager` read distinguishes "Thor removed this
+ * for the user" from "the vendor shipped it removed" or "another debloater removed it", and
+ * importing it means the next `Unfreeze all` runs `pm install-existing` on a package Thor never
+ * touched. The same reasoning covers a *user* app uninstalled with its data retained: Thor cannot
+ * bring it back at all, so tracking it in the watchlist only produces a row that fails every
+ * unfreeze. Apps frozen at freeze time are offered the "Add to Freezer" snackbar
+ * (`FreezerEvent.ShowFreezerPrompt`, `AppListEvent.ShowFreezerPrompt`) regardless of mechanic —
+ * this list is the recovery path for freezes that happened elsewhere, not the primary one.
+ *
+ * **not already tracked** — the prompt is about apps the watchlist does not know.
+ *
+ * **[isBlockedFromFreeze]** — this replaces a blanket `!isSystem` clause. That clause was added
+ * before Thor had a risk model at all (2026-06-21, five weeks before [freezeTierOf] existed) as a
+ * coarse "system apps are dangerous, skip them all" proxy, and it has always excluded real,
+ * Thor-frozen system apps rather than being the no-op it looked like. It is also the only place in
+ * the Freezer that refuses system apps outright — the watchlist sheet, the freezer list and the
+ * profile editor all have a SYSTEM tab. Expressing the proxy as the tier check is what it was
+ * reaching for, and the check is load-bearing in its own right: [freezableCandidates] drops a
+ * BLOCKED app from FREEZE runs but never from UNFREEZE ones, so importing one would be a one-way
+ * door — `Unfreeze all` enables it and every later freeze refuses to put it back.
+ *
+ * The tier check also keeps the old behaviour as its failure mode. [freezeTierOf] answers BLOCKED
+ * for *every* system app when the UAD list could not be read, so a device with no usable list
+ * degrades this to "user apps only" — exactly what the blanket clause did — instead of offering a
+ * set of system apps it could not classify.
+ */
+fun importableDisabledApps(
+    allInstalledApps: List<AppInfo>,
+    freezerPackageNames: Set<String>,
+): List<AppInfo> = allInstalledApps.filter { app ->
+    !app.enabled &&
+            app.isInstalled &&
+            app.packageName !in freezerPackageNames &&
+            !isBlockedFromFreeze(app)
+}

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
@@ -8,9 +8,10 @@ package com.valhalla.thor.domain.model
  * recommendation.
  *
  * Only system apps have a tier. Freezing a user app is always reversible with `pm enable`, so
- * there is nothing to warn about; system apps are frozen with `pm uninstall --user`, and the
- * ones the UAD list marks unsafe can leave the device unable to boot, place calls, or reach the
- * network.
+ * there is nothing to warn about; a system app is frozen by disabling it where the platform
+ * allows that and by removing it for the current user where it does not (see [FreezeMechanic]),
+ * and the ones the UAD list marks unsafe can leave the device unable to boot, place calls, or
+ * reach the network.
  */
 enum class FreezeTier {
     /** No warning: a user app, or a system app UAD considers safe to remove. */
@@ -67,3 +68,88 @@ val AppInfo.freezeTier: FreezeTier
  */
 fun isBlockedFromFreeze(app: AppInfo?): Boolean =
     app == null || app.freezeTier == FreezeTier.BLOCKED
+
+/**
+ * How a freeze was actually carried out. The two are not interchangeable, and what separates them
+ * is the user's data.
+ *
+ * [DISABLE] is reversible in the sense users expect: the package stays installed, keeps its data,
+ * and `pm enable` returns it exactly as it was. [UNINSTALL] is `pm uninstall --user N` *without*
+ * `-k`, which removes the package for the current user and takes its data with it —
+ * `pm install-existing` brings the app back factory-fresh, with its logins, settings and local
+ * content gone.
+ *
+ * Thor prefers [DISABLE] everywhere it works. [UNINSTALL] exists because on some platform and
+ * privilege combinations disabling a system app is not permitted at all, and a freeze that cannot
+ * happen is worse than one that costs data the user was warned about — but *only* on those
+ * combinations, which is what [destructiveFreezeFallbackAllowed] decides.
+ */
+enum class FreezeMechanic {
+    /** `pm disable`, or the equivalent `setApplicationEnabledSetting` reflection. Keeps data. */
+    DISABLE,
+
+    /** `pm uninstall --user N`, no `-k`. Destroys the app's data for the current user. */
+    UNINSTALL,
+}
+
+/**
+ * Android 16 (Baklava). Named rather than inlined because this one number is the entire reason
+ * [destructiveFreezeFallbackAllowed] exists, and a bare `36` at a call site reads like a typo.
+ *
+ * `data/source/local/shizuku/Targets.B` is the data-layer mirror of this check. The duplication is
+ * deliberate: `domain` must not import from `data`, and the alternative — passing `Targets.B` down
+ * as a boolean — would hide *which* version boundary a caller meant.
+ */
+const val ANDROID_16_BAKLAVA = 36
+
+/**
+ * May a failed [FreezeMechanic.DISABLE] escalate to [FreezeMechanic.UNINSTALL] for this package?
+ *
+ * This gate is the difference between a fallback chain and a data-loss bug. Without it, *any*
+ * transient failure to disable — a busy PackageManager, a binder timeout, an OEM refusing one
+ * specific package — silently escalates to destroying that app's data, and the user is told the
+ * freeze succeeded. With it, escalation is confined to the one combination where disabling a
+ * system app is genuinely not available, and everywhere else a failure to disable stays a
+ * *failure*, visible and reportable.
+ *
+ * Failing loudly is the deliberate choice here. A freeze that reports an error costs the user an
+ * annoyance and Thor a bug report; a freeze that quietly wipes an app's data costs the user
+ * something they cannot get back and produces no report at all, because from the outside it looked
+ * like it worked.
+ *
+ * @param sdkInt injected rather than read from `Build.VERSION.SDK_INT` so this stays a pure
+ *   function that unit tests can drive across the version boundary — the boundary being the whole
+ *   point, it is the one thing that must be testable.
+ */
+fun destructiveFreezeFallbackAllowed(
+    isSystem: Boolean,
+    privilegeMode: PrivilegeMode,
+    sdkInt: Int,
+): Boolean = when {
+    // A user app disables with `pm enable`/`pm disable` on every supported release, so there is
+    // no platform gap to work around and no reason to ever reach for the destructive mechanic.
+    !isSystem -> false
+
+    else -> when (privilegeMode) {
+        // The reported gap. Under the shell uid, disabling a *system* app stopped being available
+        // on Android 16, so uninstall-for-user is the only remaining way to freeze one and
+        // refusing to escalate would mean Shizuku users on 16+ simply cannot freeze system apps.
+        PrivilegeMode.SHIZUKU -> sdkInt >= ANDROID_16_BAKLAVA
+
+        // Root can disable any package on any release, so a failure here is a real failure worth
+        // surfacing rather than a platform restriction worth working around. This is a behaviour
+        // change: root used to freeze system apps by uninstalling them unconditionally, so a
+        // package that root cannot disable now reports an error where it previously "worked" by
+        // destroying data.
+        PrivilegeMode.ROOT -> false
+
+        // Dhizuku does not consult this policy yet — DhizukuSystemGateway still uninstalls system
+        // apps unconditionally. This branch is what it *should* get, but flipping it on without a
+        // device check would risk removing Dhizuku's only working system-app freeze, so the
+        // gateway is deliberately left unconverted rather than half-converted here.
+        PrivilegeMode.DHIZUKU -> false
+
+        // No privilege means no freeze at all; nothing can reach the destructive rung from here.
+        PrivilegeMode.NONE -> false
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
@@ -79,10 +79,11 @@ fun isBlockedFromFreeze(app: AppInfo?): Boolean =
  * `pm install-existing` brings the app back factory-fresh, with its logins, settings and local
  * content gone.
  *
- * Thor prefers [DISABLE] everywhere it works. [UNINSTALL] exists because on some platform and
- * privilege combinations disabling a system app is not permitted at all, and a freeze that cannot
- * happen is worse than one that costs data the user was warned about — but *only* on those
- * combinations, which is what [destructiveFreezeFallbackAllowed] decides.
+ * Thor prefers [DISABLE] everywhere it works, which — measurably — is everywhere stock Android
+ * runs. [UNINSTALL] exists because some OEM builds refuse to let the shell uid disable their own
+ * system packages at all, and on those devices a freeze that cannot happen is worse than one that
+ * costs data the user was warned about. It is reached *only* where the platform actually refused,
+ * which is what [destructiveFreezeFallbackAllowed] decides.
  */
 enum class FreezeMechanic {
     /** `pm disable`, or the equivalent `setApplicationEnabledSetting` reflection. Keeps data. */
@@ -93,54 +94,79 @@ enum class FreezeMechanic {
 }
 
 /**
- * Android 16 (Baklava). Named rather than inlined because this one number is the entire reason
- * [destructiveFreezeFallbackAllowed] exists, and a bare `36` at a call site reads like a typo.
- *
- * `data/source/local/shizuku/Targets.B` is the data-layer mirror of this check. The duplication is
- * deliberate: `domain` must not import from `data`, and the alternative — passing `Targets.B` down
- * as a boolean — would hide *which* version boundary a caller meant.
- */
-const val ANDROID_16_BAKLAVA = 36
-
-/**
  * May a failed [FreezeMechanic.DISABLE] escalate to [FreezeMechanic.UNINSTALL] for this package?
  *
  * This gate is the difference between a fallback chain and a data-loss bug. Without it, *any*
- * transient failure to disable — a busy PackageManager, a binder timeout, an OEM refusing one
- * specific package — silently escalates to destroying that app's data, and the user is told the
- * freeze succeeded. With it, escalation is confined to the one combination where disabling a
- * system app is genuinely not available, and everywhere else a failure to disable stays a
- * *failure*, visible and reportable.
+ * failure to disable — a busy PackageManager, a binder timeout, a package that happened to be
+ * mid-update — silently escalates to destroying that app's data, and the user is told the freeze
+ * succeeded. With it, escalation is confined to the case where the platform has *refused* to
+ * disable the package, and everywhere else a failure to disable stays a *failure*, visible and
+ * reportable.
  *
- * Failing loudly is the deliberate choice here. A freeze that reports an error costs the user an
+ * Failing loudly is the deliberate choice. A freeze that reports an error costs the user an
  * annoyance and Thor a bug report; a freeze that quietly wipes an app's data costs the user
  * something they cannot get back and produces no report at all, because from the outside it looked
  * like it worked.
  *
- * @param sdkInt injected rather than read from `Build.VERSION.SDK_INT` so this stays a pure
- *   function that unit tests can drive across the version boundary — the boundary being the whole
- *   point, it is the one thing that must be testable.
+ * ### Why this is not a version check
+ *
+ * It was, briefly: `sdkInt >= 36`, on the report that shell-uid disabling of system apps "stopped
+ * working on Android 16". That boundary does not exist, and the measurement is not close:
+ *
+ *  - On a **stock AOSP Android 16 (API 36) emulator**, as uid 2000, `pm disable-user --user 0`
+ *    succeeds on system apps — verified on `com.android.egg`, `com.android.printspooler`,
+ *    `com.android.wallpaper.livepicker` and `com.android.traceur`, each landing on `enabled=3`
+ *    with `installed=true`, and each reversed by `pm enable`.
+ *  - AOSP's shell guard in `PackageManagerService.setEnabledSettings` is **byte-identical** across
+ *    android14-, android15-, android16-, android16-qpr1- and android16-qpr2-release. The 15→16
+ *    diff of that method contains tracing and metrics changes and no security logic at all.
+ *  - The restriction users actually hit is **Xiaomi's**, not Android's: a vendor
+ *    `PackageManagerServiceImpl.canBeDisabled` — a class that does not exist in AOSP — throws
+ *    `SecurityException("Cannot disable system packages.")` for `callingUid == 2000` on a system
+ *    package. It was first reported on HyperOS running **Android 14**, roughly a year before
+ *    Android 16 shipped, and is not tied to an API level in either direction.
+ *
+ * So a version test is wrong in *both* directions at once: it would destroy data on a Pixel that
+ * could have disabled the app, and it would refuse to freeze at all on the Xiaomi devices that are
+ * the entire reason the fallback exists. What actually distinguishes the two cases is not which
+ * release the device runs but whether the platform refused — so that is what this asks.
+ *
+ * One thing the shell uid genuinely cannot do, on every release since API 25 and still true on 17:
+ * set `COMPONENT_ENABLED_STATE_DISABLED` (state 2, what `pm disable` sends). It may only set
+ * `DEFAULT`, `ENABLED` or `DISABLED_USER`. That is a *command* constraint, not a version one, and
+ * Thor already satisfies it by sending `pm disable-user` from the Shizuku path.
+ *
+ * @param disableRefusedByPolicy true only when a privileged rung was refused by the platform —
+ *   a `SecurityException` from `PackageManagerService`, not merely a non-zero exit or a read that
+ *   came back unreadable. Passed in rather than inferred so this stays a pure function, and so the
+ *   one decision that can cost a user their data is reachable from a plain JVM test.
  */
 fun destructiveFreezeFallbackAllowed(
     isSystem: Boolean,
     privilegeMode: PrivilegeMode,
-    sdkInt: Int,
+    disableRefusedByPolicy: Boolean,
 ): Boolean = when {
-    // A user app disables with `pm enable`/`pm disable` on every supported release, so there is
-    // no platform gap to work around and no reason to ever reach for the destructive mechanic.
+    // A user app disables under every privilege mode on every supported release, so there is no
+    // platform gap to work around and no reason to ever reach for the destructive mechanic.
     !isSystem -> false
 
-    else -> when (privilegeMode) {
-        // The reported gap. Under the shell uid, disabling a *system* app stopped being available
-        // on Android 16, so uninstall-for-user is the only remaining way to freeze one and
-        // refusing to escalate would mean Shizuku users on 16+ simply cannot freeze system apps.
-        PrivilegeMode.SHIZUKU -> sdkInt >= ANDROID_16_BAKLAVA
+    // Nothing refused us, so nothing is unavailable. Whatever went wrong is a failure to report,
+    // not a restriction to work around — and this is the branch that stops a binder timeout from
+    // costing someone their app data.
+    !disableRefusedByPolicy -> false
 
-        // Root can disable any package on any release, so a failure here is a real failure worth
-        // surfacing rather than a platform restriction worth working around. This is a behaviour
-        // change: root used to freeze system apps by uninstalling them unconditionally, so a
-        // package that root cannot disable now reports an error where it previously "worked" by
-        // destroying data.
+    else -> when (privilegeMode) {
+        // The real gap, and the only one measured: an OEM that refuses to let the shell uid
+        // disable its system packages. Uninstall-for-user is then the only remaining way to
+        // freeze one, and refusing to escalate would mean those users cannot freeze system apps
+        // at all — which is the state this whole change is trying to get *out* of.
+        PrivilegeMode.SHIZUKU -> true
+
+        // Root is uid 0, and every refusal found in the wild — AOSP's own and Xiaomi's alike —
+        // keys on the *shell* uid (2000). Root has no observed platform restriction to work
+        // around, so a refusal here is a genuine anomaly worth surfacing rather than an
+        // invitation to delete the user's data. This is a behaviour change: root used to freeze
+        // system apps by uninstalling them unconditionally.
         PrivilegeMode.ROOT -> false
 
         // Dhizuku does not consult this policy yet — DhizukuSystemGateway still uninstalls system

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
@@ -70,43 +70,49 @@ fun isBlockedFromFreeze(app: AppInfo?): Boolean =
     app == null || app.freezeTier == FreezeTier.BLOCKED
 
 /**
- * How a freeze was actually carried out. The two are not interchangeable, and what separates them
- * is the user's data.
+ * How a freeze was actually carried out. The two are not interchangeable.
  *
  * [DISABLE] is reversible in the sense users expect: the package stays installed, keeps its data,
- * and `pm enable` returns it exactly as it was. [UNINSTALL] is `pm uninstall --user N` *without*
- * `-k`, which removes the package for the current user and takes its data with it —
- * `pm install-existing` brings the app back factory-fresh, with its logins, settings and local
- * content gone.
+ * and `pm enable` returns it exactly as it was.
  *
- * Thor prefers [DISABLE] everywhere it works, which — measurably — is everywhere stock Android
- * runs. [UNINSTALL] exists because some OEM builds refuse to let the shell uid disable their own
- * system packages at all, and on those devices a freeze that cannot happen is worse than one that
- * costs data the user was warned about. It is reached *only* where the platform actually refused,
- * which is what [destructiveFreezeFallbackAllowed] decides.
+ * [UNINSTALL] is `pm uninstall -k --user N` — it clears `FLAG_INSTALLED` for the current user, so
+ * the package disappears from launchers and from most `PackageManager` queries, and `-k`
+ * (`DELETE_KEEP_DATA`) is what keeps `/data/user/N/<pkg>` and `/data/user_de/N/<pkg>` from being
+ * destroyed. Measured on a HyperOS device: uninstall-with-`-k` then `pm install-existing` returned
+ * the app with byte-identical `ceDataInode` and `deDataInode`. For a system app the data survives
+ * indefinitely, because the package record never goes away — the APK is still on the read-only
+ * partition. **Without `-k` this mechanic destroys the app's data**, which is what every build
+ * before this one did, for every system app, on every release.
+ *
+ * The residual cost of [UNINSTALL] is not data but per-user package state: runtime permission
+ * grants and app-ops are expected not to survive the round trip, so an unfrozen app may have to ask
+ * for its permissions again. That is why [DISABLE] is still preferred everywhere it works — which,
+ * measurably, is everywhere stock Android runs. [UNINSTALL] exists because some OEM builds refuse
+ * to let the shell uid disable their own system packages at all, and it is reached *only* where the
+ * platform actually refused, which is what [uninstallFreezeFallbackAllowed] decides.
  */
 enum class FreezeMechanic {
     /** `pm disable`, or the equivalent `setApplicationEnabledSetting` reflection. Keeps data. */
     DISABLE,
 
-    /** `pm uninstall --user N`, no `-k`. Destroys the app's data for the current user. */
+    /** `pm uninstall -k --user N`. Keeps the app's data; loses its per-user permission grants. */
     UNINSTALL,
 }
 
 /**
  * May a failed [FreezeMechanic.DISABLE] escalate to [FreezeMechanic.UNINSTALL] for this package?
  *
- * This gate is the difference between a fallback chain and a data-loss bug. Without it, *any*
- * failure to disable — a busy PackageManager, a binder timeout, a package that happened to be
- * mid-update — silently escalates to destroying that app's data, and the user is told the freeze
- * succeeded. With it, escalation is confined to the case where the platform has *refused* to
- * disable the package, and everywhere else a failure to disable stays a *failure*, visible and
- * reportable.
+ * Without this gate, *any* failure to disable — a busy PackageManager, a binder timeout, a package
+ * that happened to be mid-update — silently escalates to removing the package for the user, who is
+ * told the freeze succeeded. With it, escalation is confined to the case where the platform has
+ * *refused* to disable the package, and everywhere else a failure to disable stays a *failure*,
+ * visible and reportable.
  *
  * Failing loudly is the deliberate choice. A freeze that reports an error costs the user an
- * annoyance and Thor a bug report; a freeze that quietly wipes an app's data costs the user
- * something they cannot get back and produces no report at all, because from the outside it looked
- * like it worked.
+ * annoyance and Thor a bug report; a freeze that quietly swaps one mechanic for another produces no
+ * report at all, because from the outside it looked like it worked. Before `-k` was added to the
+ * fallback the price of getting this wrong was the user's data; it is now their per-user permission
+ * grants, which is smaller but still not something to spend on a binder timeout.
  *
  * ### Why this is not a version check
  *
@@ -121,15 +127,20 @@ enum class FreezeMechanic {
  *    android14-, android15-, android16-, android16-qpr1- and android16-qpr2-release. The 15→16
  *    diff of that method contains tracing and metrics changes and no security logic at all.
  *  - The restriction users actually hit is **Xiaomi's**, not Android's: a vendor
- *    `PackageManagerServiceImpl.canBeDisabled` — a class that does not exist in AOSP — throws
+ *    `PackageManagerServiceImpl.shouldRestrictEnabledSettingsChange` — a class that does not exist
+ *    in AOSP, and which 404s at every `android.googlesource.com` tag from 13 to 17 — throws
  *    `SecurityException("Cannot disable system packages.")` for `callingUid == 2000` on a system
  *    package. It was first reported on HyperOS running **Android 14**, roughly a year before
- *    Android 16 shipped, and is not tied to an API level in either direction.
+ *    Android 16 shipped, and is not tied to an API level in either direction. Reproduced on
+ *    `25053PC47G` (HyperOS OS3.0, build `BP2A.250605.031.A3`): `pm disable-user --user 0` exits 255
+ *    on `/system/app`, `/system/priv-app`, `/product/app` and `UPDATED_SYSTEM_APP` packages alike,
+ *    while third-party packages disable normally.
  *
- * So a version test is wrong in *both* directions at once: it would destroy data on a Pixel that
- * could have disabled the app, and it would refuse to freeze at all on the Xiaomi devices that are
- * the entire reason the fallback exists. What actually distinguishes the two cases is not which
- * release the device runs but whether the platform refused — so that is what this asks.
+ * So a version test is wrong in *both* directions at once: it would strip the wrong mechanic onto a
+ * Pixel that could have disabled the app, and it would refuse to freeze at all on the Xiaomi
+ * devices that are the entire reason the fallback exists. What actually distinguishes the two cases
+ * is not which release the device runs but whether the platform refused — so that is what this
+ * asks.
  *
  * One thing the shell uid genuinely cannot do, on every release since API 25 and still true on 17:
  * set `COMPONENT_ENABLED_STATE_DISABLED` (state 2, what `pm disable` sends). It may only set
@@ -141,7 +152,7 @@ enum class FreezeMechanic {
  *   came back unreadable. Passed in rather than inferred so this stays a pure function, and so the
  *   one decision that can cost a user their data is reachable from a plain JVM test.
  */
-fun destructiveFreezeFallbackAllowed(
+fun uninstallFreezeFallbackAllowed(
     isSystem: Boolean,
     privilegeMode: PrivilegeMode,
     disableRefusedByPolicy: Boolean,
@@ -162,11 +173,18 @@ fun destructiveFreezeFallbackAllowed(
         // at all — which is the state this whole change is trying to get *out* of.
         PrivilegeMode.SHIZUKU -> true
 
-        // Root is uid 0, and every refusal found in the wild — AOSP's own and Xiaomi's alike —
-        // keys on the *shell* uid (2000). Root has no observed platform restriction to work
-        // around, so a refusal here is a genuine anomaly worth surfacing rather than an
-        // invitation to delete the user's data. This is a behaviour change: root used to freeze
-        // system apps by uninstalling them unconditionally.
+        // Root is uid 0, and the two refusals this fallback was built for — AOSP's shell guard and
+        // Xiaomi's vendor one — both key on the *shell* uid (2000), so neither can reach root.
+        //
+        // One refusal genuinely can: `ProtectedPackages` (device provisioning package, device or
+        // profile owner, DPM owner-protected) throws `Cannot disable a protected package: <pkg>`
+        // and is *not* uid-gated, so it refuses root identically. Reported on Amazon Fire and on
+        // Infinix XOS. That case still answers false, and deliberately: a package the platform
+        // protects this hard is one where "uninstall it for the user instead" is the wrong reading
+        // of the refusal, not a workaround for it. Surface it and let the user decide.
+        //
+        // This is a behaviour change either way: root used to freeze system apps by uninstalling
+        // them unconditionally.
         PrivilegeMode.ROOT -> false
 
         // Dhizuku does not consult this policy yet — DhizukuSystemGateway still uninstalls system

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
@@ -95,7 +95,15 @@ enum class FreezeMechanic {
     /** `pm disable`, or the equivalent `setApplicationEnabledSetting` reflection. Keeps data. */
     DISABLE,
 
-    /** `pm uninstall -k --user N`. Keeps the app's data; loses its per-user permission grants. */
+    /**
+     * `pm uninstall -k --user N`. Keeps the app's data directories *and* its runtime permission
+     * grants — `-k` retains the whole `PackageUserState`, not just the data. What it does change is
+     * `FLAG_INSTALLED`, so the package stops resolving for this user without `MATCH_UNINSTALLED_PACKAGES`.
+     *
+     * Not reachable at shell uid on API 37: Android 17 answers this command with
+     * `Failure [only root can delete system app for a particular user]` where API 36 answers
+     * `Success`.
+     */
     UNINSTALL,
 }
 

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/FreezeAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/FreezeAppUseCase.kt
@@ -20,8 +20,10 @@ import org.koin.core.annotation.Factory
  * renders no confirm button for `BLOCKED`, so on the three single-app paths there was simply
  * nothing tappable wired to the freeze. That covered every surface that existed and nothing that
  * did not — a shortcut, an extension trigger, an automation intent or a widget would reach for the
- * obvious entry point and hand a `packageName` straight to `pm uninstall --user`. The dialog is
- * still the front door; this is the backstop under it.
+ * obvious entry point and hand a `packageName` straight to the freeze, which on an Unsafe system
+ * app means disabling a package the device needs to boot, or removing it for this user where
+ * disabling is not available (`FreezePolicy.kt`). The dialog is still the front door; this is the
+ * backstop under it.
  *
  * Freeze-only on purpose. Unfreezing keeps calling [ManageAppUseCase] directly, because it is the
  * way *out* of a bad state — a block that caught it too would trap the very app it protects.

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -66,6 +66,7 @@ import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.MultiAppAction
+import com.valhalla.thor.domain.model.importableDisabledApps
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import com.valhalla.asgard.components.ConnectedButtonGroup
@@ -123,12 +124,12 @@ fun FreezerScreen(
     // survive a config change.
     var freezerPrompt by remember { mutableStateOf<FreezerPrompt?>(null) }
 
+    // Candidates for the import prompt below. The rule lives in the domain rather than inline here
+    // because it is pure list logic that was silently wrong — a blanket `!isSystem` clause skipped
+    // every system app Thor had frozen — and a filter written inside a Composable has nowhere to be
+    // tested from. See importableDisabledApps for why each of its four conditions is there.
     val disabledAppsNotInFreezer = remember(state.allInstalledApps, state.freezerPackageNames) {
-        state.allInstalledApps.filter {
-            !it.enabled &&
-                    it.packageName !in state.freezerPackageNames &&
-                    !it.isSystem
-        }
+        importableDisabledApps(state.allInstalledApps, state.freezerPackageNames)
     }
 
     LaunchedEffect(state.isLoading, state.hasShownDisabledAppsPrompt, disabledAppsNotInFreezer) {

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -518,9 +518,16 @@ class FreezerViewModel(
     /**
      * The "you have disabled apps that aren't in the Freezer — import them?" dialog.
      *
-     * Not tier-gated for the same reason as [addToFreezer] — these apps are already disabled — and
-     * it could not matter anyway: `disabledAppsNotInFreezer` filters on `!isSystem`, and
-     * `freezeTierOf` opens with `!isSystem -> NORMAL`, so nothing blocked can reach this list.
+     * Not tier-gated here, for the same reason as [addToFreezer]: every app in this list is already
+     * frozen, so importing records a freeze that has happened rather than performing one.
+     *
+     * The *list* is tier-gated, by `importableDisabledApps`, and that is no longer incidental. This
+     * doc used to argue the gate could not matter because the candidate filter dropped every system
+     * app and `freezeTierOf` opens with `!isSystem -> NORMAL`. Both halves of that are gone: a
+     * system app frozen with `pm disable` is exactly what the filter now exists to offer, and a
+     * BLOCKED one must not reach the watchlist — `freezableCandidates` would refuse to re-freeze it
+     * while `Unfreeze all` would happily enable it, which is a one-way door out of a frozen state
+     * the user chose.
      */
     fun addAppsToFreezer(packageNames: List<String>) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
@@ -570,6 +570,45 @@ private fun AppListContent(
     }
 }
 
+/**
+ * The one status badge an app row shows, or nothing when the app is in its ordinary state.
+ *
+ * Extracted because the list and the grid carried near-identical copies of this `if` chain, and
+ * "near-identical" is what let them drift: both copies tested `isSystem && !isInstalled` *first*
+ * and painted a red "Uninstalled" danger icon for it, so one frozen system app looked different
+ * from another depending only on which mechanic had frozen it. The two call sites differ in their
+ * modifier and nothing else, so that is the only thing they still pass in.
+ *
+ * The `!isInstalled` branch is gone rather than merged, because it was unreachable once `!enabled`
+ * is tested first: [AppInfo.enabled] folds `FLAG_INSTALLED` in (see `AppInfoMapper` and
+ * `AppRepositoryImpl`), so a package that is not installed for this user *always* reads as not
+ * enabled. It could never describe a state this branch does not already cover — and it could not be
+ * kept as a distinct one either, since a system app removed with `pm uninstall --user N` is
+ * indistinguishable from one the vendor shipped removed. `FreezerMode.isFrozen` has always treated
+ * both as the same thing; this is the list agreeing with it.
+ *
+ * Order matters: an app can be disabled *and* suspended (a freezer mode switch does that), and
+ * "frozen" is the more fundamental of the two, so it wins.
+ */
+@Composable
+private fun AppStatusBadge(app: AppInfo, modifier: Modifier = Modifier) {
+    when {
+        !app.enabled -> Icon(
+            painterResource(R.drawable.frozen),
+            stringResource(R.string.cd_frozen),
+            modifier = modifier,
+            tint = MaterialTheme.colorScheme.primary
+        )
+
+        app.isSuspended -> Icon(
+            painterResource(R.drawable.bolt),
+            stringResource(R.string.cd_suspended),
+            modifier = modifier,
+            tint = MaterialTheme.colorScheme.secondary
+        )
+    }
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun AppItemList(
@@ -646,34 +685,12 @@ internal fun AppItemList(
                     .weight(1f, fill = false)
                     .then(textSharedModifier)
             )
-            if (app.isSystem && !app.isInstalled) {
-                Icon(
-                    painterResource(R.drawable.danger),
-                    stringResource(R.string.cd_uninstalled),
-                    modifier = Modifier
-                        .size(16.dp)
-                        .padding(start = 4.dp),
-                    tint = MaterialTheme.colorScheme.error
-                )
-            } else if (!app.enabled) {
-                Icon(
-                    painterResource(R.drawable.frozen),
-                    stringResource(R.string.cd_frozen),
-                    modifier = Modifier
-                        .size(16.dp)
-                        .padding(start = 4.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-            } else if (app.isSuspended) {
-                Icon(
-                    painterResource(R.drawable.bolt),
-                    stringResource(R.string.cd_suspended),
-                    modifier = Modifier
-                        .size(16.dp)
-                        .padding(start = 4.dp),
-                    tint = MaterialTheme.colorScheme.secondary
-                )
-            }
+            AppStatusBadge(
+                app = app,
+                modifier = Modifier
+                    .size(16.dp)
+                    .padding(start = 4.dp)
+            )
         }
     }
 }
@@ -725,41 +742,17 @@ internal fun AppItemGrid(
                         .background(MaterialTheme.colorScheme.surface, CircleShape)
                 )
             } else {
-                // Status Indicator
-                if (app.isSystem && !app.isInstalled) {
-                    Icon(
-                        painterResource(R.drawable.danger),
-                        stringResource(R.string.cd_uninstalled),
-                        tint = MaterialTheme.colorScheme.error,
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .size(16.dp)
-                            .background(MaterialTheme.colorScheme.surface, CircleShape)
-                            .padding(2.dp)
-                    )
-                } else if (!app.enabled) {
-                    Icon(
-                        painterResource(R.drawable.frozen),
-                        stringResource(R.string.cd_frozen),
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .size(16.dp)
-                            .background(MaterialTheme.colorScheme.surface, CircleShape)
-                            .padding(2.dp)
-                    )
-                } else if (app.isSuspended) {
-                    Icon(
-                        painterResource(R.drawable.bolt),
-                        stringResource(R.string.cd_suspended),
-                        tint = MaterialTheme.colorScheme.secondary,
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .size(16.dp)
-                            .background(MaterialTheme.colorScheme.surface, CircleShape)
-                            .padding(2.dp)
-                    )
-                }
+                // Status Indicator. The badge is the direct child of this Box, so `align` still
+                // reaches the Icon that AppStatusBadge emits — parent data travels with the
+                // modifier, not with the call site.
+                AppStatusBadge(
+                    app = app,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .size(16.dp)
+                        .background(MaterialTheme.colorScheme.surface, CircleShape)
+                        .padding(2.dp)
+                )
             }
         }
         Spacer(Modifier.height(8.dp))

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppRiskDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppRiskDialog.kt
@@ -26,7 +26,10 @@ import com.valhalla.thor.presentation.utils.getBloatRecommendationColors
 
 /** Which of the two risky things [AppRiskDialog] is asking about. */
 enum class AppRiskAction {
-    /** `pm disable` for user apps, `pm uninstall --user` for system ones. */
+    /**
+     * `pm disable` for a user app. For a system app, disabling it where the platform allows that
+     * and removing it for the current user where it does not — `FreezePolicy.kt` owns which.
+     */
     Freeze,
 
     /** A real uninstall. */
@@ -50,8 +53,10 @@ enum class AppRiskAction {
  * a backstop underneath it. See docs/follow-ups/single-app-freeze-tier-gate.md.
  *
  * [AppRiskAction.Freeze] is only ever confirmed for system apps — freezing a user app is a
- * reversible `pm disable`, so every caller acts on it directly without asking. The freeze wording
- * therefore only covers the system case.
+ * reversible `pm disable` with nothing to warn about, so every caller acts on it directly without
+ * asking. The freeze wording therefore only covers the system case, and what it warns about is the
+ * device, not the mechanic: `freeze_system_app_desc` is about reboot loops and broken services, so
+ * it stays correct now that a system freeze usually disables the package and keeps its data.
  *
  * [onConfirm] owns the action *and* the dismissal: the dialog does not close itself, so callers
  * can uninstall by intent or by privileged command, and can close the surface underneath, as each

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -156,7 +156,6 @@
     <string name="cd_config">تكوين</string>
     <string name="cd_close">إغلاق</string>
     <string name="cd_frozen">مجمد</string>
-    <string name="cd_uninstalled">تم إلغاء التثبيت</string>
     <string name="cd_suspended">معلق</string>
     <string name="cd_selected">مختار</string>
     <string name="cd_clear">مسح</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -156,7 +156,6 @@
     <string name="cd_config">Configuración</string>
     <string name="cd_close">Cerrar</string>
     <string name="cd_frozen">Congelado</string>
-    <string name="cd_uninstalled">Desinstalado</string>
     <string name="cd_suspended">Suspendido</string>
     <string name="cd_selected">Seleccionado</string>
     <string name="cd_clear">Limpiar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -156,7 +156,6 @@
     <string name="cd_config">Configuration</string>
     <string name="cd_close">Fermer</string>
     <string name="cd_frozen">Gelé</string>
-    <string name="cd_uninstalled">Désinstallé</string>
     <string name="cd_suspended">Suspendu</string>
     <string name="cd_selected">Sélectionné</string>
     <string name="cd_clear">Effacer</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -155,7 +155,6 @@
     <string name="cd_config">配置</string>
     <string name="cd_close">关闭</string>
     <string name="cd_frozen">已冻结</string>
-    <string name="cd_uninstalled">已卸载</string>
     <string name="cd_suspended">已暂停</string>
     <string name="cd_selected">已选择</string>
     <string name="cd_clear">清除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,7 +198,6 @@
     <string name="cd_config">Config</string>
     <string name="cd_close">Close</string>
     <string name="cd_frozen">Frozen</string>
-    <string name="cd_uninstalled">Uninstalled</string>
     <string name="cd_suspended">Suspended</string>
     <string name="cd_selected">Selected</string>
     <string name="cd_clear">Clear</string>

--- a/app/src/test/java/com/valhalla/thor/data/freezer/FreezeMatchFlagsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/freezer/FreezeMatchFlagsTest.kt
@@ -21,15 +21,18 @@ class FreezeMatchFlagsTest {
 
     /**
      * Thor freezes with two different mechanics and the flags have to cover both, because the
-     * failure is asymmetric: without MATCH_UNINSTALLED_PACKAGES the lookup **throws** for a frozen
-     * system app, and every caller's catch turns that into "not frozen" rather than into an error.
+     * failure is asymmetric: without MATCH_UNINSTALLED_PACKAGES the lookup **throws** for a system
+     * app frozen by removal for this user, and every caller's catch turns that into "not frozen"
+     * rather than into an error. Preferring to disable narrows when that mechanic is *chosen*
+     * (`FreezePolicy.kt`); it does not retire it, and it does nothing for the system apps already
+     * frozen that way on devices in the field.
      * That is how extensions were told an already-frozen app was thawed, and how `Unfreeze all`
      * silently found nothing to do.
      */
     @Test
     fun `both freeze mechanics are covered`() {
         assertNotEquals(
-            "a system app frozen with `pm uninstall --user N` is not installed for this user, " +
+            "a system app frozen by removal for the current user is not installed for this user, " +
                 "so it is invisible without MATCH_UNINSTALLED_PACKAGES",
             0,
             MATCH_FLAGS and PackageManager.MATCH_UNINSTALLED_PACKAGES

--- a/app/src/test/java/com/valhalla/thor/data/gateway/RootFreezeChainTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/gateway/RootFreezeChainTest.kt
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.gateway
+
+import android.content.pm.ApplicationInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The state arithmetic the root freeze chain runs on.
+ *
+ * The gateway itself is not reachable from a JVM test — it needs a live root shell and a real
+ * `PackageManager` — but the part worth pinning is not the shell. It is *which rung the chain picks
+ * from a given state*, because one of the rungs it can pick destroys the user's data and the other
+ * does not. `ApplicationInfo.FLAG_*` are JLS constant variables (public static final int), so
+ * kotlinc inlines them and this needs no Android runtime — the same trick `ExtensionOpsGateTest`
+ * uses.
+ */
+class RootFreezeChainTest {
+
+    // --- isEffectivelyEnabled: the freeze verdict ---
+
+    @Test
+    fun `installed and enabled is effectively enabled`() {
+        assertTrue(RootFreezeChain.isEffectivelyEnabled(true, ApplicationInfo.FLAG_INSTALLED))
+    }
+
+    @Test
+    fun `a disabled but installed app is not effectively enabled`() {
+        // The `pm disable` mechanic's own shape: still installed for the user, data intact.
+        assertFalse(RootFreezeChain.isEffectivelyEnabled(false, ApplicationInfo.FLAG_INSTALLED))
+    }
+
+    @Test
+    fun `an app uninstalled for this user is not effectively enabled despite enabled being true`() {
+        // The trap the whole fold exists for. Under MATCH_UNINSTALLED_PACKAGES the lookup *succeeds*
+        // for a package uninstalled for this user and reports enabled == true; only the missing
+        // FLAG_INSTALLED says it is frozen. Without the fold the freeze chain would read a
+        // legacy-frozen system app as active and re-freeze it.
+        assertFalse(RootFreezeChain.isEffectivelyEnabled(true, ApplicationInfo.FLAG_SYSTEM))
+    }
+
+    @Test
+    fun `unrelated flags do not change the verdict`() {
+        // Guards the bit test against an `and` result compared to the wrong side: a live system app
+        // carries plenty of other flags and must still read as enabled.
+        assertTrue(
+            RootFreezeChain.isEffectivelyEnabled(
+                enabled = true,
+                flags = ApplicationInfo.FLAG_INSTALLED or
+                    ApplicationInfo.FLAG_SYSTEM or
+                    ApplicationInfo.FLAG_ALLOW_BACKUP,
+            )
+        )
+    }
+
+    @Test
+    fun `a suspended app is still effectively enabled`() {
+        // Suspend is a different op with a different undo (`pm unsuspend`), so it must not read as
+        // "already frozen" — that would make the freeze chain short-circuit and report success
+        // without ever disabling anything.
+        assertTrue(
+            RootFreezeChain.isEffectivelyEnabled(
+                enabled = true,
+                flags = ApplicationInfo.FLAG_INSTALLED or ApplicationInfo.FLAG_SUSPENDED,
+            )
+        )
+    }
+
+    // --- unfreezeStep: the rung order ---
+
+    @Test
+    fun `an app that is installed and enabled needs no rung`() {
+        assertEquals(
+            RootFreezeChain.UnfreezeStep.VERIFIED,
+            RootFreezeChain.unfreezeStep(true, ApplicationInfo.FLAG_INSTALLED)
+        )
+    }
+
+    @Test
+    fun `an app uninstalled for this user is restored before anything else`() {
+        // The legacy mechanic: `pm uninstall --user N` leaves FLAG_INSTALLED clear and enabled true.
+        assertEquals(
+            RootFreezeChain.UnfreezeStep.INSTALL_EXISTING,
+            RootFreezeChain.unfreezeStep(true, ApplicationInfo.FLAG_SYSTEM)
+        )
+    }
+
+    @Test
+    fun `an installed but disabled app is enabled`() {
+        // The `pm disable` mechanic. Reaching for install-existing here would be a no-op that never
+        // clears the enabled-setting, so the app would stay frozen and the unfreeze would "succeed".
+        assertEquals(
+            RootFreezeChain.UnfreezeStep.ENABLE,
+            RootFreezeChain.unfreezeStep(false, ApplicationInfo.FLAG_INSTALLED)
+        )
+    }
+
+    @Test
+    fun `an app that is both uninstalled and disabled is installed first, not enabled first`() {
+        // Reachable in one freeze: rung 1 (`pm disable`) lands but is not observed to, and the
+        // destructive rung then runs on top of it. `pm enable` on a package that is not installed
+        // for the user does not bring it back, so ordering these the other way round would leave the
+        // app missing while reporting a successful unfreeze.
+        assertEquals(
+            RootFreezeChain.UnfreezeStep.INSTALL_EXISTING,
+            RootFreezeChain.unfreezeStep(false, ApplicationInfo.FLAG_SYSTEM)
+        )
+    }
+
+    @Test
+    fun `the second pass after install-existing asks for enable`() {
+        // The caller re-reads between rungs, so the state machine is walked twice on a package that
+        // needed both. This is that second call, with FLAG_INSTALLED now set and the disabled
+        // enabled-setting that install-existing does not clear still in place.
+        assertEquals(
+            RootFreezeChain.UnfreezeStep.ENABLE,
+            RootFreezeChain.unfreezeStep(false, ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_INSTALLED)
+        )
+    }
+
+    @Test
+    fun `VERIFIED and isEffectivelyEnabled are the same question`() {
+        // Two functions, one definition of "this app is up and running". If they ever disagree, the
+        // freeze chain and the unfreeze chain disagree about what frozen means — which is how an
+        // unfreeze reports success on a package the freezer still lists as frozen.
+        for (enabled in listOf(true, false)) {
+            for (flags in listOf(0, ApplicationInfo.FLAG_INSTALLED)) {
+                assertEquals(
+                    "enabled=$enabled flags=$flags",
+                    RootFreezeChain.isEffectivelyEnabled(enabled, flags),
+                    RootFreezeChain.unfreezeStep(enabled, flags) == RootFreezeChain.UnfreezeStep.VERIFIED
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/source/local/shizuku/EnableRungChainTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/shizuku/EnableRungChainTest.kt
@@ -4,8 +4,11 @@
 package com.valhalla.thor.data.source.local.shizuku
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.IOException
 
 /**
  * The rung chain behind `Shizuku.setAppDisabled`.
@@ -13,13 +16,17 @@ import org.junit.Test
  * The rungs themselves cannot be tested here — every one of them needs a live Shizuku binder, a
  * `PackageManager`, or both, and no gateway in Thor has a unit test for exactly that reason. What
  * *is* reachable is the part that changed and the part that is easy to get wrong later: which rung
- * runs first, and the rule that a rung is judged by re-reading the state rather than by what it
- * reported. [orderRungs] and [firstRungThatSticks] are pure for this purpose.
+ * runs first, the rule that a rung is judged by re-reading the state rather than by what it
+ * reported, and whether the platform refusing is carried back out of the chain. [orderRungs] and
+ * [firstRungThatSticks] are pure for this purpose.
  */
 class EnableRungChainTest {
 
-    private fun rung(label: String, reports: Boolean = true, onRun: (String) -> Unit = {}) =
-        EnableRung(label) { onRun(label); reports }
+    private fun rung(
+        label: String,
+        reports: RungResult = RungResult.RAN,
+        onRun: (String) -> Unit = {},
+    ) = EnableRung(label) { onRun(label); reports }
 
     private val shell = rung(RUNG_SHELL)
     private val reflection = rung(RUNG_REFLECTION)
@@ -75,7 +82,7 @@ class EnableRungChainTest {
             rung("third", onRun = { ran += it }),
         )
 
-        assertEquals("second", firstRungThatSticks(rungs) { stateChanged })
+        assertEquals("second", firstRungThatSticks(rungs) { stateChanged }.winner)
         assertEquals(listOf("first", "second"), ran)
     }
 
@@ -90,11 +97,11 @@ class EnableRungChainTest {
         val ran = mutableListOf<String>()
         var stateChanged = false
         val rungs = listOf(
-            rung("liar", reports = true, onRun = { ran += it }),
-            rung("worker", reports = true, onRun = { ran += it; stateChanged = true }),
+            rung("liar", reports = RungResult.RAN, onRun = { ran += it }),
+            rung("worker", reports = RungResult.RAN, onRun = { ran += it; stateChanged = true }),
         )
 
-        assertEquals("worker", firstRungThatSticks(rungs) { stateChanged })
+        assertEquals("worker", firstRungThatSticks(rungs) { stateChanged }.winner)
         assertEquals(listOf("liar", "worker"), ran)
     }
 
@@ -107,27 +114,131 @@ class EnableRungChainTest {
     fun `a rung that reports failure still wins if the state changed`() {
         var stateChanged = false
         val rungs = listOf(
-            rung("silent-worker", reports = false, onRun = { stateChanged = true }),
-            rung("never-reached", reports = true),
+            rung("silent-worker", reports = RungResult.FAILED, onRun = { stateChanged = true }),
+            rung("never-reached", reports = RungResult.RAN),
         )
 
-        assertEquals("silent-worker", firstRungThatSticks(rungs) { stateChanged })
+        assertEquals("silent-worker", firstRungThatSticks(rungs) { stateChanged }.winner)
     }
 
     /**
-     * Null is what escalates the system-app freeze to its destructive rung, so "nothing stuck" has
-     * to mean every rung genuinely ran and was verified — not that the loop gave up early.
+     * A null winner is what escalates the system-app freeze to its destructive rung, so "nothing
+     * stuck" has to mean every rung genuinely ran and was verified — not that the loop gave up
+     * early.
      */
     @Test
-    fun `returns null only after every rung has run`() {
+    fun `returns a null winner only after every rung has run`() {
         val ran = mutableListOf<String>()
         val rungs = listOf(
-            rung("a", reports = true, onRun = { ran += it }),
-            rung("b", reports = false, onRun = { ran += it }),
-            rung("c", reports = true, onRun = { ran += it }),
+            rung("a", reports = RungResult.RAN, onRun = { ran += it }),
+            rung("b", reports = RungResult.FAILED, onRun = { ran += it }),
+            rung("c", reports = RungResult.RAN, onRun = { ran += it }),
         )
 
-        assertNull(firstRungThatSticks(rungs) { false })
+        assertNull(firstRungThatSticks(rungs) { false }.winner)
         assertEquals(listOf("a", "b", "c"), ran)
+    }
+
+    // --- The refusal flag: the bit that costs a user their data ---------------------------------
+
+    /**
+     * The default. Everything failing without the platform having said no must leave the flag
+     * clear, because the caller spends a set flag on `pm uninstall --user N`.
+     */
+    @Test
+    fun `plain failures never set the refusal flag`() {
+        val rungs = listOf(
+            rung("a", reports = RungResult.FAILED),
+            rung("b", reports = RungResult.FAILED),
+            rung("c", reports = RungResult.RAN),
+        )
+
+        assertFalse(firstRungThatSticks(rungs) { false }.refusedByPolicy)
+    }
+
+    /**
+     * Sticky across rungs. A refusal from the reflection rung is a fact about the *device*, so a
+     * later rung merely failing must not erase it — otherwise the flag would report whatever the
+     * last rung happened to say, and the OEM devices this fallback exists for would never reach it.
+     */
+    @Test
+    fun `a refusal on any rung survives later rungs that merely fail`() {
+        val rungs = listOf(
+            rung("refused", reports = RungResult.REFUSED_BY_POLICY),
+            rung("failed", reports = RungResult.FAILED),
+            rung("failed too", reports = RungResult.FAILED),
+        )
+
+        assertTrue(firstRungThatSticks(rungs) { false }.refusedByPolicy)
+    }
+
+    /**
+     * A refused rung whose state nonetheless moved reports both: the winner is real (the caller
+     * returns success and never consults the flag), but the refusal is not fabricated away.
+     */
+    @Test
+    fun `a chain that wins after a refusal reports the winner and the refusal`() {
+        var stateChanged = false
+        val rungs = listOf(
+            rung("refused", reports = RungResult.REFUSED_BY_POLICY),
+            rung("worker", reports = RungResult.RAN, onRun = { stateChanged = true }),
+        )
+
+        val outcome = firstRungThatSticks(rungs) { stateChanged }
+        assertEquals("worker", outcome.winner)
+        assertTrue(outcome.refusedByPolicy)
+    }
+
+    // --- Recognising a refusal ------------------------------------------------------------------
+
+    /**
+     * The shell rung only ever sees a refusal as text on stderr. Both refusals Thor can actually
+     * meet are covered: AOSP's, verified verbatim on a stock API 36 emulator, and Xiaomi's vendor
+     * one out of `PackageManagerServiceImpl.canBeDisabled`.
+     */
+    @Test
+    fun `recognises both real refusal messages`() {
+        assertTrue(
+            isPolicyRefusal(
+                "java.lang.SecurityException: Shell cannot change component state for null to 2"
+            )
+        )
+        assertTrue(
+            isPolicyRefusal("java.lang.SecurityException: Cannot disable system packages.")
+        )
+    }
+
+    @Test
+    fun `ordinary shell failures are not refusals`() {
+        assertFalse(isPolicyRefusal(null as String?))
+        assertFalse(isPolicyRefusal(""))
+        assertFalse(isPolicyRefusal("Error: java.lang.IllegalArgumentException: Unknown package: x"))
+        assertFalse(isPolicyRefusal("Shell command failed with code 1: pm disable-user --user 0 x"))
+    }
+
+    /** The reflection rung throws rather than printing, so the throwable overload must agree. */
+    @Test
+    fun `recognises a thrown SecurityException through its cause chain`() {
+        assertTrue(isPolicyRefusal(SecurityException("nope")))
+        assertTrue(
+            isPolicyRefusal(
+                RuntimeException("reflection failed", IOException("io", SecurityException("nope")))
+            )
+        )
+        assertFalse(isPolicyRefusal(null as Throwable?))
+        assertFalse(isPolicyRefusal(IllegalStateException("binder is dead")))
+    }
+
+    /**
+     * A self-referential cause chain is what a badly-wrapped reflection failure can produce, and an
+     * unbounded walk would hang the freeze rather than fail it.
+     */
+    @Test
+    fun `a cyclic cause chain terminates`() {
+        val a = RuntimeException("a")
+        val b = RuntimeException("b", a)
+        a.initCause(b)
+
+        assertFalse(isPolicyRefusal(a))
     }
 }

--- a/app/src/test/java/com/valhalla/thor/data/source/local/shizuku/EnableRungChainTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/shizuku/EnableRungChainTest.kt
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local.shizuku
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The rung chain behind `Shizuku.setAppDisabled`.
+ *
+ * The rungs themselves cannot be tested here — every one of them needs a live Shizuku binder, a
+ * `PackageManager`, or both, and no gateway in Thor has a unit test for exactly that reason. What
+ * *is* reachable is the part that changed and the part that is easy to get wrong later: which rung
+ * runs first, and the rule that a rung is judged by re-reading the state rather than by what it
+ * reported. [orderRungs] and [firstRungThatSticks] are pure for this purpose.
+ */
+class EnableRungChainTest {
+
+    private fun rung(label: String, reports: Boolean = true, onRun: (String) -> Unit = {}) =
+        EnableRung(label) { onRun(label); reports }
+
+    private val shell = rung(RUNG_SHELL)
+    private val reflection = rung(RUNG_REFLECTION)
+    private val unprivileged = rung(RUNG_UNPRIVILEGED)
+
+    /**
+     * The default order, and the one every non-system caller keeps. `pm disable --user N` works for
+     * user apps and costs less than a binder reflection round trip; reordering that path was
+     * explicitly out of scope for the system-app fix.
+     */
+    @Test
+    fun `shell-first tries the shell rung before reflection`() {
+        assertEquals(
+            listOf(RUNG_SHELL, RUNG_REFLECTION, RUNG_UNPRIVILEGED),
+            orderRungs(EnableRungOrder.SHELL_FIRST, shell, reflection, unprivileged).map { it.label }
+        )
+    }
+
+    /** The system-app freeze order: the direct `IPackageManager` call gets the first attempt. */
+    @Test
+    fun `reflection-first tries the reflection rung before the shell`() {
+        assertEquals(
+            listOf(RUNG_REFLECTION, RUNG_SHELL, RUNG_UNPRIVILEGED),
+            orderRungs(EnableRungOrder.REFLECTION_FIRST, shell, reflection, unprivileged)
+                .map { it.label }
+        )
+    }
+
+    /**
+     * The unprivileged rung can only throw for a package Thor does not own, so it must never be
+     * spent before a privileged one whatever the order — this is the invariant that would break
+     * silently if a future order were added to the `when` without thinking about it.
+     */
+    @Test
+    fun `the unprivileged rung is last in every order`() {
+        EnableRungOrder.entries.forEach { order ->
+            assertEquals(
+                "unprivileged rung must stay last for $order",
+                RUNG_UNPRIVILEGED,
+                orderRungs(order, shell, reflection, unprivileged).last().label
+            )
+        }
+    }
+
+    /** Nothing after the winning rung runs; the chain is a chain, not a broadcast. */
+    @Test
+    fun `stops at the first rung after which the state actually changed`() {
+        val ran = mutableListOf<String>()
+        var stateChanged = false
+        val rungs = listOf(
+            rung("first", onRun = { ran += it }),
+            rung("second", onRun = { ran += it; stateChanged = true }),
+            rung("third", onRun = { ran += it }),
+        )
+
+        assertEquals("second", firstRungThatSticks(rungs) { stateChanged })
+        assertEquals(listOf("first", "second"), ran)
+    }
+
+    /**
+     * The rule the whole fix rests on: `pm` exits 0 for a disable `PackageManagerService` refused,
+     * and a `Bypass.invoke` that threw nothing has still proven nothing. A rung reporting success
+     * while the state did not move must not end the chain — that is what used to let a freeze
+     * report success without freezing anything.
+     */
+    @Test
+    fun `a rung that reports success without changing the state does not end the chain`() {
+        val ran = mutableListOf<String>()
+        var stateChanged = false
+        val rungs = listOf(
+            rung("liar", reports = true, onRun = { ran += it }),
+            rung("worker", reports = true, onRun = { ran += it; stateChanged = true }),
+        )
+
+        assertEquals("worker", firstRungThatSticks(rungs) { stateChanged })
+        assertEquals(listOf("liar", "worker"), ran)
+    }
+
+    /**
+     * And the mirror image: `Shizuku.execute` returns -1 when it cannot read an exit code at all
+     * (null binder, timeout), which is not the same statement as "the state did not change". The
+     * post-read outranks the report in both directions.
+     */
+    @Test
+    fun `a rung that reports failure still wins if the state changed`() {
+        var stateChanged = false
+        val rungs = listOf(
+            rung("silent-worker", reports = false, onRun = { stateChanged = true }),
+            rung("never-reached", reports = true),
+        )
+
+        assertEquals("silent-worker", firstRungThatSticks(rungs) { stateChanged })
+    }
+
+    /**
+     * Null is what escalates the system-app freeze to its destructive rung, so "nothing stuck" has
+     * to mean every rung genuinely ran and was verified — not that the loop gave up early.
+     */
+    @Test
+    fun `returns null only after every rung has run`() {
+        val ran = mutableListOf<String>()
+        val rungs = listOf(
+            rung("a", reports = true, onRun = { ran += it }),
+            rung("b", reports = false, onRun = { ran += it }),
+            rung("c", reports = true, onRun = { ran += it }),
+        )
+
+        assertNull(firstRungThatSticks(rungs) { false })
+        assertEquals(listOf("a", "b", "c"), ran)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/DestructiveFreezeFallbackTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/DestructiveFreezeFallbackTest.kt
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The gate that decides whether a failed disable may escalate to `pm uninstall --user` — the one
+ * freeze decision that can cost a user data they cannot recover. No Android deps.
+ *
+ * These tests are deliberately exhaustive over `PrivilegeMode` rather than spot-checking the
+ * interesting branch. The failure mode being guarded against is someone adding a mode, or relaxing
+ * a branch to make a freeze "work", without noticing that the branch's price is the user's data.
+ */
+class DestructiveFreezeFallbackTest {
+
+    private fun allowed(
+        isSystem: Boolean = true,
+        mode: PrivilegeMode = PrivilegeMode.SHIZUKU,
+        sdkInt: Int = ANDROID_16_BAKLAVA,
+    ) = destructiveFreezeFallbackAllowed(isSystem, mode, sdkInt)
+
+    // --- The one combination that is allowed to escalate -------------------------------------
+
+    @Test
+    fun `shizuku on android 16 may escalate for a system app`() {
+        assertTrue(allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = ANDROID_16_BAKLAVA))
+    }
+
+    @Test
+    fun `shizuku above android 16 may escalate for a system app`() {
+        assertTrue(allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = ANDROID_16_BAKLAVA + 1))
+        assertTrue(allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = 99))
+    }
+
+    // --- The boundary itself -------------------------------------------------------------------
+
+    /**
+     * Off-by-one here is not a cosmetic bug in either direction: one release too low destroys data
+     * on devices that could have disabled the app, one too high leaves Shizuku users on 16 unable
+     * to freeze system apps at all.
+     */
+    @Test
+    fun `shizuku one release below the boundary may not escalate`() {
+        assertFalse(allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = ANDROID_16_BAKLAVA - 1))
+    }
+
+    @Test
+    fun `shizuku on older releases may not escalate`() {
+        // 28 is Thor's minSdk; 35 is the release immediately before the restriction landed.
+        for (sdk in listOf(28, 29, 30, 31, 33, 34, 35)) {
+            assertFalse("sdk $sdk must not escalate", allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = sdk))
+        }
+    }
+
+    // --- Every other privilege mode fails closed, at every version -----------------------------
+
+    @Test
+    fun `root never escalates at any version`() {
+        for (sdk in listOf(28, 35, ANDROID_16_BAKLAVA, ANDROID_16_BAKLAVA + 1, 99)) {
+            assertFalse("root at sdk $sdk", allowed(mode = PrivilegeMode.ROOT, sdkInt = sdk))
+        }
+    }
+
+    @Test
+    fun `dhizuku never escalates at any version`() {
+        for (sdk in listOf(28, 35, ANDROID_16_BAKLAVA, ANDROID_16_BAKLAVA + 1, 99)) {
+            assertFalse("dhizuku at sdk $sdk", allowed(mode = PrivilegeMode.DHIZUKU, sdkInt = sdk))
+        }
+    }
+
+    @Test
+    fun `no privilege never escalates at any version`() {
+        for (sdk in listOf(28, 35, ANDROID_16_BAKLAVA, ANDROID_16_BAKLAVA + 1, 99)) {
+            assertFalse("none at sdk $sdk", allowed(mode = PrivilegeMode.NONE, sdkInt = sdk))
+        }
+    }
+
+    // --- User apps are never in scope, whatever else is true -----------------------------------
+
+    /**
+     * A user app disables on every supported release under every privilege mode, so there is no
+     * platform gap to work around. If this ever returns true, some caller has lost the `isSystem`
+     * distinction and is one failed `pm disable` away from wiping a user-installed app.
+     */
+    @Test
+    fun `a user app never escalates under any mode or version`() {
+        for (mode in PrivilegeMode.entries) {
+            for (sdk in listOf(28, 35, ANDROID_16_BAKLAVA, 99)) {
+                assertFalse(
+                    "user app under $mode at sdk $sdk",
+                    allowed(isSystem = false, mode = mode, sdkInt = sdk),
+                )
+            }
+        }
+    }
+
+    /** Guards the enum itself: a new mode must be considered, not silently inherit `true`. */
+    @Test
+    fun `only shizuku can ever escalate`() {
+        val escalating = PrivilegeMode.entries.filter {
+            destructiveFreezeFallbackAllowed(isSystem = true, privilegeMode = it, sdkInt = 99)
+        }
+        assertTrue(
+            "unexpected modes may destroy data: $escalating",
+            escalating == listOf(PrivilegeMode.SHIZUKU),
+        )
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/DestructiveFreezeFallbackTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/DestructiveFreezeFallbackTest.kt
@@ -20,63 +20,73 @@ class DestructiveFreezeFallbackTest {
     private fun allowed(
         isSystem: Boolean = true,
         mode: PrivilegeMode = PrivilegeMode.SHIZUKU,
-        sdkInt: Int = ANDROID_16_BAKLAVA,
-    ) = destructiveFreezeFallbackAllowed(isSystem, mode, sdkInt)
+        refused: Boolean = true,
+    ) = destructiveFreezeFallbackAllowed(isSystem, mode, refused)
 
     // --- The one combination that is allowed to escalate -------------------------------------
 
     @Test
-    fun `shizuku on android 16 may escalate for a system app`() {
-        assertTrue(allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = ANDROID_16_BAKLAVA))
+    fun `shizuku refused by the platform may escalate for a system app`() {
+        assertTrue(allowed(mode = PrivilegeMode.SHIZUKU, refused = true))
     }
 
-    @Test
-    fun `shizuku above android 16 may escalate for a system app`() {
-        assertTrue(allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = ANDROID_16_BAKLAVA + 1))
-        assertTrue(allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = 99))
-    }
-
-    // --- The boundary itself -------------------------------------------------------------------
+    // --- The discriminator: refusal, not failure ----------------------------------------------
 
     /**
-     * Off-by-one here is not a cosmetic bug in either direction: one release too low destroys data
-     * on devices that could have disabled the app, one too high leaves Shizuku users on 16 unable
-     * to freeze system apps at all.
+     * This is the branch the whole gate exists for. A busy PackageManager, a binder timeout or a
+     * package caught mid-update all fail to disable without the platform having refused anything;
+     * escalating on those is how a transient error turns into permanent data loss that nobody ever
+     * reports, because from the outside it looked like the freeze worked.
      */
     @Test
-    fun `shizuku one release below the boundary may not escalate`() {
-        assertFalse(allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = ANDROID_16_BAKLAVA - 1))
+    fun `shizuku that merely failed may not escalate`() {
+        assertFalse(allowed(mode = PrivilegeMode.SHIZUKU, refused = false))
     }
 
+    /**
+     * Guards against the version gate coming back. It was `sdkInt >= 36` on the report that
+     * shell-uid disabling broke on Android 16; a stock AOSP API 36 emulator disables system apps
+     * from uid 2000 without complaint, and the restriction that does exist is Xiaomi's, first seen
+     * on Android 14. Nothing about the answer may depend on the release — only on the refusal.
+     */
     @Test
-    fun `shizuku on older releases may not escalate`() {
-        // 28 is Thor's minSdk; 35 is the release immediately before the restriction landed.
-        for (sdk in listOf(28, 29, 30, 31, 33, 34, 35)) {
-            assertFalse("sdk $sdk must not escalate", allowed(mode = PrivilegeMode.SHIZUKU, sdkInt = sdk))
+    fun `the answer depends only on the refusal, never on anything version-like`() {
+        for (mode in PrivilegeMode.entries) {
+            val refusedAnswer = destructiveFreezeFallbackAllowed(true, mode, true)
+            val failedAnswer = destructiveFreezeFallbackAllowed(true, mode, false)
+            assertFalse("$mode escalated without a refusal", failedAnswer)
+            // Called twice with identical arguments the answer must be identical — the function is
+            // pure, so there is no ambient SDK_INT, Build field or clock it could be reading.
+            assertTrue(
+                "$mode is not deterministic",
+                refusedAnswer == destructiveFreezeFallbackAllowed(true, mode, true),
+            )
         }
     }
 
-    // --- Every other privilege mode fails closed, at every version -----------------------------
+    // --- Every other privilege mode fails closed, refused or not -------------------------------
 
+    /**
+     * Root is uid 0. Every refusal observed in the wild — AOSP's own shell guard and Xiaomi's
+     * vendor `canBeDisabled` alike — keys on the shell uid (2000), so a refusal reaching root is an
+     * anomaly worth surfacing, not a licence to delete the user's data.
+     */
     @Test
-    fun `root never escalates at any version`() {
-        for (sdk in listOf(28, 35, ANDROID_16_BAKLAVA, ANDROID_16_BAKLAVA + 1, 99)) {
-            assertFalse("root at sdk $sdk", allowed(mode = PrivilegeMode.ROOT, sdkInt = sdk))
-        }
+    fun `root never escalates, refused or not`() {
+        assertFalse("root refused", allowed(mode = PrivilegeMode.ROOT, refused = true))
+        assertFalse("root failed", allowed(mode = PrivilegeMode.ROOT, refused = false))
     }
 
     @Test
-    fun `dhizuku never escalates at any version`() {
-        for (sdk in listOf(28, 35, ANDROID_16_BAKLAVA, ANDROID_16_BAKLAVA + 1, 99)) {
-            assertFalse("dhizuku at sdk $sdk", allowed(mode = PrivilegeMode.DHIZUKU, sdkInt = sdk))
-        }
+    fun `dhizuku never escalates, refused or not`() {
+        assertFalse("dhizuku refused", allowed(mode = PrivilegeMode.DHIZUKU, refused = true))
+        assertFalse("dhizuku failed", allowed(mode = PrivilegeMode.DHIZUKU, refused = false))
     }
 
     @Test
-    fun `no privilege never escalates at any version`() {
-        for (sdk in listOf(28, 35, ANDROID_16_BAKLAVA, ANDROID_16_BAKLAVA + 1, 99)) {
-            assertFalse("none at sdk $sdk", allowed(mode = PrivilegeMode.NONE, sdkInt = sdk))
-        }
+    fun `no privilege never escalates, refused or not`() {
+        assertFalse("none refused", allowed(mode = PrivilegeMode.NONE, refused = true))
+        assertFalse("none failed", allowed(mode = PrivilegeMode.NONE, refused = false))
     }
 
     // --- User apps are never in scope, whatever else is true -----------------------------------
@@ -87,12 +97,12 @@ class DestructiveFreezeFallbackTest {
      * distinction and is one failed `pm disable` away from wiping a user-installed app.
      */
     @Test
-    fun `a user app never escalates under any mode or version`() {
+    fun `a user app never escalates under any mode, even when refused`() {
         for (mode in PrivilegeMode.entries) {
-            for (sdk in listOf(28, 35, ANDROID_16_BAKLAVA, 99)) {
+            for (refused in listOf(true, false)) {
                 assertFalse(
-                    "user app under $mode at sdk $sdk",
-                    allowed(isSystem = false, mode = mode, sdkInt = sdk),
+                    "user app under $mode, refused=$refused",
+                    allowed(isSystem = false, mode = mode, refused = refused),
                 )
             }
         }
@@ -102,7 +112,11 @@ class DestructiveFreezeFallbackTest {
     @Test
     fun `only shizuku can ever escalate`() {
         val escalating = PrivilegeMode.entries.filter {
-            destructiveFreezeFallbackAllowed(isSystem = true, privilegeMode = it, sdkInt = 99)
+            destructiveFreezeFallbackAllowed(
+                isSystem = true,
+                privilegeMode = it,
+                disableRefusedByPolicy = true,
+            )
         }
         assertTrue(
             "unexpected modes may destroy data: $escalating",

--- a/app/src/test/java/com/valhalla/thor/domain/model/ExtensionOpsGateTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/ExtensionOpsGateTest.kt
@@ -72,10 +72,11 @@ class ExtensionOpsFreezeStateTest {
     }
 
     @Test fun `a system app uninstalled for this user is frozen`() {
-        // The regression. Thor freezes system apps with `pm uninstall --user N`, and under
-        // MATCH_UNINSTALLED_PACKAGES that package comes back with enabled == true — only the
-        // missing FLAG_INSTALLED says it is frozen. Reading it as active made `toggle` re-freeze
-        // an already-frozen cluster instead of thawing it.
+        // The regression. A system app frozen by removal for this user — what FreezePolicy still
+        // permits, and what every system app frozen before Thor preferred disabling is in — comes
+        // back under MATCH_UNINSTALLED_PACKAGES with enabled == true; only the missing
+        // FLAG_INSTALLED says it is frozen. Reading it as active made `toggle` re-freeze an
+        // already-frozen cluster instead of thawing it.
         assertTrue(
             isFrozenAppInfo(enabled = true, flags = ApplicationInfo.FLAG_SYSTEM)
         )

--- a/app/src/test/java/com/valhalla/thor/domain/model/FreezeImportTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/FreezeImportTest.kt
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The Freezer's "import disabled apps" candidate rule. Pure list logic, no Android deps.
+ *
+ * This filter had no test while it lived inline in `FreezerScreen`, which is exactly why a clause
+ * that skipped every system app survived for a month without anyone noticing.
+ */
+class FreezeImportTest {
+
+    /**
+     * `enabled` and `isInstalled` are not independent on a real device: `AppInfoMapper` and
+     * `AppRepositoryImpl` both compute `enabled` as `ApplicationInfo.enabled && FLAG_INSTALLED`,
+     * so a package that is not installed for this user can never read as enabled. This helper
+     * enforces that here so no test can assert against a state the mapper cannot produce.
+     */
+    private fun app(
+        packageName: String,
+        isSystem: Boolean = false,
+        disabled: Boolean = true,
+        installedForUser: Boolean = true,
+        bloatRecommendation: String? = null,
+        uadLoadFailed: Boolean = false,
+    ) = AppInfo(
+        packageName = packageName,
+        isSystem = isSystem,
+        enabled = !disabled && installedForUser,
+        isInstalled = installedForUser,
+        bloatRecommendation = bloatRecommendation,
+        isUadLoadFailed = uadLoadFailed,
+    )
+
+    @Test
+    fun `a disabled user app that is not tracked is offered`() {
+        val apps = listOf(app("com.user.frozen"))
+        assertEquals(
+            listOf("com.user.frozen"),
+            importableDisabledApps(apps, emptySet()).map { it.packageName }
+        )
+    }
+
+    @Test
+    fun `an enabled app is never offered`() {
+        val apps = listOf(app("com.user.running", disabled = false))
+        assertEquals(emptyList<String>(), importableDisabledApps(apps, emptySet()).map { it.packageName })
+    }
+
+    @Test
+    fun `an app already on the watchlist is not offered`() {
+        val apps = listOf(app("com.user.frozen"))
+        assertEquals(
+            emptyList<String>(),
+            importableDisabledApps(apps, setOf("com.user.frozen")).map { it.packageName }
+        )
+    }
+
+    @Test
+    fun `a disabled system app is offered`() {
+        // The regression this filter was rewritten for. Freezing a system app now leaves it
+        // installed-but-disabled wherever the platform allows disabling, and the old `!isSystem`
+        // clause dropped precisely that app from the import prompt.
+        val apps = listOf(app("com.system.frozen", isSystem = true))
+        assertEquals(
+            listOf("com.system.frozen"),
+            importableDisabledApps(apps, emptySet()).map { it.packageName }
+        )
+    }
+
+    @Test
+    fun `an unsafe system app is not offered`() {
+        // Importing a BLOCKED app would be a one-way door: Unfreeze-all enables it, and
+        // freezableCandidates then refuses to ever freeze it again.
+        val apps = listOf(
+            app("com.system.unsafe", isSystem = true, bloatRecommendation = "Unsafe")
+        )
+        assertEquals(emptyList<String>(), importableDisabledApps(apps, emptySet()).map { it.packageName })
+    }
+
+    @Test
+    fun `the unsafe recommendation is matched regardless of case`() {
+        // uad_lists.json capitalises the recommendation; freezeTierOf lowercases before comparing.
+        val apps = listOf(
+            app("com.system.unsafe", isSystem = true, bloatRecommendation = "UNSAFE")
+        )
+        assertEquals(emptyList<String>(), importableDisabledApps(apps, emptySet()).map { it.packageName })
+    }
+
+    @Test
+    fun `an expert-tier system app is still offered`() {
+        // EXPERT warns, it does not block — and this list only records an already-completed
+        // freeze, so there is nothing left to warn about by the time we get here.
+        val apps = listOf(
+            app("com.system.expert", isSystem = true, bloatRecommendation = "Expert")
+        )
+        assertEquals(
+            listOf("com.system.expert"),
+            importableDisabledApps(apps, emptySet()).map { it.packageName }
+        )
+    }
+
+    @Test
+    fun `an unreadable UAD list withholds every system app but keeps user apps`() {
+        // Fail closed, and land on exactly the behaviour the old blanket clause had: with no
+        // classification available, no system app is offered.
+        val apps = listOf(
+            app("com.system.one", isSystem = true, uadLoadFailed = true),
+            app("com.system.two", isSystem = true, bloatRecommendation = "Recommended", uadLoadFailed = true),
+            app("com.user.frozen", uadLoadFailed = true),
+        )
+        assertEquals(
+            listOf("com.user.frozen"),
+            importableDisabledApps(apps, emptySet()).map { it.packageName }
+        )
+    }
+
+    @Test
+    fun `a system app uninstalled for this user is not offered`() {
+        // The destructive mechanic's output, and indistinguishable from a vendor-removed package
+        // or another debloater's work. Offering it means Unfreeze-all would run
+        // `pm install-existing` on something Thor may never have removed.
+        val apps = listOf(app("com.system.removed", isSystem = true, installedForUser = false))
+        assertEquals(emptyList<String>(), importableDisabledApps(apps, emptySet()).map { it.packageName })
+    }
+
+    @Test
+    fun `a user app uninstalled with data retained is not offered`() {
+        // Thor cannot unfreeze this at all — there is no APK to enable — so a watchlist row for it
+        // would only fail every unfreeze it took part in.
+        val apps = listOf(app("com.user.gone", installedForUser = false))
+        assertEquals(emptyList<String>(), importableDisabledApps(apps, emptySet()).map { it.packageName })
+    }
+
+    @Test
+    fun `scan order is preserved`() {
+        // The prompt shows a count and the confirm button imports the whole list, so order is only
+        // cosmetic — but a filter is the wrong place to reorder anything, and asserting it here
+        // stops a future rewrite from quietly sorting.
+        val apps = listOf(
+            app("com.b"),
+            app("com.a"),
+            app("com.c", disabled = false),
+            app("com.d", isSystem = true),
+        )
+        assertEquals(
+            listOf("com.b", "com.a", "com.d"),
+            importableDisabledApps(apps, emptySet()).map { it.packageName }
+        )
+    }
+
+    @Test
+    fun `an empty install list yields no candidates`() {
+        assertEquals(
+            emptyList<String>(),
+            importableDisabledApps(emptyList(), setOf("com.x")).map { it.packageName }
+        )
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/FreezeStateTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/FreezeStateTest.kt
@@ -75,7 +75,8 @@ class FreezeStateTest {
     //
     // The QS tile and the launcher Freeze-all shortcut act on the watchlist with no dialog in
     // front of them, so this filter is the only thing standing between a stored watchlist entry
-    // and a `pm uninstall --user` on a package the in-app dialog refuses to freeze at all.
+    // and a freeze — disable, or removal for this user where disabling is not available — on a
+    // package the in-app dialog refuses to freeze at all.
 
     private fun blocked(state: FreezeState) = FreezeCandidate(state, blockedFromFreeze = true)
 

--- a/app/src/test/java/com/valhalla/thor/domain/model/UninstallFreezeFallbackTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/UninstallFreezeFallbackTest.kt
@@ -15,13 +15,13 @@ import org.junit.Test
  * interesting branch. The failure mode being guarded against is someone adding a mode, or relaxing
  * a branch to make a freeze "work", without noticing that the branch's price is the user's data.
  */
-class DestructiveFreezeFallbackTest {
+class UninstallFreezeFallbackTest {
 
     private fun allowed(
         isSystem: Boolean = true,
         mode: PrivilegeMode = PrivilegeMode.SHIZUKU,
         refused: Boolean = true,
-    ) = destructiveFreezeFallbackAllowed(isSystem, mode, refused)
+    ) = uninstallFreezeFallbackAllowed(isSystem, mode, refused)
 
     // --- The one combination that is allowed to escalate -------------------------------------
 
@@ -52,14 +52,14 @@ class DestructiveFreezeFallbackTest {
     @Test
     fun `the answer depends only on the refusal, never on anything version-like`() {
         for (mode in PrivilegeMode.entries) {
-            val refusedAnswer = destructiveFreezeFallbackAllowed(true, mode, true)
-            val failedAnswer = destructiveFreezeFallbackAllowed(true, mode, false)
+            val refusedAnswer = uninstallFreezeFallbackAllowed(true, mode, true)
+            val failedAnswer = uninstallFreezeFallbackAllowed(true, mode, false)
             assertFalse("$mode escalated without a refusal", failedAnswer)
             // Called twice with identical arguments the answer must be identical — the function is
             // pure, so there is no ambient SDK_INT, Build field or clock it could be reading.
             assertTrue(
                 "$mode is not deterministic",
-                refusedAnswer == destructiveFreezeFallbackAllowed(true, mode, true),
+                refusedAnswer == uninstallFreezeFallbackAllowed(true, mode, true),
             )
         }
     }
@@ -112,7 +112,7 @@ class DestructiveFreezeFallbackTest {
     @Test
     fun `only shizuku can ever escalate`() {
         val escalating = PrivilegeMode.entries.filter {
-            destructiveFreezeFallbackAllowed(
+            uninstallFreezeFallbackAllowed(
                 isSystem = true,
                 privilegeMode = it,
                 disableRefusedByPolicy = true,

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
@@ -25,8 +25,9 @@ private const val PKG = "com.some.system.app"
  * Everything that reached the privilege gateway, in order.
  *
  * The load-bearing assertion in most of these tests is that [calls] is **empty**: a gate that
- * returned a refusal *after* running `pm uninstall --user` would satisfy any assertion made on
- * the returned `Result` alone, and the app would still be gone.
+ * returned a refusal *after* the freeze had already reached the gateway would satisfy any assertion
+ * made on the returned `Result` alone, and the app would already be frozen — disabled, or, where
+ * disabling is unavailable, removed for this user with its data.
  */
 private class RecordingSystemRepository : SystemRepository {
     val calls = mutableListOf<String>()

--- a/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
@@ -52,14 +52,15 @@ import java.nio.file.Files
  * - a `BLOCKED` app must not be frozen or uninstalled by a batch, and the *count the user sees*
  *   must describe what the run will actually attempt;
  * - unfreeze must never be gated — it is the way out of a bad freeze;
- * - a system app uninstalled through Thor must land on the freezer watchlist, because
- *   `pm uninstall --user` is how Thor freezes system apps and the watchlist row is the only record
- *   that the app is recoverable;
+ * - a system app uninstalled through Thor must land on the freezer watchlist, because a system app
+ *   can only be removed for the current user (`pm uninstall --user`) and so is recoverable with
+ *   `pm install-existing` — the watchlist row is the only record that it is;
  * - a refusal that carries its own message must be shown as that message.
  *
  * Every assertion is made against [FakeSystemRepository.calls] — the list of commands that reached
- * the privilege layer — rather than against the returned `Result`. A gate that refuses *after*
- * running `pm uninstall` satisfies any assertion on the result alone, and the app is still gone.
+ * the privilege layer — rather than against the returned `Result`. A gate that refuses *after* the
+ * command has reached that layer satisfies any assertion on the result alone, and the app is
+ * already frozen or already gone.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
@@ -171,9 +172,10 @@ class MainViewModelTest {
         )
         advanceUntilIdle()
 
-        // Not "the result was a failure" — the package must never appear in a command at all.
-        // Thor freezes a system app with `pm uninstall --user`, so a leaked call is not recoverable
-        // by retrying with the right answer.
+        // Not "the result was a failure" — the package must never appear in a command at all. A
+        // leaked call disables a package UAD says the device needs, or removes it for this user
+        // where disabling is not available; neither is recoverable by retrying with the right
+        // answer, and the first can cost the boot.
         assertEquals(listOf("setAppDisabled:com.ok:true"), system.calls)
     }
 
@@ -311,9 +313,10 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf("uninstallApp:com.sys", "uninstallApp:com.user"), system.calls)
-        // `pm uninstall --user` on a system app is Thor's freeze; the watchlist row is the only
-        // record that it can be brought back, so losing it strands the app. A user app is really
-        // gone, and a row for it would offer a restore that cannot work.
+        // Uninstalling a system app can only remove it for the current user (`pm uninstall --user`),
+        // so `pm install-existing` can bring it back — and the watchlist row is the only record
+        // that it can be, so losing it strands the app. A user app is really gone, and a row for it
+        // would offer a restore that cannot work.
         assertEquals(listOf("com.sys"), freezer.added)
     }
 

--- a/docs/follow-ups/shortcut-match-flags-system-apps.md
+++ b/docs/follow-ups/shortcut-match-flags-system-apps.md
@@ -17,7 +17,8 @@ Two lookups in `FreezerShortcutManager` resolve a package without the match flag
 
 A system app is frozen by disabling it where the platform allows that, and by removing it for the
 current user where it does not (`domain/model/FreezePolicy.kt`). Under the second mechanic — the
-only one Thor used when this was written, and still what Shizuku on Android 16+ and Dhizuku do, plus
+only one Thor used when this was written, and still what Shizuku does on devices that refuse to
+disable system packages and what Dhizuku does everywhere, plus
 what every system app frozen before the split is already sitting in — the package is **not installed
 for the current user**. `PackageInfoUtils.generateApplicationInfo` → `checkUseInstalledOrHidden` →
 `PackageUserStateUtils.isAvailable` then returns false without `MATCH_UNINSTALLED_PACKAGES` /

--- a/docs/follow-ups/shortcut-match-flags-system-apps.md
+++ b/docs/follow-ups/shortcut-match-flags-system-apps.md
@@ -15,18 +15,20 @@ Two lookups in `FreezerShortcutManager` resolve a package without the match flag
 | `appLabel` (`FreezerShortcutManager.kt:281`) | `getApplicationInfo(pkg, MATCH_DISABLED_COMPONENTS)` | `MATCH_UNINSTALLED_PACKAGES` |
 | `appIcon` (`FreezerShortcutManager.kt:293`) | `getApplicationIcon(pkg)` | everything — the `String` overload resolves via `getApplicationInfo(pkg, sDefaultFlags)`, and `sDefaultFlags` is `GET_SHARED_LIBRARY_FILES` |
 
-Thor freezes system apps with `pm uninstall --user N`, not `pm disable`, so a frozen system app
-is **not installed for the current user**. `PackageInfoUtils.generateApplicationInfo` →
-`checkUseInstalledOrHidden` → `PackageUserStateUtils.isAvailable` then returns false without
-`MATCH_UNINSTALLED_PACKAGES` / `MATCH_KNOWN_PACKAGES`, and `getApplicationInfo` throws
-`NameNotFoundException`.
+A system app is frozen by disabling it where the platform allows that, and by removing it for the
+current user where it does not (`domain/model/FreezePolicy.kt`). Under the second mechanic — the
+only one Thor used when this was written, and still what Shizuku on Android 16+ and Dhizuku do, plus
+what every system app frozen before the split is already sitting in — the package is **not installed
+for the current user**. `PackageInfoUtils.generateApplicationInfo` → `checkUseInstalledOrHidden` →
+`PackageUserStateUtils.isAvailable` then returns false without `MATCH_UNINSTALLED_PACKAGES` /
+`MATCH_KNOWN_PACKAGES`, and `getApplicationInfo` throws `NameNotFoundException`.
 
 `AppFreezeStateReader.MATCH_FLAGS` is the correct reference pattern; these two sites predate it.
 
-User apps are unaffected. `getApplicationInfo` does **not** filter on the enabled setting —
-`ComputerEngine.getApplicationInfoInternalBody` carries the literal comment *"Note: isEnabledLP()
-does not apply here - always return info"* — so a `pm disable`d package still resolves with flags
-`0`. That is why `AutoFreezeManager.kt:122` works.
+A *disabled* package is unaffected, system or user. `getApplicationInfo` does **not** filter on the
+enabled setting — `ComputerEngine.getApplicationInfoInternalBody` carries the literal comment *"Note:
+isEnabledLP() does not apply here - always return info"* — so it still resolves with flags `0`, and
+comes back with `enabled == false`. That is why `AutoFreezeManager.kt:129` works.
 
 ## Why it is unreachable today
 
@@ -99,5 +101,12 @@ be resolved without the info the icon also uses) is what stands in for it until 
   the follow-ups README), and now reads the shared constant rather than its own copy.
 - `FreezerLaunchActivity.kt:168` (`isSuspended`) — benign; the `||` at `:137` short-circuits so it
   is only evaluated once `getLaunchIntentForPackage` has already resolved.
-- `AutoFreezeManager.kt:122` (flags `0`) — benign; a frozen system app throws, is logged
-  "not found, skipping", and skipping an already-frozen app is the desired outcome anyway.
+- `AutoFreezeManager.kt:129` (flags `0`) — still benign, but the reason changed with the mechanic.
+  A system app *removed for this user* throws and is logged "not found, skipping", as before. A
+  system app *disabled in place* resolves instead — `getApplicationInfo` ignores the enabled
+  setting — and comes back with `enabled == false`, so the `if (appInfo.enabled && !alreadySuspended)`
+  guard four lines down skips it. Both routes end at "already frozen, do nothing"; the exception is
+  simply no longer the thing doing the skipping. Note that widening these flags to
+  `AppFreezeStateReader.MATCH_FLAGS` would *break* this: under `MATCH_UNINSTALLED_PACKAGES` a
+  package uninstalled for this user resolves with `enabled == true`, so the guard would pass and
+  auto-freeze would act on an app it can already see is frozen. Flags `0` is load-bearing here.

--- a/docs/follow-ups/shortcut-match-flags-system-apps.md
+++ b/docs/follow-ups/shortcut-match-flags-system-apps.md
@@ -29,7 +29,8 @@ for the current user**. `PackageInfoUtils.generateApplicationInfo` → `checkUse
 A *disabled* package is unaffected, system or user. `getApplicationInfo` does **not** filter on the
 enabled setting — `ComputerEngine.getApplicationInfoInternalBody` carries the literal comment *"Note:
 isEnabledLP() does not apply here - always return info"* — so it still resolves with flags `0`, and
-comes back with `enabled == false`. That is why `AutoFreezeManager.kt:129` works.
+comes back with `enabled == false`. That is why the `pm.getApplicationInfo(pkg, 0)` lookup in
+`AutoFreezeManager`'s `screenReceiver` works (`data/service/AutoFreezeManager.kt:141`).
 
 ## Why it is unreachable today
 
@@ -102,7 +103,7 @@ be resolved without the info the icon also uses) is what stands in for it until 
   the follow-ups README), and now reads the shared constant rather than its own copy.
 - `FreezerLaunchActivity.kt:168` (`isSuspended`) — benign; the `||` at `:137` short-circuits so it
   is only evaluated once `getLaunchIntentForPackage` has already resolved.
-- `AutoFreezeManager.kt:129` (flags `0`) — still benign, but the reason changed with the mechanic.
+- `data/service/AutoFreezeManager.kt:141` (flags `0`) — still benign, but the reason changed with the mechanic.
   A system app *removed for this user* throws and is logged "not found, skipping", as before. A
   system app *disabled in place* resolves instead — `getApplicationInfo` ignores the enabled
   setting — and comes back with `enabled == false`, so the `if (appInfo.enabled && !alreadySuspended)`


### PR DESCRIPTION
## The bug

Freezing a **preinstalled** app destroyed its data.

Every privilege mode ran `pm uninstall --user N` — with no `-k` — as the *first and only* mechanic for system apps. Unfreezing ran `pm install-existing`, which brings the package back **factory-fresh**: logins, settings and local content gone. The UI reported an ordinary, reversible freeze. Nothing warned about it, and nothing in the codebase distinguished the two outcomes.

Both gateways now **try to disable first**, and only escalate where the platform genuinely leaves no alternative.

## The chains

**Root** — `RootSystemGateway`

1. `pm disable --user N` — data preserved.
2. `pm uninstall -k --user N` — **gated off entirely**. A failure to disable now surfaces as a failure instead of silently changing mechanic.

`--user N` rather than the bare form is deliberate: `PackageManagerShellCommand.runSetEnabledSetting` seeds `userId = USER_SYSTEM`, so a bare `pm disable` issued from a work profile or Second Space targets user 0 and then fails its own verification. This file already documents that exact trap for `pm grant`/`pm revoke`.

**Shizuku** — `ShizukuSystemGateway`

1. `IPackageManager.setApplicationEnabledSetting` via `:bypass`.
2. `pm disable-user --user N`.
3. unprivileged `PackageManager` — free, and almost always a no-op.
4. `pm uninstall -k --user N` — **gated**.

## The fallback no longer destroys anything

`-k` sets `DELETE_KEEP_DATA`, which leaves `/data/user/N/<pkg>` and `/data/user_de/N/<pkg>` in place instead of having `installd` destroy them. Measured on the HyperOS device that refuses to disable system packages at all — the device this fallback exists for:

```
pm uninstall -k --user 0 <pkg>      -> Success, exit 0
pm install-existing --user 0 <pkg>
ceDataInode / deDataInode           -> byte-identical before and after
```

For a system app the data survives indefinitely: the package record never goes away, because the APK is still on the read-only partition and `pm uninstall --user` only clears `PackageUserState.installed` for one user. (The adb client's "there is no way to remove the remaining data" warning about `-k` is about orphaned data after a *full* uninstall of a user app. It does not apply here, and it did not appear on the device.)

**The grants survive too — this was measured after an earlier revision of this PR guessed otherwise.** Five sites in the branch said runtime permission grants were "expected not to survive the round trip". They do. On a stock AOSP API 36 emulator at uid 2000:

```
pm grant com.android.egg READ_EXTERNAL_STORAGE  -> granted=true
pm uninstall -k --user 0 com.android.egg        -> Success
pm install-existing --user 0 com.android.egg    -> Success
READ_EXTERNAL_STORAGE                           -> granted=true, flags unchanged
ceDataInode / deDataInode                       -> byte-identical
```

`-k` retains the whole `PackageUserState`, not just the data directories. The pessimistic guess had been stated in two user-visible log strings as if it were fact; all five sites are corrected. What the rung *does* still change is `FLAG_INSTALLED`, which is the part the rest of the app has to handle.

**The rung does not exist at shell uid on API 37.** Identical command, same uid, AOSP emulators:

```
pm uninstall -k --user 0 com.android.egg
  API 36 -> Success, exit 0
  API 37 -> Failure [only root can delete system app for a particular user], exit 1
```

The package is left untouched, so on Android 17 a Shizuku at uid 2000 ends the chain at "could not disable" with an honest failure rather than a wrong state. A Shizuku started as root is unaffected. Documented at the call site, with an explicit note not to add a rung below it.

`freezeSystemAppForUser` is deliberately a **separate function** from `uninstallApp`, in both the Shizuku helper and the reflector — adding `-k` to the shared one would silently make the user-facing "uninstall this app" feature leave data behind on every app it removes. The new one is shell-only with no `PackageInstaller` fallback, because that fallback cannot express `DELETE_KEEP_DATA` and would quietly turn a data-preserving freeze back into a destroying one.

## The gate — and why it is not a version check

`uninstallFreezeFallbackAllowed` in `domain/model/FreezePolicy.kt` is the single home for the escalation decision. It answers `true` for exactly one combination: **Shizuku, on a system app, where a privileged rung was refused by the platform.** Everything else fails loudly rather than switching mechanic behind the user's back.

It briefly answered `sdkInt >= 36` instead, on the report that shell-uid disabling of system apps stopped working on Android 16. **That boundary does not exist.** Measured on a stock AOSP Android 16 (API 36) emulator as uid 2000:

| command | result |
|---|---|
| `pm disable --user 0 com.android.egg` | `SecurityException: Shell cannot change component state for null to 2`, exit 255 |
| `pm disable-user --user 0 com.android.egg` | **exit 0**, `enabled=3`, `installed=true` |

Same on `com.android.printspooler`, `com.android.wallpaper.livepicker` and `com.android.traceur`; all four reversed with `pm enable` and verified back at `enabled=1`. Disabling a system app from the shell uid on Android 16 works, and the data survives.

The command that fails is `pm disable` — `COMPONENT_ENABLED_STATE_DISABLED` (state 2), which the shell uid has been forbidden from setting **since API 25**; it may only set `DEFAULT`, `ENABLED` or `DISABLED_USER`. That is a *command* constraint, not a version one, and the Shizuku path already satisfies it by sending `pm disable-user`. AOSP's guard block in `PackageManagerService.setEnabledSettings` is **byte-identical** across android14-, android15-, android16-, android16-qpr1- and android16-qpr2-release; the 15→16 diff of that method contains tracing and metrics and no security logic.

The restriction users actually hit is **Xiaomi's**: a vendor `PackageManagerServiceImpl.shouldRestrictEnabledSettingsChange` — a class with no AOSP counterpart, which 404s at every `android.googlesource.com` tag from 13 to 17 and lives in `/system_ext/framework/miui-services.jar` on the device — throws `SecurityException("Cannot disable system packages.")` for `callingUid == 2000` on a system package. It was first reported on HyperOS running **Android 14**, roughly a year before Android 16 shipped. Reproduced here on `25053PC47G` (HyperOS OS3.0, `BP2A.250605.031.A3`), where it covers `/system/app`, `/system/priv-app`, `/product/app` and `UPDATED_SYSTEM_APP` alike while third-party packages disable normally.

So a version test is wrong in both directions at once: it would strip the wrong mechanic onto a Pixel that could have disabled the app, and refuse to freeze at all on the devices that are the entire reason the fallback exists. What separates the two cases is not the release but whether the platform **refused** — so that is what the gate asks. `disableRefusedByPolicy` is set only by a `SecurityException` from `PackageManagerService`, never by a non-zero exit, a timeout or an unreadable read.

Confining escalation is the whole point. Without that distinction, any transient failure to disable — a busy `PackageManager`, a binder timeout, a package caught mid-update — silently swaps the mechanic and produces no bug report, because from the outside it looked like it worked.

**Root answers `false` whatever the flag says.** The two refusals this fallback was built for both key on the **shell** uid (2000), and root is uid 0. One refusal genuinely can reach root — `ProtectedPackages` (device provisioning package, DO/PO, DPM owner-protected) throws `Cannot disable a protected package: <pkg>` and is *not* uid-gated; reported on Amazon Fire and on Infinix XOS. That case still answers `false`, and deliberately: a package the platform protects that hard is one where "remove it for the user instead" is the wrong reading of the refusal. Root's flag is still computed and passed honestly, so both gateways call the gate identically and letting root escalate would be a change in the policy, not at the call site.

**Unfreeze deliberately does not consult the gate.** Devices in the field carry apps frozen by the old unconditional-uninstall builds, and a single package can be *both* disabled *and* uninstalled-for-user, so both gateways walk `install-existing` → `enable` and verify the end state. Gating the thaw would strand exactly the users who most need it.

## No rung trusts an exit code

`pm` prints `Success` for a no-op and returns non-zero from commands that did take effect, so every rung is judged by **re-reading `ApplicationInfo`**. The ordering and short-circuit rules are extracted as pure functions — `firstRungThatSticks`, `RootFreezeChain`, `orderRungs` — to make them reachable from plain JVM tests.

Rungs report a `RungResult` (`RAN` / `FAILED` / `REFUSED_BY_POLICY`) rather than a bare `Boolean`, and `firstRungThatSticks` returns a `ChainOutcome` whose refusal flag is **sticky**: a refusal on the reflection rung is a fact about the device, so a later rung merely failing must not erase it. The unprivileged rung can never report a refusal — Thor holds no `CHANGE_COMPONENT_ENABLED_STATE`, so it throws `SecurityException` on every device, and counting that would green-light the destructive fallback permanently.

The `setApplicationEnabledSetting` reflection is now the one and only copy in the codebase. Its two conditionals are load-bearing and documented as such: `COMPONENT_ENABLED_STATE_DISABLED` vs `DISABLED_USER`, and `com.android.shell` vs Thor's own package name — `PackageManagerService` validates `callingPackage` against the calling uid, which differs between a shell-uid Shizuku (2000) and a root Shizuku (0, owns no package).

## Two UI leaks, both widened by the new mechanic

- **The Freezer import prompt filtered on `!isSystem`**, which skipped every system app Thor itself had frozen. That clause predates the tier model by five weeks and was never a no-op: `AppInfo.enabled` folds in `FLAG_INSTALLED`, so uninstalled-for-user system apps have *always* matched `!enabled` and have always been excluded. Replaced by `importableDisabledApps`, gated on `isBlockedFromFreeze` instead — importing a BLOCKED app is a one-way door, since Unfreeze-all would enable it and Thor would then refuse to re-freeze it.
- **`AppList` drew a second, differently-styled badge** for `!isInstalled` — a branch that is unreachable once `!enabled` is tested first. Deleted, and the badge extracted to `AppStatusBadge` so the list and grid cannot drift again. `cd_uninstalled` had no other use and is removed from all five locales (465 → 464 entries each; named-resource sets verified identical, so `MissingTranslation` stays clean).

## Prose

~22 comments, KDoc blocks and test-assertion messages asserted the old mechanic as fact. All corrected.

One is a real hazard rather than stale prose: `AutoFreezeManager`'s `getApplicationInfo(pkg, 0)` looks like an oversight next to every other lookup in the codebase, but **flags `0` is load-bearing**. Widening it to `AppFreezeStateReader.MATCH_FLAGS` would make an uninstalled-for-user package resolve with `enabled == true`, and auto-freeze would start issuing freeze commands against apps it can already see are frozen. Now annotated as do-not-widen at the call site.

## Known gaps — deliberate, and worth a reviewer's attention

- **`DhizukuSystemGateway` still uninstalls unconditionally.** Converting it without a device check risks removing Dhizuku's only working system-app freeze, so it is left unconverted rather than half-converted. After this ships, the same button preserves data under Root/Shizuku and wipes it under Dhizuku, with no UI difference.
- **The refusal predicate is text-matching on the shell rung.** `Shizuku.execute` hands back stderr as a string, so `isPolicyRefusal(String?)` looks for `SecurityException` in it; the reflection rung gets the real throwable and walks its cause chain (bounded at 10 hops, so a cyclic chain terminates). An OEM that refuses with a differently-worded exception would read as an ordinary failure — which fails *closed*, costing that device the fallback rather than costing its owner a mechanic change they did not ask for.
- **`pm suspend` was measured working on the refusing device** and would be a better rung than uninstall-for-user — it keeps the data *and* the launcher icon with no uninstall/reinstall round trip. It is not added here because Thor already exposes suspend as a **user-chosen freeze mode** (the v1.92.0 Freeze Mode Selector), and silently substituting it inside the *disable* mode is a product decision, not a bug fix. Worth its own issue. (`pm hide` is blocked on that device, so it must not go ahead of suspend in any future ladder.)
- **API 37's new required-packages guard is live, not inert.** An earlier revision of this section had it backwards: it reasoned that because shell's manifest holds zero occurrences of `ALLOW_CONTROL_SYSTEM_REQUIRED_PACKAGES`, the restriction was inert. Holding that permission is the **bypass** — holding none means shell is *subject* to it. Measured on Android 17 (`CP31.260623.005`):

  ```
  pm disable-user --user 0 com.google.android.packageinstaller
  -> SecurityException: Cannot disable required package
     at PackageManagerService.setEnabledSettings(PackageManagerService.java:4218)
  ```

  It fires for a small allowlist — `packageinstaller` and `permissioncontroller` — and not for `settings`, `systemui`, `gms`, `nexuslauncher` or `intentresolver`, all of which still disable normally at uid 2000. It is a `SecurityException`, so `isPolicyRefusal` already classifies it correctly and the existing gate handles it with **no code change**: the chain records the refusal, finds the uninstall rung unavailable on 17, and fails closed. That is the right outcome for a package the platform says the device requires.
- **Pre-existing, out of scope:** the non-system branch of `RootSystemGateway.setAppDisabled` still uses bare `pm disable` with no `--user`, so on a work profile it targets user 0 — the same bug fixed six lines above it.

## Verification

- `assembleFossDebug` — green
- `testFossDebugUnitTest --rerun-tasks` — **429 tests, 0 failures**, 45 of them new
- `lintFossDebug` — clean (`warningsAsErrors`, `abortOnError` both on)
- Zero new Kotlin compiler warnings
- **Device-tested on three devices.** A stock AOSP **Android 16 (API 36)** emulator and an **Android 17 (API 37)** Pixel 10 Pro Fold emulator, both via the shell uid 2000 that Shizuku runs as, plus the HyperOS handset `25053PC47G` for the OEM refusal and the original `-k` inode measurement. Every package mutated during the probes was restored to `default-state` and verified on both emulators.
- **The branch build runs on Android 17.** `app-foss-debug.apk` (`versionCode=1931`, `targetSdk=37`) installed on the Pixel 10 Pro Fold: `HomeActivity` resumes, no `AndroidRuntime` fatal, and the privilege probe reports `active=SHIZUKU` — the exact configuration this PR changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
