### PR TITLE
ci(web): publish from master, stage from dev — and correct what #321 said about Vercel

### DIFF
--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -20,7 +20,15 @@ on:
       # web-ci.yml already gates it. Its own build reads gradle.properties and
       # gradle/libs.versions.toml, which are deliberately NOT ignored here, so a
       # chore(release) bump still runs everything.
+      #
+      # The site's plumbing is listed alongside it because 'web/**' alone does not
+      # cover it, and a push carrying only site plumbing would therefore still run
+      # this whole workflow. That is not hypothetical: the merge that first puts the
+      # landing page on master carries all four of these.
       - 'web/**'
+      - 'vercel.json'
+      - '.github/workflows/web-*.yml'
+      - '.github/labeler.yml'
       - 'LICENSE'
       - '.gitignore'
       - '.github/**/*.md'

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -17,7 +17,14 @@ on:
       # Gradle module, and cannot reach the APK or the Play upload. It has its own
       # gate in web-ci.yml and its own deploy in Vercel. gradle.properties stays out
       # of this list, so a release push still builds.
+      #
+      # The three entries after 'web/**' are the site's plumbing, which that glob
+      # does not cover — without them a push carrying only site plumbing would run
+      # a full build and a Play upload to prove nothing.
       - 'web/**'
+      - 'vercel.json'
+      - '.github/workflows/web-*.yml'
+      - '.github/labeler.yml'
       - 'LICENSE'
       - '.gitignore'
       - '.github/**/*.md'

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -13,13 +13,20 @@ name: Web Deploy
 # in git. See web/docs/deploy.md.
 #
 # ────────────────────────────────────────────────────────────────────────────
-# THE ONE THING THAT MUST STAY TRUE: `web/vercel.json` sets
-#   "git": { "deploymentEnabled": false }
-# If that is ever removed while this workflow exists, EVERY web commit deploys
-# twice — once by Vercel's Git integration and once by this workflow — and the
-# two race for the production alias. The loser is whichever finishes first, so
-# the symptom is the site intermittently serving the older of two commits.
-# Nothing reports this. The two settings are one decision.
+# THE ONE THING THAT MUST STAY TRUE: the Vercel project is NOT connected to the
+# GitHub repository. Create it with `cd web && vercel link`, never by importing
+# the repo — importing also sets Root Directory to `web`, which resolves to
+# `web/web` because this workflow already runs the CLI from inside web/.
+#
+# `"git": { "deploymentEnabled": false }` is defence in depth, and it is in TWO
+# files — web/vercel.json and /vercel.json — because Vercel does not document
+# which one its Git integration reads. Delete neither.
+#
+# If the repo does get connected: Vercel's production branch here is `master`,
+# so a dev push is a Git-sourced *preview* and there is no alias race. The
+# hazard is the first dev→master release merge, when a master push becomes a
+# real Vercel production deploy built from the Gradle repo root, with no run of
+# this workflow competing. Not a race — an uncontested overwrite.
 # ────────────────────────────────────────────────────────────────────────────
 #
 # Path filter: identical to web-ci.yml's, and for the same reason. The site
@@ -248,7 +255,7 @@ jobs:
           out=".vercel/output/static"
 
           if [ ! -f "$out/index.html" ]; then
-            echo "::error::$out/index.html is missing, so the artifact about to be deployed is not the site. The usual cause is a Root Directory mismatch — this job already runs inside web/, so the Vercel project's Root Directory must not also be 'web'. See web/docs/deploy.md."
+            echo "::error::$out/index.html is missing, so the artifact about to be deployed is not the site. The usual cause is a Root Directory mismatch — this job already runs inside web/, so the Vercel project's Root Directory must be UNSET, not 'web'. Note that this check is not the first thing a Root Directory mismatch trips: if the project was created by importing the repo, its pulled settings carry framework=astro and the Build step dies earlier with 'Command \"astro build\" exited with 127', which names nothing about paths. See web/docs/deploy.md."
             ls -la .vercel/output 2>/dev/null || echo "(no .vercel/output at all)"
             exit 1
           fi
@@ -283,6 +290,13 @@ jobs:
       # `--archive=tgz` compresses the upload into a single tarball. The site
       # ships six PNG screenshots plus a font set; archiving keeps the deploy
       # well clear of Vercel's per-request file-count limits.
+      #
+      # NEVER add `--no-wait` here. The CLI uploads a commandForIgnoringBuildStep
+      # derived from vercel.json even on a --prebuilt deploy, and Vercel has
+      # shipped (then rolled back) a build where the Ignored Build Step cancelled
+      # prebuilt deployments. Waiting is what makes that loud: `vercel deploy`
+      # prints "The deployment has been canceled." and exits 1 under `set -e`.
+      # With --no-wait the same cancellation is a green job that shipped nothing.
       - name: Deploy
         id: deploy
         if: steps.creds.outputs.present == 'true'

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -22,11 +22,12 @@ name: Web Deploy
 # files — web/vercel.json and /vercel.json — because Vercel does not document
 # which one its Git integration reads. Delete neither.
 #
-# If the repo does get connected: Vercel's production branch here is `master`,
-# so a dev push is a Git-sourced *preview* and there is no alias race. The
-# hazard is the first dev→master release merge, when a master push becomes a
-# real Vercel production deploy built from the Gradle repo root, with no run of
-# this workflow competing. Not a race — an uncontested overwrite.
+# If the repo does get connected, the consequence is now a genuine race, not a
+# theoretical one. Vercel's default production branch is `master`, which is also
+# this workflow's production branch, so one master push fires two production
+# deploys at the same alias: this one, carrying a gated artifact, and a
+# Git-sourced Vercel build started from the Gradle repository root — which has no
+# package.json. Whichever finishes last wins the alias.
 # ────────────────────────────────────────────────────────────────────────────
 #
 # Path filter: identical to web-ci.yml's, and for the same reason. The site
@@ -34,7 +35,7 @@ name: Web Deploy
 # gradle/libs.versions.toml (web/src/lib/repo-facts), so a chore(release) commit
 # touches nothing under web/ and still changes what the site renders.
 #
-# That list lives in FOUR places: here, web-ci.yml's paths:, the (inert)
+# That list lives in FOUR places: here, web-ci.yml's paths:, the
 # ignoreCommand in web/vercel.json, and — as GRADLE_PROPERTIES and
 # VERSION_CATALOG — web/src/lib/repo-facts/read.ts. Deriving a new fact from a
 # new file means editing all four in the same commit. Edit read.ts alone and the
@@ -46,9 +47,21 @@ name: Web Deploy
 # GitHub reports a path-skipped required check as "Expected — Waiting for
 # status" forever, which would leave every Android-only PR unmergeable.
 
+# BRANCH MODEL: `master` publishes, `dev` stages. Both are push triggers, and the
+# difference between them is the `--prod` flag resolved below, not the trigger
+# list. Site work is merged to `dev` like everything else and gets a real,
+# deployed preview URL for the integrated state; the live site changes only when
+# `dev` is merged to `master`. That merge is a deliberate act, which is the whole
+# point — "we are sure" is a decision someone makes, not a side effect of pushing.
+#
+# `dev` is kept as a push trigger on purpose. Dropping it would mean the only
+# deployed artifact between releases is a per-PR preview, and no URL would ever
+# show the merged state of several site PRs together — which is exactly the state
+# the release merge is about to publish.
+
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "master", "dev" ]
     paths:
       - 'web/**'
       - 'gradle.properties'
@@ -125,10 +138,22 @@ jobs:
             echo "present=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Production is a push to `dev` — that is the site's production branch, as
-      # the design has said throughout. Everything else, including a manual
-      # dispatch from another branch, is a preview. A dispatch is treated as an
-      # explicit request to publish only when it is aimed at `dev`.
+      # Production is a push to `master`, and nothing else is. A push to `dev`, a
+      # pull request, and a manual dispatch from any branch other than `master`
+      # are all previews. A dispatch counts as a request to publish only when it
+      # is aimed at `master`, which is also the only branch GitHub offers the
+      # Run-workflow button from, since it is the default branch.
+      #
+      # `strict` is the third output and it is the one that is easy to miss.
+      # `check:screenshots` refuses a placeholder frame when VERCEL_ENV=production
+      # OR when REQUIRE_SCREENSHOTS=1 (web/scripts/check-screenshots.mjs). Setting
+      # it on pull requests based on `master` is what makes the release PR's
+      # preview assert production strictness BEFORE the merge that publishes.
+      # Without it the first build ever held to the production standard would be
+      # the one already serving on the live domain, and a placeholder would be
+      # found by a visitor rather than by a check. It stays off for PRs into `dev`
+      # and for `dev` pushes: work in progress is allowed to carry a placeholder,
+      # which is the entire reason the gate is conditional.
       - name: Resolve the target environment
         id: target
         if: steps.creds.outputs.present == 'true'
@@ -136,15 +161,23 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           REF: ${{ github.ref }}
+          BASE: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          if [ "$EVENT" != "pull_request" ] && [ "$REF" = "refs/heads/dev" ]; then
+          if [ "$EVENT" != "pull_request" ] && [ "$REF" = "refs/heads/master" ]; then
             echo "env=production" >> "$GITHUB_OUTPUT"
             echo "flag=--prod" >> "$GITHUB_OUTPUT"
+            echo "strict=1" >> "$GITHUB_OUTPUT"
             echo "Target: production (thor.trinadhthatakula.com)"
+          elif [ "$EVENT" = "pull_request" ] && [ "$BASE" = "master" ]; then
+            echo "env=preview" >> "$GITHUB_OUTPUT"
+            echo "flag=" >> "$GITHUB_OUTPUT"
+            echo "strict=1" >> "$GITHUB_OUTPUT"
+            echo "Target: preview, held to production strictness (base is master)"
           else
             echo "env=preview" >> "$GITHUB_OUTPUT"
             echo "flag=" >> "$GITHUB_OUTPUT"
+            echo "strict=" >> "$GITHUB_OUTPUT"
             echo "Target: preview"
           fi
 
@@ -212,6 +245,10 @@ jobs:
       # strictness a property of this file instead of a property of Vercel's
       # internals.
       #
+      # REQUIRE_SCREENSHOTS rides alongside it and is empty except on a pull
+      # request into `master`, where it holds a preview build to the production
+      # screenshot standard — see the target step for why.
+      #
       # The build itself is `npm run build` (web/vercel.json's buildCommand),
       # which is the whole gate chain: check:types, astro build, check:links,
       # check:claims, check:markup, check:sitemap, check:screenshots.
@@ -220,6 +257,7 @@ jobs:
         if: steps.creds.outputs.present == 'true'
         env:
           VERCEL_ENV: ${{ steps.target.outputs.env }}
+          REQUIRE_SCREENSHOTS: ${{ steps.target.outputs.strict }}
         run: vercel build ${{ steps.target.outputs.flag }} --token="${{ secrets.VERCEL_TOKEN }}"
 
       # ──────────────────────────────────────────────────────────────────────
@@ -250,6 +288,7 @@ jobs:
         if: steps.creds.outputs.present == 'true'
         env:
           VERCEL_ENV: ${{ steps.target.outputs.env }}
+          REQUIRE_SCREENSHOTS: ${{ steps.target.outputs.strict }}
         run: |
           set -euo pipefail
           out=".vercel/output/static"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}

--- a/web/README.md
+++ b/web/README.md
@@ -82,7 +82,12 @@ only when `dev` is merged to `master`.
 
 A PR based on `master` additionally builds with `REQUIRE_SCREENSHOTS=1`, so `check:screenshots` is
 strict on the release PR's preview rather than first becoming strict on the deploy that is already
-live. `web/docs/deploy.md` is the reference — secrets, project settings, rollback. What follows is
+live.
+
+Both PR cases mean a PR from a branch in this repository. A **forked** PR gets no repository secrets,
+so the deploy job skips itself rather than failing on an empty token — no preview, no comment, no
+strict check. The `master` push re-gates everything before it uploads, so that costs coverage, not
+safety. `web/docs/deploy.md` is the reference — secrets, project settings, rollback. What follows is
 only the part you need in order not to break it from inside this directory.
 
 The trade is deliberate: under the Git integration, four dashboard settings decide whether the gates

--- a/web/README.md
+++ b/web/README.md
@@ -152,8 +152,10 @@ nothing, and exits 0 for *every* commit — the site would show "Build skipped",
   `dev` and `master` rulesets, `on.pull_request.paths` filters the whole workflow, and GitHub reports
   a path-skipped required check as pending forever. A site-only PR would be unmergeable. The ~7
   minutes of Android CI on a CSS change is the accepted price.
-- **`dev-check.yml` / `production-deploy.yml`** — `web/**` is in their `paths-ignore`. Neither is a
-  required check, and a change that cannot reach the APK should not spend seven minutes proving it.
+- **`dev-check.yml` / `production-deploy.yml`** — `web/**` is in their `paths-ignore`, and so are
+  `vercel.json`, `.github/workflows/web-*.yml` and `.github/labeler.yml`, because `web/**` alone does
+  not cover the site's own plumbing. Neither is a required check, and a change that cannot reach the
+  APK should not spend seven minutes proving it.
 
 ---
 

--- a/web/README.md
+++ b/web/README.md
@@ -1,7 +1,7 @@
 # Thor landing page
 
 The static site at **<https://thor.trinadhthatakula.com>** — seven routes plus a 404, built with
-Astro, deployed on Vercel from the `dev` branch. No backend, no forms, no analytics, and no client
+Astro, deployed on Vercel from the `master` branch. No backend, no forms, no analytics, and no client
 JavaScript except the theme toggle.
 
 It lives inside the app repository on purpose: a feature and the page that describes it move in one
@@ -74,10 +74,16 @@ ceiling and hand you a green local build for the wrong reason.
 
 ## Deploying
 
-**Deploys run from `.github/workflows/web-deploy.yml`, not from Vercel's Git integration.** A push to
-`dev` touching the site deploys production; a PR into `dev` or `master` deploys a preview and
-comments the URL. `web/docs/deploy.md` is the reference — secrets, project settings, rollback. What
-follows is only the part you need in order not to break it from inside this directory.
+**Deploys run from `.github/workflows/web-deploy.yml`, not from Vercel's Git integration.**
+`master` publishes and `dev` stages: a push to `master` touching the site deploys production, a push
+to `dev` deploys a preview of the integrated site, and a PR into either deploys a preview and
+comments the URL. Site work therefore merges to `dev` like everything else, and the live site changes
+only when `dev` is merged to `master`.
+
+A PR based on `master` additionally builds with `REQUIRE_SCREENSHOTS=1`, so `check:screenshots` is
+strict on the release PR's preview rather than first becoming strict on the deploy that is already
+live. `web/docs/deploy.md` is the reference — secrets, project settings, rollback. What follows is
+only the part you need in order not to break it from inside this directory.
 
 The trade is deliberate: under the Git integration, four dashboard settings decide whether the gates
 above run at all, none of them is visible in a diff, and every one produces **no error when wrong**.

--- a/web/README.md
+++ b/web/README.md
@@ -84,15 +84,23 @@ above run at all, none of them is visible in a diff, and every one produces **no
 Driving the CLI from Actions puts those decisions in `vercel.json` and the workflow, where they get
 reviewed.
 
-### `git.deploymentEnabled: false` is load-bearing
+### The Vercel project is not connected to the repository
+
+That is the actual guarantee that the site deploys once per commit, and it is a property of the
+Vercel project, not of anything in this directory. Create the project with `cd web && vercel link`;
+importing the repository from `vercel.com/new` connects it *and* sets Root Directory to `web`, which
+resolves to `web/web` once the workflow runs the CLI from inside `web/`.
 
 ```json
 "git": { "deploymentEnabled": false }
 ```
 
-Remove that while `web-deploy.yml` exists and every web commit deploys **twice** — Vercel's Git
-integration and the workflow, racing for the same production alias. The symptom is the site
-intermittently serving the older of two commits, and nothing reports it. The two are one decision.
+That flag is defence in depth for the case where the repository gets connected anyway, and it lives
+in **two** files: here in `vercel.json`, and in `/vercel.json` at the repository root. Vercel does
+not document which one its Git integration reads — the setting is evaluated at webhook time, before
+a build container exists, so the CLI's resolution rules do not apply. Two copies remove the guess;
+delete neither. It is also not fully dependable even when placed correctly, so treat a connected
+repository as something to verify by counting deployments, not something the flag has handled.
 
 `vercel.json` also carries `buildCommand`, `installCommand` and `outputDirectory`, and it takes
 precedence over the dashboard's fields — which is what stops a dashboard edit from silently
@@ -120,12 +128,14 @@ One file is read that is deliberately *not* in the list: `findRepoRoot()` reads 
 to locate the repository root. Only its existence matters, never its contents, so a change to it
 cannot change a rendered fact and must not trigger a rebuild.
 
-`ignoreCommand` is currently **inert** — it is a Git-integration feature and the Git integration is
-off. It is kept as defence in depth for the case where someone flips `deploymentEnabled` back on
-without reading `docs/deploy.md`. Its `:/` prefixes are still load-bearing on that path: the command
-would run inside the Root Directory, where a bare `gradle.properties` pathspec resolves to
-`web/gradle.properties`, matches nothing, and exits 0 for *every* commit — the site would show
-"Build skipped", correctly, forever.
+`ignoreCommand` is a Git-integration feature and the Git integration is off, so it should do nothing
+today — but do not treat it as provably inert. `vercel deploy` sends
+`projectSettings.commandForIgnoringBuildStep`, derived from `vercel.json`, on the same payload as
+`--prebuilt`, and Vercel has previously shipped (then rolled back) a build in which the Ignored Build
+Step cancelled `--prebuilt` deploys. If that recurs the job goes red rather than silently green.
+Its `:/` prefixes are load-bearing whenever it does run: the command executes inside the Root
+Directory, where a bare `gradle.properties` pathspec resolves to `web/gradle.properties`, matches
+nothing, and exits 0 for *every* commit — the site would show "Build skipped", correctly, forever.
 
 ### GitHub Actions, and why the asymmetry
 
@@ -156,6 +166,15 @@ cname.vercel-dns.com.
 Add the domain in the Vercel project and let Vercel issue the certificate. Errors between "grey
 cloud" and "Vercel has claimed the hostname" are expected.
 
+**The error you will actually see is an expired certificate, not a Cloudflare one.** Vercel's edge
+already answers for this hostname and, with no project claiming it, falls back to a stale
+`*.trinadhthatakula.com` certificate that expired on 11 May 2026 (`x-vercel-error:
+DEPLOYMENT_NOT_FOUND`, `server: Vercel`). Vercel cannot renew a wildcard without a DNS-01 record and
+the zone is on Cloudflare nameservers, so it will not self-heal. It also serves a two-year HSTS
+header and 308s plain HTTP to HTTPS, so a browser cannot be clicked through. `ERR_CERT_DATE_INVALID`
+here means *unclaimed hostname*, not *broken DNS* — verify with `vercel domains inspect` and
+`vercel certs ls`, never a browser, until the certificate exists.
+
 **The zone has a proxied `*` wildcard.** Every subdomain of `trinadhthatakula.com` resolves,
 including names that were never configured:
 
@@ -173,10 +192,14 @@ Two consequences:
   to the wildcard and serves the wrong thing, or a TLS error. Ordinary DNS smoke tests will not
   catch it.
 
-**Never fix a Cloudflare 526 by switching the SSL mode to Flexible.** It appears to work, and it
-serves the origin hop unencrypted — on a site whose privacy stance is the entire argument. A 526
-during setup means the Vercel project has not claimed the hostname yet. The correct order is grey
-cloud → create the Vercel project → add the domain → Vercel issues the certificate.
+**A Cloudflare 526 cannot occur while the record stays grey.** 526 requires Cloudflare to be in the
+request path, which means an orange cloud; this record is DNS-only. If one is ever orange-clouded and
+a 526 appears, **never fix it by switching the SSL mode to Flexible** — it appears to work, and it
+serves the origin hop unencrypted, on a site whose privacy stance is the entire argument.
+
+The correct order is grey cloud → create the Vercel project → first production deploy → add the
+domain → Vercel issues the certificate. Adding the domain before a production deployment exists
+leaves it attached to nothing, which is indistinguishable from "still issuing".
 
 ---
 

--- a/web/docs/deploy.md
+++ b/web/docs/deploy.md
@@ -12,6 +12,15 @@ Vercel.
 | pull request into `dev` touching the web paths | preview | URL commented on the PR |
 | `workflow_dispatch` from `master` | production | same as a push to `master` |
 | `workflow_dispatch` from any other branch | preview | escape hatch, deploys nothing live |
+| **pull request from a fork** | **nothing** | job skipped — see below |
+
+The two pull-request rows mean a pull request **from a branch in this repository**. A forked PR gets
+no repository secrets, so the deploy job would fail on an empty token — a red check the contributor
+cannot fix and did not cause — and the job skips itself instead. A fork PR therefore gets no preview
+URL, no comment, and no strict screenshot check. Nothing is silently weakened by that: the `master`
+push re-runs every gate, strictly, *before* it uploads, so a placeholder that slipped through a fork
+PR turns the deploy red and leaves the previous deployment serving. It is caught after the merge
+rather than before it.
 
 ## The branch model: `master` publishes, `dev` stages
 
@@ -25,10 +34,12 @@ forgotten:
 - **A `dev` push still deploys**, as a preview. That is on purpose. A per-PR preview only ever shows
   one branch; the `dev` preview is the only URL that shows several merged site PRs *together*, which
   is the state the release merge is about to publish.
-- **A pull request into `master` is built to the production standard.** The workflow sets
-  `REQUIRE_SCREENSHOTS=1` when `github.base_ref` is `master`, which makes `check:screenshots` refuse a
-  placeholder frame on a *preview* build. Without it, the first build ever held to the production
-  standard would be the one already serving on the live domain.
+- **A pull request into `master` is built to the production standard**, as long as it comes from this
+  repository rather than a fork. The workflow sets `REQUIRE_SCREENSHOTS=1` when `github.base_ref` is
+  `master`, which makes `check:screenshots` refuse a placeholder frame on a *preview* build. Without
+  it, the first build ever held to the production standard would be the one already serving on the
+  live domain. The release PR comes from `dev`, so in the flow this was written for it always
+  applies.
 - **`workflow_dispatch` needs this file on `master`**, because GitHub only offers the Run-workflow
   button for workflows on the **default branch**. That is the same condition production deploys need,
   so the two arrive together: until `web/` reaches `master` there is no production deploy and no
@@ -73,10 +84,20 @@ npx vercel@58 link      # answer "create a new project" when it offers
 | Framework in the pulled settings | `astro`, auto-detected inside `web/` | `null` |
 
 The import flow produces the one combination that is confirmed broken. `vercel build` computes its
-work path as `join(cwd, rootDirectory)`, and this workflow already runs the CLI from inside `web/`,
-so Root Directory `web` resolves to `web/web`
-(`packages/cli/src/commands/build/index.ts`; `vercel/vercel#16749` documents the same double-append
-as a live bug). Worse, it does not fail the way this repo advertises: with `framework: "astro"` in
+work path as `join(cwd, rootDirectory)` (`packages/cli/src/commands/build/index.ts`), so the breakage
+needs both halves: the CLI running from `web/`, *and* a Root Directory of `web`. This workflow does
+the first unconditionally, which is why the second must stay unset — `join('…/web', 'web')` is
+`web/web`, a path that does not exist. Either half alone is fine.
+
+That is the behaviour of **`vercel@58.4.4`**, read from source; `vercel@58` resolves to exactly that
+today, and it is what the workflow installs. Vercel has a fix in flight for the general monorepo case
+— `vercel/vercel#16749`, which re-anchors per-directory links to the repository root — but it is
+closed unmerged and its `VERCEL_RESOLVE_ROOT_DIRECTORY` guard does not appear anywhere in the
+published 58.4.4 tarball. If a later CLI does land it, this stops being a build failure and starts
+being silently fine, which changes nothing about the advice and everything about what the tripwire
+below catches.
+
+Worse, it does not fail the way this repo advertises: with `framework: "astro"` in
 the pulled settings the build dies first at `Command "astro build" exited with 127`, which reads as a
 broken toolchain and says nothing about paths. The "Gate the staged artifact" tripwire only fires
 when the pulled settings are all null — that is, only when the project was made with the CLI.
@@ -167,7 +188,7 @@ repo-root copy is the one that is plausibly read, and the `web/` copy plausibly 
 cost nothing and remove the guess. Do not delete either.
 
 Even correctly placed, the flag is not a dependable kill switch: `vercel/vercel#11176`
-("deploymentEnabled option in vercel.json is ignored") has been open since November 2024 with
+("deploymentEnabled option in vercel.json is ignored") has been open since **19 February 2024** with
 independent confirmations, and the file must exist on the branch being pushed for it to apply at
 all. Set it, then **verify by observation** — push one no-op commit under `web/` and count the
 deployments the Vercel project creates. If there is more than one, disconnect the repository.

--- a/web/docs/deploy.md
+++ b/web/docs/deploy.md
@@ -11,6 +11,12 @@ Vercel.
 | `workflow_dispatch` from `dev` | production | same as a push |
 | `workflow_dispatch` from any other branch | preview | escape hatch, deploys nothing live |
 
+**The two `workflow_dispatch` rows do not work yet.** GitHub only offers the Run-workflow button for
+workflows that exist on the **default branch**, and `web-deploy.yml` is on `dev`, not `master`. Until
+the first `dev` → `master` release merge there is no manual trigger at all: the only ways to deploy
+are a push to `dev` or a pull request. Do not plan the first deploy around a button that is not
+there.
+
 "the web paths" is `web/**`, `gradle.properties`, `gradle/libs.versions.toml` and the workflow file
 itself. The two Gradle files are in the list because `web/src/lib/repo-facts` derives the site's
 version name and SDK levels from them, so a `chore(release)` commit changes what the site renders
@@ -32,13 +38,46 @@ Driving the CLI from Actions moves each of those into `web-deploy.yml` and `web/
 they are in git and under review, and it puts a gate failure in the same place as every other CI
 failure instead of on a Vercel page nobody has open.
 
+## Create the project with the CLI, not by importing the repository
+
+This is the first decision and it silently sets three others. It was not written down until after the
+pipeline shipped, and it is the single most likely way a first deploy fails.
+
+```sh
+cd web
+npx vercel@58 login
+npx vercel@58 link      # answer "create a new project" when it offers
+```
+
+| | `vercel.com/new` → Import Git Repository | `cd web && vercel link` |
+|---|---|---|
+| Root Directory | the import UI asks, and `web` is the only sane-looking answer | unset — which is what this workflow needs |
+| Git connected | **yes**, webhook installed | **no** — `web/.git/config` does not exist, so the connect prompt never fires |
+| Framework in the pulled settings | `astro`, auto-detected inside `web/` | `null` |
+
+The import flow produces the one combination that is confirmed broken. `vercel build` computes its
+work path as `join(cwd, rootDirectory)`, and this workflow already runs the CLI from inside `web/`,
+so Root Directory `web` resolves to `web/web`
+(`packages/cli/src/commands/build/index.ts`; `vercel/vercel#16749` documents the same double-append
+as a live bug). Worse, it does not fail the way this repo advertises: with `framework: "astro"` in
+the pulled settings the build dies first at `Command "astro build" exited with 127`, which reads as a
+broken toolchain and says nothing about paths. The "Gate the staged artifact" tripwire only fires
+when the pulled settings are all null — that is, only when the project was made with the CLI.
+
+If the project has already been imported: Settings → Git → Disconnect, and clear Root Directory back
+to empty.
+
+**Not connecting the repository is also the only guarantee that the site deploys once per commit.**
+See "The one thing that must stay true" below — the `vercel.json` kill switch is real but not
+dependable, and disconnection is.
+
 ## The three secrets
 
 Repository secrets, Settings → Secrets and variables → Actions.
 
 | Secret | Where it comes from |
 |---|---|
-| `VERCEL_TOKEN` | Vercel → Account Settings → Tokens → Create. Scope it to the team that owns the project. |
+| `VERCEL_TOKEN` | Vercel → Account Settings → Tokens → Create. **Scope must match `VERCEL_ORG_ID`.** On a personal/Hobby account the scope is your own username, not a team; picking a team scope for a personal project fails at `vercel pull` with an authorization error that does not say the scope is the problem. |
 | `VERCEL_ORG_ID` | `.vercel/project.json` after running `vercel link` locally in `web/` (field `orgId`). |
 | `VERCEL_PROJECT_ID` | the same file, field `projectId`. |
 
@@ -55,10 +94,10 @@ landing before the Vercel project exists must not redden every web PR in between
 
 Far fewer matter than under the Git integration, because the build no longer happens on Vercel.
 
-- **Root Directory — leave at the repository root (the default).** The workflow already runs the
-  CLI from inside `web/`. Setting it to `web` as well risks resolving to `web/web`. If it is wrong,
-  the "Gate the staged artifact" step fails with a message naming this cause rather than deploying
-  something empty.
+- **Root Directory — leave it UNSET.** The workflow already runs the CLI from inside `web/`, and
+  `vercel build`/`vercel deploy` both resolve `join(cwd, rootDirectory)`, so a Root Directory of
+  `web` becomes `web/web`. See the creation table above for why this is the setting most likely to
+  be wrong, and why the tripwire that is supposed to catch it often does not.
 - **"Include files outside the Root Directory"** — no longer relevant. It exists because
   `repo-facts` reads `gradle.properties` from the repo root, and under Actions the whole repository
   is checked out, so the read just works.
@@ -66,32 +105,73 @@ Far fewer matter than under the Git integration, because the build no longer hap
   `web/vercel.json` sets `buildCommand`, `installCommand` and `outputDirectory`, and `vercel.json`
   takes precedence over project settings. That precedence is what keeps a dashboard edit from
   silently removing the gate chain.
-- **Production Branch** — irrelevant to this pipeline. Which deploy is production is decided by
-  `web-deploy.yml` (`--prod` only for `dev`), not by Vercel. Setting it does no harm.
-- **Domain** — add `thor.trinadhthatakula.com` in Vercel and let it issue the certificate. A
-  production deployment picks up the domain automatically.
+- **Production Branch — leave it alone, and specifically never set it to `dev`.** Which deploy is
+  production is decided by `web-deploy.yml` (`--prod` only for `dev`), not by Vercel. The default is
+  `main` if it exists, otherwise `master`; this repo has `master` and no `main`. Setting it to `dev`
+  is the one edit that would make a connected Git integration race this workflow for the production
+  alias — the exact failure the section below is about.
+- **Deployment Protection** — a team-level default can protect preview deployments. That does not
+  break the deploy, but the URL commented on a PR then returns 401 to anyone outside the team, with
+  no notice explaining why.
+- **Domain** — add `thor.trinadhthatakula.com` **after** the first production deployment exists, not
+  before. Vercel applies a newly added domain to the project's latest *production* deployment; add
+  it to an empty project and the hostname sits attached to nothing. See "Domain and certificate" in
+  `launch-checklist.md` for what that failure looks like, because it does not look like an error.
 
 ## The one thing that must stay true
 
-`web/vercel.json` contains:
+**The Vercel project must not be connected to the GitHub repository.** That is the guarantee. The
+`vercel.json` kill switch below is defence in depth, and it is worth having, but it is not the thing
+being relied on.
+
+If the project *is* connected while `web-deploy.yml` exists, the consequences are not the ones this
+file used to claim. Vercel's production branch would be `master`, so a `dev` push would produce a
+Git-sourced **preview** — no alias race. The real hazards are worse and quieter:
+
+- every commit deploys, Android-only ones included, because the path filter lives in a file that may
+  not be read (below);
+- once `web/` reaches `master` at the first release merge, a push to `master` is a genuine Vercel
+  **production** deploy built from the repository root — which is a Gradle project with no
+  `package.json` — and `web-deploy.yml` has no `master` push trigger, so nothing competes with it.
+  That is not a race. It is an uncontested overwrite of the production alias by a broken build.
+
+The kill switch is:
 
 ```json
 "git": { "deploymentEnabled": false }
 ```
 
-If that is removed while `web-deploy.yml` exists, **every web commit deploys twice** — once by
-Vercel's Git integration and once by Actions — and the two race for the production alias. The
-symptom is the site intermittently serving the older of two commits, and nothing reports it. Vercel's
-own guidance names this as the most common failure of the Actions approach. The two settings are one
-decision.
+It is in **two** files on purpose. `web/vercel.json` is what the CLI reads. `/vercel.json` at the
+repository root exists only for this flag, because **Vercel does not document which `vercel.json`
+its Git integration reads for `git.deploymentEnabled`.** The setting is evaluated at webhook time,
+before any build container exists, so the CLI's `join(cwd, rootDirectory)` rule verified in source
+does not transfer to it. With Root Directory unset — which is what this pipeline requires — the
+repo-root copy is the one that is plausibly read, and the `web/` copy plausibly is not. Two copies
+cost nothing and remove the guess. Do not delete either.
 
-`ignoreCommand` is still in `vercel.json` and is currently **inert**: it is a Git-integration
-feature, and the Git integration is off. It is kept as defence in depth for the case where someone
-flips `deploymentEnabled` back on without reading this file, where it would at least confine the
-duplicate builds to commits that actually touched the site. Do not "clean it up" on the grounds that
-nothing reads it, and do not assume it is protecting anything today.
+Even correctly placed, the flag is not a dependable kill switch: `vercel/vercel#11176`
+("deploymentEnabled option in vercel.json is ignored") has been open since November 2024 with
+independent confirmations, and the file must exist on the branch being pushed for it to apply at
+all. Set it, then **verify by observation** — push one no-op commit under `web/` and count the
+deployments the Vercel project creates. If there is more than one, disconnect the repository.
+
+`ignoreCommand` is still in `web/vercel.json`. It was previously described here as inert. That is
+not provable: `vercel deploy` sends `projectSettings.commandForIgnoringBuildStep` derived from
+`vercel.json` on the same payload as `--prebuilt`, so the CLI actively uploads an ignore command on
+prebuilt deploys, and Vercel has shipped — then rolled back — a build where the Ignored Build Step
+cancelled `--prebuilt` deployments. If that happens again the job goes **red**, not silently green:
+`vercel deploy` prints "The deployment has been canceled." and exits 1, under `set -euo pipefail`.
+**Never add `--no-wait` to the deploy step** — that single flag is what would convert this from loud
+to silently green. Leave the dashboard's Ignored Build Step on "Automatic".
 
 ## What the pipeline checks before it uploads
+
+**Make the first credentialed run a push to `dev`, not a test pull request.** Vercel documents that
+"the first deployment of a new project is always a production deployment", including when the CLI is
+run without `--prod`. A PR run would be built with `VERCEL_ENV=preview` — `check:screenshots` in
+advisory mode, preview environment variables pulled — and would still become the deployment the
+domain later attaches to, while the PR comment calls it a preview. Testing on a PR is the natural
+instinct and it is the one that puts a non-strict build on the production alias.
 
 `vercel build` runs `npm run build`, which is the gate chain: `check:types`, `astro build`,
 `check:links`, `check:claims`, `check:markup`, `check:sitemap`, `check:screenshots`. `npm test` runs

--- a/web/docs/deploy.md
+++ b/web/docs/deploy.md
@@ -6,16 +6,33 @@ Vercel.
 
 | Trigger | Target | Result |
 |---|---|---|
-| push to `dev` touching the web paths | production | live at `thor.trinadhthatakula.com` |
-| pull request into `dev` or `master` touching the web paths | preview | URL commented on the PR |
-| `workflow_dispatch` from `dev` | production | same as a push |
+| push to `master` touching the web paths | production | live at `thor.trinadhthatakula.com` |
+| push to `dev` touching the web paths | preview | staging URL for the integrated site, in the run summary |
+| pull request into `master` touching the web paths | preview, production-strict | URL commented on the PR |
+| pull request into `dev` touching the web paths | preview | URL commented on the PR |
+| `workflow_dispatch` from `master` | production | same as a push to `master` |
 | `workflow_dispatch` from any other branch | preview | escape hatch, deploys nothing live |
 
-**The two `workflow_dispatch` rows do not work yet.** GitHub only offers the Run-workflow button for
-workflows that exist on the **default branch**, and `web-deploy.yml` is on `dev`, not `master`. Until
-the first `dev` → `master` release merge there is no manual trigger at all: the only ways to deploy
-are a push to `dev` or a pull request. Do not plan the first deploy around a button that is not
-there.
+## The branch model: `master` publishes, `dev` stages
+
+Site work merges to `dev` like everything else. The live site changes only when `dev` is merged to
+`master`, which is a deliberate act rather than a side effect of pushing — that is the whole reason
+production is not `dev`.
+
+Three consequences worth stating, because each is the kind of thing that is obvious once and then
+forgotten:
+
+- **A `dev` push still deploys**, as a preview. That is on purpose. A per-PR preview only ever shows
+  one branch; the `dev` preview is the only URL that shows several merged site PRs *together*, which
+  is the state the release merge is about to publish.
+- **A pull request into `master` is built to the production standard.** The workflow sets
+  `REQUIRE_SCREENSHOTS=1` when `github.base_ref` is `master`, which makes `check:screenshots` refuse a
+  placeholder frame on a *preview* build. Without it, the first build ever held to the production
+  standard would be the one already serving on the live domain.
+- **`workflow_dispatch` needs this file on `master`**, because GitHub only offers the Run-workflow
+  button for workflows on the **default branch**. That is the same condition production deploys need,
+  so the two arrive together: until `web/` reaches `master` there is no production deploy and no
+  manual trigger, and after it there are both.
 
 "the web paths" is `web/**`, `gradle.properties`, `gradle/libs.versions.toml` and the workflow file
 itself. The two Gradle files are in the list because `web/src/lib/repo-facts` derives the site's
@@ -105,11 +122,12 @@ Far fewer matter than under the Git integration, because the build no longer hap
   `web/vercel.json` sets `buildCommand`, `installCommand` and `outputDirectory`, and `vercel.json`
   takes precedence over project settings. That precedence is what keeps a dashboard edit from
   silently removing the gate chain.
-- **Production Branch — leave it alone, and specifically never set it to `dev`.** Which deploy is
-  production is decided by `web-deploy.yml` (`--prod` only for `dev`), not by Vercel. The default is
-  `main` if it exists, otherwise `master`; this repo has `master` and no `main`. Setting it to `dev`
-  is the one edit that would make a connected Git integration race this workflow for the production
-  alias — the exact failure the section below is about.
+- **Production Branch — it does nothing here, and there is no safe value for it.** Which deploy is
+  production is decided by `web-deploy.yml` (`--prod` only for a `master` push), not by Vercel. The
+  setting only becomes live if the repository is connected, and then the *default* is the dangerous
+  one: Vercel defaults to `main` if it exists, otherwise `master`, and `master` is now this
+  workflow's production branch too. Do not look for a setting that makes a connected project safe —
+  there isn't one. Leave the repository disconnected; see the section below.
 - **Deployment Protection** — a team-level default can protect preview deployments. That does not
   break the deploy, but the URL commented on a PR then returns 401 to anyone outside the team, with
   no notice explaining why.
@@ -124,16 +142,15 @@ Far fewer matter than under the Git integration, because the build no longer hap
 `vercel.json` kill switch below is defence in depth, and it is worth having, but it is not the thing
 being relied on.
 
-If the project *is* connected while `web-deploy.yml` exists, the consequences are not the ones this
-file used to claim. Vercel's production branch would be `master`, so a `dev` push would produce a
-Git-sourced **preview** — no alias race. The real hazards are worse and quieter:
+If the project *is* connected while `web-deploy.yml` exists, two things go wrong:
 
 - every commit deploys, Android-only ones included, because the path filter lives in a file that may
   not be read (below);
-- once `web/` reaches `master` at the first release merge, a push to `master` is a genuine Vercel
-  **production** deploy built from the repository root — which is a Gradle project with no
-  `package.json` — and `web-deploy.yml` has no `master` push trigger, so nothing competes with it.
-  That is not a race. It is an uncontested overwrite of the production alias by a broken build.
+- a push to `master` produces **two production deploys racing for the same alias**. Vercel's default
+  production branch is `master`, which is also this workflow's, so the release merge fires both a
+  Git-sourced Vercel build — started from the repository root, a Gradle project with no
+  `package.json` — and this workflow's gated one. Whichever finishes last wins. Nothing in either
+  system reports the collision; the only symptom is the live site sometimes being the wrong thing.
 
 The kill switch is:
 
@@ -166,12 +183,17 @@ to silently green. Leave the dashboard's Ignored Build Step on "Automatic".
 
 ## What the pipeline checks before it uploads
 
-**Make the first credentialed run a push to `dev`, not a test pull request.** Vercel documents that
-"the first deployment of a new project is always a production deployment", including when the CLI is
-run without `--prod`. A PR run would be built with `VERCEL_ENV=preview` — `check:screenshots` in
-advisory mode, preview environment variables pulled — and would still become the deployment the
-domain later attaches to, while the PR comment calls it a preview. Testing on a PR is the natural
-instinct and it is the one that puts a non-strict build on the production alias.
+**Make the first credentialed run a `workflow_dispatch` from `master`, not a test pull request.**
+Vercel documents that "the first deployment of a new project is always a production deployment",
+including when the CLI is run without `--prod`. Whatever runs first after the three secrets land is
+therefore the production deployment, and the domain will later attach to it — so it should be a run
+that *knew* it was production. A dispatch from `master` builds with `VERCEL_ENV=production`,
+`--prod`, and the strict screenshot gate.
+
+The trap is the natural instinct: add the secrets, then push a test PR to see whether it works. That
+run is built with `VERCEL_ENV=preview` and preview environment variables, becomes the production
+deployment anyway, and the PR comment calls it a preview. Add the secrets when no web pull request is
+open and no web push is about to land, and dispatch immediately.
 
 `vercel build` runs `npm run build`, which is the gate chain: `check:types`, `astro build`,
 `check:links`, `check:claims`, `check:markup`, `check:sitemap`, `check:screenshots`. `npm test` runs
@@ -190,6 +212,12 @@ vacuously.
 `vercel build` the build runs outside Vercel's infrastructure, where Vercel's documentation warns
 that System Environment Variables are not injected. Letting `--prod` imply it would have quietly
 downgraded that gate to advisory.
+
+`REQUIRE_SCREENSHOTS` is set on the same two steps and is the other half of that switch — the check
+is strict when `VERCEL_ENV=production` **or** `REQUIRE_SCREENSHOTS=1`. The workflow sets it to `1` on
+a pull request whose base is `master`, so the release PR's preview is held to the production standard
+before the merge that publishes, and it is empty everywhere else, because work in progress is allowed
+to carry a placeholder.
 
 ## Lighthouse
 
@@ -216,7 +244,8 @@ vercel promote <deploy-url>  # to a specific one
 ```
 
 or Vercel → Project → Deployments → "…" → Promote to Production. Rolling back does not revert git,
-so follow it with a revert commit or the next push to `dev` will put the bad build straight back.
+so follow it with a revert commit on `master` or the next `master` push will put the bad build
+straight back.
 
 ## Path filters and required checks
 

--- a/web/docs/launch-checklist.md
+++ b/web/docs/launch-checklist.md
@@ -144,8 +144,9 @@ failing in a way that does not look like a failure.
       repository disconnected; see `web/docs/deploy.md`.
 - [ ] Optional, for the advisory Lighthouse job only: **`VERCEL_AUTOMATION_BYPASS_SECRET`**
       (Vercel → Project → Settings → Deployment Protection → Protection Bypass for Automation).
-      Without it that job skips with a notice; nothing else is affected. Set it before the first PR
-      run or it skips invisibly on every one.
+      Without it that job skips with a notice on the run — `::notice::VERCEL_AUTOMATION_BYPASS_SECRET
+      is not set…`, which names the exact dashboard path to fix it. Nothing else is affected. Set it
+      before the first PR run, or every PR carries that notice and no Lighthouse number.
 - [ ] **Before every `dev` → `master` merge**, confirm the project is still not connected to the
       repository. On a connected project a `master` push starts a Vercel production build from the
       Gradle repo root — no `package.json` — at the same moment this workflow deploys a gated
@@ -171,8 +172,10 @@ answers like this:
 
 ```console
 $ openssl s_client -connect thor.trinadhthatakula.com:443 \
-    -servername thor.trinadhthatakula.com </dev/null 2>/dev/null | openssl x509 -noout -subject -dates
-subject=CN=*.trinadhthatakula.com
+    -servername thor.trinadhthatakula.com </dev/null 2>/dev/null \
+    | openssl x509 -noout -ext subjectAltName -dates
+X509v3 Subject Alternative Name:
+    DNS:*.trinadhthatakula.com, DNS:trinadhthatakula.com
 notBefore=Feb 10 12:08:05 2026 GMT
 notAfter=May 11 12:08:04 2026 GMT        # expired
 
@@ -200,11 +203,19 @@ project has claimed this hostname yet" — it does not mean the DNS record is wr
       npx vercel@58 domains inspect thor.trinadhthatakula.com   # expect Valid Configuration
       npx vercel@58 certs ls                                    # expect a cert for the exact host
       openssl s_client -connect thor.trinadhthatakula.com:443 \
-        -servername thor.trinadhthatakula.com </dev/null 2>/dev/null | openssl x509 -noout -subject -dates
+        -servername thor.trinadhthatakula.com </dev/null 2>/dev/null \
+        | openssl x509 -noout -ext subjectAltName -dates
 
-      The `openssl` step must show `CN=thor.trinadhthatakula.com`, **not** the
-      `*.trinadhthatakula.com` wildcard. Seeing the wildcard means the hostname is still unclaimed,
-      whatever the dashboard says.
+      Read the **SAN**, not the subject. The identity of a modern certificate lives in
+      `subjectAltName`; the CN is legacy and may be absent or may not be the name you connected to.
+      The step passes when the SAN lists `thor.trinadhthatakula.com` **explicitly** and `notAfter` is
+      in the future.
+
+      A SAN of only `*.trinadhthatakula.com` is the failing case even though that wildcard does
+      technically match the host — it is the stale certificate Vercel's edge already falls back to,
+      and seeing it means the hostname is still unclaimed whatever the dashboard says. Checking the
+      dates alone is not enough either: a renewed wildcard would pass a date check and still not be
+      this project's certificate.
 
 - [ ] If `vercel certs ls` shows nothing after about 15 minutes, the domain is not attached —
       re-run `domains inspect`. **Do not touch Cloudflare.**

--- a/web/docs/launch-checklist.md
+++ b/web/docs/launch-checklist.md
@@ -88,51 +88,132 @@ Deploys run from `.github/workflows/web-deploy.yml`, not from Vercel's Git integ
 nothing here is a dashboard setting. `web/docs/deploy.md` is the full reference; this is the launch
 sequence.
 
-- [ ] Create the Vercel project, then `cd web && npx vercel link` locally. That writes
-      `.vercel/project.json` — gitignored, so it stays local.
-- [ ] Add three repository secrets (Settings → Secrets and variables → Actions):
-      **`VERCEL_TOKEN`** (Vercel → Account Settings → Tokens), **`VERCEL_ORG_ID`** and
-      **`VERCEL_PROJECT_ID`** (the `orgId` and `projectId` fields of that file).
+**The order matters more than any individual step.** Each of these is what stops the next one from
+failing in a way that does not look like a failure.
 
-      Until all three exist the workflow exits **green** with a notice naming what is missing, so
-      web PRs stay mergeable in the meantime. A green `web-deploy` run before this step is done has
-      deployed nothing — check the notice, not the tick.
+- [ ] **Create the project from the CLI. Do not use `vercel.com/new` → Import Git Repository.**
 
-- [ ] **Leave Root Directory at the repository root.** The workflow already runs the CLI from inside
-      `web/`; setting it to `web` as well risks resolving to `web/web`. If it is wrong, the "Gate the
-      staged artifact" step fails naming this cause rather than shipping an empty tree.
+      cd web && npx vercel@58 login && npx vercel@58 link   # choose "create a new project"
+
+      This is the whole ball game. Importing the repository sets Root Directory to `web` (the only
+      sane-looking answer in that UI), installs the deploy webhook, and writes `framework: astro`
+      into the project settings. The workflow already runs the CLI inside `web/`, so a Root
+      Directory of `web` resolves to `web/web` — and with `framework: astro` pulled it fails at
+      `Command "astro build" exited with 127`, which names nothing about paths. `vercel link` from
+      `web/` leaves Root Directory unset and connects no repository, which is what this pipeline
+      wants. If it has already been imported: Settings → Git → Disconnect, and clear Root Directory.
+
+      `vercel link` writes `.vercel/project.json` — gitignored, so it stays local.
+
+- [ ] **Add all three repository secrets in one sitting** (Settings → Secrets and variables →
+      Actions): **`VERCEL_TOKEN`** (Vercel → Account Settings → Tokens; scope it to whatever owns
+      the project — on a personal account that is your username, not a team), **`VERCEL_ORG_ID`**
+      and **`VERCEL_PROJECT_ID`** (the `orgId` and `projectId` fields of `.vercel/project.json`).
+
+      A partial set behaves exactly like no set at all: the workflow exits **green** with a notice
+      naming what is missing, having skipped even the checkout. A green `web-deploy` run before this
+      step is complete deployed nothing. Read the notice, or the run duration — the credential-less
+      runs finish in under ten seconds.
+
+- [ ] **Make the first credentialed run a push to `dev`, not a test PR.** Vercel makes the first
+      deployment of a new project a production deployment regardless of `--prod`. A PR run would be
+      built with `VERCEL_ENV=preview` — screenshot gate advisory, preview environment variables —
+      and would still be the deployment the domain attaches to, while the PR comment calls it a
+      preview.
+- [ ] **Confirm Root Directory is empty** in Settings → Build & Deployment, whichever way the
+      project was made.
 - [ ] **Set no Build / Install / Output override in the dashboard.** `web/vercel.json` carries all
       three and takes precedence over project settings — that precedence is the only thing keeping a
       dashboard edit from silently removing the gate chain.
-- [ ] **Confirm `web/vercel.json` still contains `"git": { "deploymentEnabled": false }`.** Removing
-      it while this workflow exists makes every web commit deploy twice — Git integration and Actions
-      racing for the same production alias — and the only symptom is the site intermittently serving
-      the older of two commits.
+- [ ] **Leave Production Branch alone, and never set it to `dev`.** It defaults to `master` here,
+      which is harmless. Pointing it at `dev` is the one edit that would make a connected Git
+      integration race this workflow for the production alias.
+- [ ] **Confirm both copies of the kill switch survive**: `"git": { "deploymentEnabled": false }` in
+      `web/vercel.json` *and* in `/vercel.json` at the repository root. Two copies because Vercel
+      does not document which one its Git integration reads. Neither is a substitute for leaving the
+      repository disconnected; see `web/docs/deploy.md`.
 - [ ] Optional, for the advisory Lighthouse job only: **`VERCEL_AUTOMATION_BYPASS_SECRET`**
       (Vercel → Project → Settings → Deployment Protection → Protection Bypass for Automation).
-      Without it that job skips with a notice; nothing else is affected.
+      Without it that job skips with a notice; nothing else is affected. Set it before the first PR
+      run or it skips invisibly on every one.
+- [ ] **Before the first `dev` → `master` release merge**, confirm the project is still not
+      connected to the repository. That merge is what puts `web/` on `master`, and on a connected
+      project a `master` push is a real Vercel production deploy built from the Gradle repo root,
+      with no Actions run competing. Getting this wrong breaks the site at release time, not at
+      setup time.
 
-"Production Branch" and "Include files outside of the Root Directory" no longer matter: which deploy
-is production is decided by the workflow (`--prod` only for `dev`), and the whole repository is
-checked out in Actions, so `repo-facts` reading `gradle.properties` from the root just works.
+"Include files outside of the Root Directory" no longer matters: the whole repository is checked out
+in Actions, so `repo-facts` reading `gradle.properties` from the root just works.
 
-The Ignored Build Step is likewise obsolete — the path filter now lives in the workflow's `paths:`
-list. `ignoreCommand` remains in `vercel.json` as inert defence in depth; see `web/docs/deploy.md`
-before touching it.
+Leave the Ignored Build Step on **Automatic** — the path filter lives in the workflow's `paths:`
+list, and Vercel has previously shipped a build where the Ignored Build Step cancelled `--prebuilt`
+CLI deploys. `ignoreCommand` remains in `web/vercel.json`; see `web/docs/deploy.md` before touching
+it, and never add `--no-wait` to the deploy step.
 
 ## 6. Domain and certificate
 
-- [ ] Add `thor.trinadhthatakula.com` in Vercel and let it issue the certificate. DNS needs no
-      change; the Cloudflare wildcard already resolves.
-- [ ] Confirm the certificate is actually issued before announcing. A proxied `*` wildcard means the
-      name resolves whether or not anything is serving it, so "it resolves" is not a test.
-- [ ] **If you see a 526, do not switch Cloudflare's SSL mode to Flexible.** It appears to fix the
-      error and serves the site over an unencrypted hop to the origin — on a site whose privacy
-      stance is the entire argument. A 526 means the certificate is not issued yet; wait for it.
+**Do not check this in a browser until `vercel certs ls` says the certificate exists.** The browser
+will fail for a reason that has nothing to do with anything you did, and the obvious diagnosis is
+the one that breaks the working DNS record.
+
+Right now, before any Vercel project claims the hostname, `https://thor.trinadhthatakula.com`
+answers like this:
+
+```console
+$ openssl s_client -connect thor.trinadhthatakula.com:443 \
+    -servername thor.trinadhthatakula.com </dev/null 2>/dev/null | openssl x509 -noout -subject -dates
+subject=CN=*.trinadhthatakula.com
+notBefore=Feb 10 12:08:05 2026 GMT
+notAfter=May 11 12:08:04 2026 GMT        # expired
+
+$ curl -sSI -k https://thor.trinadhthatakula.com | head -3
+HTTP/2 404
+server: Vercel
+x-vercel-error: DEPLOYMENT_NOT_FOUND
+```
+
+Vercel's edge is already answering for the name and falling back to a stale `*.trinadhthatakula.com`
+wildcard that expired on 11 May 2026. It cannot renew a wildcard without a DNS-01 record and the zone
+is on Cloudflare nameservers, so this will not fix itself. Vercel also serves a two-year HSTS header
+and 308s plain HTTP to HTTPS, so a browser that ever saw the valid certificate will refuse to let you
+click through, and there is no HTTP fallback to test with. `ERR_CERT_DATE_INVALID` here means "no
+project has claimed this hostname yet" — it does not mean the DNS record is wrong.
+
+- [ ] Add `thor.trinadhthatakula.com` in Vercel **after** the first production deployment exists.
+      A newly added domain is applied to the project's latest production deployment; added first, it
+      attaches to nothing.
+- [ ] DNS needs no change. The `thor` record is already a **DNS-only (grey cloud)** CNAME to
+      `cname.vercel-dns.com`, which Vercel accepts — it validates that the name resolves *to Vercel*,
+      not that it matches the currently recommended target string.
+- [ ] Verify in this order, and only this order:
+
+      npx vercel@58 domains inspect thor.trinadhthatakula.com   # expect Valid Configuration
+      npx vercel@58 certs ls                                    # expect a cert for the exact host
+      openssl s_client -connect thor.trinadhthatakula.com:443 \
+        -servername thor.trinadhthatakula.com </dev/null 2>/dev/null | openssl x509 -noout -subject -dates
+
+      The `openssl` step must show `CN=thor.trinadhthatakula.com`, **not** the
+      `*.trinadhthatakula.com` wildcard. Seeing the wildcard means the hostname is still unclaimed,
+      whatever the dashboard says.
+
+- [ ] If `vercel certs ls` shows nothing after about 15 minutes, the domain is not attached —
+      re-run `domains inspect`. **Do not touch Cloudflare.**
+- [ ] If Vercel reports the domain is already in use by another project or account, check
+      `vercel domains ls` first: the expired wildcard being served from Vercel's edge means
+      `*.trinadhthatakula.com` was registered with Vercel at some point, and it may still be.
+- [ ] A Cloudflare **526 cannot happen here** and is not the error to look for. 526 requires
+      Cloudflare to be in the request path, which means an orange-clouded record; this one is grey.
+      If a record is ever orange-clouded and a 526 appears, **do not switch the SSL mode to
+      Flexible** — it appears to fix the error and serves the origin hop unencrypted, on a site
+      whose privacy stance is the entire argument.
 
 ## 7. After launch
 
-- [ ] Weekly external link check runs against the live site and opens an issue on failure.
+- [ ] Weekly external link check runs against the live site and opens an issue on failure. It is
+      dormant today: `schedule` and the Run-workflow button only exist for workflows on the **default
+      branch**, and `web-link-check.yml` is on `dev`. The first `dev` → `master` release merge arms
+      it — so if that merge lands before the site is deployed, it files an issue every Tuesday until
+      it is. Deploy first, or expect the noise.
 - [ ] The Lighthouse job (now the second job in `web-deploy.yml`) reports as a warning only. If it
       ever becomes a required check, the site cannot ship a legitimate large screenshot.
 - [ ] Neither `web-ci.yml` nor `web-deploy.yml` has been added to a branch ruleset. Both are

--- a/web/docs/launch-checklist.md
+++ b/web/docs/launch-checklist.md
@@ -76,11 +76,12 @@ gate which exits 0 for the wrong reason looks identical to one that passes.
       is the check that stops "green" from meaning "finished".
 
       **This one is now enforced, not just listed.** `check:screenshots` runs in the `build` chain
-      on every build, but it only *fails* when `VERCEL_ENV=production` — so placeholders stay green
-      locally, in CI and on preview deploys, and a production deploy carrying one is refused. That
-      matters because the production branch is `dev`: merging the release PR **is** the deploy, so
-      there is no window in which a human runs this list first. Run the command above to see the
-      strict verdict early; a green production deploy has already asserted it.
+      on every build, but it only *fails* when `VERCEL_ENV=production` or `REQUIRE_SCREENSHOTS=1` —
+      so placeholders stay green locally, in CI and on `dev` previews, and a production deploy
+      carrying one is refused. The workflow also sets `REQUIRE_SCREENSHOTS=1` on any pull request
+      based on `master`, so the release PR's preview is held to the production standard *before* the
+      merge that publishes rather than at it. Running the command above still has a point — it is the
+      only way to see the strict verdict without opening a PR.
 
 ## 5. Deploy configuration — create the Vercel project and wire the secrets
 
@@ -90,6 +91,12 @@ sequence.
 
 **The order matters more than any individual step.** Each of these is what stops the next one from
 failing in a way that does not look like a failure.
+
+- [ ] **Get `web/` onto `master` first.** Production is a push to `master`, and GitHub only offers
+      the Run-workflow button for workflows on the **default branch** — so until `web-deploy.yml`
+      exists on `master` there is no production deploy and no manual trigger, only `dev` previews.
+      This is safe to do before the Vercel project exists: with no secrets set, the workflow prints a
+      notice naming what is missing and exits green.
 
 - [ ] **Create the project from the CLI. Do not use `vercel.com/new` → Import Git Repository.**
 
@@ -115,19 +122,22 @@ failing in a way that does not look like a failure.
       step is complete deployed nothing. Read the notice, or the run duration — the credential-less
       runs finish in under ten seconds.
 
-- [ ] **Make the first credentialed run a push to `dev`, not a test PR.** Vercel makes the first
-      deployment of a new project a production deployment regardless of `--prod`. A PR run would be
-      built with `VERCEL_ENV=preview` — screenshot gate advisory, preview environment variables —
-      and would still be the deployment the domain attaches to, while the PR comment calls it a
-      preview.
+- [ ] **Make the first credentialed run a `workflow_dispatch` from `master`, not a test PR.** Vercel
+      makes the first deployment of a new project a production deployment regardless of `--prod`, so
+      whatever runs first after the secrets land is the one the domain will attach to. A test PR
+      would be built with `VERCEL_ENV=preview` — preview environment variables, and the screenshot
+      gate advisory unless its base is `master` — and would become that deployment anyway, while the
+      PR comment calls it a preview. Add the secrets when no web PR is open and no web push is
+      imminent, then dispatch straight away.
 - [ ] **Confirm Root Directory is empty** in Settings → Build & Deployment, whichever way the
       project was made.
 - [ ] **Set no Build / Install / Output override in the dashboard.** `web/vercel.json` carries all
       three and takes precedence over project settings — that precedence is the only thing keeping a
       dashboard edit from silently removing the gate chain.
-- [ ] **Leave Production Branch alone, and never set it to `dev`.** It defaults to `master` here,
-      which is harmless. Pointing it at `dev` is the one edit that would make a connected Git
-      integration race this workflow for the production alias.
+- [ ] **Ignore Production Branch. There is no safe value for it.** It only takes effect on a
+      connected project, and its default — `master` — is now this workflow's production branch too,
+      so on a connected project the default is what causes the race. Do not go looking for a setting
+      that makes connecting the repository safe; the next item is the answer.
 - [ ] **Confirm both copies of the kill switch survive**: `"git": { "deploymentEnabled": false }` in
       `web/vercel.json` *and* in `/vercel.json` at the repository root. Two copies because Vercel
       does not document which one its Git integration reads. Neither is a substitute for leaving the
@@ -136,11 +146,11 @@ failing in a way that does not look like a failure.
       (Vercel → Project → Settings → Deployment Protection → Protection Bypass for Automation).
       Without it that job skips with a notice; nothing else is affected. Set it before the first PR
       run or it skips invisibly on every one.
-- [ ] **Before the first `dev` → `master` release merge**, confirm the project is still not
-      connected to the repository. That merge is what puts `web/` on `master`, and on a connected
-      project a `master` push is a real Vercel production deploy built from the Gradle repo root,
-      with no Actions run competing. Getting this wrong breaks the site at release time, not at
-      setup time.
+- [ ] **Before every `dev` → `master` merge**, confirm the project is still not connected to the
+      repository. On a connected project a `master` push starts a Vercel production build from the
+      Gradle repo root — no `package.json` — at the same moment this workflow deploys a gated
+      artifact to the same alias, and whichever finishes last wins. It breaks the site at release
+      time, not at setup time, which is why it is worth re-checking rather than assuming.
 
 "Include files outside of the Root Directory" no longer matters: the whole repository is checked out
 in Actions, so `repo-facts` reading `gradle.properties` from the root just works.
@@ -211,9 +221,11 @@ project has claimed this hostname yet" — it does not mean the DNS record is wr
 
 - [ ] Weekly external link check runs against the live site and opens an issue on failure. It is
       dormant today: `schedule` and the Run-workflow button only exist for workflows on the **default
-      branch**, and `web-link-check.yml` is on `dev`. The first `dev` → `master` release merge arms
-      it — so if that merge lands before the site is deployed, it files an issue every Tuesday until
-      it is. Deploy first, or expect the noise.
+      branch**, and `web-link-check.yml` is on `dev`. Putting `web/` on `master` arms it — the same
+      merge that makes production deploys possible at all — so the window between "armed" and
+      "deployed" is however long the Vercel setup in §5 takes. It runs Tuesdays at 06:00 UTC and
+      files an issue against a site that is not up yet; finish §5 and §6 inside that window, or
+      expect one issue and close it.
 - [ ] The Lighthouse job (now the second job in `web-deploy.yml`) reports as a warning only. If it
       ever becomes a required check, the site cannot ship a legitimate large screenshot.
 - [ ] Neither `web-ci.yml` nor `web-deploy.yml` has been added to a branch ruleset. Both are


### PR DESCRIPTION
Two changes to the deploy pipeline shipped in #321, in the same paragraphs.

1. **The site's production branch moves from `dev` to `master`**, so day-to-day site work lands on `dev` like everything else and the live site changes only on a deliberate release merge.
2. **Corrections to what #321's docs asserted about Vercel**, several of which were wrong in ways that would have cost the owner a broken first deploy.

Companion PR **#323** puts `web/` on `master`, which the first change requires. **Merge this one first** — #323 carries byte-identical copies of two `paths-ignore` blocks introduced here, and they only stay identical in that order.

---

## 1. `master` publishes, `dev` stages

| Trigger | Before | After |
|---|---|---|
| push to `master` | *(no trigger)* | **production** |
| push to `dev` | production | preview |
| PR into `master` | preview | preview, production-strict |
| PR into `dev` | preview | preview |
| `workflow_dispatch` from `master` | — | production |

`dev` is kept as a push trigger on purpose rather than dropped. A per-PR preview only ever shows one branch; the `dev` preview is the only URL that shows several merged site PRs *together*, which is the state the release merge is about to publish.

### This closes a real gap

The workflow now sets `REQUIRE_SCREENSHOTS=1` when `github.base_ref` is `master`. `check:screenshots` refuses a placeholder frame when `VERCEL_ENV=production` **or** `REQUIRE_SCREENSHOTS=1` (`web/scripts/check-screenshots.mjs:48-50`), so the release PR's preview is held to the production standard *before* the merge that publishes.

Previously the first build ever held to the production standard was the one already serving on the live domain. A placeholder would have been found by a visitor, not by a check.

### And opens one, stated plainly

If the Vercel project ever gets connected to the repository, a `master` push now starts **two production deploys racing for the same alias** — this workflow's gated artifact, and a Git-sourced Vercel build from the Gradle repository root, which has no `package.json`. Whichever finishes last wins.

Before this PR it was an *uncontested overwrite* — worse in outcome, but at least deterministic. Either way the answer is the same and it is the one the docs now lead with: do not connect the repository. There is no Production Branch value that makes a connected project safe; Vercel's default is `master`, which is precisely the dangerous one.

All six trigger shapes were exercised against the extracted step:

```
EVENT             REF                 BASE     OUTPUTS
push              refs/heads/master   —        env=production flag=--prod strict=1
push              refs/heads/dev      —        env=preview    flag=       strict=
pull_request      refs/pull/9/merge   master   env=preview    flag=       strict=1
pull_request      refs/pull/9/merge   dev      env=preview    flag=       strict=
workflow_dispatch refs/heads/master   —        env=production flag=--prod strict=1
workflow_dispatch refs/heads/feat/x   —        env=preview    flag=       strict=
```

### `paths-ignore` on the Android workflows

`web/**` was added to `dev-check.yml` and `production-deploy.yml` on the reasoning that the site adds no Gradle module and cannot change a byte of the APK. That reasoning covers three paths the glob does not: `/vercel.json`, `.github/workflows/web-*.yml` and `.github/labeler.yml`.

Not hypothetical — #323 carries all three, so without this the merge that first puts the site on `master` would have run the full Android build.

---

## 2. Corrections to #321's Vercel documentation

Researched against Vercel's live documentation and the `vercel@58.4.4` CLI source, with adversarial verification. Five things were wrong or missing.

**The kill switch was oversold.** `web/vercel.json`'s `"git": { "deploymentEnabled": false }` was documented as *the* guarantee against double deploys. Vercel does not document which `vercel.json` its Git integration reads for that flag — it is evaluated at webhook time, before any build container exists, so the CLI's `join(cwd, rootDirectory)` rule verified in source does not transfer. `vercel/vercel#11176` ("deploymentEnabled is ignored") has been open since November 2024 with independent confirmations.

Fixed by adding `/vercel.json` at the repository root so the flag exists in both plausible locations, and by rewriting the docs around the guarantee that *is* structural: **do not connect the repository**. The CLI is unaffected either way — it reads `join(cwd=web, '.')/vercel.json` and never the root copy.

**How the project gets created was never written down**, and it is the single most likely way a first deploy fails. Importing the repo from `vercel.com/new` sets Root Directory to `web`, installs the webhook, and writes `framework: astro` into the project settings. This workflow already runs the CLI from inside `web/`, so Root Directory `web` resolves to `web/web` (`packages/cli/src/commands/build/index.ts`; `vercel/vercel#16749`). Worse, it does not fail the way the repo advertises — with `framework: astro` pulled it dies at `Command "astro build" exited with 127`, which names nothing about paths, *before* reaching the "Gate the staged artifact" tripwire written to catch exactly this. `cd web && vercel link` leaves Root Directory unset and connects nothing.

**"Production Branch — irrelevant, setting it does no harm" was backwards.** Corrected twice: first to name `dev` as the dangerous value, and now — since production moved — to state that the *default* is the dangerous one and no safe value exists.

**`ignoreCommand` was called inert. It is not provably inert.** `vercel deploy` sends `projectSettings.commandForIgnoringBuildStep` on the same payload as `--prebuilt`, and Vercel has shipped then rolled back a build where the Ignored Build Step cancelled prebuilt deployments. It fails loudly — `vercel deploy` prints "The deployment has been canceled." and exits 1 under `set -euo pipefail`. A comment on the deploy step now says **never add `--no-wait`**, which is the one flag that would convert that from loud to silently green.

**The domain guidance coached the owner through an error that cannot occur.** A Cloudflare 526 requires Cloudflare in the request path; the `thor` record is grey-clouded. What the owner will actually see, verified live:

```console
$ openssl s_client -connect thor.trinadhthatakula.com:443 -servername thor.trinadhthatakula.com \
    </dev/null 2>/dev/null | openssl x509 -noout -subject -dates
subject=CN=*.trinadhthatakula.com
notBefore=Feb 10 12:08:05 2026 GMT
notAfter=May 11 12:08:04 2026 GMT        # expired

$ curl -sSI -k https://thor.trinadhthatakula.com | head -3
HTTP/2 404
server: Vercel
x-vercel-error: DEPLOYMENT_NOT_FOUND
```

Vercel's edge already answers for the hostname and falls back to a `*.trinadhthatakula.com` wildcard that expired 83 days ago. It cannot renew a wildcard without DNS-01 and the zone is on Cloudflare nameservers, so it will not self-heal. Two years of HSTS and a 308 on plain HTTP mean there is no way to click through in a browser. `ERR_CERT_DATE_INVALID` here means "no project has claimed this hostname yet" — **not** that the DNS record is wrong, which is the diagnosis that would break the working record. The checklist now gives a browser-free verification order: `domains inspect` → `certs ls` → `openssl`, expecting `CN=thor.trinadhthatakula.com` rather than the wildcard.

Also corrected: the first credentialed run should be a `workflow_dispatch` from `master`, not a test PR — Vercel makes the first deployment of a new project production regardless of `--prod`, so whatever runs first is what the domain attaches to. The natural instinct (add secrets, push a test PR to see if it works) is the one that puts a preview-environment build on the production alias.

---

## Verification

291 tests / 16 files pass. `npm run build` clean — 8 pages, 16 claim rules, 78 custom properties, 182 internal links, 0 failing axe nodes. `REQUIRE_SCREENSHOTS=1 npm run check:screenshots` reports `strict: production`, 0 placeholders. The workflow YAML parses and all 13 `run:` blocks pass `bash -n`.

No site content changes — this is the workflow, three markdown docs, and the two Android `paths-ignore` lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
