### PR TITLE
docs(web): the screenshot gate is enforced — its setting was confirmed on

### DIFF
--- a/web/docs/deploy.md
+++ b/web/docs/deploy.md
@@ -114,8 +114,10 @@ can only report on it afterwards.
   System Environment Variables". `check:screenshots` is strict only when `VERCEL_ENV=production`, and
   Vercel injects that variable. If the box is off, `VERCEL_ENV` is empty, `isProductionDeploy()`
   returns false, and the screenshot gate silently downgrades from gate to advisory **on the
-  production build**. Vercel does not document whether it is on by default for a portal import.
-  Verify it once, in one click.
+  production build**. Vercel does not document whether it is on by default for a portal import, so it
+  was checked rather than assumed: **confirmed on, 2026-08-03**. Note what that does and does not
+  establish — the setting is on; no production build has run since, so `VERCEL_ENV` reaching the
+  build has not been observed.
 - **Deployment Protection.** A protected preview URL returns 401 with no notice explaining why. Every
   branch and every PR now gets a preview URL posted by the Vercel bot, so this is more visible than
   it was.

--- a/web/docs/deploy.md
+++ b/web/docs/deploy.md
@@ -115,9 +115,12 @@ can only report on it afterwards.
   Vercel injects that variable. If the box is off, `VERCEL_ENV` is empty, `isProductionDeploy()`
   returns false, and the screenshot gate silently downgrades from gate to advisory **on the
   production build**. Vercel does not document whether it is on by default for a portal import, so it
-  was checked rather than assumed: **confirmed on, 2026-08-03**. Note what that does and does not
-  establish — the setting is on; no production build has run since, so `VERCEL_ENV` reaching the
-  build has not been observed.
+  was checked rather than assumed: **confirmed on, 2026-08-02** (UTC). Note what that does and does
+  not establish — the setting is on; no production build has run since, so `VERCEL_ENV` reaching the
+  build has not been observed. A passing production build will not establish it either: with no
+  placeholders left there is nothing for the strict path to fail on, so it exits 0 either way. The
+  evidence is the `check-screenshots` line in the build log — `0 placeholders (strict: production)`
+  means the variable arrived, `0 placeholders (advisory)` means it did not and the gate downgraded.
 - **Deployment Protection.** A protected preview URL returns 401 with no notice explaining why. Every
   branch and every PR now gets a preview URL posted by the Vercel bot, so this is more visible than
   it was.

--- a/web/docs/launch-checklist.md
+++ b/web/docs/launch-checklist.md
@@ -75,14 +75,21 @@ gate which exits 0 for the wrong reason looks identical to one that passes.
       See `web/docs/screenshot-checklist.md`. The build is green with placeholders by design; this
       is the check that stops "green" from meaning "finished".
 
-      **Whether this is enforced or only advisory is currently unconfirmed.** `check:screenshots`
-      runs in the `build` chain on every build, but it only *fails* when `VERCEL_ENV=production` or
-      `REQUIRE_SCREENSHOTS=1` — so placeholders stay green locally, in CI and on `dev` previews by
-      design, and the intent is that a production deploy carrying one is refused. That intent rests
-      entirely on Vercel injecting `VERCEL_ENV`, which it does only when **"Enable access to System
-      Environment Variables" is on** — the §5 item that is still unticked. With that box off,
-      `isProductionDeploy()` returns false and the production build downgrades silently to advisory
-      placeholder checking. Treat this as unresolved until that setting has been inspected in Vercel.
+      **This one is enforced, not just listed** — as of 2026-08-03, when the setting it depends on
+      was confirmed. `check:screenshots` runs in the `build` chain on every build, but it only
+      *fails* when `VERCEL_ENV=production` or `REQUIRE_SCREENSHOTS=1`, so placeholders stay green
+      locally, in CI and on `dev` previews by design, and a production deploy carrying one is
+      refused. That last half rests entirely on Vercel injecting `VERCEL_ENV`, which it does only
+      when **"Enable access to System Environment Variables" is on** — now ticked in §5. With that
+      box off, `isProductionDeploy()` returns false and the production build would downgrade silently
+      to advisory placeholder checking.
+
+      One honest limit: the setting is confirmed, the *behaviour* is not. No production build has run
+      since it was turned on, so nothing has yet observed `VERCEL_ENV=production` reaching
+      `check-screenshots.mjs`. The first release merge is what proves it, and it proves it by
+      passing — which is indistinguishable from the downgraded case unless a placeholder is present.
+      Running `REQUIRE_SCREENSHOTS=1 npm run build` locally is still the only way to see the strict
+      verdict on demand.
 
       Nothing sets `REQUIRE_SCREENSHOTS=1` on a pull request into `master` any more — that was the
       Actions pipeline, which is dormant. So the release PR's preview is *not* held to the production
@@ -110,11 +117,13 @@ confirming because **none of them is visible in a diff and most fail without an 
       `../gradle.properties` and `../gradle/libs.versions.toml`. This one fails *loudly*
       (`RepoFactsError`), and it is currently correct — `/download` renders "Android 9 (API 28)",
       which is derived from `gradle/libs.versions.toml`.
-- [ ] **Confirm "Enable access to System Environment Variables" is on**, Settings → Environment
-      Variables. `check:screenshots` is strict only when `VERCEL_ENV=production`, and Vercel is what
-      injects it. If the box is off the gate silently downgrades to advisory **on the production
-      build**, which is the one place it is supposed to bite. Vercel does not document the default
-      for a portal import, so this is a one-click check worth actually doing.
+- [x] **"Enable access to System Environment Variables" is on** — confirmed by the owner in the
+      dashboard, 2026-08-03. Settings → Environment Variables. `check:screenshots` is strict only
+      when `VERCEL_ENV=production`, and Vercel is what injects it, so with the box off the gate would
+      silently downgrade to advisory **on the production build** — the one place it is supposed to
+      bite. Vercel does not document the default for a portal import, which is why this needed
+      checking rather than assuming. **It has not yet been exercised**: no production build has run
+      since, so the injection is confirmed at the setting, not at the artifact.
 - [ ] **Set no Build / Install / Output override in the dashboard.** `web/vercel.json` carries all
       three and takes precedence over project settings — that precedence is the only thing keeping a
       dashboard edit from silently removing the gate chain.

--- a/web/docs/launch-checklist.md
+++ b/web/docs/launch-checklist.md
@@ -3,6 +3,10 @@
 Run top to bottom before pointing the domain at the deployment. Everything in "Owner action" needs a
 person; everything else is a command whose output is the evidence.
 
+Dates here are **UTC**, anchored to the certificate timestamps quoted in §6. The launch work ran past
+local midnight in the owner's timezone, so a `git log` timestamp for the commit that recorded an item
+can read a day later than the item's date. That is the timezone, not a gap in the timeline.
+
 ## 1. Owner action — two external claims that the new site contradicts
 
 The homepage trust note says Thor declares `INTERNET` and names the one file that uses it. Two
@@ -75,7 +79,7 @@ gate which exits 0 for the wrong reason looks identical to one that passes.
       See `web/docs/screenshot-checklist.md`. The build is green with placeholders by design; this
       is the check that stops "green" from meaning "finished".
 
-      **This one is enforced, not just listed** — as of 2026-08-03, when the setting it depends on
+      **This one is enforced, not just listed** — as of 2026-08-02, when the setting it depends on
       was confirmed. `check:screenshots` runs in the `build` chain on every build, but it only
       *fails* when `VERCEL_ENV=production` or `REQUIRE_SCREENSHOTS=1`, so placeholders stay green
       locally, in CI and on `dev` previews by design, and a production deploy carrying one is
@@ -86,10 +90,27 @@ gate which exits 0 for the wrong reason looks identical to one that passes.
 
       One honest limit: the setting is confirmed, the *behaviour* is not. No production build has run
       since it was turned on, so nothing has yet observed `VERCEL_ENV=production` reaching
-      `check-screenshots.mjs`. The first release merge is what proves it, and it proves it by
-      passing — which is indistinguishable from the downgraded case unless a placeholder is present.
-      Running `REQUIRE_SCREENSHOTS=1 npm run build` locally is still the only way to see the strict
-      verdict on demand.
+      `check-screenshots.mjs`.
+
+      A **passing production build is not the proof**. All six screenshots have landed, so there are
+      zero placeholders; the strict path has nothing to fail on and exits 0 whether or not the
+      variable arrived. The exit code carries no information. What separates the two cases is the
+      line `report()` prints on success as well as failure:
+
+      ```console
+      check-screenshots: OK — 8 pages checked, 0 placeholders (strict: production)
+      check-screenshots: OK — 8 pages checked, 0 placeholders (advisory)
+      ```
+
+      The first says `VERCEL_ENV=production` arrived and the gate is armed; the second says it did
+      not and the gate silently downgraded. On Vercel the reading is unambiguous, because
+      `REQUIRE_SCREENSHOTS` is the only other input to `isProductionDeploy()` and nothing sets it
+      there — so `strict: production` in a Vercel build log can only have come from `VERCEL_ENV`.
+      **Read that line in the build log of the first `master` deploy.** That is the observation that
+      closes this out; a green checkmark is not.
+
+      Locally, `REQUIRE_SCREENSHOTS=1 npm run build` prints the same strict line on demand, which is
+      how to see the strict verdict without waiting for a deploy.
 
       Nothing sets `REQUIRE_SCREENSHOTS=1` on a pull request into `master` any more — that was the
       Actions pipeline, which is dormant. So the release PR's preview is *not* held to the production
@@ -118,12 +139,13 @@ confirming because **none of them is visible in a diff and most fail without an 
       (`RepoFactsError`), and it is currently correct — `/download` renders "Android 9 (API 28)",
       which is derived from `gradle/libs.versions.toml`.
 - [x] **"Enable access to System Environment Variables" is on** — confirmed by the owner in the
-      dashboard, 2026-08-03. Settings → Environment Variables. `check:screenshots` is strict only
+      dashboard, 2026-08-02. Settings → Environment Variables. `check:screenshots` is strict only
       when `VERCEL_ENV=production`, and Vercel is what injects it, so with the box off the gate would
       silently downgrade to advisory **on the production build** — the one place it is supposed to
       bite. Vercel does not document the default for a portal import, which is why this needed
       checking rather than assuming. **It has not yet been exercised**: no production build has run
-      since, so the injection is confirmed at the setting, not at the artifact.
+      since, so the injection is confirmed at the setting, not at the artifact. §4 names the one log
+      line that settles it, and why the build going green does not.
 - [ ] **Set no Build / Install / Output override in the dashboard.** `web/vercel.json` carries all
       three and takes precedence over project settings — that precedence is the only thing keeping a
       dashboard edit from silently removing the gate chain.


### PR DESCRIPTION
You enabled **"Enable access to System Environment Variables"** in Vercel today. That was the one §5 item #327 could not resolve, and the reason §4 had to hedge its own gate as *possibly* advisory. This unhedges it.

### What changes

`check:screenshots` is a gate again rather than a hopeful one. `VERCEL_ENV` is now injected, `isProductionDeploy()` returns true on the production build, and a placeholder frame fails it instead of shipping.

- `web/docs/launch-checklist.md` §4 — "currently unconfirmed" → **enforced**
- `web/docs/launch-checklist.md` §5 — the checkbox is ticked, dated, with the reason it needed checking rather than assuming (Vercel doesn't document the default for a portal import)
- `web/docs/deploy.md` — the same correction in the project-settings list

### What I did not claim

The **setting** is confirmed. The **behaviour** is not, and the docs now say which is which.

No production build has run since the box was turned on, so nothing has observed `VERCEL_ENV=production` actually reaching `check-screenshots.mjs`. The first release merge proves it — and proves it *by passing*, which is indistinguishable from the downgraded case unless a placeholder happens to be present at that moment. That is a weak proof and is labelled as one, because "it went green" is exactly what the failure mode also looks like.

`REQUIRE_SCREENSHOTS=1 npm run build` locally remains the only way to see the strict verdict on demand.

### Verification

291 tests pass, full `npm run build` gate chain green. Docs-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guidance to reflect the verified system environment variable setting.
  * Added UTC/date interpretation guidance and instructions for checking `VERCEL_ENV` in the first production build log.
  * Clarified that a successful build alone does not confirm production propagation, which remains unobserved.
  * Documented the screenshot gate’s strict and advisory behaviors in the launch checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->