### PR TITLE
fix(privilege): make Dhizuku usable on device — user id, re-init, Refresh

### DIFF
--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -12,6 +12,7 @@ import com.rosan.dhizuku.api.Dhizuku
 import com.valhalla.bypass.Bypass
 import com.valhalla.thor.core.ThorShellConfig
 import com.valhalla.thor.data.service.AutoFreezeManager
+import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.presentation.settings.BillingProcessor
 import com.valhalla.thor.presentation.utils.AppIconFetcher
@@ -86,10 +87,16 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
         Bypass.prepareThor()
         ThorShellConfig.init()
 
+        // Hand the outcome to DhizukuHelper rather than dropping it. This init runs once, at process
+        // start — which for a first-run user is *before* they have authorised Thor in Dhizuku, so it
+        // returns false and there is nothing here to retry it. Recording the answer is what lets the
+        // later probe tell "already bound, just ask about permission" apart from "never bound, bind
+        // now" instead of asking an unbound client whether it has permission and always hearing no.
         try {
-            Dhizuku.init(this)
+            DhizukuHelper.markClientInitialised(Dhizuku.init(this))
         } catch (e: Exception) {
             Logger.e("ThorApp", "Dhizuku init failed", e)
+            DhizukuHelper.markClientInitialised(false)
         }
 
         autoFreezeManager.startObserving()

--- a/app/src/main/java/com/valhalla/thor/data/gateway/AndroidUserIds.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/AndroidUserIds.kt
@@ -16,5 +16,9 @@ private const val PER_USER_RANGE = 100_000
  * Shared by all three gateways rather than repeated in each: they must agree on which user a package
  * lives in, or the same `pm grant` would land on a different user depending on which privilege mode
  * happened to be active. One copy is also one place to correct if the platform ever moves the range.
+ *
+ * This answers *which user does this uid belong to*. For *which user is Thor itself*, see
+ * `thorUserId` in `data/source/local/ThorUser.kt` — that one is also read by the two privilege
+ * helpers, so it sits in the package they share rather than here.
  */
 internal fun userIdOf(uid: Int): Int = uid / PER_USER_RANGE

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -11,6 +11,7 @@ import com.valhalla.thor.data.source.local.dhizuku.DhizukuReflector
 import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
+import com.valhalla.thor.data.source.local.shizuku.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
@@ -27,9 +28,9 @@ private val USER_ID_REGEX = Regex("^\\d+$")
 
 @Single
 class DhizukuSystemGateway(
-    // Present for one reason: the system-app freeze's refusal message is read by the user, so it
-    // has to come out of resources. ShizukuSystemGateway and RootSystemGateway take theirs the
-    // same way.
+    // Two uses: the system-app freeze's refusal message is read by the user, so it has to come out
+    // of resources (ShizukuSystemGateway and RootSystemGateway take theirs the same way), and the
+    // availability probe binds the Dhizuku client through it — see DhizukuHelper.isDhizukuAvailable.
     private val context: Context,
     private val reflector: DhizukuReflector,
     private val preferenceRepository: PreferenceRepository
@@ -39,10 +40,11 @@ class DhizukuSystemGateway(
 
     override suspend fun isShizukuAvailable(): Boolean = false
 
-    // DhizukuHelper.isDhizukuAvailable() performs blocking binder IPC (DhizukuAPI); confine it
-    // to IO at the gateway boundary so this probe is main-safe regardless of the caller's dispatcher.
+    // DhizukuHelper.isDhizukuAvailable() performs blocking binder IPC (DhizukuAPI) and may re-bind
+    // the client; confine it to IO at the gateway boundary so this probe is main-safe regardless of
+    // the caller's dispatcher.
     override suspend fun isDhizukuAvailable(): Boolean = withContext(Dispatchers.IO) {
-        DhizukuHelper.isDhizukuAvailable()
+        DhizukuHelper.isDhizukuAvailable(context)
     }
 
     override suspend fun executeShellCommand(command: String): Result<Pair<Int, String?>> {
@@ -367,8 +369,8 @@ class DhizukuSystemGateway(
 
             val combinedPath = paths.joinToString(" ") { it.escapeForShell() }
 
-            // 2. Get Current User ID
-            val currentUser = DhizukuHelper.getCurrentUserId()
+            // 2. The user to install for — Thor's own, matching every other `--user` here.
+            val currentUser = thorUserId
 
             // 3. Execute the reinstallation command
             val command =

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -11,7 +11,7 @@ import com.valhalla.thor.data.source.local.dhizuku.DhizukuReflector
 import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
-import com.valhalla.thor.data.source.local.shizuku.thorUserId
+import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -13,7 +13,7 @@ import com.valhalla.thor.data.source.local.shizuku.ShizukuReflector
 import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
-import com.valhalla.thor.data.source.local.shizuku.thorUserId
+import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -13,6 +13,7 @@ import com.valhalla.thor.data.source.local.shizuku.ShizukuReflector
 import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
+import com.valhalla.thor.data.source.local.shizuku.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
@@ -378,7 +379,7 @@ class ShizukuSystemGateway(
             val combinedPath = paths.joinToString(" ") { it.escapeForShell() }
 
             // 2. Get Current User ID
-            val currentUser = ShizukuHelper.getCurrentUserId()
+            val currentUser = thorUserId
 
             // 3. Execute the reinstallation command
             val command =

--- a/app/src/main/java/com/valhalla/thor/data/source/local/ThorUser.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/ThorUser.kt
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import android.os.Process
+
+/**
+ * The Android user Thor itself runs as — the one every per-package command has to name.
+ *
+ * Read in-process from [Process.myUserHandle]: no shell, no permission, no binder. Both privilege
+ * helpers resolve the user through this one symbol so that a freeze rung and its fallback cannot
+ * name different users; a rung that disables for user 10 followed by a fallback that uninstalls for
+ * user 0 leaves the verify confirming a state nobody set. `SUSPEND_USER_ID` in `RootSystemGateway`
+ * makes the same point from the other direction.
+ *
+ * Deliberately **not** `am get-current-user`, which is what the two helpers used to shell out for.
+ * That reports the *foreground* user — a different number from this one on any work-profile device
+ * — and it is a command Dhizuku's device-owner identity is not permitted to run at all.
+ *
+ * It lives here, in the package both privilege helpers sit under, rather than in either of them:
+ * neither Shizuku nor Dhizuku owns this question, and a value used by both should not make one
+ * privilege mode's package depend on the other's. `userIdOf` in `data/gateway/AndroidUserIds.kt`
+ * answers the neighbouring question — which user some *other* uid belongs to — and stays with the
+ * gateways that ask it.
+ */
+internal val thorUserId: Int get() = Process.myUserHandle().hashCode()

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -108,6 +108,9 @@ object DhizukuHelper {
      * documented recovery could not work and only a force-stop would. Observed on an Android 17
      * device: grant, Refresh, still red; force-stop and relaunch, `active=DHIZUKU`.
      *
+     * That Refresh reaches here at all is the other half of the same fix — it used to reload the
+     * app list and nothing else, so the probe never re-ran; see `HomeViewModel.refreshPrivileges`.
+     *
      * Shizuku needs no equivalent because `PrivilegeManager` owns its binder and
      * permission-result listeners; Dhizuku 2.6.0 publishes no connection callback to register, so
      * the retry has to be pulled from the probe rather than pushed from an event.
@@ -422,12 +425,17 @@ object DhizukuHelper {
      * useful string in the whole flow, so it is passed back to the caller rather than reduced to
      * false — see [SystemAppRemovalOutcome].
      *
-     * The identity claim above is now **measured**, on an Android 17 device with Dhizuku as device
-     * owner: rung 1 is refused for the device-owner uid while the same `pm disable-user --user 0`
-     * exits 0 at shell uid on that very device, so the refusal belongs to the identity and not to
-     * the platform version. What remains unmeasured is this rung's own answer — the user-id bug
-     * fixed alongside this comment threw before `pm` ever ran, so nothing on that pass reached
-     * `pm uninstall` to find out whether Android 17 replies with the root-only line here too.
+     * Both claims above are now **measured**, on an Android 17 device with Dhizuku as device owner,
+     * freezing `com.android.egg`. Rung 1 is refused for the device-owner uid while the same
+     * `pm disable-user --user 0` exits 0 at shell uid on that very device, so the refusal belongs to
+     * the identity and not to the platform version. This rung then ran and answered exactly as
+     * predicted:
+     * ```
+     * `pm uninstall -k --user 0 com.android.egg` exited 1:
+     *   Failure [only root can delete system app for a particular user]
+     * ```
+     * — the same sentence the shell uid gets, reaching the user as the Root-mode message. The
+     * package was left untouched: `installed=true enabled=0`, `ceDataInode` unchanged.
      */
     fun freezeSystemAppForUser(packageName: String): SystemAppRemovalOutcome =
         removeForUser(packageName, keepData = true)

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -25,7 +25,7 @@ import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.firstRungThatSticks
 import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
 import com.valhalla.thor.data.source.local.shizuku.shellRungResult
-import com.valhalla.thor.data.source.local.shizuku.thorUserId
+import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
 import rikka.shizuku.ShizukuBinderWrapper
 import rikka.shizuku.SystemServiceHelper

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -25,6 +25,7 @@ import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.firstRungThatSticks
 import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
 import com.valhalla.thor.data.source.local.shizuku.shellRungResult
+import com.valhalla.thor.data.source.local.shizuku.thorUserId
 import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
 import rikka.shizuku.ShizukuBinderWrapper
 import rikka.shizuku.SystemServiceHelper
@@ -32,6 +33,52 @@ import com.rosan.dhizuku.api.Dhizuku as DhizukuAPI
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.R
 import java.util.concurrent.TimeUnit
+
+/**
+ * What one availability probe learned: whether the client is bound, and whether Thor is authorised.
+ *
+ * Two fields because they are not the same answer and the caller latches only the first. `available`
+ * is per-probe — the user can revoke in Dhizuku at any moment — while `initialised` is the binding,
+ * which survives.
+ */
+internal data class DhizukuProbe(val initialised: Boolean, val available: Boolean)
+
+/**
+ * The probe's decision table, lifted out of [DhizukuHelper.isDhizukuAvailable] so it can be
+ * exercised without a Dhizuku client — every call it makes is a static on `DhizukuAPI`, which is
+ * why the logic and not the wiring is what gets tested.
+ *
+ * Two properties are the point, and both were wrong before:
+ *
+ * - **A failed [init] is not remembered.** It was never retried at all before this — the one attempt
+ *   in `ThorApplication` ran at process start, which on a first run is before the user has
+ *   authorised Thor. Latching that `false` would restore exactly the bug, one layer down.
+ * - **A successful [init] is not repeated.** The probe runs on every privilege refresh, and every
+ *   screen that shows a privilege chip; re-binding each time would be a service bind per probe.
+ *
+ * [isPermissionGranted] is consulted only once bound, because an unbound client answers `false` to
+ * it regardless — which is what made the stale `false` look like a denied grant rather than a
+ * missing connection.
+ */
+internal fun probeDhizuku(
+    alreadyInitialised: Boolean,
+    init: () -> Boolean,
+    isPermissionGranted: () -> Boolean,
+): DhizukuProbe {
+    val initialised = try {
+        alreadyInitialised || init()
+    } catch (_: Exception) {
+        return DhizukuProbe(initialised = alreadyInitialised, available = false)
+    }
+    // A throw here loses the authorisation answer, never the binding: the bind above already
+    // succeeded, and forgetting it would make the next probe re-bind for nothing.
+    val available = try {
+        initialised && isPermissionGranted()
+    } catch (_: Exception) {
+        false
+    }
+    return DhizukuProbe(initialised = initialised, available = available)
+}
 
 /**
  * Helper to interact with Dhizuku service using the actual API.
@@ -49,12 +96,47 @@ object DhizukuHelper {
     /** Grace period for reader threads to drain their streams after the process has exited/been destroyed. */
     private const val READER_JOIN_TIMEOUT_MS = 5_000L
 
-    fun isDhizukuAvailable(): Boolean {
-        return try {
-            DhizukuAPI.isPermissionGranted()
-        } catch (_: Exception) {
-            false
-        }
+    /**
+     * Whether Dhizuku is connected *and* has authorised Thor.
+     *
+     * Re-runs `DhizukuAPI.init` when no connection has been established yet, and that is the whole
+     * point of taking a [context]. `ThorApplication` initialises once at process start, which on a
+     * first run is *before* the user has authorised Thor in Dhizuku; that bind is refused and
+     * nothing ever retried it, so [DhizukuAPI.isPermissionGranted] answered `false` for the rest of
+     * the process lifetime. The Privilege Check dialog tells the user to grant access and press
+     * **Refresh** — and Refresh re-probes through exactly this function, so without the retry the
+     * documented recovery could not work and only a force-stop would. Observed on an Android 17
+     * device: grant, Refresh, still red; force-stop and relaunch, `active=DHIZUKU`.
+     *
+     * Shizuku needs no equivalent because `PrivilegeManager` owns its binder and
+     * permission-result listeners; Dhizuku 2.6.0 publishes no connection callback to register, so
+     * the retry has to be pulled from the probe rather than pushed from an event.
+     *
+     * Only a successful init is latched, so a failed attempt is retried on the next probe rather
+     * than being remembered as a permanent no.
+     */
+    fun isDhizukuAvailable(context: Context): Boolean {
+        val probe = probeDhizuku(
+            alreadyInitialised = clientInitialised,
+            init = { DhizukuAPI.init(context) },
+            isPermissionGranted = { DhizukuAPI.isPermissionGranted() },
+        )
+        clientInitialised = probe.initialised
+        return probe.available
+    }
+
+    // Written from whichever IO thread probes first and read by every later probe; @Volatile is
+    // for safe publication of that hand-off, not for making the check-then-set atomic. Two probes
+    // racing both call init(), which is idempotent, and both land on the same value.
+    @Volatile
+    private var clientInitialised = false
+
+    /**
+     * Records the outcome of the one-shot init `ThorApplication` runs at process start, so a
+     * successful early bind is not re-attempted on the first probe.
+     */
+    fun markClientInitialised(initialised: Boolean) {
+        clientInitialised = initialised
     }
 
     fun getSystemService(serviceName: String): IBinder? {
@@ -284,22 +366,22 @@ object DhizukuHelper {
         }
     }
 
-    // @Volatile for safe cross-thread publication (getCurrentUserId() may be called from IO
-    // coroutines); only a successfully-resolved id is ever cached (it throws before assigning
-    // on failure), matching the Shizuku/RootSystemGateway pattern (#41/#34).
-    @Volatile
-    private var cachedUserId: String? = null
-
-    fun getCurrentUserId(): String {
-        cachedUserId?.let { return it }
-        val userResult = execute("am get-current-user")
-        val output = userResult.second?.trim()
-        if (userResult.first != 0 || output == null || !output.matches(Regex("^\\d+$"))) {
-            throw IllegalStateException("Failed to determine current user ID: exitCode=${userResult.first}, output=$output")
-        }
-        cachedUserId = output
-        return output
-    }
+    // The user id every `--user` below names is [thorUserId], read in process.
+    //
+    // This helper used to shell out to `am get-current-user` here, and under Dhizuku that could
+    // never work: `DhizukuAPI.newProcess` runs the command inside the **device-owner app**, and
+    // `ActivityManager.getCurrentUser()` requires INTERACT_ACROSS_USERS, which that app does not
+    // hold. Measured on an Android 17 device (Dhizuku at uid 10231):
+    //
+    //   SecurityException: Permission Denial: getCurrentUser() from pid=5209, uid=10231
+    //     requires android.permission.INTERACT_ACROSS_USERS               -> exit 255
+    //
+    // The throw landed before `pm` ever ran, so rung 2 of the system-app freeze, the user-facing
+    // uninstall and unfreeze/reinstall were all dead under Dhizuku — the last one silently, since
+    // reinstallApp swallowed the cause. It predates the rung chain rather than regressing from it.
+    //
+    // Even where the shell call is permitted it answers the wrong question, and no cache is needed
+    // for the answer that replaces it; both reasons are in [thorUserId]'s KDoc.
 
     /**
      * The user-facing "uninstall this app" action: removes [packageName] for the current user
@@ -340,9 +422,12 @@ object DhizukuHelper {
      * useful string in the whole flow, so it is passed back to the caller rather than reduced to
      * false — see [SystemAppRemovalOutcome].
      *
-     * Unverified on hardware: no device with Dhizuku installed was available for this change, so
-     * every claim here about what the device-owner identity is *allowed* to do is inference from
-     * the platform source, not a measurement.
+     * The identity claim above is now **measured**, on an Android 17 device with Dhizuku as device
+     * owner: rung 1 is refused for the device-owner uid while the same `pm disable-user --user 0`
+     * exits 0 at shell uid on that very device, so the refusal belongs to the identity and not to
+     * the platform version. What remains unmeasured is this rung's own answer — the user-id bug
+     * fixed alongside this comment threw before `pm` ever ran, so nothing on that pass reached
+     * `pm uninstall` to find out whether Android 17 replies with the root-only line here too.
      */
     fun freezeSystemAppForUser(packageName: String): SystemAppRemovalOutcome =
         removeForUser(packageName, keepData = true)
@@ -356,7 +441,7 @@ object DhizukuHelper {
      * 0 having changed nothing, and can exit non-zero having done the work).
      */
     private fun removeForUser(packageName: String, keepData: Boolean): SystemAppRemovalOutcome = try {
-        val currentUser = getCurrentUserId()
+        val currentUser = thorUserId
         val keepDataFlag = if (keepData) "-k " else ""
         val (code, output) = execute(
             "pm uninstall $keepDataFlag--user $currentUser ${packageName.escapeForShell()}"
@@ -377,15 +462,31 @@ object DhizukuHelper {
         SystemAppRemovalOutcome(succeeded = false, exitCode = -1, platformMessage = e.message)
     }
 
+    /**
+     * The unfreeze half: restores a package that was removed for this user, data and all where `-k`
+     * kept it.
+     *
+     * Still returns a `Boolean` — the caller re-reads `FLAG_INSTALLED` and reports on *that*, so
+     * there is no message to carry out the way [removeForUser] carries one. But every way this can
+     * answer `false` is now logged with its reason, which is the part that was missing. Measured on
+     * an Android 17 Dhizuku device before the fix, the whole user-visible failure was
+     * `unfreeze(com.android.egg): install-existing reported success=false` — the `SecurityException`
+     * that actually caused it was swallowed by a bare `catch { false }` and appeared nowhere.
+     */
     fun reinstallApp(packageName: String): Boolean {
         return try {
-            val currentUser = getCurrentUserId()
-            execute(
-                "pm install-existing --user $currentUser ${
-                    packageName.escapeForShell()
-                }"
-            ).first == 0
-        } catch (_: Exception) {
+            val (code, output) = execute(
+                "pm install-existing --user $thorUserId ${packageName.escapeForShell()}"
+            )
+            if (code != 0) {
+                Logger.w(
+                    "DhizukuHelper",
+                    "`pm install-existing --user $thorUserId $packageName` exited $code: $output"
+                )
+            }
+            code == 0
+        } catch (e: Exception) {
+            Logger.e("DhizukuHelper", "reinstallApp($packageName) failed", e)
             false
         }
     }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
@@ -12,9 +12,24 @@ import android.os.Process
 import androidx.core.content.getSystemService
 import com.valhalla.bypass.Bypass
 
+/**
+ * The Android user Thor itself runs as — the one every per-package command has to name.
+ *
+ * Read in-process from [Process.myUserHandle]: no shell, no permission, no binder. Both privilege
+ * helpers resolve the user through this one symbol so that a freeze rung and its fallback cannot
+ * name different users; a rung that disables for user 10 followed by a fallback that uninstalls for
+ * user 0 leaves the verify confirming a state nobody set. `SUSPEND_USER_ID` in `RootSystemGateway`
+ * makes the same point from the other direction.
+ *
+ * Deliberately **not** `am get-current-user`, which is what the two helpers used to shell out for.
+ * That reports the *foreground* user — a different number from this one on any work-profile device
+ * — and it is a command Dhizuku's device-owner identity is not permitted to run at all.
+ */
+internal val thorUserId: Int get() = Process.myUserHandle().hashCode()
+
 class Packages(private val app: Context) {
 
-    val myUserId get() = Process.myUserHandle().hashCode()
+    val myUserId get() = thorUserId
 
     fun packageUri(packageName: String) = "package:$packageName"
 

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
@@ -8,24 +8,9 @@ import android.app.AppOpsManager
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import android.os.Process
 import androidx.core.content.getSystemService
 import com.valhalla.bypass.Bypass
-
-/**
- * The Android user Thor itself runs as — the one every per-package command has to name.
- *
- * Read in-process from [Process.myUserHandle]: no shell, no permission, no binder. Both privilege
- * helpers resolve the user through this one symbol so that a freeze rung and its fallback cannot
- * name different users; a rung that disables for user 10 followed by a fallback that uninstalls for
- * user 0 leaves the verify confirming a state nobody set. `SUSPEND_USER_ID` in `RootSystemGateway`
- * makes the same point from the other direction.
- *
- * Deliberately **not** `am get-current-user`, which is what the two helpers used to shell out for.
- * That reports the *foreground* user — a different number from this one on any work-profile device
- * — and it is a command Dhizuku's device-owner identity is not permitted to run at all.
- */
-internal val thorUserId: Int get() = Process.myUserHandle().hashCode()
+import com.valhalla.thor.data.source.local.thorUserId
 
 class Packages(private val app: Context) {
 

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -1004,35 +1004,30 @@ object Shizuku {
         }.getOrElse { false }
     }
 
-    // @Volatile guarantees safe publication across threads: getCurrentUserId() may be invoked from
-    // arbitrary threads, and only a *successfully* resolved id is ever cached (the read throws
-    // before the assignment on failure), so a transient shell blip can't persist a wrong user (#41,
-    // mirrors the RootSystemGateway #34 pattern).
-    @Volatile
-    private var cachedUserId: String? = null
-
-    fun getCurrentUserId(): String {
-        cachedUserId?.let { return it }
-        val userResult = execute("am get-current-user")
-        val output = userResult.second?.trim()
-        if (userResult.first != 0 || output == null || !output.matches(Regex("^\\d+$"))) {
-            throw IllegalStateException("Failed to determine current user ID: exitCode=${userResult.first}, output=$output")
-        }
-        cachedUserId = output
-        return output
-    }
+    // The user id every `--user` below names is [thorUserId], read in process.
+    //
+    // This used to shell out to `am get-current-user` and cache the answer. Nothing was broken at
+    // shell uid — the call is permitted there and returns the same number on a single-user device
+    // — but it answered a different question from the one the disable rungs ask. Those target
+    // `Packages.myUserId`, so on a work-profile device (Thor in profile 10, parent 0 in the
+    // foreground) rung 1 disabled for 10 while the `pm uninstall -k` fallback removed for 0: a
+    // fallback acting on a package the rung it is covering for never touched. Both now resolve
+    // through the one symbol, for the reason its KDoc gives, and the cache goes with the shell
+    // call — [thorUserId] is a process-lifetime constant.
+    //
+    // The same swap on the Dhizuku side fixes an outright failure rather than a latent mismatch;
+    // see the note in DhizukuHelper.
 
     fun uninstallApp(context: Context, packageName: String): Boolean {
         // Escape the package identifier before interpolating it into the shell command, mirroring
-        // the Dhizuku helper (#40). currentUser is regex-validated numeric, so it needs no escaping.
+        // the Dhizuku helper (#40). thorUserId is an Int, so it needs no escaping.
         val escapedPackage = packageName.escapeForShell()
         val normally = Packages(context).canUninstallNormally(packageName)
         if (normally) {
             return execute("pm uninstall $escapedPackage").first == 0
         }
         return try {
-            val currentUser = getCurrentUserId()
-            execute("pm uninstall --user $currentUser $escapedPackage").first == 0
+            execute("pm uninstall --user $thorUserId $escapedPackage").first == 0
         } catch (_: Exception) {
             false
         }
@@ -1098,7 +1093,7 @@ object Shizuku {
      * code is the whole point of this rung's failure; see that class for what dropping it cost.
      */
     fun freezeSystemAppForUser(packageName: String): SystemAppRemovalOutcome = try {
-        val currentUser = getCurrentUserId()
+        val currentUser = thorUserId
         val (code, output) = execute(
             "pm uninstall -k --user $currentUser ${packageName.escapeForShell()}"
         )
@@ -1125,10 +1120,9 @@ object Shizuku {
 
     fun reinstallApp(packageName: String): Boolean {
         return try {
-            val currentUser = getCurrentUserId()
             // Escape the package identifier before interpolating it (#40).
             val escapedPackage = packageName.escapeForShell()
-            execute("pm install-existing --user $currentUser $escapedPackage").first == 0
+            execute("pm install-existing --user $thorUserId $escapedPackage").first == 0
         } catch (_: Exception) {
             false
         }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -9,6 +9,7 @@ import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import com.valhalla.bypass.Bypass
 import com.valhalla.superuser.utils.escapeForShell
+import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
 import com.valhalla.thor.domain.model.canLiftSuspension
 import com.valhalla.thor.domain.model.parseSuspendingPackages
@@ -883,7 +884,7 @@ object Shizuku {
     @SuppressLint("PrivateApi", "SdCardPath")
     fun clearCache(packageName: String): Boolean {
         // 1. Try shell first
-        val userId = android.os.Process.myUserHandle().hashCode()
+        val userId = thorUserId
         val paths = listOf(
             "/data/data/$packageName/cache",
             "/data/user/$userId/$packageName/cache",
@@ -943,7 +944,7 @@ object Shizuku {
                 arrayOf(String::class.java, observerClass, Int::class.javaPrimitiveType!!),
                 packageName,
                 null,
-                android.os.Process.myUserHandle().hashCode()
+                thorUserId
             )
             true
         }.getOrElse { false }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -338,7 +338,7 @@ fun HomeScreen(
             },
             confirmButton = {
                 Button(onClick = {
-                    viewModel.loadDashboardData()
+                    viewModel.refreshPrivileges()
                     showPrivilegeDialog = false
                 }) {
                     Text(stringResource(R.string.refresh))

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -135,6 +135,22 @@ class HomeViewModel(
         }
     }
 
+    /**
+     * What the Privilege Check dialog's **Refresh** does — re-probe the three privilege sources,
+     * then reload the dashboard.
+     *
+     * The dialog says "grant access in your manager app and click Refresh", so the probe is the
+     * part that has to re-run; reloading the app list alone leaves the privilege state at whatever
+     * the cold-start probe found. Shizuku recovered anyway, which is why this went unnoticed —
+     * [PrivilegeManager] owns Shizuku's binder and permission listeners and refreshes itself from
+     * them. Root and Dhizuku publish no such callback, so without this a grant made while Thor is
+     * running stays invisible until the process is killed and relaunched.
+     */
+    fun refreshPrivileges() {
+        privilegeManager.refresh()
+        loadDashboardData()
+    }
+
     fun onTypeChanged(type: AppListType) {
         // The stats derivation (combine over _rawAppData + _selectedType) recomputes reactively;
         // no manual re-processing needed.

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -81,7 +81,7 @@
     <string name="frozen">مجمد</string>
     <string name="suspended">معلق</string>
     <string name="privilege_check">فحص الصلاحيات</string>
-    <string name="privilege_check_desc">يتطلب Thor صلاحيات Root أو Shizuku ليعمل بشكل صحيح.\n\nيرجى منح الصلاحيات في تطبيق الإدارة والنقر فوق تحديث.</string>
+    <string name="privilege_check_desc">يتطلب Thor صلاحيات Root أو Shizuku أو Dhizuku ليعمل بشكل صحيح.\n\nيرجى منح الصلاحيات في تطبيق الإدارة والنقر فوق تحديث.</string>
 
     <!-- App List / Freezer -->
     <string name="system_apps_warning">⚠ تطبيقات النظام</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -81,7 +81,7 @@
     <string name="frozen">Congelado</string>
     <string name="suspended">Suspendido</string>
     <string name="privilege_check">Verificación de privilegios</string>
-    <string name="privilege_check_desc">Thor requiere acceso Root o Shizuku para funcionar correctamente.\n\nPor favor, concede acceso en tu aplicación de gestión y pulsa Actualizar.</string>
+    <string name="privilege_check_desc">Thor requiere acceso Root, Shizuku o Dhizuku para funcionar correctamente.\n\nPor favor, concede acceso en tu aplicación de gestión y pulsa Actualizar.</string>
 
     <!-- App List / Freezer -->
     <string name="system_apps_warning">⚠ Aplicaciones del sistema</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -81,7 +81,7 @@
     <string name="frozen">Gelé</string>
     <string name="suspended">Suspendu</string>
     <string name="privilege_check">Vérification des privilèges</string>
-    <string name="privilege_check_desc">Thor nécessite un accès Root ou Shizuku pour fonctionner correctement.\n\nVeuillez accorder l\'accès dans votre application de gestion et cliquer sur Actualiser.</string>
+    <string name="privilege_check_desc">Thor nécessite un accès Root, Shizuku ou Dhizuku pour fonctionner correctement.\n\nVeuillez accorder l\'accès dans votre application de gestion et cliquer sur Actualiser.</string>
 
     <!-- App List / Freezer -->
     <string name="system_apps_warning">⚠ Applis Système</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -80,7 +80,7 @@
     <string name="active">活跃</string>
     <string name="frozen">已冻结</string>
     <string name="suspended">已暂停</string>
-    <string name="privilege_check_desc">Thor 需要 Root 或 Shizuku 权限才能正常运行。\n\n请在管理应用中授予权限并点击刷新。</string>
+    <string name="privilege_check_desc">Thor 需要 Root、Shizuku 或 Dhizuku 权限才能正常运行。\n\n请在管理应用中授予权限并点击刷新。</string>
 
     <!-- App List / Freezer -->
     <string name="system_apps_warning">⚠ 系统应用</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,7 +83,7 @@
     <string name="frozen">Frozen</string>
     <string name="suspended">Suspended</string>
     <string name="privilege_check">Privilege Check</string>
-    <string name="privilege_check_desc">Thor requires Root or Shizuku access to function correctly.\n\nPlease grant access in your manager app and click Refresh.</string>
+    <string name="privilege_check_desc">Thor requires Root, Shizuku or Dhizuku access to function correctly.\n\nPlease grant access in your manager app and click Refresh.</string>
 
     <!-- App List / Freezer -->
     <string name="system_apps_warning">⚠ System Apps</string>

--- a/app/src/test/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuProbeTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuProbeTest.kt
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local.dhizuku
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * When the Dhizuku availability probe binds the client, and when it declines to bind it again.
+ *
+ * This is the pure half of a bug measured on an Android 17 device with Dhizuku as device owner:
+ * grant Thor access while it is running, press the **Refresh** the Privilege Check dialog tells you
+ * to press, and the chip stays red — only a force-stop and relaunch resolved to `active=DHIZUKU`.
+ * `Dhizuku.init` ran exactly once, in `ThorApplication.onCreate`, which on a first run is *before*
+ * the user has authorised anything; nothing retried it, so every later probe asked an unbound client
+ * whether it had permission and was told `false`. Dhizuku 2.6.0 publishes no connection callback to
+ * register — unlike Shizuku, whose binder and permission listeners `PrivilegeManager` owns — so the
+ * retry has to be pulled from the probe.
+ *
+ * [probeDhizuku] is that retry's decision table with the two `DhizukuAPI` statics passed in, which
+ * is the only reason any of it is reachable from a plain JVM test.
+ */
+class DhizukuProbeTest {
+
+    /** The regression itself: an unbound client is re-bound rather than asked again. */
+    @Test
+    fun `binds when not yet initialised`() {
+        var initCalls = 0
+        val probe = probeDhizuku(
+            alreadyInitialised = false,
+            init = { initCalls++; true },
+            isPermissionGranted = { true },
+        )
+
+        assertEquals("init should have been attempted exactly once", 1, initCalls)
+        assertTrue("a successful bind is latched", probe.initialised)
+        assertTrue(probe.available)
+    }
+
+    /**
+     * The other half. This probe runs on every privilege refresh and behind every privilege chip, so
+     * re-binding whenever it is called would mean a service bind per screen.
+     */
+    @Test
+    fun `does not re-bind once initialised`() {
+        var initCalls = 0
+        val probe = probeDhizuku(
+            alreadyInitialised = true,
+            init = { initCalls++; true },
+            isPermissionGranted = { true },
+        )
+
+        assertEquals("an already-bound client must not be re-bound", 0, initCalls)
+        assertTrue(probe.initialised)
+        assertTrue(probe.available)
+    }
+
+    /**
+     * A refused bind must stay retryable. Latching it would reproduce the original bug one layer
+     * down: the first probe of a first run happens before the user has authorised Thor, so the
+     * answer that gets remembered would be the wrong one, permanently.
+     */
+    @Test
+    fun `a failed bind is not latched`() {
+        val probe = probeDhizuku(
+            alreadyInitialised = false,
+            init = { false },
+            isPermissionGranted = { throw AssertionError("must not be asked while unbound") },
+        )
+
+        assertFalse("a failed bind must not be remembered as a permanent no", probe.initialised)
+        assertFalse(probe.available)
+    }
+
+    /** Same rule when the bind throws rather than returning false — Dhizuku's absence looks like this. */
+    @Test
+    fun `a throwing bind is not latched`() {
+        val probe = probeDhizuku(
+            alreadyInitialised = false,
+            init = { throw IllegalStateException("Dhizuku not installed") },
+            isPermissionGranted = { throw AssertionError("must not be asked while unbound") },
+        )
+
+        assertFalse(probe.initialised)
+        assertFalse(probe.available)
+    }
+
+    /**
+     * Bound but not authorised — the state a user is in between installing Dhizuku and granting
+     * Thor access. `available` is false, but the binding is kept, so the Refresh that follows the
+     * grant is one permission call rather than a re-bind.
+     */
+    @Test
+    fun `bound without permission keeps the binding`() {
+        val probe = probeDhizuku(
+            alreadyInitialised = false,
+            init = { true },
+            isPermissionGranted = { false },
+        )
+
+        assertTrue("the bind succeeded and must be latched", probe.initialised)
+        assertFalse(probe.available)
+    }
+
+    /**
+     * A throw from the permission check costs the authorisation answer and nothing else. The bind
+     * above it already succeeded; forgetting it would make the next probe re-bind an already-bound
+     * client for no gain.
+     */
+    @Test
+    fun `a throwing permission check does not undo the binding`() {
+        val probe = probeDhizuku(
+            alreadyInitialised = false,
+            init = { true },
+            isPermissionGranted = { throw SecurityException("binder died") },
+        )
+
+        assertTrue(probe.initialised)
+        assertFalse("an unreadable grant is not a grant", probe.available)
+    }
+
+    /**
+     * Revocation is visible immediately, because only `initialised` is latched. The user can turn
+     * Thor off in Dhizuku while Thor is running, and the next probe has to say so.
+     */
+    @Test
+    fun `permission is re-read on every probe`() {
+        val probe = probeDhizuku(
+            alreadyInitialised = true,
+            init = { throw AssertionError("must not re-bind") },
+            isPermissionGranted = { false },
+        )
+
+        assertTrue(probe.initialised)
+        assertFalse("a revoked grant must be reported on the very next probe", probe.available)
+    }
+}


### PR DESCRIPTION
Three defects found while device-testing #332's freeze rungs on an Android 17 emulator with Dhizuku as device owner. All three are Dhizuku-facing; one of them (Refresh) also affects root.

## 1 — `am get-current-user` fails under Dhizuku's identity

`DhizukuAPI.newProcess` spawns `pm`/`am` **inside the device-owner app**, not at shell uid, and that identity holds no `INTERACT_ACROSS_USERS`. So `am get-current-user` returned `SecurityException … exit 255` and every `--user`-scoped command died before it ran — including the `pm uninstall -k` fallback #332 had just added.

`removeForUser` and `reinstallApp` now read `Process.myUserHandle().hashCode()` in process (`thorUserId`): no shell, no permission, no binder.

The Shizuku helper moved to the same symbol. Nothing was broken there — the call is permitted at shell uid — but it answered a *different question* from the one the disable rungs ask. Those target `Packages.myUserId`, so on a work-profile device (Thor in profile 10, parent 0 in the foreground) rung 1 disabled for 10 while the fallback removed for 0: a fallback acting on a package the rung it covers for never touched. `RootSystemGateway` deliberately keeps its own shell-based lookup — root runs at uid 0, where the question and the permission both hold.

`reinstallApp` under Dhizuku also swallowed non-zero exits silently; it now logs what `pm` said.

## 2 — the Privilege Check dialog never named Dhizuku

`privilege_check_desc` said "Root or Shizuku" in all five locales, while `privilege_required_warning` right beside it already listed three. Each locale follows its own existing phrasing for the three-way list.

## 3 — Refresh did not refresh privileges

The dialog says *"grant access in your manager app and click Refresh"*. The button called `viewModel.loadDashboardData()`, which reloads the app list and nothing else — `PrivilegeManager.refresh()` had **no call site** outside its own Shizuku listeners.

Shizuku recovered anyway, which is why this went unnoticed: `PrivilegeManager` owns Shizuku's binder and permission listeners and refreshes itself from them. **Root and Dhizuku publish no such callback**, so a grant made while Thor was running stayed invisible until the process was killed and relaunched.

And once the probe *did* re-run, `DhizukuHelper` still latched the `Dhizuku.init` result from `ThorApplication.onCreate` — which on a first run is *before* the user has authorised anything — so every later probe asked an unbound client whether it had permission and was told `false`. Dhizuku 2.6.0 publishes no connection callback to register, so the retry has to be *pulled* from the probe: `probeDhizuku` re-binds whenever the client is not already bound, keeps a successful bind, and re-reads the grant on every probe so a revocation is visible on the very next one.

## Measured

**emulator-5558 — Android 17, Dhizuku device owner, `active=DHIZUKU`**

Freeze `com.android.egg`:

| | message |
|---|---|
| before | *"Android reported: Failed to determine cur…"* — rung 2 threw at `am get-current-user` |
| after | rung 1 refused, rung 2 issued `pm uninstall -k --user 0` and got `Failure [only root can delete system app for a particular user]` → the Root-mode message |

```
E/DhizukuHelper: setAppDisabled(com.android.egg, disabled=true): all rungs ran
  (pm shell, IPackageManager reflection, unprivileged PackageManager) and the
  state did not change — the platform REFUSED (SecurityException)
W/DhizukuSystemGateway: freeze(com.android.egg): this device refuses to let
  Dhizuku's device-owner identity disable system packages; falling back to
  `pm uninstall -k --user N`, which keeps the app's data
W/DhizukuHelper: `pm uninstall -k --user 0 com.android.egg` exited 1:
  Failure [only root can delete system app for a particular user]
```

The `--user 0` in that last line is `thorUserId` resolving in process on real hardware. This is also the hardware answer #332 left open — *"the same on Android 17 where rung 2 should produce the Root-mode message"*: yes.

`com.android.egg` unchanged throughout — `installed=true enabled=0 ceDataInode=549088`, before and after.

Refresh, on the same process (no force-stop, pid 7453 both times):

```
17:24:17  probe total=90ms root=87ms/false shizuku=4ms/false dhizuku=8ms/false
17:24:17  ready sinceProcessStart=564ms active=NONE      <- launched with access revoked
          … access granted in Dhizuku while Thor stays in the background …
17:25:45  probe total=34ms root=3ms/false shizuku=0ms/false dhizuku=32ms/true
```

Chip red → green. The 32 ms is the re-bind doing its job; steady-state was 1–8 ms. Returning to the app did *not* re-probe on its own — the second line appears only after Refresh, which is what makes it evidence.

**emulator-5556 — Android 17, `active=SHIZUKU`** — Fix Store on a user app ran `pm install -r -d -i "com.android.vending" --user $thorUserId …` and moved `installerPackageName` `null` → `com.android.vending`, `versionCode` unchanged. Restored to `null` afterwards.

## Tests

7 new tests pin `probeDhizuku`'s decision table. There is no Robolectric/mockk here and `unitTests.returnDefaultValues` is off, so the two `DhizukuAPI` statics are passed in as lambdas — that seam is the only reason any of this is reachable from a plain JVM test. They cover the two properties the fix rests on: a failed bind stays retryable, and a successful bind is not repeated.

- `:app:testFossDebugUnitTest --rerun-tasks` — **49 classes / 497 tests / 0 failures** (dev baseline 48 / 490)
- `:app:lintFossDebug` — 5 issues, all pre-existing `VectorPath` hints, 0 errors, 0 warnings

Follow-up to #332 (GH#316). No issue closed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Dhizuku support for privilege detection and package management.
  - Privilege checks can now be refreshed directly from the home screen.
  - Improved app operations across the active user profile.

- **Bug Fixes**
  - Dhizuku initialization now retries after failures and preserves successful connections.
  - Improved error reporting for uninstall and reinstall operations.
  - System-app freezing continues to preserve app data.

- **Documentation**
  - Updated Arabic, Chinese, English, French, and Spanish privilege messages to mention Dhizuku.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->