### PR TITLE
docs(gateway): correct comments that contradict the -k freeze fallback

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -236,13 +236,16 @@ class RootSystemGateway(
      *     package stays installed for the user, so app data, accounts and permissions all survive
      *     and unfreezing hands the app back exactly as it was. With root this should almost always
      *     be the rung that takes; it was simply never tried before.
-     *  2. `pm uninstall --user N` — the historical rung, kept but **gated behind
+     *  2. `pm uninstall -k --user N` — the historical rung, kept but **gated behind
      *     [uninstallFreezeFallbackAllowed]**, which answers `false` for [PrivilegeMode.ROOT] on
      *     every release: root can disable any package, so a refusal to disable is a real failure
-     *     worth surfacing, not a platform gap worth working around by deleting the user's data.
-     *     Under root this rung is therefore unreachable today and a failed rung 1 returns
-     *     `Result.failure`. The code stays because the gate — not this gateway — owns that decision,
-     *     and a device check could legitimately flip the root branch later.
+     *     worth surfacing, not a platform gap worth working around. `-k` is `DELETE_KEEP_DATA`, so
+     *     this rung keeps the app's files, settings and granted permissions too; what it does *not*
+     *     keep is the per-user installed bit, which is why a package frozen this way reads as gone
+     *     to anything querying without `MATCH_UNINSTALLED_PACKAGES`. Under root this rung is
+     *     unreachable today and a failed rung 1 returns `Result.failure`. The code stays because
+     *     the gate — not this gateway — owns that decision, and a device check could legitimately
+     *     flip the root branch later.
      *
      * Unfreeze has to undo **both** mechanics, in the order install-existing → enable. Devices in
      * the field carry apps frozen by the uninstall-only builds and must still thaw after this ships;
@@ -312,10 +315,12 @@ class RootSystemGateway(
     /**
      * Rung 1 → (gated) rung 2 of the system-app freeze, with a state re-read between them.
      *
-     * Rung 1 (`pm disable`) preserves the app's data; rung 2 (`pm uninstall --user`) deletes it, and
-     * is only reached when [uninstallFreezeFallbackAllowed] says this privilege mode has no other
-     * way to freeze a system app — which for root is never. Nothing here trusts a shell exit code:
-     * the rung that "succeeded" is the one the platform agrees changed the package state.
+     * Rung 1 (`pm disable`) preserves the app's data and leaves it installed. Rung 2
+     * (`pm uninstall -k --user`) preserves the data too — `-k` is `DELETE_KEEP_DATA` — but clears
+     * the per-user installed bit, so it is the rung with the visible consequence, and it is only
+     * reached when [uninstallFreezeFallbackAllowed] says this privilege mode has no other way to
+     * freeze a system app — which for root is never. Nothing here trusts a shell exit code: the
+     * rung that "succeeded" is the one the platform agrees changed the package state.
      */
     private suspend fun freezeSystemApp(
         packageName: String,
@@ -324,7 +329,7 @@ class RootSystemGateway(
     ): Result<Unit> {
         // Already frozen — by us, by an older build, or by another tool. Short-circuit before any
         // rung runs: re-freezing a package that is merely disabled must never walk down into the
-        // destructive rung just because the first command reported nothing to do.
+        // uninstall rung just because the first command reported nothing to do.
         if (readEffectivelyEnabled(packageName) == false) {
             Logger.i("RootSystemGateway", "freeze $packageName: already frozen, no rung run")
             return Result.success(Unit)
@@ -348,23 +353,26 @@ class RootSystemGateway(
                 // The package resolved a moment ago (isSystem was derived from it) and `pm disable`
                 // cannot make it unresolvable — getApplicationInfoCompat carries
                 // MATCH_UNINSTALLED_PACKAGES, and a disabled application is still returned. So this
-                // is a failed *read*, not a known state, and the next rung deletes user data. Fail
-                // closed: a retry re-reads and, if rung 1 actually landed, short-circuits above.
+                // is a failed *read*, not a known state, and the next rung would uninstall the
+                // package for this user on a state nobody can confirm. Fail closed: a retry
+                // re-reads and, if rung 1 actually landed, short-circuits above.
                 val e = java.io.IOException(
                     "Root freeze of $packageName: `pm disable --user $currentUser` ran but the package " +
-                        "state could no longer be read, so `pm uninstall --user $currentUser` was NOT " +
-                        "attempted — it would destroy app data on a state we cannot confirm."
+                        "state could no longer be read, so `pm uninstall -k --user $currentUser` was NOT " +
+                        "attempted — it would uninstall the package for this user on a state we cannot confirm."
                 )
                 Logger.e("RootSystemGateway", e.message.orEmpty(), e)
                 return Result.failure(e)
             }
 
-            true -> Unit // Rung 1 did not take. Consider the destructive rung — see the gate below.
+            true -> Unit // Rung 1 did not take. Consider the uninstall rung — see the gate below.
         }
 
-        // --- Rung 2: pm uninstall --user. DESTROYS the app's data; `pm install-existing` brings the
-        // package back factory-fresh. Gated, not merely last: the policy — not this gateway — owns
-        // the question of whether a privilege mode has any other way to freeze a system app.
+        // --- Rung 2: pm uninstall -k --user. `-k` is DELETE_KEEP_DATA, so the app's data survives
+        // and `pm install-existing` hands it back as it was; what does not survive is the per-user
+        // installed bit, which is the whole visible consequence of this rung. Gated, not merely
+        // last: the policy — not this gateway — owns the question of whether a privilege mode has
+        // any other way to freeze a system app.
         // Passing PrivilegeMode.ROOT literally is correct rather than lazy: this class *is* the root
         // implementation, and reading the user's configured mode here would let a fallback chain
         // that landed on root apply Shizuku's escalation rules. Under root the gate answers false
@@ -398,7 +406,7 @@ class RootSystemGateway(
         runCommand("pm uninstall -k --user $currentUser $escapedPackage")
         // Nothing is left to try, so anything but "definitely still enabled" is the state we asked
         // for: a null read can now only mean the package is no longer resolvable for this user,
-        // which is precisely what `pm uninstall --user` produces.
+        // which is precisely what `pm uninstall -k --user` produces.
         if (readEffectivelyEnabled(packageName) != true) {
             Logger.w(
                 "RootSystemGateway",

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -123,8 +123,9 @@ class ShizukuSystemGateway(
 
         // Rung 3, gated on the platform having actually refused — not on the Android version.
         // A stock AOSP API 36 emulator disables system apps from the shell uid without complaint,
-        // so a version test would destroy data on every device that never needed this rung, while
-        // still missing the OEM builds (Xiaomi HyperOS, reported on Android 14) that do. isSystem
+        // so a version test would uninstall the package for the user on every device that never
+        // needed this rung — losing its permission grants for no reason — while still missing the
+        // OEM builds (Xiaomi HyperOS, reported on Android 14) that do. isSystem
         // is true by construction here, but it is passed explicitly so the gate — not this call
         // site — owns the whole rule.
         if (!uninstallFreezeFallbackAllowed(

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -245,7 +245,9 @@ object Shizuku {
      *
      * Only the preinstalled-app freeze needs this. It is the one caller whose next move depends on
      * the difference between "the platform refused" and "that did not work", because its next move
-     * is `pm uninstall --user N` and that deletes the user's data.
+     * is `pm uninstall -k --user N` — which keeps the app's data, but clears its installed-for-this-user
+     * bit and its runtime permission grants, and so is worth reaching only where the platform left
+     * no alternative.
      */
     fun setAppDisabledDetailed(
         context: Context,


### PR DESCRIPTION
## What

Seven comments around the system-app freeze chain still describe `pm uninstall --user N` and its consequence — "DESTROYS the app's data", "brings the package back factory-fresh". #314 changed that command to `pm uninstall -k --user N`, and the comments did not follow.

Two of them contradict code within a few lines of themselves. `freezeSystemApp`'s rung 2 header:

```kotlin
// --- Rung 2: pm uninstall --user. DESTROYS the app's data; `pm install-existing` brings the
// package back factory-fresh. ...
```

and, twenty lines below it, the comment on the command that actually runs:

```kotlin
// `-k` (DELETE_KEEP_DATA) is not optional here: without it this line deletes
// /data/user/N/<pkg> ... With it, the data directories keep the same inodes across
// uninstall → install-existing (measured).
runCommand("pm uninstall -k --user $currentUser $escapedPackage")
```

## Why it is worth a PR of its own

These symbols are the source of record for what freezing does. The landing page under construction cites `RootSystemGateway.freezeSystemApp`, `uninstallFreezeFallbackAllowed` and `ShizukuSystemGateway.freezeApp` by name as the evidence for the sentence "your data stays where it is". A reviewer who opens the file and reads the KDoc first concludes the page is lying.

## Changes

Comments and one log message only. No behaviour change, no test change.

- `RootSystemGateway.setAppDisabled` KDoc, rung 2
- `RootSystemGateway.freezeSystemApp` KDoc
- the failed-state-read branch: comment and the `IOException` message it builds
- the rung 2 header comment
- the post-uninstall verification comment
- two "destructive rung" references, now "uninstall rung"
- `ShizukuSystemGateway` rung 3 gate rationale
- `Shizuku.setAppDisabledDetailed` KDoc

Each now states the real consequence: `-k` keeps the app's files, settings and granted permissions, and clears `FLAG_INSTALLED` for the user — so the package stops resolving for anything not passing `MATCH_UNINSTALLED_PACKAGES`. That is a genuine cost and the reason the rung stays gated. It is not the cost the comments claimed.

## Deliberately not changed

- **`FreezePolicy.FreezeMechanic`** — "Without `-k` this mechanic destroys the app's data" is a correct statement about every build before #314, and reads as history.
- **`DhizukuSystemGateway`** — still unconverted. It really does remove the package for the user without `-k`, so its comments are accurate as they stand. That gap is worth its own issue, not a comment edit.

## Verification

`./gradlew :app:compileFossDebugKotlin` → BUILD SUCCESSFUL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified app-freezing behavior to preserve app data and settings while removing the per-user installed state.
  * Updated guidance to explain that runtime permissions and grants are cleared during fallback removal.
  * Documented that fallback behavior depends on whether disabling is refused, including device-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->