### PR TITLE
docs(freezer): fix the two `-k` permission-grant claims 4524387d missed

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -411,8 +411,8 @@ class RootSystemGateway(
             Logger.w(
                 "RootSystemGateway",
                 "freeze $packageName: rung 1 `pm disable` had no effect; fell back to rung 2 " +
-                    "`pm uninstall -k --user $currentUser` — the app's data directories and its " +
-                    "runtime permission grants both survive the round trip"
+                    "`pm uninstall -k --user $currentUser` — data directories survive; the package " +
+                    "stops resolving without MATCH_UNINSTALLED_PACKAGES"
             )
             return Result.success(Unit)
         }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -161,8 +161,8 @@ class ShizukuSystemGateway(
         return if (isFrozen(packageName)) {
             Logger.w(
                 "ShizukuSystemGateway",
-                "freeze($packageName): frozen by uninstall-for-user with -k — data directories and " +
-                    "runtime permission grants both survive the round trip (measured on API 36)"
+                "freeze($packageName): frozen by uninstall-for-user with -k — data directories " +
+                    "survive; the package stops resolving without MATCH_UNINSTALLED_PACKAGES"
             )
             Result.success(Unit)
         } else {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -124,7 +124,8 @@ class ShizukuSystemGateway(
         // Rung 3, gated on the platform having actually refused — not on the Android version.
         // A stock AOSP API 36 emulator disables system apps from the shell uid without complaint,
         // so a version test would uninstall the package for the user on every device that never
-        // needed this rung — losing its permission grants for no reason — while still missing the
+        // needed this rung — clearing FLAG_INSTALLED, and with it the package's visibility to every
+        // query that omits MATCH_UNINSTALLED_PACKAGES, for no reason — while still missing the
         // OEM builds (Xiaomi HyperOS, reported on Android 14) that do. isSystem
         // is true by construction here, but it is passed explicitly so the gate — not this call
         // site — owns the whole rule.

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -686,12 +686,15 @@ object Shizuku {
      * goes away, because the APK is still on the read-only partition and `pm uninstall --user` only
      * clears `PackageUserState.installed` for one user.
      *
-     * **Runtime permission grants survive too.** This was previously documented here as a likely
-     * cost — "the app may come back having to ask for its permissions again" — and that guess was
-     * wrong. Measured on a stock AOSP API 36 emulator at uid 2000: `pm grant` a revocable runtime
-     * permission, round-trip through `pm uninstall -k` / `pm install-existing`, and the permission
-     * returns `granted=true` with its flags unchanged. `-k` retains the whole `PackageUserState`,
-     * not just the data directories.
+     * **Runtime permission grants survived the round trip that was measured.** This was previously
+     * documented here as a likely cost — "the app may come back having to ask for its permissions
+     * again" — and that guess measured false. On a stock AOSP API 36 emulator at uid 2000: `pm
+     * grant` a revocable runtime permission, round-trip through `pm uninstall -k` /
+     * `pm install-existing`, and the permission returns `granted=true` with its flags unchanged.
+     * The grant was made from the shell rather than by a user tapping Allow, and app-ops were not
+     * tested, so this retires the old claim without establishing its opposite. Note what `-k` does
+     * *not* do: it keeps the data directories, not the whole `PackageUserState` — `installed` still
+     * goes false, which is the sentence two paragraphs above.
      *
      * **This rung does not exist at shell uid on API 37.** Measured on an Android 17 emulator
      * (`CP31.260623.005`), the identical command that succeeds on API 36 fails:

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
@@ -85,11 +85,17 @@ fun isBlockedFromFreeze(app: AppInfo?): Boolean =
  * before this one did, for every system app, on every release.
  *
  * The residual cost of [UNINSTALL] is narrower than it looks, and narrower than this comment used
- * to claim: `-k` retains the whole `PackageUserState`, so runtime permission grants and app-ops
- * survive the round trip too — measured at uid 2000 on a stock API 36 emulator, where a granted
- * permission came back granted with its flags unchanged. What [UNINSTALL] really costs is
- * `FLAG_INSTALLED`: the package stops resolving for this user unless the caller passes
- * `MATCH_UNINSTALLED_PACKAGES`, which is why every query in the freeze path has to.
+ * to claim. What it costs unconditionally is `FLAG_INSTALLED`: `-k` still sets the user's installed
+ * state to false, so the package stops resolving for this user unless the caller passes
+ * `MATCH_UNINSTALLED_PACKAGES` — which is why every query in the freeze path has to.
+ *
+ * It does *not* cost the runtime permission grants, which this comment used to assert it did. That
+ * assertion was a guess, and it measured false: at uid 2000 on a stock API 36 emulator, a permission
+ * granted before the round trip came back granted with its flags unchanged. Read that for the scope
+ * it has — one permission, granted by `pm grant` from the shell rather than by a user tapping Allow,
+ * on one platform build. It retires the old blanket claim without earning the opposite one, and it
+ * says nothing about app-ops, which were never measured. Nor is `-k` "keep the whole
+ * `PackageUserState`": AOSP still clears per-user state on this path regardless of the flag.
  *
  * [DISABLE] is still preferred everywhere it works — which, measurably, is everywhere stock Android
  * runs — because it costs none of that. [UNINSTALL] exists because some OEM builds refuse to let
@@ -102,9 +108,10 @@ enum class FreezeMechanic {
     DISABLE,
 
     /**
-     * `pm uninstall -k --user N`. Keeps the app's data directories *and* its runtime permission
-     * grants — `-k` retains the whole `PackageUserState`, not just the data. What it does change is
-     * `FLAG_INSTALLED`, so the package stops resolving for this user without `MATCH_UNINSTALLED_PACKAGES`.
+     * `pm uninstall -k --user N`. Keeps the app's data directories, and — measured once, on a
+     * shell-granted permission at API 36 — its runtime permission grants with them. What it changes
+     * unconditionally is `FLAG_INSTALLED`, so the package stops resolving for this user without
+     * `MATCH_UNINSTALLED_PACKAGES`.
      *
      * Not reachable at shell uid on API 37: Android 17 answers this command with
      * `Failure [only root can delete system app for a particular user]` where API 36 answers
@@ -125,8 +132,9 @@ enum class FreezeMechanic {
  * Failing loudly is the deliberate choice. A freeze that reports an error costs the user an
  * annoyance and Thor a bug report; a freeze that quietly swaps one mechanic for another produces no
  * report at all, because from the outside it looked like it worked. Before `-k` was added to the
- * fallback the price of getting this wrong was the user's data; it is now their per-user permission
- * grants, which is smaller but still not something to spend on a binder timeout.
+ * fallback the price of getting this wrong was the user's data; it is now the package silently
+ * vanishing from every query that omits `MATCH_UNINSTALLED_PACKAGES`, which is smaller but still
+ * not something to spend on a binder timeout.
  *
  * ### Why this is not a version check
  *

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
@@ -84,12 +84,18 @@ fun isBlockedFromFreeze(app: AppInfo?): Boolean =
  * partition. **Without `-k` this mechanic destroys the app's data**, which is what every build
  * before this one did, for every system app, on every release.
  *
- * The residual cost of [UNINSTALL] is not data but per-user package state: runtime permission
- * grants and app-ops are expected not to survive the round trip, so an unfrozen app may have to ask
- * for its permissions again. That is why [DISABLE] is still preferred everywhere it works — which,
- * measurably, is everywhere stock Android runs. [UNINSTALL] exists because some OEM builds refuse
- * to let the shell uid disable their own system packages at all, and it is reached *only* where the
- * platform actually refused, which is what [uninstallFreezeFallbackAllowed] decides.
+ * The residual cost of [UNINSTALL] is narrower than it looks, and narrower than this comment used
+ * to claim: `-k` retains the whole `PackageUserState`, so runtime permission grants and app-ops
+ * survive the round trip too — measured at uid 2000 on a stock API 36 emulator, where a granted
+ * permission came back granted with its flags unchanged. What [UNINSTALL] really costs is
+ * `FLAG_INSTALLED`: the package stops resolving for this user unless the caller passes
+ * `MATCH_UNINSTALLED_PACKAGES`, which is why every query in the freeze path has to.
+ *
+ * [DISABLE] is still preferred everywhere it works — which, measurably, is everywhere stock Android
+ * runs — because it costs none of that. [UNINSTALL] exists because some OEM builds refuse to let
+ * the shell uid disable their own system packages at all, and it is reached *only* where the
+ * platform actually refused, which is what [uninstallFreezeFallbackAllowed] decides. On API 37 it
+ * does not exist at shell uid at all; see [UNINSTALL].
  */
 enum class FreezeMechanic {
     /** `pm disable`, or the equivalent `setApplicationEnabledSetting` reflection. Keeps data. */

--- a/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/FreezePolicy.kt
@@ -87,7 +87,7 @@ fun isBlockedFromFreeze(app: AppInfo?): Boolean =
  * The residual cost of [UNINSTALL] is narrower than it looks, and narrower than this comment used
  * to claim. What it costs unconditionally is `FLAG_INSTALLED`: `-k` still sets the user's installed
  * state to false, so the package stops resolving for this user unless the caller passes
- * `MATCH_UNINSTALLED_PACKAGES` — which is why every query in the freeze path has to.
+ * `MATCH_UNINSTALLED_PACKAGES` — which is why every query in the freeze path must pass that flag.
  *
  * It does *not* cost the runtime permission grants, which this comment used to assert it did. That
  * assertion was a guess, and it measured false: at uid 2000 on a stock API 36 emulator, a permission


### PR DESCRIPTION
Comments, plus two `Logger.w` strings. No control flow, no API, no behaviour change.

## What this fixes

`4524387d` measured that runtime permission grants **do** survive `pm uninstall -k`, and corrected five comments that claimed they did not. Three sites were missed. One of them contradicted a comment ten lines below it in the same file:

| Location | Says |
|---|---|
| `FreezePolicy.kt` — `FreezeMechanic` KDoc | "runtime permission grants and app-ops are **expected not to survive** the round trip, so an unfrozen app may have to ask for its permissions again" |
| `FreezePolicy.kt` — `UNINSTALL` KDoc, 10 lines below | "Keeps the app's data directories **and its runtime permission grants**" |

A reader hitting those in order has no way to tell which one was measured and which one was a guess.

The second site, `ShizukuSystemGateway.kt`, is worse in a quieter way: it uses the refuted claim as the *justification* for the rung-3 gate — "a version test would uninstall the package for the user on every device that never needed this rung — **losing its permission grants for no reason**". The gate is still correct. Its stated reason was not.

The third, in `uninstallFreezeFallbackAllowed`'s KDoc, is the same shape: "the price of getting this wrong was the user's data; it is now **their per-user permission grants**". It survived the first sweep because the phrase wraps across two lines and the sweep matched line-by-line.

## The measurement being restored

From `4524387d`, at uid 2000 on a stock AOSP API 36 emulator:

```
pm grant com.android.egg READ_EXTERNAL_STORAGE   -> granted=true
pm uninstall -k --user 0 com.android.egg         -> Success
pm install-existing --user 0 com.android.egg     -> Success
READ_EXTERNAL_STORAGE                            -> granted=true, flags unchanged
ceDataInode / deDataInode                        -> byte-identical
```

So the residual cost of `UNINSTALL` is neither the data nor the grants. It is `FLAG_INSTALLED`: the package stops resolving for that user unless the caller passes `MATCH_UNINSTALLED_PACKAGES` — which is why every query in the freeze path has to.

## What review changed

CodeRabbit made two points against the first draft of this PR, and both held.

**"`-k` retains the whole `PackageUserState`" is false.** It preserves the data directories, not the per-user record wholesale — `installed` still goes false, which is the very cost the same paragraph then describes. The phrase was at three sites, one of which contradicted a sentence two paragraphs above it. Removed everywhere.

**The grant observation was over-generalised.** The run above is one permission, granted by `pm grant` from the shell rather than by a user tapping Allow, on one platform build, with app-ops never tested. Writing it up as a general property swaps a wrong blanket claim for an unmeasured one — the exact failure this PR exists to fix. I did not re-measure (a proper test needs a user-granted permission on a device I'm not authorised to mutate). Each site now names both limits and reads as what it is: evidence that retires the old claim without earning its opposite.

Two `Logger.w` strings carried the unqualified claim into logcat. A log line is the worst place to hang a caveat, so they now state the unconditional fact.

## Why it is worth a PR on its own

This is the class of defect the freezer comments exist to prevent. The whole rung ordering — disable first, uninstall only where the platform refused — is argued in prose, and the argument was resting on a fact that had already been measured false. The next person tuning that gate reads the comment, not the commit that superseded it.

## Verification

- `./gradlew compileFossDebugKotlin` — passes.
- Swept the tree for every surviving phrasing of the refuted claim, on **flattened** text rather than line-by-line, which is what hid the third site. Also swept for "whole `PackageUserState`" and for bare `app-ops` claims. Clean.
- Neither sweep used BSD `grep -E`, whose unsupported `\s` has produced false clean sweeps in this repo before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how system-app freezing behaves when using the uninstall-and-restore fallback.
  * Documented that app data is preserved, while the package may become hidden from normal queries.
  * Clarified which runtime permissions and package states are preserved, including limitations around app-ops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->