### PR TITLE
fix(apps): keep the app list intact when a ROM revokes package visibility in the background

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,15 @@
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="ReservedSystemPermission" />
 
+    <!--
+      Non-AOSP. Declared by Chinese-market ROMs (MIUI/HyperOS, ColorOS, OriginOS, MagicOS)
+      per T/TAF 108-2022, where package visibility is a three-state runtime permission
+      (allow / while-in-use / deny) *in addition to* QUERY_ALL_PACKAGES above. On a ROM that
+      grants it "while in use", getInstalledPackages() collapses once Thor is backgrounded.
+      Absent on AOSP, where requesting it is a silent no-op — never assume it exists.
+    -->
+    <uses-permission android:name="com.android.permission.GET_INSTALLED_APPS" />
+
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
 
     <uses-permission android:name="shizuku.permission.API_V23" />

--- a/app/src/main/java/com/valhalla/thor/data/permission/InstalledAppsPermissionChecker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/permission/InstalledAppsPermissionChecker.kt
@@ -33,12 +33,30 @@ class InstalledAppsPermissionChecker(
 ) : InstalledAppsPermissionGate {
 
     /**
-     * Cached, because the ROM's permission table is fixed for the life of the OS image — whether
-     * `com.android.permission.GET_INSTALLED_APPS` exists cannot change under a running process, and
-     * re-asking on every scan would put a binder call on the app-list hot path for an answer that is
-     * a build-time property of the device.
+     * Cached once resolved, because the ROM's permission table is fixed for the life of the OS
+     * image — whether `com.android.permission.GET_INSTALLED_APPS` exists cannot change under a
+     * running process, and re-asking on every scan would put a binder call on the app-list hot path
+     * for an answer that is a build-time property of the device.
+     *
+     * Deliberately *not* `by lazy`, because only a **definitive** answer may be cached. A caught
+     * `NameNotFoundException` is definitive — the device does not define the permission — and so is
+     * a successful lookup. Anything else is a failed question rather than an answer, and memoizing
+     * it would be self-defeating: as [declaredPermission] notes, the ROMs that define this
+     * permission are the same ones that throw unexpected things out of the package manager, so one
+     * unlucky probe would pin [InstalledAppsPermission.Unsupported] for the rest of the process and
+     * silently disable the banner, the prompt, and the unconditional-retain path in `scanVerdict` —
+     * on exactly the devices this exists for. A transient failure is left uncached and re-asked on
+     * the next [state] call instead.
+     *
+     * `@Volatile` for publication, not mutual exclusion: two threads racing the first probe may both
+     * make the binder call, which is wasteful for one round trip and otherwise harmless, since the
+     * answer they write is the same.
      */
-    private val declared: DeclaredPermission? by lazy { declaredPermission() }
+    @Volatile
+    private var resolved: Resolution? = null
+
+    /** A definitive answer about this device. [permission] is null when the device does not define it. */
+    private class Resolution(val permission: DeclaredPermission?)
 
     /**
      * The current state, re-reading the *grant* every time.
@@ -49,28 +67,42 @@ class InstalledAppsPermissionChecker(
      * exactly the scans that get truncated by not having it.
      */
     override fun state(): InstalledAppsPermission = installedAppsPermissionState(
-        declared = declared,
+        declared = declaredPermission(),
         isGranted = context.checkSelfPermission(GET_INSTALLED_APPS_PERMISSION) ==
                 PackageManager.PERMISSION_GRANTED,
     )
 
-    /** What this device says about the permission, or null if it does not define it. */
+    /**
+     * What this device says about the permission, or null if it does not define it — or if asking
+     * failed, in which case the next call asks again rather than trusting this one.
+     */
     @Suppress("DEPRECATION")
     private fun declaredPermission(): DeclaredPermission? {
+        resolved?.let { return it.permission }
+
         val info = try {
-            // Throws NameNotFoundException on every AOSP build, which is the authoritative answer
-            // rather than an error: T/TAF 108-2022 is a Chinese-market standard and most devices
-            // Thor runs on have simply never heard of this permission. Catching Exception rather
-            // than NameNotFoundException on purpose — the ROMs that *do* define it are also the ones
-            // that throw other things out of the package manager.
             packageManager.getPermissionInfo(GET_INSTALLED_APPS_PERMISSION, 0)
+        } catch (_: PackageManager.NameNotFoundException) {
+            // The authoritative answer rather than an error, and the one every AOSP build gives:
+            // T/TAF 108-2022 is a Chinese-market standard and most devices Thor runs on have simply
+            // never heard of this permission. Definitive, so it is cached.
+            resolved = Resolution(null)
+            return null
         } catch (_: Exception) {
+            // Something other than "no such permission" — a package-manager hiccup, not a verdict
+            // about the device. The ROMs that define this permission are also the ones most likely
+            // to throw here, so this answer is thrown away rather than cached: returning
+            // Unsupported once is a banner that does not appear, but caching it is the fix
+            // disabling itself permanently.
             return null
         }
-        return DeclaredPermission(
+
+        val permission = DeclaredPermission(
             isDangerous = (info.protectionLevel and PermissionInfo.PROTECTION_MASK_BASE) ==
                     PermissionInfo.PROTECTION_DANGEROUS,
             group = info.group
         )
+        resolved = Resolution(permission)
+        return permission
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/permission/InstalledAppsPermissionChecker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/permission/InstalledAppsPermissionChecker.kt
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.permission
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.pm.PermissionInfo
+import com.valhalla.thor.domain.model.DeclaredPermission
+import com.valhalla.thor.domain.model.GET_INSTALLED_APPS_PERMISSION
+import com.valhalla.thor.domain.model.InstalledAppsPermission
+import com.valhalla.thor.domain.model.installedAppsPermissionState
+import com.valhalla.thor.domain.repository.InstalledAppsPermissionGate
+import org.koin.core.annotation.Single
+
+/**
+ * Asks the running device the two questions [installedAppsPermissionState] needs about
+ * [GET_INSTALLED_APPS_PERMISSION], and nothing else.
+ *
+ * The split is the same one [com.valhalla.thor.data.repository.PermissionRepositoryImpl] makes for
+ * permission groups: the binder calls live here, the rule lives in a pure function that a JVM test
+ * can drive. That is what makes "a Pixel must never be prompted" assertable — `PackageManager` is
+ * abstract, `:app` has no mocking library by policy, and a device that has never heard of the
+ * permission is just `declared = null` in a test.
+ *
+ * No gateway, no shell, no reflection: this is an ordinary runtime permission requested with
+ * `ActivityResultContracts.RequestPermission()`, and nothing here needs privilege.
+ */
+@Single(binds = [InstalledAppsPermissionGate::class])
+class InstalledAppsPermissionChecker(
+    private val context: Context,
+    private val packageManager: PackageManager,
+) : InstalledAppsPermissionGate {
+
+    /**
+     * Cached, because the ROM's permission table is fixed for the life of the OS image — whether
+     * `com.android.permission.GET_INSTALLED_APPS` exists cannot change under a running process, and
+     * re-asking on every scan would put a binder call on the app-list hot path for an answer that is
+     * a build-time property of the device.
+     */
+    private val declared: DeclaredPermission? by lazy { declaredPermission() }
+
+    /**
+     * The current state, re-reading the *grant* every time.
+     *
+     * The grant very much does change at runtime — that is the whole point of this permission being
+     * three-state. A "while in use" grant reads as granted in the foreground and stops being true the
+     * moment Thor is backgrounded, so caching this would report a permission Thor no longer has for
+     * exactly the scans that get truncated by not having it.
+     */
+    override fun state(): InstalledAppsPermission = installedAppsPermissionState(
+        declared = declared,
+        isGranted = context.checkSelfPermission(GET_INSTALLED_APPS_PERMISSION) ==
+                PackageManager.PERMISSION_GRANTED,
+    )
+
+    /** What this device says about the permission, or null if it does not define it. */
+    @Suppress("DEPRECATION")
+    private fun declaredPermission(): DeclaredPermission? {
+        val info = try {
+            // Throws NameNotFoundException on every AOSP build, which is the authoritative answer
+            // rather than an error: T/TAF 108-2022 is a Chinese-market standard and most devices
+            // Thor runs on have simply never heard of this permission. Catching Exception rather
+            // than NameNotFoundException on purpose — the ROMs that *do* define it are also the ones
+            // that throw other things out of the package manager.
+            packageManager.getPermissionInfo(GET_INSTALLED_APPS_PERMISSION, 0)
+        } catch (_: Exception) {
+            return null
+        }
+        return DeclaredPermission(
+            isDangerous = (info.protectionLevel and PermissionInfo.PROTECTION_MASK_BASE) ==
+                    PermissionInfo.PROTECTION_DANGEROUS,
+            group = info.group
+        )
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -16,7 +16,11 @@ import com.valhalla.thor.data.source.local.room.AppEntity
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.PermissionDetail
+import com.valhalla.thor.domain.model.ScanVerdict
+import com.valhalla.thor.domain.model.scanVerdict
 import com.valhalla.thor.domain.repository.AppRepository
+import com.valhalla.thor.domain.repository.InstalledAppsPermissionGate
+import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -34,7 +38,8 @@ import java.io.File
 class AppRepositoryImpl(
     private val context: Context,
     private val appDao: AppDao,
-    private val uadHelper: UadHelper
+    private val uadHelper: UadHelper,
+    private val installedAppsPermission: InstalledAppsPermissionGate
 ) : AppRepository {
 
     private val pm = context.packageManager
@@ -65,6 +70,14 @@ class AppRepositoryImpl(
             }
 
             var lastLocale = context.resources.configuration.locales[0].toString()
+
+            // How many scans in a row scanVerdict() has refused to prune against. Deliberately
+            // declared out here, not inside the trigger loop: the whole point of the tolerance is
+            // that a shrinkage has to reproduce across *independent* scans before it is believed,
+            // and a counter reset on every trigger would be stuck at zero and never let the cache
+            // shrink again. Local to this collection rather than to the class, because a retained
+            // cache self-heals on the next good scan — there is no degraded state worth persisting.
+            var consecutiveSuspectScans = 0
 
             // Signal the worker to refresh
             triggerChannel.send(Unit)
@@ -161,18 +174,61 @@ class AppRepositoryImpl(
                     val currentPackageNames = installedPackages.map { it.packageName }.toSet()
                     val toDelete = cachedMap.keys.filter { it !in currentPackageNames }
 
-                    if (toUpdate.isNotEmpty() || toDelete.isNotEmpty()) {
-                        appDao.syncCache(toUpdate, toDelete)
-                        toDelete.forEach { pkgName ->
-                            cachedMap.remove(pkgName)
-                            try {
-                                File(context.filesDir, "app_icons/$pkgName.png").delete()
-                            } catch (_: Exception) {}
+                    // "Not in the scan" is only the same thing as "uninstalled" when the scan can
+                    // be trusted. On the ROMs that gate package visibility behind the runtime
+                    // GET_INSTALLED_APPS permission, backgrounding Thor makes getInstalledPackages()
+                    // return a near-empty list, and pruning against that wipes the Room rows *and*
+                    // the cached icon PNGs for almost every app the user has. scanVerdict() holds
+                    // the rules; nothing is decided here.
+                    val verdict = scanVerdict(
+                        scannedPackageNames = currentPackageNames,
+                        cachedCount = cachedMap.size,
+                        consecutiveSuspectScans = consecutiveSuspectScans,
+                        permission = installedAppsPermission.state()
+                    )
+
+                    // The cached rows this scan did not see and was not allowed to delete. Mapped
+                    // through the same AppEntity.toDomain() the initial cache emission above uses,
+                    // so a retained row reaches the UI exactly as it did a moment earlier.
+                    val retained = when (verdict) {
+                        ScanVerdict.Accept -> {
+                            consecutiveSuspectScans = 0
+                            if (toUpdate.isNotEmpty() || toDelete.isNotEmpty()) {
+                                appDao.syncCache(toUpdate, toDelete)
+                                toDelete.forEach { pkgName ->
+                                    cachedMap.remove(pkgName)
+                                    try {
+                                        File(context.filesDir, "app_icons/$pkgName.png").delete()
+                                    } catch (_: Exception) {}
+                                }
+                            }
+                            emptyList<AppInfo>()
+                        }
+
+                        is ScanVerdict.Retain -> {
+                            consecutiveSuspectScans++
+                            Logger.w(
+                                "AppRepository",
+                                "not pruning against this scan (${verdict.reason}): saw " +
+                                        "${currentPackageNames.size} package(s) against " +
+                                        "${cachedMap.size} cached, keeping ${toDelete.size} row(s)"
+                            )
+                            // Updates still land — they describe packages the scan *did* see, so
+                            // they are no less trustworthy than on an accepted scan. Only the
+                            // deletions are withheld, and the icon files with them: a retained Room
+                            // row is repaired by the next good scan, a deleted PNG is not.
+                            if (toUpdate.isNotEmpty()) {
+                                appDao.syncCache(toUpdate, emptyList())
+                            }
+                            toDelete.mapNotNull { cachedMap[it]?.toDomain() }
                         }
                     }
 
-                    // Emit a single complete snapshot of all installed apps
-                    producer.send(currentList.toList())
+                    // Emit a single complete snapshot of all installed apps. On a retained scan
+                    // that snapshot is the union, never the scan alone: emitting what a truncated
+                    // scan saw is the blank list this whole guard exists to prevent, and emitting
+                    // nothing would strand isLoading forever on a fresh collection.
+                    producer.send(currentList + retained)
 
                 } catch (e: CancellationException) {
                     // Kotlin's CancellationException is an Exception, so the broad catch below

--- a/app/src/main/java/com/valhalla/thor/domain/model/InstalledAppsVisibility.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/InstalledAppsVisibility.kt
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+/**
+ * The package-visibility permission the Chinese association standard T/TAF 108-2022 added, honoured
+ * by MIUI/HyperOS, ColorOS, OriginOS, MagicOS and xiaomi.eu.
+ *
+ * It is **in addition to** `QUERY_ALL_PACKAGES`, never a replacement: those ROMs still require the
+ * AOSP one, and every other Android build requires it alone. What makes this permission different is
+ * that it is a *runtime* permission with three states — allow / while-in-use / deny — so the answer
+ * to "which packages exist" can change while the process is alive, which is not a thing AOSP package
+ * visibility can do.
+ *
+ * Non-AOSP means a Pixel has never heard of it; see [installedAppsPermissionState] for why that has
+ * to be detected rather than assumed.
+ */
+const val GET_INSTALLED_APPS_PERMISSION = "com.android.permission.GET_INSTALLED_APPS"
+
+/**
+ * The platform package.
+ *
+ * Google's automatic-visibility rules make this one of the handful of packages every app can see on
+ * every Android version regardless of filtering, alongside the caller itself and its installer. That
+ * is exactly what makes it usable as a canary: a scan that cannot see `android` is not a device with
+ * few apps installed, it is a scan that was not allowed to answer.
+ */
+const val PLATFORM_PACKAGE = "android"
+
+/**
+ * How many consecutive suspect scans to tolerate before believing the shrinkage is real.
+ *
+ * The guard has to be able to *stop* guarding. A user who factory-resets their launcher's worth of
+ * apps, or restores a much smaller backup, produces a genuinely tiny scan, and a cache that can only
+ * grow would keep showing them rows for apps that are gone. Two independent scans agreeing, with no
+ * permission gate to explain them, is the point where "the OS is lying to us" stops being the better
+ * explanation.
+ */
+const val SUSPECT_SCAN_TOLERANCE = 2
+
+/**
+ * What this device says about [GET_INSTALLED_APPS_PERMISSION].
+ *
+ * [Unsupported] is deliberately not the same thing as [Denied]. It is the state of every AOSP device
+ * Thor runs on, it can never change, and nothing may ever be shown to the user about it — the banner
+ * and the prompt are both gated on [Denied] alone.
+ */
+sealed interface InstalledAppsPermission {
+
+    /**
+     * The ROM does not define the permission, or defines it with a protection level below
+     * `dangerous`.
+     *
+     * Either way it can never be requested at runtime: `requestPermissions` for a permission the
+     * platform does not know is a silent no-op, and a non-dangerous permission is granted (or not) at
+     * install time with no dialog to show. Treating this as "denied" is the Pixel false-nag bug —
+     * `shouldShowRequestPermissionRationale` also returns a hard `false` for an unknown permission,
+     * so the usual "denied and no rationale means permanently denied, send them to Settings" recipe
+     * would nag every AOSP user forever about a permission their device has never heard of.
+     */
+    data object Unsupported : InstalledAppsPermission
+
+    /** Defined, dangerous, and not currently held — the one state worth prompting about. */
+    data object Denied : InstalledAppsPermission
+
+    /**
+     * Held right now. Note that "while in use" reports granted too, and stops being true the moment
+     * Thor is backgrounded, which is why the grant is re-read on every scan rather than cached.
+     */
+    data object Granted : InstalledAppsPermission
+}
+
+/**
+ * Fold the two facts a caller can gather about the permission into the state the UI and the prune
+ * guard both act on.
+ *
+ * [declared] `== null` is `getPermissionInfo` having thrown `NameNotFoundException`: the
+ * authoritative "this OS has never heard of it", and the only honest way to tell a Pixel from a
+ * HyperOS device. Sniffing `Build.MANUFACTURER` would be a guess about a permission table that OEMs
+ * change between builds; asking the package manager is not.
+ *
+ * A permission that exists but is not `dangerous` is [InstalledAppsPermission.Unsupported] for the
+ * same reason — it cannot be requested at runtime, so offering the user a button that does nothing
+ * is worse than staying quiet. This mirrors the existing rule in [runtimeGroupFor]: the device is
+ * asked first, and "declared" alone is never enough.
+ *
+ * Pure so the Pixel case is assertable on the JVM — `PackageManager` is abstract and `:app` has no
+ * mocking library, so the binder calls stay in the checker and the decision lives here.
+ */
+fun installedAppsPermissionState(
+    declared: DeclaredPermission?,
+    isGranted: Boolean,
+): InstalledAppsPermission = when {
+    declared == null -> InstalledAppsPermission.Unsupported
+    !declared.isDangerous -> InstalledAppsPermission.Unsupported
+    isGranted -> InstalledAppsPermission.Granted
+    else -> InstalledAppsPermission.Denied
+}
+
+/** Why a scan was not believed, in the order [scanVerdict] tests for them. */
+enum class RetainReason {
+    /** The scan came back with nothing at all. */
+    EmptyScan,
+
+    /** The scan is missing [PLATFORM_PACKAGE], which no honest scan ever is. */
+    PlatformPackageMissing,
+
+    /** The scan lost more than half the cached rows in one go. */
+    Collapsed,
+}
+
+/** Whether a package scan is trustworthy enough to prune the cache against. */
+sealed interface ScanVerdict {
+
+    /** Believe the scan: anything the cache holds and the scan does not is genuinely uninstalled. */
+    data object Accept : ScanVerdict
+
+    /** Keep the cached rows this scan did not see, and say why. */
+    data class Retain(val reason: RetainReason) : ScanVerdict
+}
+
+/**
+ * Whether [scannedPackageNames] may be used to delete cached rows.
+ *
+ * **This is the fix for the actual defect.** With `GET_INSTALLED_APPS` granted "while in use",
+ * backgrounding Thor collapses `getInstalledPackages()` to a near-empty list. The scan loop then
+ * reads every absent package as uninstalled, `syncCache` deletes the Room rows *and* their cached
+ * icon PNGs, and the user comes back to a list containing only Thor — damage that outlives the
+ * permission blip and survives until a full rescan. Requesting the permission cures the cause; this
+ * function is what stops a scan taken through a closed gate from being destructive in the meantime.
+ *
+ * **Why identity and not a count.** Field reports include a truncated-but-large scan — 68 packages
+ * out of 175 — so a "lost more than half" threshold alone lets the worst real case straight through,
+ * while a blunt "never shrink" rule would break genuine uninstalls forever. Automatic-visibility
+ * guarantees mean the platform package is visible to every app on every version no matter what the
+ * filtering says, so its *absence* is proof about the scan rather than evidence about the device.
+ *
+ * The rules run in a fixed order, and rule 3 landing before rule 4 is load-bearing:
+ * 1. An empty cache accepts anything. There is nothing to protect, and refusing here would strand a
+ *    fresh install on an empty list forever, because the cache could never take its first rows.
+ * 2. Work out whether the scan is suspect at all, first match wins; if it is not, accept.
+ * 3. [InstalledAppsPermission.Denied] retains **unconditionally, with no tolerance**. We have a
+ *    named cause for the shrinkage, so no number of repeats makes it evidence of an uninstall —
+ *    repeating a question through a closed gate just gets the same wrong answer again. Letting the
+ *    tolerance fire here is precisely the bug coming back.
+ * 4. Only with no permission gate to explain it does [SUSPECT_SCAN_TOLERANCE] apply, and then the
+ *    shrinkage is believed. Without this the cache could never shrink again and rows for genuinely
+ *    removed apps would persist forever.
+ * 5. Otherwise retain, and let the caller count this scan towards the tolerance.
+ *
+ * [consecutiveSuspectScans] is the count of suspect scans *before* this one, which the caller keeps
+ * for the life of one collection and resets on the first accepted scan. Deliberately not persisted:
+ * a retained cache self-heals on the next good scan without an app restart, so there is no degraded
+ * state to remember.
+ */
+fun scanVerdict(
+    scannedPackageNames: Set<String>,
+    cachedCount: Int,
+    consecutiveSuspectScans: Int,
+    permission: InstalledAppsPermission,
+): ScanVerdict {
+    if (cachedCount == 0) return ScanVerdict.Accept
+
+    val reason = when {
+        scannedPackageNames.isEmpty() -> RetainReason.EmptyScan
+        PLATFORM_PACKAGE !in scannedPackageNames -> RetainReason.PlatformPackageMissing
+        scannedPackageNames.size * 2 < cachedCount -> RetainReason.Collapsed
+        else -> return ScanVerdict.Accept
+    }
+
+    // Before the tolerance check, never after it. See rule 3 above.
+    if (permission == InstalledAppsPermission.Denied) return ScanVerdict.Retain(reason)
+
+    if (consecutiveSuspectScans >= SUSPECT_SCAN_TOLERANCE) return ScanVerdict.Accept
+
+    return ScanVerdict.Retain(reason)
+}

--- a/app/src/main/java/com/valhalla/thor/domain/repository/InstalledAppsPermissionGate.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/InstalledAppsPermissionGate.kt
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+import com.valhalla.thor.domain.model.InstalledAppsPermission
+
+/**
+ * Domain port for the `com.android.permission.GET_INSTALLED_APPS` probe.
+ *
+ * Exists for the same reason [UsageAccessGate] does: the concrete checker is `Context`-bound, and
+ * both [com.valhalla.thor.presentation.appList.AppListViewModel] and
+ * [com.valhalla.thor.data.repository.AppRepositoryImpl] need the answer on a code path that
+ * `AppListViewModelTest` builds on the JVM. `:app` has no mocking library and no Robolectric by
+ * policy, so a dependency that cannot be faked by hand is a dependency that takes a test suite
+ * offline — which is why this is an interface and not the implementation class.
+ *
+ * Deliberately *not* nullable-with-a-default at the call sites. An absent probe and a device that
+ * does not define the permission both have to answer [InstalledAppsPermission.Unsupported], and
+ * making that the value of a missing binding rather than of an explicit fake would let a Koin
+ * misconfiguration present as "no device supports this" — a silent, permanent, invisible failure of
+ * exactly the feature being added.
+ */
+interface InstalledAppsPermissionGate {
+
+    /**
+     * What the running device says right now.
+     *
+     * Re-read on every call: the grant is three-state on the ROMs that define it, so a "while in
+     * use" grant is [InstalledAppsPermission.Granted] in the foreground and stops being true the
+     * moment Thor is backgrounded.
+     */
+    fun state(): InstalledAppsPermission
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
@@ -4,6 +4,11 @@
 package com.valhalla.thor.presentation.appList
 
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +22,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -25,6 +31,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,6 +41,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.basicMarquee
@@ -47,10 +57,14 @@ import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.MultiAppAction
 import com.valhalla.thor.domain.model.AppListType
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import com.valhalla.asgard.components.AsgardBanner
 import com.valhalla.asgard.components.ConnectedButtonGroup
 import com.valhalla.asgard.components.ConnectedButtonGroupItem
+import com.valhalla.thor.domain.model.GET_INSTALLED_APPS_PERMISSION
+import com.valhalla.thor.domain.model.InstalledAppsPermission
 import com.valhalla.thor.presentation.freezer.FreezerPrompt
 import com.valhalla.thor.presentation.utils.ObserveAsEvents
 import com.valhalla.thor.presentation.widgets.AppList
@@ -110,6 +124,36 @@ fun AppListScreen(
             // Screen entry: let the navigation transition settle before the scan starts.
             viewModel.loadApps(deferForTransition = true)
         }
+    }
+
+    // com.android.permission.GET_INSTALLED_APPS — an ordinary runtime permission, so an ordinary
+    // RequestPermission contract. No privilege path: Thor never self-grants the permission that
+    // decides how much of the device it is allowed to see.
+    //
+    // The result boolean is deliberately ignored and the truth re-read instead, the same way the
+    // notification row does it in SettingsScreen. This permission is three-state on the ROMs that
+    // define it, and a "while in use" grant answers `true` here and then stops being true the moment
+    // Thor is backgrounded — which is precisely the state that truncates the package scan. Only the
+    // checker's own read is worth believing.
+    val installedAppsPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _ ->
+        viewModel.refreshInstalledAppsPermission()
+    }
+
+    // A grant made in system Settings never comes back through the launcher callback, and a
+    // "while in use" grant silently lapses while Thor is away, so the state is re-read on every
+    // resume rather than only after a request. Same idiom as the permissions section of
+    // SettingsScreen.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshInstalledAppsPermission()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     // Handle one-off feedback (toasts + freezer prompt) delivered exactly once.
@@ -177,7 +221,32 @@ fun AppListScreen(
                 )
             }
 
-            // 2. The List Content
+            // 2. Package-visibility banner, above the search bar AppList draws below.
+            //
+            // Gated on Denied and nothing else. Unsupported is the state of every AOSP device Thor
+            // runs on and must stay invisible there — the permission does not exist on a Pixel, so
+            // there is nothing to grant and nothing to say. There is deliberately no rationale check
+            // and no "permanently denied, open Settings" fallback either:
+            // shouldShowRequestPermissionRationale() returns a hard false for a permission the
+            // platform does not define, so the usual denied && !rationale recipe reads every Pixel
+            // as permanently denied and nags forever. The availability probe upstream is what makes
+            // the rationale question unnecessary rather than merely skipped.
+            //
+            // If the user denies, the banner simply stays and another tap re-prompts; whether a
+            // dialog appears is the OS's call, not Thor's.
+            AnimatedVisibility(
+                visible = state.installedAppsPermission is InstalledAppsPermission.Denied,
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                IncompleteAppListBanner(
+                    onGrant = {
+                        installedAppsPermissionLauncher.launch(GET_INSTALLED_APPS_PERMISSION)
+                    }
+                )
+            }
+
+            // 3. The List Content
             val refreshState = rememberPullToRefreshState()
 
             PullToRefreshBox(
@@ -310,4 +379,45 @@ fun AppListScreen(
             )
         }
     }
+}
+
+/**
+ * "App list may be incomplete" — shown only while [InstalledAppsPermission.Denied] holds.
+ *
+ * Same error-tinted treatment as `ReadOnlyBanner` on the permission-manager screen, because it makes
+ * the same kind of claim: what is on screen is not the whole truth, and Thor cannot fix that on its
+ * own. The [onGrant] button is the only route offered — no Settings deep link, because there is no
+ * reliable way to tell "the user said no once" from "the dialog will not appear again" for a
+ * permission AOSP has never heard of, and guessing wrong strands the user in a Settings screen with
+ * no matching toggle.
+ */
+@Composable
+private fun IncompleteAppListBanner(onGrant: () -> Unit) {
+    AsgardBanner(
+        title = stringResource(R.string.installed_apps_permission_title),
+        description = stringResource(R.string.installed_apps_permission_desc),
+        icon = ImageVector.vectorResource(R.drawable.warning),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        containerBrush = Brush.horizontalGradient(
+            colors = listOf(
+                MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.8f),
+                MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f)
+            )
+        ),
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        descriptionStyle = MaterialTheme.typography.bodySmall,
+        action = {
+            // The button's content colour is pinned rather than left to the TextButton default,
+            // which is `primary` — a colour chosen to sit on the surface, not on this banner's
+            // error-tinted gradient, and unreadable against it in several of Thor's themes.
+            TextButton(
+                onClick = onGrant,
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer
+                )
+            ) { Text(stringResource(R.string.installed_apps_permission_grant)) }
+        }
+    )
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -146,6 +147,7 @@ class AppListViewModel(
     private var sizeJob: Job? = null
     private var refreshIndicatorJob: Job? = null
     private var permissionIndexJob: Job? = null
+    private var permissionRefreshJob: Job? = null
     private val _rawState = MutableStateFlow(AppListUiState())
 
     // One-off UI feedback (toasts, freezer prompt). A buffered Channel fires each event exactly
@@ -193,14 +195,23 @@ class AppListViewModel(
      * banner for a permission the user granted ten seconds later and keep showing it until the
      * process died.
      *
-     * Off the main thread because the very first call resolves the checker's `by lazy`
+     * Off the main thread because the very first call resolves the checker's cached
      * `getPermissionInfo` binder round trip, and the callers are a lifecycle observer and an
      * activity-result callback — both of which run on the main thread, on resume, which is exactly
      * where a blocking package-manager call is most expensive.
+     *
+     * Strictly last-read-wins. The result callback and `ON_RESUME` fire within milliseconds of each
+     * other when the user answers the dialog, so two reads can be in flight at once — and without
+     * this, a slower earlier read that saw `Denied` could land *after* the newer one that saw the
+     * grant, putting the banner back up over a permission the user just granted. Cancelling the
+     * previous job closes most of the window and [ensureActive] closes the rest: a read that lost
+     * the race is cancelled between the binder call and the state write, so it never publishes.
      */
     fun refreshInstalledAppsPermission() {
-        viewModelScope.launch(ioDispatcher) {
+        permissionRefreshJob?.cancel()
+        permissionRefreshJob = viewModelScope.launch(ioDispatcher) {
             val permission = installedAppsPermission.state()
+            ensureActive()
             _rawState.update { it.copy(installedAppsPermission = permission) }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -10,6 +10,7 @@ import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.FilterType
 import com.valhalla.thor.domain.model.FreezeTier
+import com.valhalla.thor.domain.model.InstalledAppsPermission
 import com.valhalla.thor.domain.model.MultiAppAction
 import com.valhalla.thor.domain.model.PermissionIndex
 import com.valhalla.thor.domain.model.SortBy
@@ -21,6 +22,7 @@ import com.valhalla.thor.domain.model.sortApps
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.AppShortcutController
 import com.valhalla.thor.domain.repository.FreezerRepository
+import com.valhalla.thor.domain.repository.InstalledAppsPermissionGate
 import com.valhalla.thor.domain.repository.PermissionRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.PrivilegeStateProvider
@@ -99,7 +101,14 @@ data class AppListUiState(
     // getAllApps() emits the Room cache before it starts the package rescan, so isLoading clears
     // after one DAO read and the indicator would blink out while the real scan is still running.
     val isManualRefreshing: Boolean = false,
-    val needsUsageAccessPrompt: Boolean = false
+    val needsUsageAccessPrompt: Boolean = false,
+    // What this device says about com.android.permission.GET_INSTALLED_APPS. Only
+    // InstalledAppsPermission.Denied puts anything on screen; the default is deliberately
+    // Unsupported so nothing can render before the device has actually been asked. That default is
+    // also the permanent answer on every AOSP build, which is the point — a Pixel does not define
+    // this permission, so "not granted" there must never be mistaken for "denied" and turned into a
+    // banner nobody can ever dismiss. See installedAppsPermissionState().
+    val installedAppsPermission: InstalledAppsPermission = InstalledAppsPermission.Unsupported
 )
 
 /**
@@ -125,6 +134,7 @@ class AppListViewModel(
     private val permissionRepository: PermissionRepository,
     private val storageStats: StorageStatsProvider,
     private val usageAccess: UsageAccessGate,
+    private val installedAppsPermission: InstalledAppsPermissionGate,
     // Injected rather than hardcoded so a test can put every stage of this view model on one
     // scheduler: the sort/filter pipeline below runs off-main, and a `Dispatchers.Default` baked
     // in here would keep it on a real thread pool while the rest ran on virtual time.
@@ -170,6 +180,29 @@ class AppListViewModel(
         observeSizeSort()
         observeFreezerMembership()
         observePermissionFilter()
+        refreshInstalledAppsPermission()
+    }
+
+    /**
+     * Re-reads whether Thor may still see the full package list, for the banner in [AppListScreen].
+     *
+     * Called from `init` and again on every `ON_RESUME` and after every request, because the grant
+     * this reports is the three-state kind: "while in use" reads as granted in the foreground and
+     * stops being true the moment Thor is backgrounded, and a grant made in system Settings never
+     * comes back through a result callback at all. A one-shot read at construction would show the
+     * banner for a permission the user granted ten seconds later and keep showing it until the
+     * process died.
+     *
+     * Off the main thread because the very first call resolves the checker's `by lazy`
+     * `getPermissionInfo` binder round trip, and the callers are a lifecycle observer and an
+     * activity-result callback — both of which run on the main thread, on resume, which is exactly
+     * where a blocking package-manager call is most expensive.
+     */
+    fun refreshInstalledAppsPermission() {
+        viewModelScope.launch(ioDispatcher) {
+            val permission = installedAppsPermission.state()
+            _rawState.update { it.copy(installedAppsPermission = permission) }
+        }
     }
 
     /**

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -518,6 +518,9 @@
     <string name="notification_access_granted_subtitle">تظهر نتائج التجميد الجماعي كإشعارات</string>
     <string name="notification_access_needed_subtitle">اسمح بالإشعارات لرؤية نتائج التجميد الجماعي</string>
     <string name="open_settings">فتح الإعدادات</string>
+    <string name="installed_apps_permission_title">قد تكون قائمة التطبيقات غير مكتملة</string>
+    <string name="installed_apps_permission_desc">يقيّد جهازك التطبيقات التي يمكن لـ Thor رؤيتها أثناء عمله في الخلفية. امنح وصولاً كاملاً إلى قائمة التطبيقات المثبّتة للحفاظ على اكتمالها.</string>
+    <string name="installed_apps_permission_grant">منح</string>
     <string name="freeze_mode">وضع التجميد</string>
     <string name="suspend_instead_of_freeze">التعليق بدلاً من التجميد</string>
     <string name="suspend_instead_of_freeze_desc">عند التجميد (بما في ذلك التجميد التلقائي)، قم بتتعليق التطبيقات بدلاً من تعطيلها. تظل التطبيقات المعلقة مرئية ولكن متوقفة مؤقتًا.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -480,6 +480,9 @@
     <string name="notification_access_granted_subtitle">Los resultados del congelado masivo se muestran como notificaciones</string>
     <string name="notification_access_needed_subtitle">Permite las notificaciones para ver los resultados del congelado masivo</string>
     <string name="open_settings">Abrir ajustes</string>
+    <string name="installed_apps_permission_title">La lista de aplicaciones puede estar incompleta</string>
+    <string name="installed_apps_permission_desc">Tu dispositivo limita qué aplicaciones puede ver Thor mientras está en segundo plano. Concede acceso completo a la lista de aplicaciones instaladas para mantenerla completa.</string>
+    <string name="installed_apps_permission_grant">Conceder</string>
     <string name="freeze_mode">Modo de congelación</string>
     <string name="suspend_instead_of_freeze">Suspender en lugar de congelar</string>
     <string name="suspend_instead_of_freeze_desc">Al congelar (incluyendo el autocongelado), suspende las aplicaciones en lugar de desactivarlas. Las aplicaciones suspendidas siguen siendo visibles pero pausadas.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -480,6 +480,9 @@
     <string name="notification_access_granted_subtitle">Les résultats du gel groupé sont affichés en notifications</string>
     <string name="notification_access_needed_subtitle">Autorisez les notifications pour voir les résultats du gel groupé</string>
     <string name="open_settings">Ouvrir les paramètres</string>
+    <string name="installed_apps_permission_title">La liste des applications peut être incomplète</string>
+    <string name="installed_apps_permission_desc">Votre appareil limite les applications que Thor peut voir lorsqu\'il est en arrière-plan. Accordez l\'accès complet à la liste des applications installées pour qu\'elle reste complète.</string>
+    <string name="installed_apps_permission_grant">Accorder</string>
     <string name="freeze_mode">Mode de congélation</string>
     <string name="suspend_instead_of_freeze">Suspendre au lieu de congeler</string>
     <string name="suspend_instead_of_freeze_desc">Lors de la congélation (y compris la congélation automatique), suspendez les applications au lieu de les désactiver. Les applications suspendues restent visibles mais en pause.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -471,6 +471,9 @@
     <string name="notification_access_granted_subtitle">批量冻结结果将以通知形式显示</string>
     <string name="notification_access_needed_subtitle">允许通知以查看批量冻结结果</string>
     <string name="open_settings">打开设置</string>
+    <string name="installed_apps_permission_title">应用列表可能不完整</string>
+    <string name="installed_apps_permission_desc">您的设备限制了 Thor 在后台运行时可以看到的应用。请授予读取已安装应用列表的完全访问权限，以保持列表完整。</string>
+    <string name="installed_apps_permission_grant">授予</string>
     <string name="freeze_mode">冻结模式</string>
     <string name="suspend_instead_of_freeze">挂起代替冻结</string>
     <string name="suspend_instead_of_freeze_desc">冻结（包括自动冻结）时挂起应用，而不是禁用它们。挂起的应用仍然可见但处于暂停状态。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,13 @@
     <string name="notification_access_granted_subtitle">Bulk freeze results are shown as notifications</string>
     <string name="notification_access_needed_subtitle">Allow notifications to see bulk freeze results</string>
     <string name="open_settings">Open settings</string>
+    <!-- Installed-apps visibility (com.android.permission.GET_INSTALLED_APPS). Only ever shown on
+         ROMs that actually declare it — Chinese-market builds such as MIUI/HyperOS, ColorOS,
+         OriginOS and MagicOS. Deliberately worded without naming the permission: on those ROMs the
+         Settings toggle is labelled "read installed app list", not the AOSP permission name. -->
+    <string name="installed_apps_permission_title">App list may be incomplete</string>
+    <string name="installed_apps_permission_desc">Your device restricts which apps Thor can see while it is in the background. Grant full access to the installed-app list to keep it complete.</string>
+    <string name="installed_apps_permission_grant">Grant</string>
 
     <!-- Quick Settings Tile -->
     <string name="tile_no_privilege">No privilege granted</string>

--- a/app/src/test/java/com/valhalla/thor/domain/model/InstalledAppsVisibilityTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/InstalledAppsVisibilityTest.kt
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The two rules that keep a lying package scan from destroying the app cache.
+ *
+ * The bug they pin is not hypothetical. On MIUI/HyperOS, ColorOS, OriginOS, MagicOS and xiaomi.eu
+ * `GET_INSTALLED_APPS` is a three-state runtime permission, and with it set to "while in use"
+ * backgrounding Thor collapses `getInstalledPackages()` to a near-empty list. The scan loop read
+ * every absent package as uninstalled, deleted the Room rows *and* the cached icon PNGs, and the
+ * user came back to a list holding only Thor. [scanVerdict] decides whether a scan is allowed to be
+ * that destructive; [installedAppsPermissionState] is what stops the fix nagging every Pixel owner
+ * about a permission their device has never defined.
+ *
+ * Both are pure for the usual reason — `PackageManager` is abstract and `:app` has no mocking
+ * library by policy — so "a while-in-use grant on a HyperOS device that has just been backgrounded"
+ * is nothing more exotic here than a small set and an [InstalledAppsPermission].
+ */
+class InstalledAppsVisibilityTest {
+
+    /** The cache size from the field report this guard was written against. */
+    private val cachedRows = 175
+
+    /** A ROM that defines the permission as the standard requires: requestable at runtime. */
+    private fun dangerous() = DeclaredPermission(isDangerous = true, group = null)
+
+    /**
+     * A scan of [count] package names, the platform package included unless a test is about it
+     * being missing. The names never matter — only how many there are and whether `android` is one
+     * of them, which is the whole point of the rule.
+     */
+    private fun packages(count: Int, withPlatform: Boolean = true): Set<String> = buildSet {
+        if (withPlatform && count > 0) add(PLATFORM_PACKAGE)
+        var i = 0
+        while (size < count) add("com.example.app${i++}")
+    }
+
+    /**
+     * The rule under test, against the field report's cache size and a first-ever suspect scan
+     * unless the case is about one of those. [suspectScans] is last because only the two tolerance
+     * tests care about it, and [permission] is named at every call site because it is what most of
+     * these cases are actually varying.
+     */
+    private fun verdict(
+        scanned: Set<String>,
+        permission: InstalledAppsPermission,
+        cachedCount: Int = cachedRows,
+        suspectScans: Int = 0,
+    ) = scanVerdict(scanned, cachedCount, suspectScans, permission)
+
+    @Test
+    fun aDeviceThatDoesNotDefineThePermissionIsUnsupportedNotDenied() {
+        // The Pixel case, and the reason this function exists at all. getPermissionInfo throws
+        // NameNotFoundException on every AOSP build, arriving here as null. Reporting Denied would
+        // put a banner in front of every non-Chinese-ROM user offering to request a permission the
+        // OS would silently ignore — and shouldShowRequestPermissionRationale returns a hard false
+        // for an unknown permission, so the usual recipe would then call it "permanently denied"
+        // and deep-link them to a Settings page with no such toggle on it.
+        assertEquals(
+            InstalledAppsPermission.Unsupported,
+            installedAppsPermissionState(declared = null, isGranted = false)
+        )
+        // Still Unsupported even if the grant somehow reads true: an undefined permission is not
+        // something the user can be asked about, whatever else the device claims.
+        assertEquals(
+            InstalledAppsPermission.Unsupported,
+            installedAppsPermissionState(declared = null, isGranted = true)
+        )
+    }
+
+    @Test
+    fun aPermissionThatIsNotDangerousIsUnsupported() {
+        // A ROM declaring the name below `dangerous` settles it at install time; there is no runtime
+        // dialog, so requestPermissions would do nothing the user can see. Same ordering rule as
+        // runtimeGroupFor — declared alone is never enough.
+        assertEquals(
+            InstalledAppsPermission.Unsupported,
+            installedAppsPermissionState(
+                declared = DeclaredPermission(isDangerous = false, group = null),
+                isGranted = false
+            )
+        )
+    }
+
+    @Test
+    fun aDangerousPermissionReportsTheGrantItActuallyHas() {
+        assertEquals(
+            InstalledAppsPermission.Granted,
+            installedAppsPermissionState(declared = dangerous(), isGranted = true)
+        )
+        assertEquals(
+            InstalledAppsPermission.Denied,
+            installedAppsPermissionState(declared = dangerous(), isGranted = false)
+        )
+    }
+
+    @Test
+    fun anEmptyCacheAcceptsEvenACatastrophicScan() {
+        // Fresh install: there is nothing to protect, and every rule below would refuse. Were this
+        // rule not first, the cache could never take its first rows and the list would stay empty
+        // forever — the guard would have become the bug it was written to prevent.
+        assertEquals(
+            ScanVerdict.Accept,
+            verdict(emptySet(), InstalledAppsPermission.Denied, cachedCount = 0)
+        )
+        assertEquals(
+            ScanVerdict.Accept,
+            verdict(packages(3), InstalledAppsPermission.Denied, cachedCount = 0)
+        )
+    }
+
+    @Test
+    fun anOrdinaryScanIsBelieved() {
+        // The overwhelmingly common path, the ordinary uninstall included: 174 packages against a
+        // 175-row cache is one app gone, and pruning it is the whole job of the scan. Note the
+        // permission being Denied does not by itself retain anything — it only ever strengthens a
+        // scan that already looks wrong.
+        assertEquals(ScanVerdict.Accept, verdict(packages(175), InstalledAppsPermission.Granted))
+        assertEquals(ScanVerdict.Accept, verdict(packages(174), InstalledAppsPermission.Denied))
+        // A scan larger than the cache is several apps installed, not shrinkage.
+        assertEquals(ScanVerdict.Accept, verdict(packages(200), InstalledAppsPermission.Denied))
+    }
+
+    @Test
+    fun aScanMissingThePlatformPackageIsNeverBelieved() {
+        // The reported field shape: 68 of 175 packages came back. `android` is visible to every app
+        // on every Android version regardless of filtering, so a scan without it did not fail to
+        // find the platform — it was not allowed to answer.
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.PlatformPackageMissing),
+            verdict(packages(68, withPlatform = false), InstalledAppsPermission.Denied)
+        )
+        // And the case that makes identity rather than counting the rule: 120 of 175 clears any
+        // "lost more than half" threshold comfortably, so a count-based guard would wave it through
+        // and delete 55 apps' rows and icons. Truncation is caught by who is absent, not how many.
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.PlatformPackageMissing),
+            verdict(packages(120, withPlatform = false), InstalledAppsPermission.Denied)
+        )
+    }
+
+    @Test
+    fun anEmptyScanAgainstANonEmptyCacheIsNeverBelieved() {
+        // The backgrounded "while in use" case at its worst: accepting this once wipes every row.
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.EmptyScan),
+            verdict(emptySet(), InstalledAppsPermission.Denied)
+        )
+    }
+
+    @Test
+    fun aScanThatLostMoreThanHalfIsSuspect() {
+        // 80 of 175 with `android` present: nothing identifies this one as truncated, so the
+        // proportion is all there is to go on. Losing more than half in a single scan is not what
+        // uninstalling apps one at a time looks like.
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.Collapsed),
+            verdict(packages(80), InstalledAppsPermission.Denied)
+        )
+        // Exactly half is the boundary and is believed — `size * 2 < cachedCount` is strict, so a
+        // 50/50 split stays on the accepting side instead of being retained on every future scan.
+        assertEquals(
+            ScanVerdict.Accept,
+            verdict(packages(88), InstalledAppsPermission.Denied, cachedCount = 176)
+        )
+    }
+
+    @Test
+    fun aDeniedPermissionNeverAcceptsNoMatterHowOftenItRepeats() {
+        // The regression test for the actual bug, and the reason the Denied rule is evaluated
+        // *before* the tolerance rule. We have a named cause for the shrinkage, so repetition is not
+        // corroboration: asking the same question through the same closed gate just gets the same
+        // wrong answer again. Swap the two rules and a backgrounded Thor on HyperOS merely takes two
+        // extra scans to delete everything.
+        listOf(0, 1, SUSPECT_SCAN_TOLERANCE, 99).forEach { suspectScans ->
+            assertEquals(
+                "an empty scan was accepted after $suspectScans suspect scans",
+                ScanVerdict.Retain(RetainReason.EmptyScan),
+                verdict(emptySet(), InstalledAppsPermission.Denied, suspectScans = suspectScans)
+            )
+            assertEquals(
+                "a truncated scan was accepted after $suspectScans suspect scans",
+                ScanVerdict.Retain(RetainReason.PlatformPackageMissing),
+                verdict(
+                    packages(68, withPlatform = false),
+                    InstalledAppsPermission.Denied,
+                    suspectScans = suspectScans
+                )
+            )
+        }
+    }
+
+    @Test
+    fun theCacheCanStillShrinkWhenNoPermissionGateExplainsIt() {
+        // The other half of the guard: it has to be able to stop guarding. A genuine mass uninstall
+        // — or a restore of a much smaller backup — on a device where the permission is Unsupported
+        // (every Pixel) or Granted produces a real collapse, and a cache that could only ever grow
+        // would keep showing rows and icons for apps that are gone.
+        val noGate = listOf(InstalledAppsPermission.Unsupported, InstalledAppsPermission.Granted)
+        noGate.forEach { permission ->
+            assertEquals(
+                "$permission accepted the very first suspect scan",
+                ScanVerdict.Retain(RetainReason.Collapsed),
+                verdict(packages(20), permission)
+            )
+            assertEquals(
+                "$permission accepted before the tolerance was exhausted",
+                ScanVerdict.Retain(RetainReason.Collapsed),
+                verdict(
+                    packages(20),
+                    permission,
+                    suspectScans = SUSPECT_SCAN_TOLERANCE - 1
+                )
+            )
+            // Enough independent scans have now agreed, with nothing to explain them away.
+            assertEquals(
+                "$permission never believed a shrinkage that reproduced",
+                ScanVerdict.Accept,
+                verdict(packages(20), permission, suspectScans = SUSPECT_SCAN_TOLERANCE)
+            )
+            assertEquals(
+                "$permission never believed a shrinkage that reproduced",
+                ScanVerdict.Accept,
+                verdict(emptySet(), permission, suspectScans = 99)
+            )
+        }
+    }
+
+    @Test
+    fun theFirstMatchingReasonIsTheOneReported() {
+        // An empty scan is also, arithmetically, a collapsed one and a scan missing the platform
+        // package. The reason ends up in a log line a user pastes into an issue, so it has to name
+        // the strongest signal rather than whichever rule happens to sit last in the chain.
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.EmptyScan),
+            verdict(emptySet(), InstalledAppsPermission.Granted)
+        )
+        // Missing platform package outranks Collapsed for the same reason: it says *why* the scan
+        // is short, where the proportion only says that it is.
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.PlatformPackageMissing),
+            verdict(packages(5, withPlatform = false), InstalledAppsPermission.Granted)
+        )
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -11,6 +11,7 @@ import com.valhalla.thor.domain.model.BundleFormat
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.FilterType
 import com.valhalla.thor.domain.model.FreezerMode
+import com.valhalla.thor.domain.model.InstalledAppsPermission
 import com.valhalla.thor.domain.model.PermissionIndex
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.PrivilegeState
@@ -24,6 +25,7 @@ import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.AppShortcutController
 import com.valhalla.thor.domain.repository.AuthCapability
 import com.valhalla.thor.domain.repository.FreezerRepository
+import com.valhalla.thor.domain.repository.InstalledAppsPermissionGate
 import com.valhalla.thor.domain.repository.PermissionRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.PrivilegeStateProvider
@@ -359,6 +361,27 @@ class FakeUsageAccessGate(var granted: Boolean = true) : UsageAccessGate {
 
     override suspend fun maybeAutoGrant() {
         autoGrantCalls++
+    }
+}
+
+/**
+ * The GET_INSTALLED_APPS probe, as a plain mutable field.
+ *
+ * Defaults to [InstalledAppsPermission.Unsupported] because that is what the overwhelming majority
+ * of devices Thor runs on answer — the permission is a Chinese-market standard and does not exist on
+ * AOSP. A test that wants the banner has to ask for [InstalledAppsPermission.Denied] explicitly,
+ * which keeps "a Pixel is never nagged" the behaviour you get by saying nothing.
+ */
+class FakeInstalledAppsPermissionGate(
+    var permission: InstalledAppsPermission = InstalledAppsPermission.Unsupported
+) : InstalledAppsPermissionGate {
+
+    var stateCalls = 0
+        private set
+
+    override fun state(): InstalledAppsPermission {
+        stateCalls++
+        return permission
     }
 }
 

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
@@ -6,6 +6,7 @@ package com.valhalla.thor.presentation.appList
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AnimationIntensity
 import com.valhalla.thor.domain.model.FilterType
+import com.valhalla.thor.domain.model.InstalledAppsPermission
 import com.valhalla.thor.domain.model.PermissionIndex
 import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
@@ -17,6 +18,7 @@ import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.presentation.FakeAppRepository
 import com.valhalla.thor.presentation.FakeAppShortcutController
 import com.valhalla.thor.presentation.FakeFreezerRepository
+import com.valhalla.thor.presentation.FakeInstalledAppsPermissionGate
 import com.valhalla.thor.presentation.FakePermissionRepository
 import com.valhalla.thor.presentation.FakePreferenceRepository
 import com.valhalla.thor.presentation.FakePrivilegeStateProvider
@@ -102,7 +104,8 @@ class AppListViewModelTest {
     private fun TestScope.viewModel(
         intensity: AnimationIntensity = AnimationIntensity.MEDIUM,
         filterType: FilterType = FilterType.Source,
-        permissions: FakePermissionRepository = FakePermissionRepository()
+        permissions: FakePermissionRepository = FakePermissionRepository(),
+        installedApps: FakeInstalledAppsPermissionGate = FakeInstalledAppsPermissionGate()
     ): AppListViewModel {
         val prefs = FakePreferenceRepository(
             UserPreferences(animationIntensity = intensity, appFilterType = filterType)
@@ -121,6 +124,7 @@ class AppListViewModelTest {
             permissionRepository = permissions,
             storageStats = FakeStorageStatsProvider(),
             usageAccess = FakeUsageAccessGate(),
+            installedAppsPermission = installedApps,
             defaultDispatcher = mainDispatcherRule.dispatcher,
             ioDispatcher = mainDispatcherRule.dispatcher
         )
@@ -434,6 +438,58 @@ class AppListViewModelTest {
         assertTrue(
             "the watchlist entry is the only route back to a still-frozen app",
             freezer.contains("a")
+        )
+    }
+
+    // --- GET_INSTALLED_APPS banner ---------------------------------------------------------
+
+    @Test
+    fun `a device that does not define the permission never reaches the banner state`() = runTest {
+        // The Pixel case, and the one that matters most: GET_INSTALLED_APPS is a Chinese-market
+        // permission, so getPermissionInfo throws on the overwhelming majority of devices Thor runs
+        // on. Because shouldShowRequestPermissionRationale() also returns a hard false for a
+        // permission the ROM has never defined, the textbook "denied && !rationale => send them to
+        // Settings" recipe reads this exact state as *permanently denied* and nags forever. Nothing
+        // downstream is allowed to see anything but Unsupported here.
+        val vm = viewModel(installedApps = FakeInstalledAppsPermissionGate())
+        runCurrent()
+
+        assertEquals(
+            InstalledAppsPermission.Unsupported,
+            vm.uiState.value.installedAppsPermission
+        )
+    }
+
+    @Test
+    fun `a denied grant on a ROM that defines the permission surfaces to the UI`() = runTest {
+        val vm = viewModel(
+            installedApps = FakeInstalledAppsPermissionGate(InstalledAppsPermission.Denied)
+        )
+        runCurrent()
+
+        assertEquals(
+            InstalledAppsPermission.Denied,
+            vm.uiState.value.installedAppsPermission
+        )
+    }
+
+    @Test
+    fun `a re-read after the permission dialog picks up the new answer`() = runTest {
+        // The activity-result callback ignores the boolean the launcher hands back and re-reads the
+        // device instead, because a "while in use" grant reports true and stops being true the
+        // moment Thor is backgrounded. This is that re-read.
+        val gate = FakeInstalledAppsPermissionGate(InstalledAppsPermission.Denied)
+        val vm = viewModel(installedApps = gate)
+        runCurrent()
+        assertEquals(InstalledAppsPermission.Denied, vm.uiState.value.installedAppsPermission)
+
+        gate.permission = InstalledAppsPermission.Granted
+        vm.refreshInstalledAppsPermission()
+        runCurrent()
+
+        assertEquals(
+            InstalledAppsPermission.Granted,
+            vm.uiState.value.installedAppsPermission
         )
     }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
@@ -492,4 +492,38 @@ class AppListViewModelTest {
             vm.uiState.value.installedAppsPermission
         )
     }
+
+    @Test
+    fun `a superseded permission read is dropped rather than published late`() = runTest {
+        // The result callback and ON_RESUME both fire within milliseconds when the user answers the
+        // dialog, so two reads are genuinely in flight at once. The stale one must not win: landing
+        // an older Denied after the newer Granted puts the banner back over a permission the user
+        // just granted, and it would stay there until the next resume.
+        //
+        // What is asserted is the supersede itself — the older read is cancelled before it ever
+        // reaches the package manager, so it has nothing to publish. The narrower interleaving,
+        // where the older read already got its answer and is descheduled just short of the state
+        // write, is what ensureActive() covers; it needs two real threads to stage and cannot be
+        // provoked on a single-threaded test dispatcher, where each job runs to completion.
+        val gate = FakeInstalledAppsPermissionGate(InstalledAppsPermission.Denied)
+        val vm = viewModel(installedApps = gate)
+        runCurrent()
+        val callsAfterInit = gate.stateCalls
+
+        // Both queued before the dispatcher runs either — the in-flight case, not a sequential one.
+        vm.refreshInstalledAppsPermission()
+        gate.permission = InstalledAppsPermission.Granted
+        vm.refreshInstalledAppsPermission()
+        runCurrent()
+
+        assertEquals(
+            "the superseded read should never have reached the package manager",
+            callsAfterInit + 1,
+            gate.stateCalls
+        )
+        assertEquals(
+            InstalledAppsPermission.Granted,
+            vm.uiState.value.installedAppsPermission
+        )
+    }
 }


### PR DESCRIPTION
## The bug

Users on Chinese-market ROMs (MIUI/HyperOS, and the xiaomi.eu builds that blend the China and Global variants) report that after leaving Thor backgrounded — switching to a RAM-hungry app, or just locking the phone for a while — the app list comes back showing **one entry: Thor itself**. It stays that way until Thor is restarted.

## Why

`com.android.permission.GET_INSTALLED_APPS` — a **non-AOSP** runtime permission from the Chinese association standard **T/TAF 108-2022**, implemented by MIUI/HyperOS, ColorOS, OriginOS and MagicOS. On those ROMs package visibility is a **three-state** permission (allow / while in use / deny) that applies *in addition to* `QUERY_ALL_PACKAGES`.

These ROMs hand out **"while in use"** by default. In that state `getInstalledPackages()` returns a near-empty list the moment Thor loses foreground. The background scan then looks exactly like *every app on the device was uninstalled at once* — and the cache prune faithfully deletes them all.

`QUERY_ALL_PACKAGES` is **not** the problem and is **not** touched here. It is still required on every Android version. The manifest diff is a pure addition; both existing elements are byte-identical.

## The fix — three independent links in the chain

### 1. Declare the permission
```xml
<uses-permission android:name="com.android.permission.GET_INSTALLED_APPS" />
```
Silent no-op on AOSP, where the permission simply does not exist.

### 2. Refuse to prune against a scan that can't be believed

`scanVerdict()` (pure function, `domain/model/InstalledAppsVisibility.kt`) inspects the scanned package **names** and returns `Accept` or `Retain(reason)`. On `Retain`, rows are kept, updates still applied, and the cached entries are re-emitted so the UI keeps showing them.

Three suspect shapes:

| Reason | Test |
|---|---|
| `EmptyScan` | scan returned nothing |
| `PlatformPackageMissing` | `"android"` not in the results |
| `Collapsed` | scan is under half the cache |

The `"android"` check is **identity-based, not count-based**, on purpose. Google's automatic-visibility guarantees mean the platform package is visible to *every* app on *every* version regardless of filtering — so its absence is **proof** about the scan, not a heuristic about it. A device with 120 of 175 packages visible passes a count threshold and still fails this one.

Escape hatches, in this order:
- `cachedCount == 0` → always `Accept` (first run must be able to populate).
- Permission **`Denied`** → `Retain` **indefinitely** (checked *before* the tolerance counter — the whole point is that this device's scans stay untrustworthy).
- Otherwise, **two** consecutive suspect scans are tolerated, then `Accept` — so a genuinely small device, or a real mass uninstall, still converges.

### 3. Offer the grant

A banner appears **only** while the permission is `Denied`, requested through the standard `ActivityResultContracts.RequestPermission()`.

Availability is probed with `getPermissionInfo()` **before** any of this, and there is deliberately **no rationale check and no "open Settings" fallback**:

> `shouldShowRequestPermissionRationale()` returns a hard `false` for a permission the platform has never defined ([`PermissionManagerServiceImpl`](https://cs.android.com/android/platform/superproject/+/main:frameworks/base/services/core/java/com/android/server/pm/permission/PermissionManagerServiceImpl.java): `if (permission == null) { return false; }`). That makes every Pixel read as `denied && !shouldShowRationale` — which the standard recipe misinterprets as *"permanently denied → send them to Settings"*, and it nags forever, pointing at a toggle that isn't there.

The availability probe is what makes the rationale question **unnecessary** rather than merely skipped. `AppListScreen.kt:224-236` documents this at the call site so it doesn't get "fixed" back in later.

The launcher's result boolean is **ignored** and the state re-read instead — a "while in use" grant answers `true` and then stops being true. Re-read on every `ON_RESUME` too, since a grant made in system Settings never comes back through the callback.

## Architecture

Binder calls stay in `data/`, decisions are pure functions in `domain/model/`. `AppListViewModel` takes an `InstalledAppsPermissionGate` port (`domain/repository/`) so `AppListViewModelTest` builds on the JVM with a hand-written fake — matching how every other dependency in that ViewModel is wired, and consistent with the no-Robolectric / no-mocking-library policy.

The gate is **non-nullable with no default**, on purpose: a nullable-with-default param would let a Koin misconfiguration present as *"no device supports this"* — a silent, permanent, invisible failure. `koinCompiler`'s safety checks turn a missing binding into a build error instead.

`declared` is cached (a ROM's permission table can't change under a running process); the **grant** is re-read every time (that's the part that changes).

## Verification

- `:app:compileFossDebugKotlin :app:compileFossDebugUnitTestKotlin` → **BUILD SUCCESSFUL**, no new warnings
- `:app:testFossDebugUnitTest --rerun-tasks` → **443 tests, 0 failures, 0 errors, 0 skipped** (45 suites; counts parsed from the JUnit XML, not inferred from `BUILD SUCCESSFUL`)
- `:app:lintFossDebug` → **BUILD SUCCESSFUL** — all five locale files carry the three new strings, so `MissingTranslation` stays quiet under `warningsAsErrors = true`
- `git diff app/src/main/AndroidManifest.xml` → pure addition, `QUERY_ALL_PACKAGES` byte-unchanged

**14 new tests**: 11 in `InstalledAppsVisibilityTest` (every verdict, reason precedence, the tolerance boundary, the `Denied`-before-tolerance ordering, `cachedCount == 0`), 3 in `AppListViewModelTest` (a device that doesn't define the permission never reaches the banner state; a denied grant surfaces; a re-read after the dialog picks up the new answer).

## Not verifiable here

No Chinese ROM in hand. The Pixel path (`Unsupported` → banner never shown, nothing requested) is fully covered by tests and by the 443-test suite passing. The MIUI path rests on the T/TAF 108-2022 semantics above; worth a device check by anyone who has one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added installed-app visibility detection across supported devices.
  * Added a warning banner with an action to grant full installed-app access.
  * Added localized messages in Arabic, Chinese, English, French, and Spanish.

* **Bug Fixes**
  * Prevented incomplete or unexpectedly reduced scans from removing previously discovered apps.
  * App visibility status now refreshes when returning to the app.
  * Improved handling of denied or unavailable access across different device environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->