### PR TITLE
fix(suspend): stop reporting success when an unsuspend removed nothing

### DIFF
--- a/app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl
+++ b/app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl
@@ -1,6 +1,62 @@
 package com.valhalla.thor.rootservice;
 
+/**
+ * The privileged surface the :root daemon exposes to the app process.
+ *
+ * <p><b>Only ever append to this interface, and never change an existing method's arity.</b> AIDL
+ * derives each transaction code from declaration order (FIRST_CALL_TRANSACTION + index), and a root
+ * daemon can outlive the app that started it -- it is a separate app_process, so an app update
+ * leaves the old one running and bound. Inserting a method renumbers everything below it, and the
+ * stale daemon keeps the old numbering: a clearAppData() call would be dispatched to whatever now
+ * sits at that index, wiping the wrong thing. Appending is safe because an unknown transaction code
+ * falls through to Binder's default onTransact, which returns false, which the generated proxy reads
+ * back as an empty reply parcel -- false for a boolean, null for a String. A stale daemon therefore
+ * degrades into an honest failure rather than a mis-dispatch.
+ *
+ * <p>That is why setAppSuspended below keeps its two-argument shape even though setAppSuspendedAs
+ * supersedes it.
+ */
 interface IThorRootService {
     boolean setAppSuspended(String packageName, boolean suspended);
     boolean clearAppData(String packageName);
+
+    /**
+     * Sets {@code packageName}'s suspended state while recording {@code suspendingPackage} as the
+     * suspending identity, and reports whether the platform's own record agrees afterwards.
+     *
+     * <p>Android keys a suspension on the suspending package name captured at suspend time, and from
+     * API 30 a caller may only lift its own entry (PackageSettingBase.removeSuspension(callingPackage),
+     * android-11.0.0_r1 PackageSettingBase.java:443-452). Naming a suspender you do not own is not an
+     * error either: it leaves oldSuspendParams == null == newSuspendParams, so changed == false, so
+     * the package is left *out* of the returned failure array and the call looks like a success. The
+     * identity therefore has to be passed in from a readback rather than guessed, which is what this
+     * overload exists for.
+     *
+     * <p>Root, and only root, may name an arbitrary identity:
+     * PackageManagerService.enforceCanSetPackagesSuspendedAsUser unconditionally early-returns for
+     * Process.ROOT_UID before any suspender-name validation (android-17.0.0_r1
+     * PackageManagerService.java:3354-3358), unchanged from API 28 to main. Shell is not exempt, so
+     * this rescue path exists in the root daemon and nowhere else.
+     *
+     * @param suspendingPackage the identity to act as. When null the daemon falls back to its own
+     *   historical behaviour: for a suspend, try com.valhalla.thor then com.android.shell then
+     *   android; for an unsuspend, clear every identity the readback reports.
+     * @return true only when a re-read of the platform's record confirms the requested state -- never
+     *   merely because the reflective call returned an empty failure array.
+     */
+    boolean setAppSuspendedAs(String packageName, boolean suspended, in @nullable String suspendingPackage);
+
+    /**
+     * Raw {@code dumpsys package <packageName>} output, or null when it could not be read.
+     *
+     * <p>Exposed so the gateway can discover who actually owns a suspension through the already-bound
+     * root process instead of spawning a second shell. It has to happen on this side of the Binder:
+     * PackageManagerService.dump gates on android.permission.DUMP via
+     * DumpUtils.checkDumpAndUsageStatsPermission (android-16 PackageManagerService.java:6689), which
+     * the app process does not hold.
+     *
+     * <p>Feed the result to {@code parseSuspendingPackages}, and treat null -- and an empty parse --
+     * as "unknown", never as "not suspended".
+     */
+    @nullable String dumpPackage(String packageName);
 }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -18,6 +18,7 @@ import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
+import com.valhalla.thor.domain.model.parseSuspendingPackages
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.util.Logger
@@ -38,6 +39,17 @@ private val USER_ID_REGEX = Regex("^\\d+$")
 // Upper bound for the RootService bind handshake. A null binder or a callback that never
 // arrives must not pin connectionMutex forever and deadlock every later privileged op (H2).
 private const val ROOT_SERVICE_BIND_TIMEOUT_MS = 10_000L
+
+/**
+ * The Android user every suspend and unsuspend in this gateway writes to and verifies against.
+ *
+ * It has to be the number `ThorRootService.TARGET_USER_ID` writes with, or the readback would
+ * confirm a state nobody set: the daemon suspends user 0, and parsing user 10's section of the same
+ * dump reports an empty suspender set for a package that is very much suspended. Deliberately not
+ * `getCurrentUserId()` for exactly that reason — on a work-profile device the foreground user is the
+ * parent (0) while the profile's packages live in 10, and the daemon would still be writing 0.
+ */
+private const val SUSPEND_USER_ID = 0
 
 /**
  * Modern implementation of SystemGateway using the reactive ShellRepository.
@@ -514,6 +526,58 @@ class RootSystemGateway(
             RootFreezeChain.unfreezeStep(it.enabled, it.flags)
         }
 
+    /**
+     * Whether the platform reports [packageName] as suspended right now, or `null` when its
+     * `ApplicationInfo` could not be read at all.
+     *
+     * `null` is deliberately not `false`, for the same reason [readEffectivelyEnabled] is shaped
+     * this way. The predecessor of this function ended in `?: false`, so a package Thor could not
+     * read reported "not suspended" — and the unsuspend path read *that* as "the suspension is
+     * gone, we succeeded". An unreadable package is an unverified one; only a positive `false` is
+     * evidence that anything was lifted.
+     *
+     * `FLAG_SUSPENDED` is a public `ApplicationInfo` flag, so unlike the suspender *names* (which
+     * need `dumpsys` and `android.permission.DUMP`) it can be read from the app process. It answers
+     * "is this app still paused" but never "who owns it", which is why both reads exist.
+     */
+    private fun readSuspendedFlag(packageName: String): Boolean? =
+        getApplicationInfoCompat(packageName)?.let {
+            (it.flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0
+        }
+
+    /**
+     * Suspends or unsuspends [packageName], reporting only what a re-read of the platform's own
+     * record can prove.
+     *
+     * ### The unsuspend side reads before it writes
+     *
+     * Android keys a suspension on the suspending package name captured at suspend time, and from
+     * API 30 `PackageSettingBase.removeSuspension(callingPackage)` (android-11.0.0_r1
+     * `PackageSettingBase.java:443-452`, carried into `SuspendPackageHelper` on 13-16) drops only
+     * the caller's own entry, leaving `suspended` true while anyone else's survives. A suspension
+     * made in Shizuku mode is recorded as `com.android.shell`, so the root path that only ever
+     * named `com.valhalla.thor` removed nothing — and was told nothing, because naming a suspender
+     * that owns no entry leaves `oldSuspendParams == null == newSuspendParams`, so `changed` is
+     * false, so the package is logged "No change is needed" and left *out* of the failure array the
+     * API returns. Switching to root to rescue such an app is the reported bug, and reading the
+     * record and issuing one removal per recorded owner is what fixes it.
+     *
+     * Root can do that and no other privilege can:
+     * `PackageManagerService.enforceCanSetPackagesSuspendedAsUser` (android-17.0.0_r1
+     * `PackageManagerService.java:3354-3358`) unconditionally early-returns for `Process.ROOT_UID`
+     * *before* any suspender-name validation, unchanged from API 28 to main, so a uid-0 call naming
+     * `com.android.shell` is accepted verbatim. The shell branch of the same check is
+     * `callingUid == SHELL_UID && isCallerSameApp(...)`, which is why Shizuku cannot do the reverse.
+     *
+     * ### Nothing here trusts an exit code
+     *
+     * `pm unsuspend` exits 0 for precisely the no-op above, so the old `cleared || shell.isSuccess`
+     * turned "removed nothing" into a success; and the old flag read ended in `?: false`, so a
+     * package whose `ApplicationInfo` could not be read reported "not suspended", which read as "we
+     * succeeded". Both are gone. Every success below is either a record that no longer names anyone
+     * or a `FLAG_SUSPENDED` that positively reads false; "could not tell" is a failure, and the
+     * failure names the owner so the user learns *which* privilege holds the app.
+     */
     override suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit> = withContext(Dispatchers.IO) {
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
             return@withContext Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
@@ -521,16 +585,16 @@ class RootSystemGateway(
         val hasReflection = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q
         val escapedPackage = packageName.escapeForShell()
 
-        fun isCurrentlySuspended() = getApplicationInfoCompat(packageName)?.run {
-            (flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0
-        } ?: false
-
         if (isSuspended) {
             // SUSPEND via the reflection path only: setPackagesSuspendedAsUser(caller = our app id).
             // A root-shell `pm suspend` (uid 0) records the suspender as "root", a non-existent
             // package, so tapping the paused app crashes SuspendedAppActivity
             // ("IllegalArgumentException: Package root does not exist"). We never fall back to the
             // shell for suspend — a broken suspension is worse than a reported failure. GH#239.
+            //
+            // The identity stays Thor's own applicationId, chosen by the daemon: the system builds
+            // the user-visible "managed by Thor" line out of the recorded suspender name, so what
+            // this writes is deliberately unchanged. Only the read and unsuspend paths moved.
             if (hasReflection) {
                 val service = getRootService()
                 if (service != null) {
@@ -539,7 +603,12 @@ class RootSystemGateway(
                     }.onFailure { e ->
                         Logger.e("RootSystemGateway", "AIDL suspend failed", e)
                     }.getOrDefault(false)
-                    if (taskResult || isCurrentlySuspended()) return@withContext Result.success(Unit)
+                    // `== true` and not a bare call: readSuspendedFlag answers null when the package
+                    // cannot be read, and "could not tell" must not stand in for the daemon's own
+                    // verified success.
+                    if (taskResult || readSuspendedFlag(packageName) == true) {
+                        return@withContext Result.success(Unit)
+                    }
                 }
                 return@withContext Result.failure(Exception("Root suspend failed via AIDL for $packageName."))
             }
@@ -549,26 +618,181 @@ class RootSystemGateway(
             else Result.failure(Exception("Root suspend failed for $packageName."))
         }
 
-        // UNSUSPEND: a suspension can only be lifted by the package that set it, so clear BOTH
-        // possible owners — our own app (reflection, for suspensions this app set) AND
-        // "root"/"shell" (shell `pm unsuspend`, for any legacy suspension left by older builds).
-        // A root-shell `pm unsuspend` alone reports success yet leaves an app suspended by us still
-        // suspended. GH#239.
-        var cleared = false
-        if (hasReflection) {
-            val service = getRootService()
-            if (service != null) {
-                cleared = runCatching {
-                    service.setAppSuspended(packageName, false)
+        return@withContext unsuspendPackage(packageName, escapedPackage, hasReflection)
+    }
+
+    /**
+     * Lifts every suspension recorded against [packageName], and says so only when a readback agrees.
+     *
+     * Two shapes, picked by whether the platform's record could be read at all:
+     *
+     *  1. **Record readable** — one `setAppSuspendedAs(…, owner)` per recorded owner, then a second
+     *     read that has to come back empty. This is the rescue path for the user's Shizuku-era
+     *     suspensions and the only one that can name an identity Thor never wrote.
+     *  2. **Record unknown, empty included** — sweep the identities Thor could have written and let
+     *     `FLAG_SUSPENDED` be the sole judge. Reached when the daemon will not bind, when the dump
+     *     is denied or in a shape the parser has never seen, and on API 28, where there is no
+     *     reflection overload to name an owner with and none is needed: `setSuspended(false)` there
+     *     clears the single suspension slot whoever set it (android-9.0.0_r1
+     *     `PackageSettingBase.java:399-407`).
+     */
+    private suspend fun unsuspendPackage(
+        packageName: String,
+        escapedPackage: String,
+        hasReflection: Boolean,
+    ): Result<Unit> {
+        // Already unsuspended — by us, by another tool, or never suspended at all. A *positive*
+        // false, not the fail-open shortcut this change deletes: an unreadable flag is null, which
+        // is neither true nor false and falls through to the full path. It also keeps a bulk
+        // unfreeze from paying a `dumpsys package` round trip per app that was never suspended.
+        if (readSuspendedFlag(packageName) == false) {
+            Logger.i("RootSystemGateway", "unsuspend $packageName: not suspended, no rung run")
+            return Result.success(Unit)
+        }
+
+        // The daemon is the only thing here that can read the record — `dumpsys package` is gated on
+        // android.permission.DUMP via DumpUtils.checkDumpAndUsageStatsPermission (android-16
+        // `PackageManagerService.java:6689`), which the app process does not hold — and the only
+        // thing that can name an arbitrary owner, since the reflective overload it calls does not
+        // exist before API 29.
+        val service = if (hasReflection) getRootService() else null
+
+        // Past the early return above, the package is either suspended or unreadable — so a parse
+        // that names nobody contradicts the flag and cannot be taken at face value. A dump in a
+        // shape this parser has never seen (an OEM that dropped the token, a format newer than this
+        // build) also parses to empty, and reading that as "nothing to remove, we are done" is the
+        // same empty-means-success lie one layer down. Empty is therefore unknown *here*, and falls
+        // through to the sweep rather than to a fabricated success.
+        val recorded = service?.let { readSuspenders(it, packageName) }?.takeIf { it.isNotEmpty() }
+
+        if (service != null && recorded != null) {
+            // One removal per recorded owner, and deliberately no break on the first accepted call:
+            // from API 30 `PackageUserState.suspendParams` is a map, so a package can carry several
+            // entries at once and stays suspended while any one of them survives.
+            for (owner in recorded) {
+                val accepted = runCatching {
+                    service.setAppSuspendedAs(packageName, false, owner)
                 }.onFailure { e ->
-                    Logger.e("RootSystemGateway", "AIDL unsuspend failed", e)
+                    Logger.e("RootSystemGateway", "AIDL unsuspend of $packageName as $owner failed", e)
                 }.getOrDefault(false)
+                if (!accepted) {
+                    Logger.w(
+                        "RootSystemGateway",
+                        "unsuspend $packageName: the daemon could not confirm the removal of $owner"
+                    )
+                }
+            }
+
+            val remaining = readSuspenders(service, packageName) ?: return unsuspendFailure(
+                "Root unsuspend of $packageName is unverified: the platform's suspension record " +
+                    "could not be read back after asking to remove ${recorded.joinToString()}, so " +
+                    "Thor will not report a success it cannot see."
+            )
+            if (remaining.isNotEmpty()) {
+                return unsuspendFailure(
+                    "Root unsuspend of $packageName failed: ${remaining.joinToString()} still " +
+                        "holds a suspension entry after Thor asked to remove " +
+                        "${recorded.joinToString()}, so the app stays paused."
+                )
+            }
+            // The record names nobody, so the flag may only veto, never vouch: null here means the
+            // package could not be read, which the record has already answered for.
+            if (readSuspendedFlag(packageName) == true) {
+                return unsuspendFailure(
+                    "Root unsuspend of $packageName failed: removing ${recorded.joinToString()} " +
+                        "left nothing recorded as suspending it for user $SUSPEND_USER_ID, yet the " +
+                        "package still reports FLAG_SUSPENDED."
+                )
+            }
+            Logger.i(
+                "RootSystemGateway",
+                "unsuspend $packageName: verified — ${recorded.joinToString()} removed and nothing " +
+                    "is recorded as suspending it"
+            )
+            return Result.success(Unit)
+        }
+
+        // Unknown record. Sweep rather than guess: the daemon's two-argument entry point clears
+        // every identity Thor has written across its history, and the root shell's `pm unsuspend`
+        // clears the "root" entry left by a pre-GH#239 build or by the API-28 suspend path above
+        // (PackageManagerShellCommand passes "root" as the calling package for uid 0). Neither is
+        // allowed to *report* anything — an exit code of 0 is what the no-op returns — so the flag
+        // read below is the only judge.
+        if (service != null) {
+            runCatching {
+                service.setAppSuspended(packageName, false)
+            }.onFailure { e ->
+                Logger.e("RootSystemGateway", "AIDL unsuspend failed", e)
             }
         }
-        val shell = runCommand("pm unsuspend $escapedPackage")
-        cleared = cleared || shell.isSuccess
-        return@withContext if (cleared || !isCurrentlySuspended()) Result.success(Unit)
-        else Result.failure(Exception("Root unsuspend failed for $packageName."))
+        runCommand("pm unsuspend $escapedPackage")
+        return when (readSuspendedFlag(packageName)) {
+            false -> {
+                Logger.i(
+                    "RootSystemGateway",
+                    "unsuspend $packageName: verified via FLAG_SUSPENDED; the suspender record was " +
+                        "unreadable, so who owned it is unknown"
+                )
+                Result.success(Unit)
+            }
+
+            true -> unsuspendFailure(
+                "Root unsuspend of $packageName failed: it is still suspended after `pm unsuspend` " +
+                    "and a sweep of every identity Thor records, and the platform's suspension " +
+                    "record could not be read to find out which one owns it."
+            )
+
+            null -> unsuspendFailure(
+                "Root unsuspend of $packageName is unverified: neither the platform's suspension " +
+                    "record nor the package's own ApplicationInfo could be read back."
+            )
+        }
+    }
+
+    /**
+     * The identities the platform records as suspending [packageName] for [SUSPEND_USER_ID], or
+     * `null` when the record could not be trusted.
+     *
+     * The `null` is the whole point of the wrapper. `parseSuspendingPackages` cannot tell a package
+     * with no suspenders from a dump that was truncated, denied, or in a shape nobody has seen — all
+     * three parse to an empty set — so "did we get a real dump?" is answered here, before anything
+     * reads meaning into that emptiness. `dumpsys package <pkg>` always prints a `Package [<pkg>]
+     * (…):` block for an installed package; a caller without `android.permission.DUMP` gets a
+     * `Permission Denial:` line instead, and a truncated dump gets neither.
+     *
+     * A daemon still running from an older build predates `dumpPackage` entirely. Binder answers an
+     * unknown transaction code with an empty reply parcel, which the generated proxy reads back as
+     * `null`, so that degrades into "unknown" here rather than into a mis-dispatch.
+     */
+    private fun readSuspenders(service: IThorRootService, packageName: String): Set<String>? {
+        val dump = runCatching {
+            service.dumpPackage(packageName)
+        }.onFailure { e ->
+            Logger.e("RootSystemGateway", "AIDL dumpPackage failed for $packageName", e)
+        }.getOrNull() ?: return null
+
+        if (!dump.contains("Package [$packageName]")) {
+            Logger.w(
+                "RootSystemGateway",
+                "dumpsys package $packageName returned no package block; suspender state unknown"
+            )
+            return null
+        }
+        return parseSuspendingPackages(dump, SUSPEND_USER_ID)
+    }
+
+    /**
+     * Logs [reason] and returns it as the failure the UI renders verbatim.
+     *
+     * `AppInfoDetailsViewModel.toggleSuspendState` (and every other caller of
+     * `ManageAppUseCase.setAppSuspended`) puts `e.message` straight into `R.string.error_format`, so
+     * these sentences are user-facing: they name the recorded suspender because that is the only
+     * thing that tells someone *which* privilege still holds their app.
+     */
+    private fun unsuspendFailure(reason: String): Result<Unit> {
+        val failure = java.io.IOException(reason)
+        Logger.e("RootSystemGateway", reason, failure)
+        return Result.failure(failure)
     }
 
     override suspend fun setAppRestricted(

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -11,6 +11,7 @@ import com.valhalla.bypass.Bypass
 import com.valhalla.superuser.utils.escapeForShell
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.source.local.shizuku.Packages
+import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
 import rikka.shizuku.ShizukuBinderWrapper
 import rikka.shizuku.SystemServiceHelper
 import com.rosan.dhizuku.api.Dhizuku as DhizukuAPI
@@ -375,6 +376,40 @@ object DhizukuHelper {
         }.getOrElse { false }
     }
 
+    /**
+     * Suspends or unsuspends [packageName], reporting success only when a readback agrees.
+     *
+     * Dhizuku is the one privilege mode with **no suspender readback at all**. `dumpsys package` is
+     * gated on `android.permission.DUMP` (`PackageManagerService.dump` →
+     * `DumpUtils.checkDumpAndUsageStatsPermission`, android-16 `PackageManagerService.java:6689`)
+     * and Dhizuku's commands run as the device-owner app rather than as shell, so there is no
+     * process here that may dump and nothing for
+     * [com.valhalla.thor.domain.model.parseSuspendingPackages] to parse. Do not add one: a dump this
+     * process is allowed to take does not exist, and a fabricated "verification" that always says
+     * yes is worse than none.
+     *
+     * What this process *can* read is `ApplicationInfo.FLAG_SUSPENDED`, and for the direction that
+     * strands apps that is enough. From API 30 on, `PackageSettingBase.removeSuspension(callingPackage)`
+     * (android-11.0.0_r1 `PackageSettingBase.java:443-452`, carried into `SuspendPackageHelper` on
+     * 13-16) removes only the caller's own entry and leaves `suspended` true while anybody else's
+     * remains — so a flag that is *still set* after an unsuspend is exactly the "another privilege
+     * owns this suspension" signal. We cannot name the owner without DUMP, but we can refuse to
+     * claim we lifted it.
+     *
+     * Every success exit is therefore gated on that flag, and an unreadable flag fails **closed**.
+     * Both of the paths this replaces reported success without ever looking:
+     * - `pm unsuspend` exits 0 even when it changed nothing. Lifting a suspension you do not own
+     *   leaves `oldSuspendParams == null == newSuspendParams` → `changed == false`, which the
+     *   platform logs as "No change is needed" and omits from the returned failure array, so the
+     *   command, the reflection call and every caller above them all read success.
+     * - the final PM re-query defaulted an unresolvable `ApplicationInfo` to "not suspended", which
+     *   on the unsuspend path reads as "it worked".
+     *
+     * Known limit, unfixable without DUMP: `FLAG_SUSPENDED` is the *aggregate* state, not our own
+     * entry in it. On the suspend direction a pre-existing foreign suspension therefore satisfies
+     * the readback even if our own call did nothing. That errs toward the state the user asked for;
+     * the unsuspend direction, the one that leaves an app permanently unusable, errs closed.
+     */
     // PrivateApi: hidden-API reflection is intentional — the core privilege mechanism, guarded by
     // the :bypass VMRuntime unseal.
     @SuppressLint("PrivateApi")
@@ -383,6 +418,20 @@ object DhizukuHelper {
         pkgs.getApplicationInfoOrNull(packageName) ?: return false
         val userId = pkgs.myUserId
 
+        // The suspended state the platform reports *now*, or null when the ApplicationInfo cannot
+        // be read. null is deliberately not false — "I could not read it" collapsing into "not
+        // suspended" is precisely how an unsuspend that did nothing used to report success. Same
+        // shape as RootSystemGateway.readEffectivelyEnabled.
+        fun readSuspended(): Boolean? = pkgs.getApplicationInfoOrNull(packageName)?.run {
+            (flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0
+        }
+
+        // Unknown compares equal to neither true nor false, so an unreadable flag is "not verified"
+        // in both directions. Re-querying PackageManager is sound even though the mutation happened
+        // in another process: PMS invalidates the app-side ApplicationInfo cache as part of the same
+        // commit, so it is already stale-free by the time the call that changed it returns.
+        fun verified(): Boolean = readSuspended() == suspended
+
         // 1. Try shell first
         val command = if (suspended) {
             "pm suspend --user $userId $packageName"
@@ -390,89 +439,200 @@ object DhizukuHelper {
             "pm unsuspend --user $userId $packageName"
         }
         val shellResult = execute(command)
-        if (shellResult.first == 0) return true
+        if (shellResult.first != 0) {
+            Logger.w(
+                "DhizukuHelper",
+                "'$command' exited ${shellResult.first}: ${shellResult.second}"
+            )
+        }
+        // Checked even on a non-zero exit, and it is the *only* thing checked on a zero one: the
+        // goal is the state, not the exit code. `pm unsuspend` exits 0 when it changed nothing, and
+        // a command that failed on an app already in the requested state left nothing to do.
+        if (verified()) return true
 
         // 2. Fallback to reflection
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            val reflectionResult = runCatching {
-                val pm =
-                    asInterface("android.content.pm.IPackageManager", "package") ?: return@runCatching false
+            runCatching {
+                // Thrown rather than returned: an unreachable IPackageManager is a diagnosable
+                // failure, and the onFailure below is the only place it gets said out loud.
+                val pm = asInterface("android.content.pm.IPackageManager", "package")
+                    ?: throw IllegalStateException("IPackageManager is unreachable through Dhizuku")
                 val dialogInfoClass = Class.forName("android.content.pm.SuspendDialogInfo")
-                val builderClass = Class.forName("android.content.pm.SuspendDialogInfo\$Builder")
-                val dialogInfo = if (suspended) {
-                    Bypass.newInstance<Any>(builderClass).let { b ->
-                        val title = context.getString(R.string.suspended_app_dialog_title)
-                        val message = context.getString(R.string.suspended_app_dialog_message)
-                        Bypass.invoke<Any>(builderClass, b, "setTitle", title)
-                        Bypass.invoke<Any>(
-                            builderClass,
-                            b,
-                            "setMessage",
-                            message
-                        )
-                        Bypass.invoke<Any>(builderClass, b, "build")
-                    }
-                } else {
-                    null
-                }
-
-                val caller = BuildConfig.APPLICATION_ID
-
-                try {
-                    // Try Android 13+ (8 args)
-                    Bypass.invoke<Array<String>>(
-                        pm.javaClass, pm, "setPackagesSuspendedAsUser",
-                        arrayOf(
-                            Array<String>::class.java,
-                            Boolean::class.javaPrimitiveType!!,
-                            android.os.PersistableBundle::class.java,
-                            android.os.PersistableBundle::class.java,
-                            dialogInfoClass,
-                            Int::class.javaPrimitiveType!!,
-                            String::class.java,
-                            Int::class.javaPrimitiveType!!
-                        ),
-                        arrayOf(packageName),
-                        suspended,
-                        null, null,
-                        dialogInfo,
-                        0,
-                        caller,
-                        userId
-                    )
-                } catch (_: NoSuchMethodException) {
-                    // Try Android 10-12 (7 args)
-                    Bypass.invoke<Array<String>>(
-                        pm.javaClass, pm, "setPackagesSuspendedAsUser",
-                        arrayOf(
-                            Array<String>::class.java,
-                            Boolean::class.javaPrimitiveType!!,
-                            android.os.PersistableBundle::class.java,
-                            android.os.PersistableBundle::class.java,
-                            dialogInfoClass,
-                            String::class.java,
-                            Int::class.javaPrimitiveType!!
-                        ),
-                        arrayOf(packageName),
-                        suspended,
-                        null, null,
-                        dialogInfo,
-                        caller,
-                        userId
+                val dialogInfo = if (suspended) buildSuspendDialogInfo(context) else null
+                val failed = callSetPackagesSuspended(
+                    pm = pm,
+                    dialogInfoClass = dialogInfoClass,
+                    packageName = packageName,
+                    suspended = suspended,
+                    dialogInfo = dialogInfo,
+                    caller = BuildConfig.APPLICATION_ID,
+                    userId = userId
+                )
+                // Logged, never trusted: see callSetPackagesSuspended on why an empty array is not
+                // a success signal. The verified() below is what decides.
+                if (failed?.contains(packageName) == true) {
+                    Logger.w(
+                        "DhizukuHelper",
+                        "setPackagesSuspendedAsUser reported $packageName in its failure list"
                     )
                 }
-                true
-            }.getOrDefault(false)
+            }.onFailure {
+                Logger.e("DhizukuHelper", "setAppSuspended reflection failed for $packageName", it)
+            }
 
-            if (reflectionResult) return true
+            if (verified()) return true
         }
 
-        // 3. Unprivileged fallback (re-query PM to observe post-mutation state)
-        val currentSuspended = pkgs.getApplicationInfoOrNull(packageName)?.run {
-            (flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0
-        } ?: false
-        return currentSuspended == suspended
+        // 3. Neither path could be confirmed. Report the failure instead of inventing a success:
+        // the caller turns this into a Result.failure the user actually sees.
+        Logger.w(
+            "DhizukuHelper",
+            "setAppSuspended($packageName, suspended=$suspended) unconfirmed — FLAG_SUSPENDED reads " +
+                "${readSuspended()}. From API 30 a suspension can only be lifted by the identity that " +
+                "recorded it, and Dhizuku can only ever act as $SHELL_SUSPENDER_IDENTITY, so one " +
+                "recorded by Thor's root mode needs root mode to clear it."
+        )
+        return false
     }
+
+    /**
+     * Invokes whichever `IPackageManager.setPackagesSuspendedAsUser` overload this platform has, and
+     * returns the packages it claims it could **not** change.
+     *
+     * Newest first, because each signature *replaced* its predecessor rather than joining it: only
+     * one exists on any given device, so a wrong guess throws `NoSuchMethodException` instead of
+     * mis-dispatching.
+     * - **API 35+ (9 args)** — the `UserPackage` rework split the single `userId` into
+     *   `suspendingUserId` (the user the *suspending* package lives in) and `targetUserId`. This
+     *   lookup was absent, so on 35+ both of the attempts below missed and the entire reflection
+     *   fallback was dead code that could only ever return "failed".
+     * - **API 33-34 (8 args)** — adds the `flags` argument that carries `FLAG_SUSPEND_QUARANTINED`.
+     * - **API 29-32 (7 args)** — the original `SuspendDialogInfo` form.
+     *
+     * **An empty return is not proof of success.** Naming a `callingPackage` that owns no entry for
+     * the package leaves `oldSuspendParams == null == newSuspendParams`, so nothing changed, nothing
+     * failed, and the package appears in neither list. Only a `FLAG_SUSPENDED` readback settles it.
+     */
+    @SuppressLint("PrivateApi")
+    private fun callSetPackagesSuspended(
+        pm: Any,
+        dialogInfoClass: Class<*>,
+        packageName: String,
+        suspended: Boolean,
+        dialogInfo: Any?,
+        caller: String,
+        userId: Int
+    ): Array<String>? {
+        try {
+            // Android 15+ (API 35+): 9 args
+            return Bypass.invoke<Array<String>?>(
+                pm.javaClass, pm, "setPackagesSuspendedAsUser",
+                arrayOf(
+                    Array<String>::class.java,
+                    Boolean::class.javaPrimitiveType!!,
+                    android.os.PersistableBundle::class.java,
+                    android.os.PersistableBundle::class.java,
+                    dialogInfoClass,
+                    Int::class.javaPrimitiveType!!,   // flags
+                    String::class.java,               // callingPackage
+                    Int::class.javaPrimitiveType!!,   // suspendingUserId
+                    Int::class.javaPrimitiveType!!    // targetUserId
+                ),
+                arrayOf(packageName),
+                suspended,
+                null, null,
+                dialogInfo,
+                0,
+                caller,
+                userId,
+                userId
+            )
+        } catch (_: NoSuchMethodException) {
+            Logger.d("DhizukuHelper", "No 9-arg setPackagesSuspendedAsUser on this platform")
+        }
+
+        try {
+            // Android 13-14 (API 33-34): 8 args
+            return Bypass.invoke<Array<String>?>(
+                pm.javaClass, pm, "setPackagesSuspendedAsUser",
+                arrayOf(
+                    Array<String>::class.java,
+                    Boolean::class.javaPrimitiveType!!,
+                    android.os.PersistableBundle::class.java,
+                    android.os.PersistableBundle::class.java,
+                    dialogInfoClass,
+                    Int::class.javaPrimitiveType!!,   // flags
+                    String::class.java,               // callingPackage
+                    Int::class.javaPrimitiveType!!    // userId
+                ),
+                arrayOf(packageName),
+                suspended,
+                null, null,
+                dialogInfo,
+                0,
+                caller,
+                userId
+            )
+        } catch (_: NoSuchMethodException) {
+            Logger.d("DhizukuHelper", "No 8-arg setPackagesSuspendedAsUser on this platform")
+        }
+
+        // Android 10-12 (API 29-32): 7 args. Last resort, so a miss here propagates rather than
+        // being swallowed — the caller logs it and the readback fails the operation anyway.
+        return Bypass.invoke<Array<String>?>(
+            pm.javaClass, pm, "setPackagesSuspendedAsUser",
+            arrayOf(
+                Array<String>::class.java,
+                Boolean::class.javaPrimitiveType!!,
+                android.os.PersistableBundle::class.java,
+                android.os.PersistableBundle::class.java,
+                dialogInfoClass,
+                String::class.java,               // callingPackage
+                Int::class.javaPrimitiveType!!    // userId
+            ),
+            arrayOf(packageName),
+            suspended,
+            null, null,
+            dialogInfo,
+            caller,
+            userId
+        )
+    }
+
+    /**
+     * Thor's custom text for the system's "app is paused" dialog, or null to let the system use its
+     * own default.
+     *
+     * Null is a fully supported argument to `setPackagesSuspendedAsUser`, so a dialog that cannot be
+     * assembled must not take the suspension down with it — which is exactly what it used to do:
+     * [Bypass.invoke]'s vararg form resolves the overload from the runtime type of the argument, and
+     * `SuspendDialogInfo.Builder.setTitle(String)` only exists from API 31 (the API 29 overload takes
+     * a `@StringRes int`). On API 29-30 that lookup threw `NoSuchMethodException` out of the caller's
+     * `runCatching` and killed the whole reflection path before it ever reached the suspend call.
+     *
+     * The `@StringRes int` overloads are deliberately not used as a pre-31 fallback: the system
+     * resolves such an id against the *suspending* package's resources, which in Dhizuku mode is
+     * `com.android.shell`, not us. A missing title is better than a wrong one.
+     */
+    @SuppressLint("PrivateApi")
+    private fun buildSuspendDialogInfo(context: Context): Any? = runCatching {
+        val builderClass = Class.forName("android.content.pm.SuspendDialogInfo\$Builder")
+        val builder = Bypass.newInstance<Any>(builderClass)
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            val title = context.getString(R.string.suspended_app_dialog_title)
+            Bypass.invoke<Any>(builderClass, builder, "setTitle", title)
+        }
+        // setMessage(String) exists from API 29, and this is only reached on Q+.
+        val message = context.getString(R.string.suspended_app_dialog_message)
+        Bypass.invoke<Any>(builderClass, builder, "setMessage", message)
+        Bypass.invoke<Any>(builderClass, builder, "build")
+    }.onFailure {
+        // Warn rather than swallow: this failing silently is why dialogInfo was always null.
+        Logger.w(
+            "DhizukuHelper",
+            "SuspendDialogInfo unavailable, falling back to the system's default dialog: $it"
+        )
+    }.getOrNull()
 
     fun setAppRestricted(context: Context, packageName: String, restricted: Boolean): Boolean {
         // 1. Try shell first

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -489,8 +489,10 @@ object DhizukuHelper {
             "DhizukuHelper",
             "setAppSuspended($packageName, suspended=$suspended) unconfirmed — FLAG_SUSPENDED reads " +
                 "${readSuspended()}. From API 30 a suspension can only be lifted by the identity that " +
-                "recorded it, and Dhizuku can only ever act as $SHELL_SUSPENDER_IDENTITY, so one " +
-                "recorded by Thor's root mode needs root mode to clear it."
+                "recorded it, and without DUMP this process cannot read which identity that is: the " +
+                "shell rung's `pm` names $SHELL_SUSPENDER_IDENTITY, the reflection rung names " +
+                "${BuildConfig.APPLICATION_ID}, and neither is confirmed against what the platform " +
+                "actually recorded. A suspension recorded by Thor's root mode needs root mode to clear it."
         )
         return false
     }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -9,6 +9,10 @@ import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import com.valhalla.bypass.Bypass
 import com.valhalla.superuser.utils.escapeForShell
+import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
+import com.valhalla.thor.domain.model.canLiftSuspension
+import com.valhalla.thor.domain.model.parseSuspendingPackages
+import com.valhalla.thor.domain.model.thorSuspenderIdentities
 import moe.shizuku.server.IShizukuService
 import rikka.shizuku.Shizuku
 import rikka.shizuku.ShizukuBinderWrapper
@@ -409,107 +413,369 @@ object Shizuku {
         )
     }
 
-    // Hidden-API reflection (SuspendDialogInfo) is intentional: it is the core privilege mechanism,
-    // guarded by the :bypass VMRuntime unseal.
-    @SuppressLint("PrivateApi")
+    /**
+     * Suspend or unsuspend a package, reporting only what a post-read can prove.
+     *
+     * ### Why the exit code was not enough
+     *
+     * This used to be `if (shellResult.first == 0) return true`. `pm unsuspend` exits 0 even when it
+     * removed nothing: lifting a suspension you do not own leaves
+     * `oldSuspendParams == null == newSuspendParams`, so `changed` is false, the package is logged
+     * "No change is needed" and is left *out* of the array of failures the API returns. That empty
+     * array — and the 0 the shell prints because of it — is exactly what every caller read as
+     * success while the user's app stayed suspended forever.
+     *
+     * ### Ownership, and the one thing a shell-uid Shizuku genuinely cannot do
+     *
+     * From API 30 a suspension is keyed on the suspending package name and only that name may remove
+     * it (`PackageSettingBase.removeSuspension`, android-11.0.0_r1 :443-452, carried into
+     * `SuspendPackageHelper` on 13-16). `PackageManagerService.enforceCanSetPackagesSuspendedAsUser`
+     * (android-17.0.0_r1 :3354-3358) early-returns for `Process.ROOT_UID` *before* any
+     * suspender-name validation, but shell gets no such exemption —
+     * `allowedShell = callingUid == SHELL_UID && isCallerSameApp(suspendingPackage, callingUid)` — so
+     * a Shizuku at uid 2000 can only ever act as [SHELL_SUSPENDER_IDENTITY]. A suspension recorded by
+     * root-mode Thor (`com.valhalla.thor`) is therefore **unliftable from here**, permanently, and
+     * the only honest move is to say so: [canLiftSuspension] decides and the throw names the owner
+     * and points at root mode. Attempting it anyway would take the "No change is needed" path above
+     * and report success, which is the bug.
+     *
+     * A Shizuku *started as root* is a different animal: uid 0 is exempt, so it names each recorded
+     * owner verbatim and performs the same rescue `RootSystemGateway` does.
+     *
+     * ### Why it throws instead of returning false
+     *
+     * `ShizukuSystemGateway.runAction` turns a thrown exception into `Result.failure(e)` and the UI
+     * renders `e.message`; a bare `false` becomes the generic "Action failed. This may happen if
+     * reflection is blocked…", which is precisely the sentence that would send a user hunting for a
+     * problem that does not exist. The owner's name is the whole point of the failure, so it has to
+     * ride an exception to survive the `Boolean` this function is stuck returning.
+     */
     fun setAppSuspended(context: Context, packageName: String, suspended: Boolean): Boolean {
         val pkgs = Packages(context)
         pkgs.getApplicationInfoOrNull(packageName) ?: return false
         val userId = pkgs.myUserId
+        // Escaped for the shell rungs only; the reflection rung passes the raw name over binder.
+        val escapedPackage = packageName.escapeForShell()
+        val sdkInt = android.os.Build.VERSION.SDK_INT
 
-        // 1. Try shell first
-        val command = if (suspended) {
-            "pm suspend --user $userId $packageName"
-        } else {
-            "pm unsuspend --user $userId $packageName"
+        // A package that is not suspended is already in the requested state, so there is nothing to
+        // lift and no owner to read. This is a *positive* read of the end state, not the fail-open
+        // "could not tell, call it success" this change exists to delete — an unreadable flag is
+        // null, which is neither true nor false and falls through to the full path below. It also
+        // keeps a bulk unfreeze from paying a `dumpsys` round trip per app that was never suspended.
+        if (!suspended && isSuspendedNow(pkgs, packageName) == false) return true
+
+        // Read the owner BEFORE writing. `dumpsys package` needs android.permission.DUMP
+        // (`PackageManagerService.dump` → `DumpUtils.checkDumpAndUsageStatsPermission`,
+        // android-16 :6689); the shell uid Shizuku runs commands as holds it and the app process
+        // does not, which is why this read can only live on this side of the binder.
+        val recorded = if (suspended) emptySet() else recordedSuspenders(escapedPackage, userId)
+        refuseUnliftableSuspension(context, packageName, recorded, sdkInt)
+
+        // Which identity each rung acts as. Only root may name someone else's.
+        val callers: List<String> = when {
+            // Suspending records a new entry, and the name it records is the one the system turns
+            // into the user-visible "managed by …" line on the pause dialog. Unchanged on purpose.
+            suspended -> listOf(if (isRoot) context.packageName else SHELL_SUSPENDER_IDENTITY)
+            // Unsuspending at uid 0: name every recorded owner verbatim. This is the rescue path —
+            // it is what lets a root Shizuku lift a suspension some other privilege wrote.
+            isRoot && recorded.isNotEmpty() -> recorded.toList()
+            // uid 0, but the dump was unreadable. Sweep every identity Thor has ever written
+            // (its own name, the legacy "root", and shell) rather than guessing one.
+            isRoot -> (thorSuspenderIdentities(context.packageName) + SHELL_SUSPENDER_IDENTITY).toList()
+            // Shell uid can only ever name itself; refuseUnliftableSuspension has already turned
+            // away everything else, so this is the only name left that can do anything.
+            else -> listOf(SHELL_SUSPENDER_IDENTITY)
         }
-        val shellResult = execute(command)
-        if (shellResult.first == 0) return true
 
-        // 2. Fallback to reflection
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-            val reflectionResult = runCatching {
-                val pm = asInterface("android.content.pm.IPackageManager", "package")
-                val dialogInfoClass = Class.forName("android.content.pm.SuspendDialogInfo")
-                val builderClass = Class.forName("android.content.pm.SuspendDialogInfo\$Builder")
-                val dialogInfo = if (suspended) {
-                    Bypass.newInstance<Any>(builderClass).let { b ->
-                        val title = context.getString(com.valhalla.thor.R.string.suspended_app_dialog_title)
-                        val message = context.getString(com.valhalla.thor.R.string.suspended_app_dialog_message)
-                        Bypass.invoke<Any>(builderClass, b, "setTitle", title)
-                        Bypass.invoke<Any>(
-                            builderClass,
-                            b,
-                            "setMessage",
-                            message
+        // `pm suspend` / `pm unsuspend` act as whoever the shell is — "com.android.shell" at uid
+        // 2000, the literal "root" at uid 0 (PackageManagerShellCommand picks the name from the
+        // calling uid, which is where legacy "root"-owned suspensions came from). Cheapest rung and
+        // the one that covers the ordinary case, so it stays first.
+        val shellRung = EnableRung(RUNG_SHELL) {
+            val verb = if (suspended) "suspend" else "unsuspend"
+            val (code, _) = execute("pm $verb --user $userId $escapedPackage")
+            if (code == 0) RungResult.RAN else RungResult.FAILED
+        }
+
+        val reflectionRung = EnableRung(RUNG_REFLECTION) {
+            if (sdkInt < android.os.Build.VERSION_CODES.Q) {
+                // `SuspendDialogInfo` does not exist before API 29 — the API 28 overload takes a
+                // String dialogMessage in its place — so there is nothing to reflect on P.
+                RungResult.FAILED
+            } else {
+                var ran = false
+                // Every caller, not the first that works: on the unsuspend path each recorded owner
+                // is a separate entry in the suspendParams map and each one has to be named to be
+                // removed. Stopping early would leave the package suspended by the rest.
+                for (caller in callers) {
+                    runCatching {
+                        setPackagesSuspendedViaBypass(context, packageName, suspended, caller, userId)
+                        ran = true
+                    }.onFailure { e ->
+                        Logger.e(
+                            "Shizuku",
+                            "setPackagesSuspendedAsUser reflection failed for $packageName " +
+                                "(suspended=$suspended, caller=$caller)",
+                            e
                         )
-                        Bypass.invoke<Any>(builderClass, b, "build")
                     }
-                } else {
-                    null
                 }
-
-                val caller =
-                    if (isRoot) com.valhalla.thor.BuildConfig.APPLICATION_ID else "com.android.shell"
-
-                try {
-                    // Try Android 13+ (8 args)
-                    Bypass.invoke<Array<String>>(
-                        pm.javaClass,
-                        pm,
-                        "setPackagesSuspendedAsUser",
-                        arrayOf(
-                            Array<String>::class.java,
-                            Boolean::class.javaPrimitiveType!!,
-                            android.os.PersistableBundle::class.java,
-                            android.os.PersistableBundle::class.java,
-                            dialogInfoClass,
-                            Int::class.javaPrimitiveType!!,
-                            String::class.java,
-                            Int::class.javaPrimitiveType!!
-                        ),
-                        arrayOf(packageName),
-                        suspended,
-                        null, null,
-                        dialogInfo,
-                        0,
-                        caller,
-                        userId
-                    )
-                } catch (_: NoSuchMethodException) {
-                    // Try Android 10-12 (7 args)
-                    Bypass.invoke<Array<String>>(
-                        pm.javaClass,
-                        pm,
-                        "setPackagesSuspendedAsUser",
-                        arrayOf(
-                            Array<String>::class.java,
-                            Boolean::class.javaPrimitiveType!!,
-                            android.os.PersistableBundle::class.java,
-                            android.os.PersistableBundle::class.java,
-                            dialogInfoClass,
-                            String::class.java,
-                            Int::class.javaPrimitiveType!!
-                        ),
-                        arrayOf(packageName),
-                        suspended,
-                        null, null,
-                        dialogInfo,
-                        caller,
-                        userId
-                    )
-                }
-                true
-            }.getOrDefault(false)
-
-            if (reflectionResult) return true
+                if (ran) RungResult.RAN else RungResult.FAILED
+            }
         }
 
-        // 3. Unprivileged fallback (re-query PM to observe post-mutation state)
-        val currentSuspended = pkgs.getApplicationInfoOrNull(packageName)?.run {
-            (flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0
-        } ?: false
-        return currentSuspended == suspended
+        // The post-read is the only evidence that counts; see firstRungThatSticks, whose types are
+        // named for their first caller (the enable/disable chain) rather than for that chain alone.
+        val outcome = firstRungThatSticks(listOf(shellRung, reflectionRung)) {
+            reachedSuspendState(pkgs, packageName, escapedPackage, userId, suspended)
+        }
+        if (outcome.winner != null) {
+            Logger.d(
+                "Shizuku",
+                "setAppSuspended($packageName, suspended=$suspended): ${outcome.winner} changed the state"
+            )
+            return true
+        }
+
+        // Nothing moved. Re-read the owner: the pre-read can come back empty because the dump was
+        // truncated or denied, not because nobody owned the package, and this second look is the one
+        // chance to turn "that did not work" into the specific "root mode owns it" the user can act
+        // on. Empty is still "unknown", so this can only ever add information, never remove it.
+        val remaining = if (suspended) emptySet() else recordedSuspenders(escapedPackage, userId)
+        refuseUnliftableSuspension(context, packageName, remaining, sdkInt)
+        Logger.e(
+            "Shizuku",
+            "setAppSuspended($packageName, suspended=$suspended): both rungs ran as " +
+                "${callers.joinToString()} and the state did not change" +
+                if (remaining.isEmpty()) "" else " (still suspended by ${remaining.joinToString()})"
+        )
+        return false
+    }
+
+    /**
+     * Is [packageName] suspended right now — or `null` when that cannot be read at all?
+     *
+     * Three-valued and never `?: false`, which is the shape `readEffectivelyEnabled` uses for the
+     * same reason: an unreadable `ApplicationInfo` collapsed to "not suspended" reads as "the
+     * unsuspend worked", so the one state where Thor knows least would be the one it is loudest
+     * about. Callers treat null as "not verified".
+     */
+    private fun isSuspendedNow(pkgs: Packages, packageName: String): Boolean? =
+        pkgs.getApplicationInfoOrNull(packageName)
+            ?.let { (it.flags and android.content.pm.ApplicationInfo.FLAG_SUSPENDED) != 0 }
+
+    /**
+     * Has [packageName] actually reached [suspended]?
+     *
+     * `FLAG_SUSPENDED` is asked first because it is a binder call rather than a shell round trip,
+     * and because it is the same bit the dump prints (`PackageInfoUtils.generateApplicationInfo`
+     * sets it from `PackageUserState.isSuspended()`, which is just "the suspendParams map is not
+     * empty"). Every rung's failure therefore costs one cheap read and no `dumpsys` at all.
+     *
+     * The dump is then asked on the unsuspend path only, and only once the flag has already said
+     * "not suspended". That ordering is what makes the dump safe to use here: an empty parse means
+     * "unknown" on its own — a denied or truncated dump looks identical to a clean one — and it is
+     * the flag's independent *positive* answer that turns this pair into a confirmation instead of
+     * two absences of evidence. Asking it at all is worth the round trip because the flag is one bit
+     * and cannot say who is still holding the package.
+     */
+    private fun reachedSuspendState(
+        pkgs: Packages,
+        packageName: String,
+        escapedPackage: String,
+        userId: Int,
+        suspended: Boolean
+    ): Boolean {
+        // null != true and null != false, so an unreadable package is never "verified".
+        if (isSuspendedNow(pkgs, packageName) != suspended) return false
+        if (suspended) return true
+        return recordedSuspenders(escapedPackage, userId).isEmpty()
+    }
+
+    /**
+     * The packages the platform records as suspending [escapedPackage] for [userId].
+     *
+     * Empty means **unknown**, not "nothing" — a package that is not suspended, a dump denied for
+     * want of `android.permission.DUMP`, a truncated read and an OEM format nobody has seen all land
+     * here identically. [parseSuspendingPackages] documents the same rule; every caller in this file
+     * either pairs it with a positive `FLAG_SUSPENDED` read or treats it as "no information".
+     */
+    private fun recordedSuspenders(escapedPackage: String, userId: Int): Set<String> {
+        val (code, output) = execute("dumpsys package $escapedPackage")
+        if (code != 0 || output.isNullOrBlank()) {
+            Logger.w(
+                "Shizuku",
+                "dumpsys package $escapedPackage failed (exit=$code): suspender ownership is unknown"
+            )
+            return emptySet()
+        }
+        return parseSuspendingPackages(output, userId)
+    }
+
+    /**
+     * Throws when [recorded] holds an identity this privilege cannot lift, naming it.
+     *
+     * At uid 0 [canLiftSuspension] is always true and this is a no-op, as is every call below API 30
+     * where `setSuspended(false)` clears the single slot regardless of who set it (android-9.0.0_r1
+     * `PackageSettingBase.java:399-407`). It bites in exactly one place: a shell-uid Shizuku facing a
+     * suspension that root-mode Thor recorded under its own name on API 30+. That is genuinely
+     * unfixable from here, and the requirement is that Thor says so — the alternative, which is what
+     * shipped, is a call that removes nothing, returns an empty failure array and reports success.
+     */
+    private fun refuseUnliftableSuspension(
+        context: Context,
+        packageName: String,
+        recorded: Set<String>,
+        sdkInt: Int
+    ) {
+        val blocked = recorded.filterNot { canLiftSuspension(it, isRoot, sdkInt) }
+        if (blocked.isEmpty()) return
+        val owners = blocked.joinToString()
+        Logger.e(
+            "Shizuku",
+            "setAppSuspended($packageName, suspended=false): suspension is owned by $owners and " +
+                "this Shizuku acts as ${if (isRoot) "root" else SHELL_SUSPENDER_IDENTITY}; refusing " +
+                "to attempt a removal the platform would silently drop"
+        )
+        throw IllegalStateException(
+            context.getString(
+                com.valhalla.thor.R.string.suspend_owned_by_other_privilege,
+                packageName,
+                owners
+            )
+        )
+    }
+
+    /**
+     * The one and only copy of the `IPackageManager.setPackagesSuspendedAsUser` reflection.
+     *
+     * All three overloads are needed and the 9-argument one was missing, which is why this rung was
+     * dead on every Android 15+ device: only the 8-arg and 7-arg lookups existed, both threw
+     * `NoSuchMethodException` there, and the outer `runCatching` swallowed it into a plain `false`.
+     *
+     * | Args | Platform | Shape |
+     * |---|---|---|
+     * | 9 | API 35+ | `…, int flags, String callingPackage, int suspendingUserId, int targetUserId` |
+     * | 8 | API 33-34 | `…, int flags, String callingPackage, int userId` |
+     * | 7 | API 29-32 | `…, String callingPackage, int userId` |
+     *
+     * `suspendingUserId` is the user the *suspending* package lives in and is what API 35 prints as
+     * the `<0>` prefix on the dump's `UserPackage` key; both ids are [userId] here because Thor
+     * suspends its own user's packages as an identity in that same user.
+     *
+     * Returns Unit and throws on failure rather than returning a boolean, for the same reason
+     * [setApplicationEnabledSettingViaBypass] does — and here the reason is sharper still: the
+     * boolean it *could* return is `!failedPackages.contains(packageName)`, and an empty
+     * `failedPackages` is precisely the lie this whole change exists to stop believing. The returned
+     * array is deliberately discarded; the post-read decides.
+     */
+    @SuppressLint("PrivateApi")
+    private fun setPackagesSuspendedViaBypass(
+        context: Context,
+        packageName: String,
+        suspended: Boolean,
+        caller: String,
+        userId: Int
+    ) {
+        val pm = asInterface("android.content.pm.IPackageManager", "package")
+        val dialogInfoClass = Class.forName("android.content.pm.SuspendDialogInfo")
+        val dialogInfo = if (suspended) buildSuspendDialogInfo(context) else null
+        val targets = arrayOf(packageName)
+
+        val stringArrayType = Array<String>::class.java
+        val boolType = Boolean::class.javaPrimitiveType!!
+        val intType = Int::class.javaPrimitiveType!!
+        val bundleType = android.os.PersistableBundle::class.java
+        val stringType = String::class.java
+
+        // API 35+ — 9 args.
+        try {
+            Bypass.invoke<Any?>(
+                pm.javaClass,
+                pm,
+                "setPackagesSuspendedAsUser",
+                arrayOf(
+                    stringArrayType, boolType, bundleType, bundleType, dialogInfoClass,
+                    intType, stringType, intType, intType
+                ),
+                targets, suspended, null, null, dialogInfo, 0, caller, userId, userId
+            )
+            return
+        } catch (_: NoSuchMethodException) {
+            // Older platform; fall through.
+        }
+
+        // API 33-34 — 8 args.
+        try {
+            Bypass.invoke<Any?>(
+                pm.javaClass,
+                pm,
+                "setPackagesSuspendedAsUser",
+                arrayOf(
+                    stringArrayType, boolType, bundleType, bundleType, dialogInfoClass,
+                    intType, stringType, intType
+                ),
+                targets, suspended, null, null, dialogInfo, 0, caller, userId
+            )
+            return
+        } catch (_: NoSuchMethodException) {
+            // Older platform; fall through.
+        }
+
+        // API 29-32 — 7 args. Uncaught on purpose: there is no overload left to try, so a
+        // NoSuchMethodException here is real news and belongs to the caller's log line.
+        Bypass.invoke<Any?>(
+            pm.javaClass,
+            pm,
+            "setPackagesSuspendedAsUser",
+            arrayOf(
+                stringArrayType, boolType, bundleType, bundleType, dialogInfoClass,
+                stringType, intType
+            ),
+            targets, suspended, null, null, dialogInfo, caller, userId
+        )
+    }
+
+    /**
+     * The custom pause dialog, or null when this platform will not build one.
+     *
+     * Null is a supported argument — the system falls back to its own generic dialog — so a failure
+     * here must never fail the suspend itself. It is logged rather than swallowed all the same,
+     * because a silently-null dialogInfo is invisible until a user asks why the dialog is generic.
+     *
+     * The overloads are picky and the wrong one throws `NoSuchMethodException` for the whole
+     * builder: `setMessage(String)` exists from API 29, `setTitle(String)` only from API 31 — asking
+     * for `setTitle` on 29 or 30 used to take the entire reflection rung down with it. The
+     * `@StringRes int` overloads are deliberately not used even though they go back to 29: the
+     * dialog is rendered by the system's `SuspendedAppActivity` against the *suspending* package's
+     * resources, which for a shell-uid Shizuku is `com.android.shell` — Thor's resource ids mean
+     * nothing there.
+     */
+    @SuppressLint("PrivateApi")
+    private fun buildSuspendDialogInfo(context: Context): Any? = runCatching {
+        val builderClass = Class.forName("android.content.pm.SuspendDialogInfo\$Builder")
+        val builder = Bypass.newInstance<Any>(builderClass)
+        Bypass.invoke<Any?>(
+            builderClass,
+            builder,
+            "setMessage",
+            arrayOf(String::class.java),
+            context.getString(com.valhalla.thor.R.string.suspended_app_dialog_message)
+        )
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            Bypass.invoke<Any?>(
+                builderClass,
+                builder,
+                "setTitle",
+                arrayOf(String::class.java),
+                context.getString(com.valhalla.thor.R.string.suspended_app_dialog_title)
+            )
+        }
+        Bypass.invoke<Any>(builderClass, builder, "build")
+    }.getOrElse { e ->
+        Logger.e("Shizuku", "SuspendDialogInfo.Builder failed; suspending without a custom dialog", e)
+        null
     }
 
     // PrivateApi: hidden-API reflection (IPackageDataObserver) is intentional — the core privilege

--- a/app/src/main/java/com/valhalla/thor/domain/model/SuspenderReadback.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/SuspenderReadback.kt
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+/**
+ * The identity every shell-uid caller is stuck with.
+ *
+ * Shizuku runs Thor's commands as uid 2000 and Dhizuku's `pm suspend` lands there too, and
+ * `PackageManagerService.enforceCanSetPackagesSuspendedAsUser` only lets a shell caller name a
+ * package that *is* the shell (`allowedShell = callingUid == SHELL_UID && isCallerSameApp(...)`).
+ * So a suspension made in Shizuku or Dhizuku mode is recorded under this name and no other — which
+ * is also why root, and only root, can lift it (see [canLiftSuspension]).
+ */
+const val SHELL_SUSPENDER_IDENTITY = "com.android.shell"
+
+/**
+ * Thor's release `applicationId`, and what the root reflection path passes as `callingPackage`.
+ *
+ * This is deliberate and must stay: the system derives the user-visible "managed by Thor" line on
+ * the paused-app dialog from the suspending package name, so recording our own name is what makes
+ * attribution work. See `ThorRootService.setAppSuspendedAs`.
+ */
+const val THOR_SUSPENDER_IDENTITY = "com.valhalla.thor"
+
+/**
+ * What a root *shell* `pm suspend` records: uid 0 has no package, so the platform stores the literal
+ * string "root", which is not an installed package at all.
+ *
+ * Thor stopped writing this in GH#239 — tapping such an app crashes `SuspendedAppActivity` with
+ * "Package root does not exist" — but suspensions written by older builds, by the pre-API-29 root
+ * path that had no reflection available, and by Shizuku *running as root* are still out there on
+ * users' devices, so the unsuspend path has to keep clearing it.
+ */
+const val LEGACY_ROOT_SUSPENDER_IDENTITY = "root"
+
+/** Identities Thor may have recorded across its own history and privilege modes. */
+val THOR_SUSPENDER_IDENTITIES: Set<String> =
+    setOf(THOR_SUSPENDER_IDENTITY, LEGACY_ROOT_SUSPENDER_IDENTITY)
+
+/**
+ * [THOR_SUSPENDER_IDENTITIES] plus the package name this build actually runs under.
+ *
+ * The debug build carries `applicationIdSuffix = ".debug"`, so it records `com.valhalla.thor.debug`
+ * as the suspender and would not recognise its own suspensions in the constant set above. Anywhere
+ * a real `Context` is in reach, pass `context.packageName` through here rather than trusting the
+ * hardcoded release name.
+ */
+fun thorSuspenderIdentities(ownPackageName: String): Set<String> =
+    THOR_SUSPENDER_IDENTITIES + ownPackageName
+
+/**
+ * `Build.VERSION_CODES.R`, spelled out.
+ *
+ * The API level arrives as a parameter so a test can name a device instead of being one, and
+ * `Build.VERSION.SDK_INT` reads 0 under the mockable `android.jar` anyway — a default argument
+ * reading it would silently put every unit test below this boundary while looking like it asked the
+ * device. Same reasoning as `PlatformPermissionGroups.TIRAMISU`.
+ */
+private const val R = 30
+
+/**
+ * Whether a caller at the current privilege can lift a suspension recorded by [recordedSuspender].
+ *
+ * The asymmetry this encodes is the whole point of the readback:
+ *
+ * - **Below API 30 ownership does not exist.** `PackageSettingBase.setSuspended(false)` clears the
+ *   single suspension slot regardless of who set it (android-9.0.0_r1
+ *   `PackageSettingBase.java:399-407`), so any caller can undo any suspension and the recorded name
+ *   is decoration.
+ * - **Root may impersonate anyone.** `PackageManagerService.enforceCanSetPackagesSuspendedAsUser`
+ *   unconditionally early-returns for `Process.ROOT_UID` *before* any suspender-name validation
+ *   (android-17.0.0_r1 `PackageManagerService.java:3354-3358`), unchanged from API 28 to main. A
+ *   uid-0 binder call naming any `suspendingPackage` is accepted verbatim, which is what lets root
+ *   rescue a Shizuku-era suspension.
+ * - **Shell may not.** The shell branch of the same check is
+ *   `allowedShell = callingUid == SHELL_UID && isCallerSameApp(suspendingPackage, callingUid)`, so
+ *   Shizuku and Dhizuku can only ever act as [SHELL_SUSPENDER_IDENTITY]. From API 30 on,
+ *   `removeSuspension(callingPackage)` (android-11.0.0_r1 `PackageSettingBase.java:443-452`, carried
+ *   into `SuspendPackageHelper` on 13-16) removes only the caller's own entry and leaves `suspended`
+ *   true while anyone else's remains.
+ *
+ * A `false` here is not a reason to try anyway and hope. Attempting it produces
+ * `oldSuspendParams == null == newSuspendParams` → `changed == false` → the package is logged
+ * "No change is needed" and left *out* of the returned failure array, so the call reports success
+ * while the app stays suspended forever. Callers must surface the failure and name
+ * [recordedSuspender] instead.
+ */
+fun canLiftSuspension(recordedSuspender: String, isRoot: Boolean, sdkInt: Int): Boolean = when {
+    sdkInt < R -> true
+    isRoot -> true
+    else -> recordedSuspender == SHELL_SUSPENDER_IDENTITY
+}
+
+/** A package block header — `  Package [com.example.app] (a1b2c3):`. */
+private const val PACKAGE_HEADER = "Package ["
+
+/** The API 30+ block header, trimmed. */
+private const val SUSPEND_PARAMS_HEADER = "Suspend params:"
+
+private const val SUSPENDED_KEY = "suspended="
+private const val SUSPENDING_PACKAGE_KEY = "suspendingPackage="
+
+/** `    User 0: ceDataInode=… installed=true …` — the per-user state section. */
+private val USER_SECTION = Regex("""^User (\d+):""")
+
+/**
+ * The API 35+ `UserPackage.toString()` prefix: `"<" + userId + ">" + packageName`
+ * (android-15.0.0_r1 `services/core/java/com/android/server/pm/UserPackage.java`).
+ */
+private val USER_PACKAGE_PREFIX = Regex("""^<(\d+)>""")
+
+/**
+ * Every package name currently recorded as suspending the dumped package for [userId].
+ *
+ * **An empty result means "unknown", never "not suspended".** A package that is not suspended, a
+ * dump truncated by a broken pipe, a `Permission Denial:` line from a process without
+ * `android.permission.DUMP`, and an OEM ROM whose dump format nobody has seen all produce exactly
+ * the same empty set. A caller that reads empty as "nothing to do, report success" reintroduces the
+ * silent-success bug this whole readback exists to kill: an app that stays suspended forever while
+ * Thor says it unsuspended it. Treat empty as "not verified" and fail closed.
+ *
+ * [dumpsysOutput] must be the output of `dumpsys package <pkg>` for a **single** package. There is
+ * no package name to filter by here, so a whole-system dump would union the suspenders of every
+ * package in it.
+ *
+ * ### The four shapes
+ *
+ * The field moved twice and its key changed twice, so all four have to parse on a range that starts
+ * at Thor's minSdk of 28. Line quoting below is from `Settings.dumpPackageLPr`:
+ *
+ * | API | Shape |
+ * |---|---|
+ * | 28 (P) | inline on the `User N:` line: `… suspended=true suspendingPackage=<pkg> dialogMessage=…` (android-9.0.0_r61 `Settings.java:4775-4778`) |
+ * | 29 (Q) | same inline, trailing key renamed to `dialogInfo=` (android-10.0.0_r47 `Settings.java:4757-4759`) |
+ * | 30-34 | a `Suspend params:` block, one `suspendingPackage=<pkg> dialogInfo=…` line per suspender — `PackageUserState.suspendParams` became a map, so a package can have several at once |
+ * | 35-37 | the same block, but the map key is now `UserPackage.toString()` — `suspendingPackage=<0>com.android.shell dialogInfo=null quarantined=false` |
+ *
+ * **The 35+ trap:** a regex written against the 30-34 shape captures the literal `<0>` prefix, and
+ * the name then goes straight into a `pm unsuspend` / `setPackagesSuspendedAsUser` argument as a
+ * package called `<0>com.android.shell`, which exists nowhere. Nothing is removed and, because
+ * naming a non-existent suspender is indistinguishable from naming one that owns nothing, nothing
+ * fails either. The prefix is stripped here and its digits are used to filter by [userId].
+ *
+ * ### Why a state machine, and why indentation is not part of it
+ *
+ * `Suspend params:` carries no user id of its own; it belongs to whichever `User N:` section it
+ * follows, which is the only thing keeping a work-profile suspension from being reported as user
+ * 0's. That is state across lines, so this is a line-oriented machine rather than one regex.
+ *
+ * Every line is trimmed first, deliberately. `dumpPackageLPr` takes its indentation as a `prefix`
+ * parameter and the `Hidden system packages:` section dumps at a deeper one, so column counts are a
+ * property of the call site rather than of the format — matching on them would drop entries on a
+ * dump that is otherwise perfectly well formed.
+ */
+fun parseSuspendingPackages(dumpsysOutput: String, userId: Int = 0): Set<String> {
+    val suspenders = LinkedHashSet<String>()
+
+    // The user id of the `User N:` section we are inside, or null before the first one.
+    var sectionUserId: Int? = null
+
+    // That section's `suspended=` flag; null when the line did not carry one.
+    var sectionSuspended: Boolean? = null
+
+    // True while consuming the entries of a `Suspend params:` block we care about.
+    var inSuspendParams = false
+
+    for (rawLine in dumpsysOutput.lineSequence()) {
+        val line = rawLine.trim()
+
+        // A new package block cannot inherit the previous one's user section. Only reachable on a
+        // dump that carries more than one — `Hidden system packages:` after an updated system app.
+        if (line.startsWith(PACKAGE_HEADER)) {
+            sectionUserId = null
+            sectionSuspended = null
+            inSuspendParams = false
+            continue
+        }
+
+        val userMatch = USER_SECTION.find(line)
+        if (userMatch != null) {
+            sectionUserId = userMatch.groupValues[1].toIntOrNull()
+            sectionSuspended = line.fields().tokenValue(SUSPENDED_KEY)?.toBooleanStrictOrNull()
+            inSuspendParams = false
+            // API 28/29: the suspender is on this very line, printed only when suspended is true.
+            if (sectionUserId == userId && sectionSuspended != false) {
+                line.fields().tokenValue(SUSPENDING_PACKAGE_KEY)
+                    ?.let { suspenderName(it, userId) }
+                    ?.let(suspenders::add)
+            }
+            continue
+        }
+
+        if (line == SUSPEND_PARAMS_HEADER) {
+            // An explicit `suspended=false` disowns any block that follows it: AOSP prints the block
+            // only inside `if (ps.getSuspended(userId))`, so text surviving a false flag is stale.
+            // A *missing* flag is unknown rather than false — the block's own existence is then the
+            // best evidence there is, and dropping it would hide a real suspension.
+            inSuspendParams = sectionUserId == userId && sectionSuspended != false
+            continue
+        }
+
+        if (inSuspendParams) {
+            val key = line.fields().tokenValue(SUSPENDING_PACKAGE_KEY)
+            if (key == null) {
+                // The block ends at the first line that is not one of its entries; anything after it
+                // belongs to the package or user state again.
+                inSuspendParams = false
+                continue
+            }
+            suspenderName(key, userId)?.let(suspenders::add)
+        }
+    }
+
+    return suspenders
+}
+
+/**
+ * The part of a dump line that is still `key=value` pairs.
+ *
+ * `dialogMessage` (28) and `dialogInfo` (29+) are the only free text on these lines — a message the
+ * suspending app chose, or a `SuspendDialogInfo.toString()` — and both are printed *after*
+ * `suspendingPackage`, so cutting there removes every value that could contain a space or forge a
+ * key. Without this, an app whose pause dialog says "suspended=false" would edit Thor's answer.
+ */
+private fun String.fields(): String =
+    substringBefore(" dialogMessage=").substringBefore(" dialogInfo=")
+
+/**
+ * The value of a whitespace-delimited `key=value` token, or null if the line has no such key.
+ *
+ * Prefix-matching whole tokens rather than searching the raw string is what keeps `suspended=` from
+ * matching inside `suspendingPackage=`, which shares its first eight characters and sits on the same
+ * line in the API 28 and 29 shapes.
+ */
+private fun String.tokenValue(key: String): String? = splitToSequence(' ', '\t')
+    .firstOrNull { it.startsWith(key) }
+    ?.substring(key.length)
+    ?.takeIf { it.isNotEmpty() }
+
+/**
+ * A recorded suspender's package name, or null if this entry is not [userId]'s.
+ *
+ * On API 35+ the map key is a `UserPackage`, so it arrives as `<0>com.android.shell`: the digits are
+ * the user the *suspending* package lives in. They are stripped from the returned name — a
+ * `<0>`-prefixed string is not a package name and must never reach a `pm` argument — and used to
+ * drop entries belonging to another user, so a work profile's DPC is not reported as suspending
+ * user 0's copy of the app. On 28-34 there is no prefix and the key is already the package name.
+ *
+ * A literal `null` is what the platform prints for an absent value; it is not a package.
+ */
+private fun suspenderName(key: String, userId: Int): String? {
+    val prefix = USER_PACKAGE_PREFIX.find(key)
+    val name = if (prefix == null) {
+        key
+    } else {
+        if (prefix.groupValues[1].toIntOrNull() != userId) return null
+        key.substring(prefix.value.length)
+    }
+    return name.takeIf { it.isNotEmpty() && it != "null" }
+}

--- a/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
+++ b/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
@@ -10,8 +10,29 @@ import android.os.IBinder
 import android.os.PersistableBundle
 import com.valhalla.superuser.ipc.RootService
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.domain.model.LEGACY_ROOT_SUSPENDER_IDENTITY
+import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
+import com.valhalla.thor.domain.model.parseSuspendingPackages
 import com.valhalla.thor.util.Logger
 import java.lang.reflect.InvocationTargetException
+
+/**
+ * The user id every suspend call in this file writes and every readback in it parses.
+ *
+ * The two numbers have to be the same one. Suspending user 0 and then verifying against user 10's
+ * section of the dump would confirm a state nobody set, so the constant exists to keep the write and
+ * the read from drifting apart the next time one of them is edited.
+ */
+private const val TARGET_USER_ID = 0
+
+/**
+ * The platform's own identity — what a device-owner/DPM suspension is recorded under.
+ *
+ * Kept last in the suspend fallback order on purpose: a suspension attributed to `android` shows the
+ * user a system-owned pause dialog with no hint that Thor is responsible, so it is a last resort for
+ * writing and mainly a name Thor has to be able to *clear*.
+ */
+private const val PLATFORM_SUSPENDER_IDENTITY = "android"
 
 /**
  * A highly-stable, persistent root-level daemon service implementing privileged actions.
@@ -35,7 +56,25 @@ class ThorRootService : RootService() {
         return object : IThorRootService.Stub() {
             override fun setAppSuspended(packageName: String, suspended: Boolean): Boolean {
                 this@ThorRootService.enforceCaller()
-                return this@ThorRootService.setAppSuspended(packageName, suspended)
+                return this@ThorRootService.setAppSuspendedAs(packageName, suspended, null)
+            }
+
+            override fun setAppSuspendedAs(
+                packageName: String,
+                suspended: Boolean,
+                suspendingPackage: String?
+            ): Boolean {
+                this@ThorRootService.enforceCaller()
+                return this@ThorRootService.setAppSuspendedAs(
+                    packageName,
+                    suspended,
+                    suspendingPackage
+                )
+            }
+
+            override fun dumpPackage(packageName: String): String? {
+                this@ThorRootService.enforceCaller()
+                return this@ThorRootService.dumpPackage(packageName)
             }
 
             override fun clearAppData(packageName: String): Boolean {
@@ -45,8 +84,29 @@ class ThorRootService : RootService() {
         }
     }
 
-    private fun setAppSuspended(packageName: String, suspended: Boolean): Boolean {
-        Logger.i("Odin", "setAppSuspended: packageName=$packageName, suspended=$suspended")
+    /**
+     * Suspends or unsuspends [packageName] as [suspendingPackage], and returns whether the
+     * platform's own record agrees afterwards.
+     *
+     * The return value used to be `runCatching { … }.isSuccess` over a loop that broke as soon as
+     * `setPackagesSuspendedAsUser` returned an empty failure array. That array is not evidence:
+     * naming a suspender that owns nothing leaves `oldSuspendParams == null == newSuspendParams`, so
+     * `changed == false`, so the package is logged "No change is needed" and is deliberately left
+     * *out* of the returned array. A root-mode Thor asking to lift a Shizuku-era suspension (recorded
+     * as [SHELL_SUSPENDER_IDENTITY]) therefore removed nothing, reported success, and left the app
+     * stuck suspended with no error anywhere. Every success below is now a re-read of the record via
+     * [readSuspenders] instead.
+     */
+    private fun setAppSuspendedAs(
+        packageName: String,
+        suspended: Boolean,
+        suspendingPackage: String?
+    ): Boolean {
+        Logger.i(
+            "Odin",
+            "setAppSuspendedAs: packageName=$packageName, suspended=$suspended, " +
+                    "as=${suspendingPackage ?: "<unspecified>"}"
+        )
         return runCatching {
             val binder = Class.forName("android.os.ServiceManager")
                 .getMethod("getService", String::class.java)
@@ -61,47 +121,211 @@ class ThorRootService : RootService() {
             }
 
             val dialogInfoClass = Class.forName("android.content.pm.SuspendDialogInfo")
-            val dialogInfo = if (suspended) buildSuspendDialogInfo() else null
 
-            // Try different caller packages in order of preference to find one that succeeds.
-            // Prioritize Thor's own package name so that the OS displays "Managed by Thor" on clicking a suspended app.
-            val callers = listOf(
-                this@ThorRootService.packageName,
-                "com.android.shell",
-                "android"
-            )
-            var success = false
-
-            for (caller in callers) {
-                try {
-                    if (callSetSuspended(pmClass, pm, dialogInfoClass, packageName, suspended, dialogInfo, caller)) {
-                        Logger.i("Odin", "setAppSuspended successfully suspended $packageName using caller $caller")
-                        success = true
-                        break
-                    } else {
-                        Logger.w("Odin", "setAppSuspended failed for $packageName using caller $caller (returned in failed list)")
-                    }
-                } catch (e: Exception) {
-                    val cause = if (e is InvocationTargetException) e.cause else e
-                    Logger.w("Odin", "setAppSuspended threw exception for $packageName using caller $caller: " + cause?.message)
-                }
-            }
-
-            if (!success) {
-                throw RuntimeException("All caller package strategies failed to suspend $packageName")
+            if (suspended) {
+                suspendAsAnyOf(
+                    pmClass, pm, dialogInfoClass, packageName,
+                    dialogInfo = buildSuspendDialogInfo(),
+                    identities = suspendIdentities(suspendingPackage)
+                )
+            } else {
+                unsuspendAllOf(
+                    pmClass, pm, dialogInfoClass, packageName,
+                    identities = unsuspendIdentities(packageName, suspendingPackage)
+                )
             }
         }.onFailure { e ->
             Logger.e("Odin", "Failed to set app suspended for $packageName", e)
-        }.isSuccess
+        }.getOrDefault(false)
     }
 
+    /**
+     * The identities to try, in order, when suspending.
+     *
+     * An explicit [suspendingPackage] is the *only* one tried — the caller read the record and knows
+     * which identity it means; falling back to another name behind its back would write a second
+     * suspension entry nobody asked for.
+     *
+     * With none given, this keeps the historical order, and Thor's own applicationId stays first for
+     * a reason: the system builds the user-visible "managed by Thor" line on the paused-app dialog
+     * out of the recorded suspender name. That is the whole point of root writing its own name rather
+     * than borrowing the shell's, it works today, and this change must not disturb it.
+     */
+    private fun suspendIdentities(suspendingPackage: String?): List<String> =
+        suspendingPackage?.let(::listOf) ?: listOf(
+            this@ThorRootService.packageName,
+            SHELL_SUSPENDER_IDENTITY,
+            PLATFORM_SUSPENDER_IDENTITY
+        )
+
+    /**
+     * The identities to clear when unsuspending [targetPackage].
+     *
+     * An explicit [suspendingPackage] is again the only entry touched: the gateway reads the record
+     * and calls once per recorded suspender, so each call stays a single well-defined removal.
+     *
+     * With none given — the legacy two-argument `setAppSuspended` entry point — the record itself is
+     * the list. Guessing is exactly what caused the bug: a Shizuku-era suspension is recorded as
+     * [SHELL_SUSPENDER_IDENTITY], and a root-mode Thor that only ever named its own package removed
+     * nothing. When the record cannot be read at all we still make a best-effort pass over every name
+     * Thor has written across its history, including the pre-GH#239
+     * [LEGACY_ROOT_SUSPENDER_IDENTITY]; that cannot turn into a false success, because the post-write
+     * readback in [unsuspendAllOf] will be just as unreadable and will fail closed.
+     */
+    private fun unsuspendIdentities(
+        targetPackage: String,
+        suspendingPackage: String?
+    ): List<String> {
+        if (suspendingPackage != null) return listOf(suspendingPackage)
+        // A readable empty set is a real answer — nothing is recorded, so there is nothing to remove
+        // and [unsuspendAllOf]'s readback confirms it. Only an unreadable dump falls through.
+        readSuspenders(targetPackage)?.let { return it.toList() }
+        return listOf(
+            this@ThorRootService.packageName,
+            SHELL_SUSPENDER_IDENTITY,
+            PLATFORM_SUSPENDER_IDENTITY,
+            LEGACY_ROOT_SUSPENDER_IDENTITY
+        )
+    }
+
+    /**
+     * Suspends [targetPackage] as the first of [identities] the platform actually ends up recording.
+     *
+     * The loop reads the record back after each attempt rather than trusting
+     * [tryCallSetSuspended]'s return value, so "the call was accepted" and "the suspension exists"
+     * stay separate facts. An unreadable record aborts instead of moving on to the next identity:
+     * without knowing whether the previous attempt landed, trying another name risks stacking a
+     * second suspension entry on the package that only a second unsuspend could remove.
+     */
+    private fun suspendAsAnyOf(
+        pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
+        targetPackage: String, dialogInfo: Any?, identities: List<String>
+    ): Boolean {
+        for (caller in identities) {
+            val accepted = tryCallSetSuspended(
+                pmClass, pm, dialogInfoClass, targetPackage, true, dialogInfo, caller
+            )
+            if (!accepted) continue
+
+            val recorded = readSuspenders(targetPackage)
+            if (recorded == null) {
+                Logger.w(
+                    "Odin",
+                    "Cannot read $targetPackage's suspenders after suspending as $caller; " +
+                            "refusing to report a success we did not verify"
+                )
+                return false
+            }
+            if (caller in recorded) {
+                Logger.i("Odin", "Suspended $targetPackage; platform recorded suspender $caller")
+                return true
+            }
+            Logger.w(
+                "Odin",
+                "setPackagesSuspendedAsUser reported no failure for $targetPackage as $caller, " +
+                        "but the platform records $recorded — that identity owns nothing"
+            )
+        }
+        return false
+    }
+
+    /**
+     * Removes every one of [identities] from [targetPackage]'s suspension record.
+     *
+     * Deliberately no break on the first accepted call. From API 30 `PackageUserState.suspendParams`
+     * is a map, so a package can carry several suspension entries at once and `suspended` stays true
+     * while any of them survives — stopping early is how one gets left behind.
+     *
+     * Success means the identities we were asked to remove are gone. A suspension owned by somebody
+     * else is not this call's to lift and is reported at warn level so the caller can name the owner
+     * to the user rather than leaving them with an app that quietly stays paused.
+     */
+    private fun unsuspendAllOf(
+        pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
+        targetPackage: String, identities: List<String>
+    ): Boolean {
+        for (caller in identities) {
+            tryCallSetSuspended(
+                pmClass, pm, dialogInfoClass, targetPackage, false, null, caller
+            )
+        }
+
+        val recorded = readSuspenders(targetPackage)
+        if (recorded == null) {
+            Logger.w(
+                "Odin",
+                "Cannot read $targetPackage's suspenders after unsuspending; " +
+                        "refusing to report a success we did not verify"
+            )
+            return false
+        }
+        val remaining = identities.filter { it in recorded }
+        if (remaining.isNotEmpty()) {
+            Logger.w(
+                "Odin",
+                "Unsuspend of $targetPackage left $remaining recorded as suspenders"
+            )
+            return false
+        }
+        if (recorded.isEmpty()) {
+            Logger.i(
+                "Odin",
+                "Unsuspend of $targetPackage verified; nothing is recorded as suspending it"
+            )
+        } else {
+            Logger.w(
+                "Odin",
+                "Removed $identities from $targetPackage, but $recorded still own entries — it " +
+                        "stays suspended until whoever owns those lifts them"
+            )
+        }
+        return true
+    }
+
+    /**
+     * [callSetSuspended] with its exceptions turned into `false`.
+     *
+     * Every identity in a fallback list is a guess about a platform we cannot interrogate, so one
+     * throwing must not abandon the rest. The failure is logged with the `InvocationTargetException`
+     * unwrapped, because the wrapper's own message is always the useless "null".
+     */
+    private fun tryCallSetSuspended(
+        pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
+        packageName: String, suspended: Boolean, dialogInfo: Any?, caller: String
+    ): Boolean = try {
+        callSetSuspended(
+            pmClass, pm, dialogInfoClass, packageName, suspended, dialogInfo, caller
+        )
+    } catch (e: Exception) {
+        val cause = if (e is InvocationTargetException) e.cause else e
+        Logger.w(
+            "Odin",
+            "setPackagesSuspendedAsUser threw for $packageName as $caller: " + cause?.message
+        )
+        false
+    }
+
+    /**
+     * Invokes `IPackageManager.setPackagesSuspendedAsUser` through whichever overload this platform
+     * exposes, and reports whether the call was **accepted**.
+     *
+     * That is not the same as "it worked", and the difference is the bug this file was carrying. The
+     * returned array holds only packages the platform actively refused; a package whose state did not
+     * change — because the named suspender owned no entry — is not in it, so an empty array is
+     * equally consistent with "done" and "silently did nothing". Callers must confirm the outcome
+     * with [readSuspenders]; this value only says the reflection found a signature and the framework
+     * did not reject the request outright.
+     */
     private fun callSetSuspended(
         pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
         packageName: String, suspended: Boolean, dialogInfo: Any?, caller: String
     ): Boolean {
-        // Android 14+ (API 34+): 9-arg signature
+        // Android 15+ (API 35+): 9-arg signature. Not 34 — the shape itself says so. This overload
+        // is where a suspension became cross-user: the suspender key turned into a UserPackage,
+        // which is exactly why it carries a suspendingUserId *and* a targetUserId, and that landed
+        // in 15. Gating it on 34 would only mean asking a 34 device for a method it does not have.
         try {
-            Logger.i("Odin", "Trying API 34+ 9-arg signature with caller=$caller")
+            Logger.i("Odin", "Trying API 35+ 9-arg signature with caller=$caller")
             val method = pmClass.getDeclaredMethod(
                 "setPackagesSuspendedAsUser",
                 Array<String>::class.java,
@@ -114,14 +338,17 @@ class ThorRootService : RootService() {
                 Int::class.javaPrimitiveType,   // suspendingUserId
                 Int::class.javaPrimitiveType    // targetUserId
             )
-            val result = method.invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller, 0, 0) as? Array<*>
+            val result = method.invoke(
+                pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller,
+                TARGET_USER_ID, TARGET_USER_ID
+            ) as? Array<*>
             val failedList = result?.filterIsInstance<String>() ?: emptyList()
-            Logger.i("Odin", "Successfully invoked API 34+ 9-arg signature. Failed packages: $failedList")
+            Logger.i("Odin", "Successfully invoked API 35+ 9-arg signature. Failed packages: $failedList")
             return !failedList.contains(packageName)
         } catch (e: NoSuchMethodException) {
-            Logger.d("Odin", "API 34+ signature not found: " + e.message)
+            Logger.d("Odin", "API 35+ signature not found: " + e.message)
         } catch (e: Exception) {
-            Logger.e("Odin", "API 34+ signature invocation error", e)
+            Logger.e("Odin", "API 35+ signature invocation error", e)
             throw e
         }
 
@@ -139,7 +366,10 @@ class ThorRootService : RootService() {
                 String::class.java,             // callingPackage
                 Int::class.javaPrimitiveType    // userId
             )
-            val result = method.invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller, 0) as? Array<*>
+            val result = method.invoke(
+                pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller,
+                TARGET_USER_ID
+            ) as? Array<*>
             val failedList = result?.filterIsInstance<String>() ?: emptyList()
             Logger.i("Odin", "Successfully invoked API 33 8-arg signature. Failed packages: $failedList")
             return !failedList.contains(packageName)
@@ -159,7 +389,9 @@ class ThorRootService : RootService() {
                 PersistableBundle::class.java, PersistableBundle::class.java,
                 dialogInfoClass, String::class.java, Int::class.javaPrimitiveType
             )
-            val result = method.invoke(pm, arrayOf(packageName), suspended, null, null, dialogInfo, caller, 0) as? Array<*>
+            val result = method.invoke(
+                pm, arrayOf(packageName), suspended, null, null, dialogInfo, caller, TARGET_USER_ID
+            ) as? Array<*>
             val failedList = result?.filterIsInstance<String>() ?: emptyList()
             Logger.i("Odin", "Successfully invoked API 29-33 7-arg signature. Failed packages: $failedList")
             return !failedList.contains(packageName)
@@ -169,16 +401,101 @@ class ThorRootService : RootService() {
         }
     }
 
+    /**
+     * The identities the platform currently records as suspending [targetPackage] for
+     * [TARGET_USER_ID], or `null` when the dump could not be trusted.
+     *
+     * The `null` is the entire point of this wrapper. `parseSuspendingPackages` cannot distinguish a
+     * package with no suspenders from a dump that was truncated, denied, or in a format nobody has
+     * seen — all three parse to an empty set — so "did we get a real dump?" has to be answered here,
+     * before anything interprets that emptiness. Without the header check an unreadable dump would
+     * parse empty and [unsuspendAllOf] would read it as "nothing left, we succeeded": the same
+     * empty-means-success lie this change exists to remove, one layer further down.
+     *
+     * `dumpsys package <pkg>` always prints a `Package [<pkg>] (…):` block for an installed package;
+     * a caller without `android.permission.DUMP` gets a `Permission Denial:` line instead, and a
+     * truncated dump gets neither.
+     */
+    private fun readSuspenders(targetPackage: String): Set<String>? {
+        val dump = dumpPackage(targetPackage) ?: return null
+        if (!dump.contains("Package [$targetPackage]")) {
+            Logger.w(
+                "Odin",
+                "dumpsys package $targetPackage returned no package block; suspender state unknown"
+            )
+            return null
+        }
+        return parseSuspendingPackages(dump, TARGET_USER_ID)
+    }
+
+    /**
+     * Raw `dumpsys package <targetPackage>` output, or `null` when it could not be read.
+     *
+     * This lives on the root side because `PackageManagerService.dump` gates on
+     * `android.permission.DUMP` through `DumpUtils.checkDumpAndUsageStatsPermission`
+     * (android-16 `PackageManagerService.java:6689`), which the app process does not hold.
+     *
+     * The daemon is already `app_process` running as uid 0, so a plain [ProcessBuilder] inherits root
+     * — going back out through `su` from in here would fork a second privileged shell for no reason.
+     * The command is exec'd as an argv array rather than through `sh -c`, so [targetPackage] is one
+     * argument and cannot be quoted out of; no escaping is applied because none would do anything.
+     */
+    private fun dumpPackage(targetPackage: String): String? = runCatching {
+        val process = ProcessBuilder("dumpsys", "package", targetPackage)
+            .redirectErrorStream(true)
+            .start()
+        val output = try {
+            process.inputStream.bufferedReader().use { it.readText() }
+        } finally {
+            // This daemon outlives any single call, so the unused stdin pipe is closed here rather
+            // than left to finalization — one leaked fd per dump adds up over a long session.
+            process.outputStream.close()
+        }
+        val exitCode = process.waitFor()
+        if (exitCode != 0) {
+            Logger.w("Odin", "dumpsys package $targetPackage exited $exitCode")
+            return@runCatching null
+        }
+        output.takeIf { it.isNotBlank() }
+    }.onFailure { e ->
+        Logger.e("Odin", "Failed to dump package $targetPackage", e)
+    }.getOrNull()
+
+    /**
+     * A `SuspendDialogInfo` carrying Thor's title and message, or `null` when this platform's builder
+     * does not expose the setters it needs.
+     *
+     * **This never worked.** Both lookups asked for `CharSequence` overloads that do not exist —
+     * `SuspendDialogInfo.Builder` takes `String` (and `@StringRes int`) — so the very first
+     * `getMethod` threw `NoSuchMethodException` into a bare `catch` that returned `null`, and every
+     * suspension Thor has ever made carried a null `dialogInfo`. Hence the [Logger.w] below: a
+     * reflective lookup that degrades in silence is indistinguishable from one that works, and that
+     * is how this hid for as long as it did.
+     *
+     * Worth knowing while reading this: the user-visible "managed by Thor" line on the paused-app
+     * dialog is **not** produced here. The system derives that from the suspending package name,
+     * which the root path already records correctly; this builder only adds a custom title and
+     * message on top of it.
+     */
     private fun buildSuspendDialogInfo(): Any? = try {
         val builderClass = Class.forName("android.content.pm.SuspendDialogInfo\$Builder")
         val builder = builderClass.getDeclaredConstructor().newInstance()
-        builderClass.getMethod("setTitle", CharSequence::class.java).invoke(builder, "Thor")
-        builderClass.getMethod("setMessage", CharSequence::class.java)
+        // setMessage(String) has been there since API 29, but setTitle(String) only arrived in API
+        // 31 — before that a title had to be a @StringRes int, and one of *our* resource ids would
+        // not resolve inside the system's dialog anyway. Asking for it unguarded on 29/30 throws and
+        // costs us the message too, since a single catch covers the whole builder.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            builderClass.getMethod("setTitle", String::class.java).invoke(builder, "Thor")
+        }
+        builderClass.getMethod("setMessage", String::class.java)
             .invoke(builder, "This app has been suspended by Thor.")
-        builderClass.getMethod("setNeutralButtonAction", Int::class.javaPrimitiveType)
-            .invoke(builder, 2)
+        // No setNeutralButtonAction call: its only valid arguments are BUTTON_ACTION_MORE_DETAILS (0)
+        // and BUTTON_ACTION_UNSUSPEND (1), and the one this replaced passed 2. MORE_DETAILS is
+        // already the platform default and the button is hidden when nothing handles the intent, so
+        // leaving it unset is both correct and the smallest change.
         builderClass.getMethod("build").invoke(builder)
-    } catch (_: Exception) {
+    } catch (e: Exception) {
+        Logger.w("Odin", "SuspendDialogInfo.Builder unusable, suspending without a dialog: $e")
         null
     }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -468,6 +468,7 @@
 
     
     <!-- Missing Translations -->
+    <string name="suspend_owned_by_other_privilege">لا يمكن إلغاء تعليق %1$s من هنا. تم تعليقه بواسطة %2$s، ولا يسمح Android إلا للصلاحية نفسها بإلغائه. بدّل Thor إلى وضع الصلاحية ذاك وحاول مرة أخرى.</string>
     <string name="auto_reinstall">إعادة التثبيت التلقائي للتطبيقات</string>
     <string name="auto_reinstall_desc">الحفاظ تلقائيًا على متجر Google Play كمثبت رئيسي لتمكين التحديثات في الخلفية</string>
     <string name="legacy_extension_title">تم اكتشاف امتداد قديم</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -434,6 +434,7 @@
 
     
     <!-- Missing Translations -->
+    <string name="suspend_owned_by_other_privilege">No se puede reanudar %1$s desde aquí. Fue suspendida por %2$s y Android solo permite que el mismo privilegio la reanude. Cambia Thor a ese modo de privilegio e inténtalo de nuevo.</string>
     <string name="auto_reinstall">Reinstalación automática de apps</string>
     <string name="auto_reinstall_desc">Mantener automáticamente Google Play Store como el instalador registrado para permitir actualizaciones en segundo plano</string>
     <string name="legacy_extension_title">Extensión heredada detectada</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -434,6 +434,7 @@
 
     
     <!-- Missing Translations -->
+    <string name="suspend_owned_by_other_privilege">Impossible de lever la suspension de %1$s ici. Elle a été suspendue par %2$s, et Android n\'autorise que le même privilège à la lever. Repassez Thor dans ce mode de privilège, puis réessayez.</string>
     <string name="auto_reinstall">Réinstallation automatique d\'applications</string>
     <string name="auto_reinstall_desc">Conserver automatiquement Google Play Store comme installateur enregistré pour activer les mises à jour en arrière-plan</string>
     <string name="legacy_extension_title">Extension obsolète détectée</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -426,6 +426,7 @@
 
     
     <!-- Missing Translations -->
+    <string name="suspend_owned_by_other_privilege">无法在此解除 %1$s 的暂停。它由 %2$s 暂停，而 Android 只允许同一权限方解除。请将 Thor 切换回该权限模式后重试。</string>
     <string name="auto_reinstall">自动重新安装应用</string>
     <string name="auto_reinstall_desc">自动保留 Google Play 商店作为主安装程序，以启用后台更新</string>
     <string name="legacy_extension_title">检测到旧版扩展</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,6 +360,10 @@
     <string name="data_cleared_success">Cleared data of %1$s</string>
     <string name="suspended_success">Suspended %1$s</string>
     <string name="unsuspended_success">Unsuspended %1$s</string>
+    <!-- %1$s is an app name, %2$s a comma-separated list of package names that recorded the
+         suspension. Shown when Thor cannot lift a suspension because Android only lets the
+         privilege that applied it remove it (API 30+). -->
+    <string name="suspend_owned_by_other_privilege">Can\'t unsuspend %1$s from here. It was suspended by %2$s, and Android only lets the same privilege lift it. Switch Thor back to that privilege mode and try again.</string>
     <string name="unfreezing_app">Unfreezing %1$s…</string>
     <string name="uninstall_success">Uninstalled %1$s</string>
     <string name="error_app_info_missing">Error: App info missing for action</string>

--- a/app/src/test/java/com/valhalla/thor/domain/model/SuspenderReadbackTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/SuspenderReadbackTest.kt
@@ -1,0 +1,389 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The `dumpsys package <pkg>` suspender readback, and the ownership rule it feeds.
+ *
+ * This is the foundation of the fix for the report "suspended via Shizuku, switched to root, now the
+ * app is stuck": Android keys a suspension on the *suspending package name*, and from API 30 a
+ * caller may only lift its own entry. Lifting one you do not own is not an error — it produces
+ * `changed == false`, the package is left out of the returned failure array, and every call site in
+ * Thor reads that empty array as success. So the only way to know whether an unsuspend worked is to
+ * read who owns it before, and read again after; this parser is that read.
+ *
+ * All four dump shapes are covered because Thor's minSdk is 28 and the field moved twice on the way
+ * to 37 — inline on the `User N:` line, then a `Suspend params:` block, then the same block keyed by
+ * `UserPackage.toString()`. The fixtures are multi-line because [parseSuspendingPackages] is a state
+ * machine: the block carries no user id of its own and inherits the section it follows, so a
+ * one-line fixture would not exercise the part most likely to be wrong.
+ *
+ * `dumpsys` output is a String, so none of this needs a device — which is the whole reason the
+ * parser lives in `domain/model` as a pure function. `:app` has no mocking library and no
+ * Robolectric by policy, and a parser that could only be tested on a phone would not be tested.
+ */
+class SuspenderReadbackTest {
+
+    /** The oldest device Thor supports, where the suspender is printed inline. */
+    private val pie = 28
+
+    /** Android 10: still inline, but the trailing key is `dialogInfo=`. */
+    private val q = 29
+
+    /** Android 11: `Suspend params:` block, and the first level that enforces ownership. */
+    private val r = 30
+
+    /** Android 15: the block's key becomes `UserPackage.toString()`. */
+    private val vanillaIceCream = 35
+
+    /**
+     * API 28. The suspender rides on the `User N:` line itself and the trailing key is
+     * `dialogMessage=` — android-9.0.0_r61 `Settings.java:4775-4778`. No `distractionFlags` yet;
+     * that arrives in Q.
+     */
+    private val api28Dump = """
+        Packages:
+          Package [com.example.chat] (5f3a1c7):
+            userId=10214
+            pkg=Package{9a1b2c3 com.example.chat}
+            codePath=/data/app/com.example.chat-1
+            versionCode=421 minSdk=23 targetSdk=28
+            versionName=4.2.1
+            dataDir=/data/user/0/com.example.chat
+            timeStamp=2024-03-11 09:12:44
+            firstInstallTime=2024-03-11 09:12:44
+            signatures=PackageSignatures{2f1c0aa version:2, signatures:[a3d90f11]}
+            installPermissionsFixed=true
+            pkgFlags=[ HAS_CODE ALLOW_CLEAR_USER_DATA ALLOW_BACKUP ]
+            User 0: ceDataInode=1310749 installed=true hidden=false suspended=true suspendingPackage=com.android.shell dialogMessage=null stopped=false notLaunched=false enabled=0 instant=false virtual=false
+              gids=[3003]
+              runtime permissions:
+                android.permission.CAMERA: granted=true
+    """.trimIndent()
+
+    /**
+     * API 29. Same line, `dialogInfo=` in place of `dialogMessage=` — android-10.0.0_r47
+     * `Settings.java:4757-4759` — and a real `SuspendDialogInfo.toString()` in it, spaces and all,
+     * sitting between the name we want and the rest of the line.
+     */
+    private val api29Dump = """
+        Packages:
+          Package [com.example.chat] (5f3a1c7):
+            userId=10214
+            versionCode=421 minSdk=23 targetSdk=29
+            dataDir=/data/user/0/com.example.chat
+            pkgFlags=[ HAS_CODE ALLOW_CLEAR_USER_DATA ALLOW_BACKUP ]
+            User 0: ceDataInode=1310749 installed=true hidden=false suspended=true suspendingPackage=com.android.shell dialogInfo=SuspendDialogInfo: {mTitleResId = 0, mDialogMessage = Paused by your admin} distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+              gids=[3003]
+    """.trimIndent()
+
+    /**
+     * API 30-34. `PackageUserState.suspendParams` is a map now, so the suspenders move into their
+     * own block below the user line and there can be more than one.
+     */
+    private val api30Dump = """
+        Packages:
+          Package [com.example.chat] (5f3a1c7):
+            userId=10214
+            versionCode=421 minSdk=23 targetSdk=31
+            dataDir=/data/user/0/com.example.chat
+            pkgFlags=[ HAS_CODE ALLOW_CLEAR_USER_DATA ALLOW_BACKUP ]
+            User 0: ceDataInode=1310749 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+            Suspend params:
+              suspendingPackage=com.android.shell dialogInfo=null
+              gids=[3003]
+    """.trimIndent()
+
+    /**
+     * API 35-37. The map is keyed by `UserPackage`, whose `toString()` is
+     * `"<" + userId + ">" + packageName`, and `quarantined=` joins the tail.
+     */
+    private val api35Dump = """
+        Packages:
+          Package [com.example.chat] (5f3a1c7):
+            userId=10214
+            versionCode=421 minSdk=24 targetSdk=36
+            dataDir=/data/user/0/com.example.chat
+            pkgFlags=[ HAS_CODE ALLOW_CLEAR_USER_DATA ALLOW_BACKUP ]
+            User 0: ceDataInode=1310749 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+            Suspend params:
+              suspendingPackage=<0>com.android.shell dialogInfo=null quarantined=false
+              gids=[3003]
+    """.trimIndent()
+
+    @Test
+    fun theInlineApi28ShapeParses() {
+        // The whole point of supporting this one: minSdk is 28, so it is an ordinary device rather
+        // than a corner case, and it is the only shape where the answer never appears on a line of
+        // its own.
+        assertEquals(setOf("com.android.shell"), parseSuspendingPackages(api28Dump))
+    }
+
+    @Test
+    fun theInlineApi29ShapeParsesPastItsDialogInfo() {
+        // `dialogInfo=` is free text the suspending app chose, it contains spaces, and on this shape
+        // it sits on the same line as the name we want. Reading tokens after it — or letting a
+        // greedy match run into it — is how the trailing junk ends up in a package name.
+        assertEquals(setOf("com.android.shell"), parseSuspendingPackages(api29Dump))
+    }
+
+    @Test
+    fun theApi30BlockShapeParses() {
+        assertEquals(setOf("com.android.shell"), parseSuspendingPackages(api30Dump))
+    }
+
+    @Test
+    fun theApi35UserPackagePrefixIsStrippedFromTheName() {
+        // The highest-value assertion in this file. A regex written against the 30-34 block captures
+        // `<0>com.android.shell` verbatim on 35+, and that string then goes into a `pm unsuspend`
+        // argument as if it were a package name. No such package exists, so nothing is removed — and
+        // because naming a suspender that owns nothing is indistinguishable from naming one that
+        // does not exist, nothing fails either. The app stays suspended and Thor reports success.
+        val suspenders = parseSuspendingPackages(api35Dump)
+
+        assertEquals(setOf("com.android.shell"), suspenders)
+        assertFalse(
+            "the UserPackage prefix reached the package name",
+            suspenders.contains("<0>com.android.shell")
+        )
+        assertTrue(suspenders.none { it.startsWith("<") })
+    }
+
+    @Test
+    fun everyRecordedSuspenderIsReturnedNotJustTheFirst() {
+        // From API 30 a package can be suspended by several callers at once and stays suspended
+        // while any entry remains. Returning only the first is the same bug in a different costume:
+        // Thor lifts its own entry, the app is still suspended, and the caller was told it worked.
+        val dump = """
+            Packages:
+              Package [com.example.chat] (5f3a1c7):
+                userId=10214
+                User 0: ceDataInode=1310749 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                Suspend params:
+                  suspendingPackage=<0>com.android.shell dialogInfo=null quarantined=false
+                  suspendingPackage=<0>com.valhalla.thor dialogInfo=SuspendDialogInfo: {mTitleResId = 0} quarantined=false
+                  suspendingPackage=<0>android dialogInfo=null quarantined=true
+                  gids=[3003]
+        """.trimIndent()
+
+        assertEquals(
+            setOf("com.android.shell", "com.valhalla.thor", "android"),
+            parseSuspendingPackages(dump)
+        )
+    }
+
+    @Test
+    fun aWorkProfileSuspensionIsNotAttributedToUserZero() {
+        // `Suspend params:` carries no user id; it belongs to the `User N:` section above it. Both
+        // profiles here have the app suspended, by different owners, and asking about one must never
+        // hand back the other's — unsuspending as the wrong identity is a guaranteed silent no-op.
+        val dump = """
+            Packages:
+              Package [com.example.chat] (5f3a1c7):
+                userId=10214
+                User 0: ceDataInode=1310749 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                Suspend params:
+                  suspendingPackage=<0>com.android.shell dialogInfo=null quarantined=false
+                User 10: ceDataInode=1441822 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                Suspend params:
+                  suspendingPackage=<10>com.example.dpc dialogInfo=null quarantined=false
+        """.trimIndent()
+
+        assertEquals(setOf("com.android.shell"), parseSuspendingPackages(dump, userId = 0))
+        assertEquals(setOf("com.example.dpc"), parseSuspendingPackages(dump, userId = 10))
+    }
+
+    @Test
+    fun theUserPackagePrefixItselfFiltersByUser() {
+        // The digits are not decoration: they say which user the *suspending* package lives in, so a
+        // work-profile DPC's entry can appear inside user 0's own section. Stripping the prefix
+        // without reading it would report `com.example.dpc` as a suspender of user 0's copy, and the
+        // unsuspend aimed at it would quietly do nothing.
+        val dump = """
+            Packages:
+              Package [com.example.chat] (5f3a1c7):
+                userId=10214
+                User 0: ceDataInode=1310749 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                Suspend params:
+                  suspendingPackage=<0>com.android.shell dialogInfo=null quarantined=false
+                  suspendingPackage=<10>com.example.dpc dialogInfo=null quarantined=false
+        """.trimIndent()
+
+        assertEquals(setOf("com.android.shell"), parseSuspendingPackages(dump, userId = 0))
+    }
+
+    @Test
+    fun aUserSectionThatIsNotSuspendedContributesNothing() {
+        // AOSP prints the block only inside `if (ps.getSuspended(userId))`, so text surviving a
+        // `suspended=false` is stale — an OEM dump quirk or a torn read. Reporting a suspender for
+        // an app that is not suspended sends the unsuspend path chasing an entry that is gone.
+        val dump = """
+            Packages:
+              Package [com.example.chat] (5f3a1c7):
+                userId=10214
+                User 0: ceDataInode=1310749 installed=true hidden=false suspended=false distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                Suspend params:
+                  suspendingPackage=<0>com.android.shell dialogInfo=null quarantined=false
+        """.trimIndent()
+
+        assertEquals(emptySet<String>(), parseSuspendingPackages(dump))
+    }
+
+    @Test
+    fun freeTextInADialogCannotForgeAField() {
+        // `dialogInfo` is a string the suspending app controls. It is printed after the name we
+        // want, so everything from it onward is cut before any key is read — otherwise an app whose
+        // pause dialog happens to read "suspended=false" would delete Thor's answer for it.
+        val dump = """
+            Packages:
+              Package [com.example.chat] (5f3a1c7):
+                userId=10214
+                User 0: ceDataInode=1310749 installed=true hidden=false suspended=true suspendingPackage=com.android.shell dialogInfo=SuspendDialogInfo: {mDialogMessage = suspended=false suspendingPackage=com.evil.app} distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+        """.trimIndent()
+
+        assertEquals(setOf("com.android.shell"), parseSuspendingPackages(dump))
+    }
+
+    @Test
+    fun aDeeperIndentedDumpStillParses() {
+        // `Settings.dumpPackageLPr` takes its indentation as a `prefix` argument and the hidden
+        // system package section passes a deeper one, so column counts belong to the call site, not
+        // to the format. A parser keyed on them would drop entries from a well-formed dump.
+        val dump = """
+            Hidden system packages:
+                  Package [com.example.chat] (5f3a1c7):
+                    userId=10214
+                        User 0: ceDataInode=1310749 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                        Suspend params:
+                            suspendingPackage=<0>com.android.shell dialogInfo=null quarantined=false
+        """.trimIndent()
+
+        assertEquals(setOf("com.android.shell"), parseSuspendingPackages(dump))
+    }
+
+    @Test
+    fun aBlockWithNoUserSectionOfItsOwnIsNotAttributedToThePreviousPackage() {
+        // An updated system app is dumped twice, and the second copy is a different PackageSetting
+        // whose user state may be stale or absent. An entry we cannot attribute to a user is
+        // unknown, and unknown must not become "user 0 said so".
+        val dump = """
+            Packages:
+              Package [com.example.chat] (5f3a1c7):
+                userId=10214
+                User 0: ceDataInode=1310749 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                Suspend params:
+                  suspendingPackage=<0>com.android.shell dialogInfo=null quarantined=false
+            Hidden system packages:
+              Package [com.example.chat] (0b4e29a):
+                userId=10214
+                Suspend params:
+                  suspendingPackage=<0>com.example.stale dialogInfo=null quarantined=false
+        """.trimIndent()
+
+        assertEquals(setOf("com.android.shell"), parseSuspendingPackages(dump))
+    }
+
+    @Test
+    fun anUnreadableDumpIsEmptyRatherThanAThrow() {
+        // Each of these is a *different* reason to know nothing, and all three land on the same
+        // empty set — which is exactly why callers must read empty as "unknown" and fail closed.
+        // The permission denial is what the app process gets: `dumpsys package` needs
+        // android.permission.DUMP, which root and Shizuku's shell uid have and Thor does not.
+        val denied = """
+            Permission Denial: can't dump package from from pid=9142, uid=10214 without permission android.permission.DUMP
+        """.trimIndent()
+        val truncated = """
+            Packages:
+              Package [com.example.chat] (5f3a1c7):
+                userId=10214
+                User 0: ceDataInode=1310749 installed=true hidden=false suspended=true distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                Suspend params:
+        """.trimIndent()
+        val garbage = """
+            /system/bin/sh: dumpsys: inaccessible or not found
+            <0>com.android.shell
+            suspendingPackage
+        """.trimIndent()
+
+        assertEquals(emptySet<String>(), parseSuspendingPackages(""))
+        assertEquals(emptySet<String>(), parseSuspendingPackages("   \n\n  "))
+        assertEquals(emptySet<String>(), parseSuspendingPackages(denied))
+        assertEquals(emptySet<String>(), parseSuspendingPackages(truncated))
+        assertEquals(emptySet<String>(), parseSuspendingPackages(garbage))
+    }
+
+    @Test
+    fun anAppThatIsSimplyNotSuspendedIsEmptyToo() {
+        // The ordinary case, and the reason the sentence above matters: it is indistinguishable from
+        // every failure in the previous test, so "empty" can never be spent as evidence of success.
+        val dump = """
+            Packages:
+              Package [com.example.chat] (5f3a1c7):
+                userId=10214
+                User 0: ceDataInode=1310749 installed=true hidden=false suspended=false distractionFlags=0 stopped=false notLaunched=false enabled=0 instant=false virtual=false
+                  gids=[3003]
+        """.trimIndent()
+
+        assertEquals(emptySet<String>(), parseSuspendingPackages(dump))
+    }
+
+    @Test
+    fun rootCanLiftASuspensionItDoesNotOwn() {
+        // `enforceCanSetPackagesSuspendedAsUser` early-returns for ROOT_UID before it validates the
+        // suspender name, on every level from 28 to main. This is the line that makes the reported
+        // bug fixable at all: a Shizuku-era suspension recorded as com.android.shell can be lifted
+        // after the user switches Thor to root.
+        assertTrue(canLiftSuspension(SHELL_SUSPENDER_IDENTITY, isRoot = true, sdkInt = 37))
+        assertTrue(canLiftSuspension(THOR_SUSPENDER_IDENTITY, isRoot = true, sdkInt = 37))
+        assertTrue(canLiftSuspension("android", isRoot = true, sdkInt = vanillaIceCream))
+        assertTrue(canLiftSuspension(LEGACY_ROOT_SUSPENDER_IDENTITY, isRoot = true, sdkInt = r))
+    }
+
+    @Test
+    fun shellCanOnlyLiftItsOwnSuspensionsFromApi30() {
+        // The reverse direction, and the one that is genuinely unfixable: Shizuku is uid 2000 and
+        // `isCallerSameApp` pins it to com.android.shell, so a root-era suspension cannot be lifted
+        // in Shizuku mode at all. The requirement is that the UI says so, naming the owner, instead
+        // of running an unsuspend that removes nothing and reports success.
+        assertTrue(canLiftSuspension(SHELL_SUSPENDER_IDENTITY, isRoot = false, sdkInt = r))
+        assertTrue(canLiftSuspension(SHELL_SUSPENDER_IDENTITY, isRoot = false, sdkInt = 37))
+        assertFalse(canLiftSuspension(THOR_SUSPENDER_IDENTITY, isRoot = false, sdkInt = r))
+        assertFalse(canLiftSuspension(THOR_SUSPENDER_IDENTITY, isRoot = false, sdkInt = 37))
+        assertFalse(canLiftSuspension("android", isRoot = false, sdkInt = 34))
+        THOR_SUSPENDER_IDENTITIES.forEach {
+            assertFalse(
+                "$it must not look liftable without root on API 30+",
+                canLiftSuspension(it, isRoot = false, sdkInt = r)
+            )
+        }
+    }
+
+    @Test
+    fun ownershipIsNotEnforcedBelowApi30() {
+        // The version boundary, asserted from both sides. Before R, `setSuspended(false)` clears the
+        // single slot whatever the caller is called, so refusing to try there would strand API 28
+        // and 29 users on a suspension Thor could actually have lifted.
+        assertTrue(canLiftSuspension(THOR_SUSPENDER_IDENTITY, isRoot = false, sdkInt = pie))
+        assertTrue(canLiftSuspension(THOR_SUSPENDER_IDENTITY, isRoot = false, sdkInt = q))
+        assertTrue(canLiftSuspension("android", isRoot = false, sdkInt = q))
+        assertFalse(canLiftSuspension(THOR_SUSPENDER_IDENTITY, isRoot = false, sdkInt = r))
+    }
+
+    @Test
+    fun thorsOwnIdentitiesIncludeTheOneThisBuildRunsUnder() {
+        // The debug build carries applicationIdSuffix = ".debug", so it records a suspender name the
+        // constant set does not contain and would not recognise its own suspensions. "root" stays in
+        // the set forever: pre-GH#239 builds wrote it, and those suspensions are still on devices.
+        assertEquals(setOf("com.valhalla.thor", "root"), THOR_SUSPENDER_IDENTITIES)
+        assertTrue(
+            thorSuspenderIdentities("com.valhalla.thor.debug")
+                .containsAll(THOR_SUSPENDER_IDENTITIES + "com.valhalla.thor.debug")
+        )
+    }
+}


### PR DESCRIPTION
## The bug

A user switched from Shizuku to root and found **every app they had suspended under Shizuku stuck suspended**. Thor reported each unsuspend as successful. Nothing in the logs said otherwise.

## Why

Android records **who** suspended a package, and from **API 30** only that identity can lift it — [`PackageSettingBase.removeSuspension(callingPackage)`](https://cs.android.com/android/platform/superproject/+/android-11.0.0_r1:frameworks/base/services/core/java/com/android/server/pm/PackageSettingBase.java;l=443-452) removes the caller's own entry and nothing else.

Thor's suspender identity is **not stable across privilege modes**:

| Privilege | Recorded as |
|---|---|
| Root | `com.valhalla.thor` |
| Shizuku / Dhizuku | `com.android.shell` |
| Device owner (DPM) | `android` |
| Pre-GH#239 builds, API < 28 root path | `root` |

So a suspension applied under one privilege is simply unliftable under another.

**And the failure is silent by construction.** Unsuspending under a non-owning identity finds no entry to remove, so `oldSuspendParams == newSuspendParams == null` → `changed` stays `false` → PackageManagerService logs *"No change is needed"* → the package is **never added to `unmodifiablePackages`** → the API returns an **empty failure array**. Every caller reads that as total success. Thor did too.

## The fix — stop inferring, start reading

### `parseSuspendingPackages()` — `domain/model/SuspenderReadback.kt`

Reads the suspender set out of `dumpsys package <pkg>`. Four line shapes, because this changed three times:

| API | Shape |
|---|---|
| 28 | inline, `suspendingPackage=<pkg> dialogMessage=` |
| 29 | inline, with ` dialogInfo=` |
| 30–34 | `Suspend params:` block, `suspendingPackage=` entries |
| 35–37 | same block, but the key is `UserPackage.toString()` = `"<" + userId + ">" + packageName` |

That last one is the trap: **a regex written for 30–34 silently captures `<0>com.android.shell`** — a name that matches nothing. Asserted three ways in the tests (equals the bare name, does *not* contain the prefixed form, nothing starts with `<`).

Two more hardening decisions:
- **Free text is cut before any key is read.** `dialogMessage=` / `dialogInfo=` print attacker-influenced text *after* the name, so a crafted message containing `suspended=false suspendingPackage=com.evil.app` would otherwise be parsed. Tested.
- **Indentation-insensitive.** `dumpPackageLPr` takes its prefix from the call site — the `Hidden system packages:` section dumps deeper — so columns are not a reliable anchor. Content is.

### `canLiftSuspension()` — encode the version split, don't assume the modern rule

Below API 30, `setSuspended(false)` blows away the single slot **regardless of who set it** ([android-9.0.0_r1 :399-407](https://cs.android.com/android/platform/superproject/+/android-9.0.0_r1:frameworks/base/services/core/java/com/android/server/pm/PackageSettingBase.java;l=399-407)) — any identity can lift any suspension. From API 30, only the recorder can. Getting this wrong in either direction produces a wrong refusal or a wrong success.

### Unsuspend now reads, acts, and reads back

Read the record → issue one removal **per recorded owner, under that owner's name** → read back to confirm.

Root can name another package because [`enforceCanSetPackagesSuspendedAsUser`](https://cs.android.com/android/platform/superproject/+/android-17.0.0_r1:frameworks/base/services/core/java/com/android/server/pm/PackageManagerService.java;l=3354-3358) **unconditionally early-returns for `Process.ROOT_UID` before any suspender-name validation**. Shell cannot — `allowedShell = callingUid == SHELL_UID && isCallerSameApp(...)`.

Where the platform genuinely will not allow it — a shell-uid Shizuku facing a root-recorded suspension on API 30+ — **Thor now says so and names the owner** rather than returning success.

### An unreadable dump is never "nothing to do"

`readSuspenders()` returns `null` unless the output actually contained a `Package [<pkg>]` block, and `null` fails closed everywhere it is consumed.

This is load-bearing: `dumpsys` requires `android.permission.DUMP`, so a permission-denied read parses as **the empty set** — which is the exact same silent-success bug one level down. `parseSuspendingPackages` documents in bold that empty means *unknown*, never *not suspended*.

## AIDL compatibility

`setAppSuspendedAs` and `dumpPackage` are **appended, not inserted**. Transaction codes are derived from declaration order (`FIRST_CALL_TRANSACTION + index`) and a root daemon **outlives an app update** — inserting would make a stale daemon dispatch `clearAppData()` to whatever moved into that index. Verified with the `aidl` binary that `setAppSuspended` stays +0 and `clearAppData` stays +1.

A stale daemon asked for a method it doesn't have reads back an **empty reply parcel** — `null` for a String — which `readSuspenders()` already treats as unknown and fails closed on. (Note: the generated proxy ignores `transact()`'s return value, so this degrades honestly rather than throwing.)

## Incidental fix

The `SuspendDialogInfo` builder **has never worked**: the `setTitle(CharSequence)` / `setMessage(CharSequence)` overloads don't exist (only the `@StringRes int` ones), and `setNeutralButtonAction(2)` is out of range — only `0` and `1` are defined. The *"managed by Thor"* line users actually see is **system-generated from the suspending package name**, which is why it kept appearing regardless. Now the builder is correct too.

## Verification

- `:app:compileFossDebugKotlin :app:compileFossDebugUnitTestKotlin` → **BUILD SUCCESSFUL**, no new warnings
- `:app:testFossDebugUnitTest --rerun-tasks` → **446 tests, 0 failures, 0 errors, 0 skipped** (counts parsed from JUnit XML, not inferred from `BUILD SUCCESSFUL`)
- `:app:lintFossDebug` → **BUILD SUCCESSFUL** (all five locales carry the new string)

**17 new tests**: all four dump shapes, the `<0>` prefix trap (three assertions), multi-suspender dumps, work-profile sectioning in both directions, `<10>`-inside-`User 0:` filtering, `suspended=false` with a stale block, free-text forgery, deeper indentation, unattributable blocks, empty/whitespace/permission-denied/truncated/garbage input, and `canLiftSuspension` across the API 29→30 boundary from both sides.

## Not verifiable here

**No device testing has been done.** Everything above rests on AOSP source reading and unit tests over captured dump shapes. The parser is pinned against fixtures written from the documented formats, not against output from a real device — worth a check on hardware before release, particularly the API 35+ `<0>`-keyed shape and the cross-privilege refusal path.
