### PR TITLE
chore(release): bump to 1932 and write the v1.93.2 release notes

### DIFF
--- a/docs/follow-ups/telegram-caption-length-guard.md
+++ b/docs/follow-ups/telegram-caption-length-guard.md
@@ -1,0 +1,75 @@
+# Follow-up: assert the Telegram caption length before `sendDocument`
+
+**Status:** open. Raised in review of PR #334 (the v1.93.2 release notes). Deliberately **not**
+fixed there — see "Why not in #334".
+
+## The failure it prevents
+
+Release notes reach Telegram as a `sendDocument` **caption**, not as a message
+(`.github/workflows/telegram-release.yml:146`, `.github/workflows/dev-check.yml:249`). Telegram caps
+captions at **1024 UTF-16 code units** and **rejects** an oversized one outright — it does not
+truncate. The `curl` carries no `--fail` and its output goes to `/dev/null`, so the step exits 0
+having broadcast nothing. Every downstream signal — the job, the check, the release — stays green.
+
+`release-notes/README.md` documents a ~870-unit budget for `telegram.md`, but that is a *manual*
+gate applied to only one input. The value actually sent is `CAPTION`, which is `telegram.md` plus a
+header the workflow builds and, on the release path, a GitHub link footer.
+
+## Measured, for v1.93.2
+
+| | UTF-16 units | headroom to 1024 |
+|---|---|---|
+| `telegram.md` alone | 825 | — |
+| `dev-check.yml` final caption | 974 | 50 |
+| `telegram-release.yml` final caption | 966 | 58 |
+
+Wrapper cost: **149** units on the dev path, **141** on the release path. It is not a constant — the
+dev header interpolates `github.ref_name`, `github.actor` and a track label, so a longer branch name
+or actor pushes it up with nothing to notice.
+
+v1.93.2 ships with 50 units of headroom, and only after two bullets were trimmed to buy it back: a
+one-line accuracy fix in review took the dev caption to 1006 units — 18 from silence — and nothing
+but a hand-run `python3` one-liner said so. v1.93.0's notes were 1008 units *before* any wrapper,
+i.e. already over.
+
+## What to add
+
+After `CAPTION` is fully assembled and before the `curl`, in **both** workflows:
+
+```bash
+CAPTION_UNITS=$(printf '%s' "$CAPTION" | python3 -c \
+  'import sys; t=sys.stdin.read(); print(sum(2 if ord(c) > 0xFFFF else 1 for c in t))')
+if [ "$CAPTION_UNITS" -ge 1024 ]; then
+  echo "::error::Telegram caption is $CAPTION_UNITS UTF-16 units; the cap is 1024. \
+Trim release-notes/v\$VERSION_NAME/telegram.md."
+  exit 1
+fi
+```
+
+## Why not in #334
+
+Two reasons, and the second is the design question that makes this its own change.
+
+1. #334 is a release PR that ships a 988-unit caption on the path the guard would run on. A guard
+   with an off-by-one in its own arithmetic would redden the release it is meant to protect, and the
+   only way to find out is to publish.
+
+2. **Placement is the actual decision, and a naive fix gets it wrong.** In `dev-check.yml` the
+   Telegram step runs *after* fastlane has uploaded to Play and *before* "Create GitHub
+   Pre-Release". A guard there fails loudly — but it fails a release that is already half-published:
+   on Play, absent from GitHub, silent on Telegram. That is arguably worse than the silent skip it
+   replaces.
+
+   The gate belongs **before the build**, as a pre-flight step that reads `versionCode`, derives the
+   version name, reconstructs the caption the later step would send, and fails while nothing has
+   shipped. That step does not exist yet, and inventing it inside a release PR is how a release PR
+   stops being one.
+
+A pre-flight step is also the natural home for the other unchecked size — `playstore.txt` must stay
+under 500 characters and nothing in CI verifies that either. Both belong in the same script.
+
+## See also
+
+* `release-notes/README.md` — trap 1, and Step 6, which is the manual gate this would replace.
+* `.github/scripts/check-shizu-manifest.sh` — the precedent: a script whose every assertion exists
+  to make one silent failure loud, wired into `pr-ci.yml` on every PR.

--- a/fastlane/metadata/android/en-US/changelogs/1932.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1932.txt
@@ -1,0 +1,11 @@
+• 🧊 Freezing a preinstalled app no longer wipes its data — Thor disables it, and keeps the data if it must remove it.
+
+• ❄️ Removing an app from the Freezer unfreezes it first, on every screen — and says so if it can't.
+
+• 📱 Fixed the app list collapsing to one entry on Chinese-market ROMs.
+
+• ⏸️ Thor no longer claims success when it couldn't unsuspend an app.
+
+• 🔄 Privilege Check's Refresh re-checks Root, Shizuku and Dhizuku.
+
+• 💖 New: more ways to support Thor's development.

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ org.gradle.welcome=never
 initialVersionCode=1921
 # REQUIRED: The active source of truth for our release manager
 # Logic: 1822 -> 1.82.2 (based on math: code/1000 . code%1000/10 . code%10)
-versionCode=1931
+versionCode=1932
 # versionName intentionally omitted — auto-calculated from versionCode by the
 # resolveVersionName()/calculateVersionName() helpers in app/build.gradle.kts
 # (1908 -> 1.90.8). Per CLAUDE.md, never set versionName directly; bump versionCode only.

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,71 +1,164 @@
 # 📦 Thor Release Notes Guide
 
-Welcome! This directory contains the official release notes for Thor, structured specifically to be consumed by both developers and automated CI/CD deployment pipelines. 
+This directory holds Thor's official release notes. They are written by hand and consumed by
+automation, so the shape of each file matters as much as its content.
 
-Every release must have its own directory named `v[Version_Name]` (e.g., `v1.92.1`) containing exactly three variants of the changelog to cater to different distribution channels.
-
----
-
-## 🛠️ Automated CI/CD Workflows Integration
-
-These release notes files are parsed automatically during tag-pushed or master-merged CI/CD workflows:
-1. **GitHub Releases Workflow**: Reads `github.md` to automatically construct the body text of the GitHub release draft.
-2. **Google Play Store / Fastlane Workflow**: Extracts `playstore.txt` to populate the `whats_new` localizations for active release tracks.
-3. **Telegram Channel Broadcast Bot**: Reads and formats `telegram.md` as the official broadcast message pushed to the Telegram channel.
+Every release gets a directory named `v<versionName>` (e.g. `v1.93.2`) containing exactly three
+files: `playstore.txt`, `telegram.md`, `github.md`. Two further channels are generated *from* those
+files rather than written separately.
 
 ---
 
-## 📋 The Three Release Note Variants
+## 🗺️ Five channels, three files
 
-For every version folder (e.g. `release-notes/v1.92.1/`), you must create these three files:
-
-### 1️⃣ Google Play Store (`playstore.txt`)
-* **Format**: Spaced plain text.
-* **Size Constraint**: **Must be strictly under 500 characters** (including newlines and spaces).
-* **Styling**: Short, consumer-friendly lines.
-* **Line Breaks**: **MANDATORY**. Leave an empty line between each bullet point to prevent the Play Console and app listings from bunching all text into a single illegible paragraph.
-
-### 2️⃣ Telegram Channel (`telegram.md`)
-* **Format**: Markdown with high-impact, punchy emojis.
-* **Size Constraint**: Short and engaging; highly mobile-optimized. Avoid heavy or long paragraphs.
-* **Line Breaks**: **MANDATORY**. Leave an empty line between each bullet point to prevent Telegram's mobile client from squeezing everything into a tight, dense block.
-
-### 3️⃣ GitHub Releases (`github.md`)
-* **Format**: Full Markdown.
-* **Size Constraint**: No restriction. Extremely detailed.
-* **Content**: Categorize changes clearly (e.g., `🔄 Features`, `🥶 Core Changes`, `🔒 Security`, `🎨 UI/UX`). Include exact Git commit hash references (e.g. `(5f3d34d)`) to maintain open-source accountability and ease of audit.
-
----
-
-## 🔄 Step-by-Step Creation Workflow (For Future Agents & Devs)
-
-When tasked with generating release notes for a new version, follow these steps exactly:
-
-### Step 1: Identify the Last Release Tag
-List existing git tags to find the immediate previous release identifier:
-```bash
-git tag --sort=-v:refname
+```
+release-notes/v<version>/
+├── playstore.txt ──┬─→ Google Play  "What's new"      (fastlane supply, via Fastfile)
+│                   ├─→ F-Droid      fastlane/metadata/android/en-US/changelogs/<versionCode>.txt
+│                   └─→ Shizu Store  shizu_store.json → .changelog
+├── telegram.md ──────→ Telegram broadcast             (sendDocument *caption*)
+└── github.md ────────→ GitHub Release body
 ```
 
-### Step 2: Fetch Git Logs
-Fetch all committed logs from the last tag up to the current `HEAD` of the development branch to see exactly what has changed:
+**`playstore.txt` is the single source for three channels.** All three copies must stay
+byte-identical — the audit in `.github/scripts/check-shizu-manifest.sh` compares them and the
+F-Droid build reads its own copy from `fastlane/`. Write the text once, then propagate it (Step 5).
+
+Who reads what, exactly:
+
+| File | Consumer | Where |
+|---|---|---|
+| `github.md` | GitHub Release body | `dev-check.yml:166`, `production-deploy.yml:159` |
+| `telegram.md` | Telegram broadcast caption | `dev-check.yml:192`, `telegram-release.yml:84` |
+| `playstore.txt` | Play `whats_new`; copied to `fastlane/…/changelogs/<versionCode>.txt` | `fastlane/Fastfile:89-113` |
+| `fastlane/…/changelogs/<versionCode>.txt` | F-Droid changelog | the F-Droid builder reads the repo directly |
+| `shizu_store.json` → `.changelog` | Shizu CoreFetch store listing | `.github/scripts/sync-shizu-changelog.sh` |
+
+Both CI paths fall back from `release-notes/v<version>/` to `release-notes/<version>/` (no `v`).
+Use the `v` form; the fallback exists only for old directories.
+
+---
+
+## 📋 The three files
+
+### 1️⃣ `playstore.txt` — Google Play, F-Droid, Shizu Store
+
+* **Format**: plain text. Bullets start with `• ` and lead with an emoji.
+* **Size**: **strictly under 500 characters**, counting newlines and spaces. Play rejects more.
+  Aim for 440–490 so a late edit does not push it over.
+* **Line breaks**: **MANDATORY** blank line between bullets. Without them the Play Console and the
+  store listing bunch everything into one illegible paragraph.
+* **Voice**: consumer language. No PR numbers, no file paths, no internal vocabulary
+  (*gateway*, *rung*, *probe*, *binder*, *reflection*, class names). Describe what changed for the
+  person holding the phone.
+* Because this text is reused verbatim by F-Droid and the Shizu Store, it has to read well with no
+  surrounding context.
+
+### 2️⃣ `telegram.md` — the broadcast
+
+* **Format**: punchy markdown, emoji-led bullets, mobile-first.
+* **Size**: **under ~870 UTF-16 code units.** ⚠️ **Exceeding this fails silently — see the trap
+  below.** Measure UTF-16 units, not characters: most emoji count as **2**.
+* **Line breaks**: **MANDATORY** blank line between bullets, or Telegram's mobile client squeezes
+  the whole thing into a dense block.
+
+### 3️⃣ `github.md` — the audit trail
+
+* **Format**: full markdown, no size limit, as detailed as the release deserves.
+* **Content**: `## ✨ Highlights`, then `## What's Changed` with one `###` section per theme
+  carrying PR numbers, then `## 🛠 Build & Dependencies`, then a commits log.
+* Include real short commit hashes (e.g. `(5f3d34d)`) — this file is the open-source accountability
+  record. Internal work (docs, CI, tests) belongs here too, in a lower section.
+
+---
+
+## ⚠️ Traps that have already cost a release
+
+**1. An oversized `telegram.md` posts NOTHING, and CI still goes green.**
+The notes are sent as a `sendDocument` **caption** (`telegram-release.yml:146`,
+`dev-check.yml:252`), not as a message. Telegram caps captions at **1024 UTF-16 units** and
+**rejects** an oversized one outright — it does not truncate. The `curl` has no `--fail` and its
+output is discarded, so the step succeeds having broadcast nothing. The workflow prepends a header
+and appends a GitHub-link footer worth roughly **140 units**, which is where the ~870 budget comes
+from. For reference: v1.93.1 was 695 units (fine); v1.93.0 was 1008 (**already over the budget when
+it shipped**).
+
+**2. Baseline the commit range on the last release TAG, not on `master`.**
+`master` runs ahead of its own release tag, so `master..dev` undercounts. Use the newest tag by
+*creation date* — including `-dev-N` pre-release tags, which are real releases for this purpose.
+
+**3. Do not write GitHub closing keywords into the notes.**
+`master` is the default branch, so a `dev` → `master` PR body **does** trigger auto-close. Any
+`closes #N` / `fixes #N` / `resolves #N` (and `-es`/`-ed` forms) will close that issue the moment
+the release merges. `part of #N` and `completes #N` are safe. Grep before opening the PR:
 ```bash
-git log <last-release-tag>..HEAD --oneline
+grep -nEi '(close[sd]?|fix(e[sd])?|resolve[sd]?) +#[0-9]+' release-notes/v<version>/*
 ```
 
-### Step 3: Categorize and Synthesize
-Map the raw commits into the three variants outlined above:
-* Group commits by functional area.
-* Extract consumer-facing highlights for `playstore.txt`.
-* Draft engaging, emoji-rich summaries for `telegram.md` (remembering the spaced lines).
-* Write the detailed commit-linked breakdown for `github.md`.
+**4. `shizu_store.json` must never gain `version_name` or `version_code`.**
+The store reads those from the GitHub release, and no workflow can push to `master` to keep them
+current — a stale pair there would misreport the current version forever. `check-shizu-manifest.sh`
+fails the build if either key appears.
 
-### Step 4: Write and Stage Files
-Create the directory and write the files:
-* Path: `release-notes/v[New_Version]/`
-* Files: `playstore.txt`, `telegram.md`, `github.md`
+---
 
-Stage the files cleanly to the index:
+## 🔄 Step-by-step
+
+### Step 1 — Find the baseline tag
 ```bash
-git add release-notes/v[New_Version]/
+git tag --sort=-creatordate | head -5
+gh release list --limit 10   # confirms which of those were pre-releases
+```
+
+### Step 2 — Read the range
+```bash
+BASE=<that tag>
+git log $BASE..dev --no-merges --format='%h %s' --reverse
+git log $BASE..dev --merges --format='%h %s'          # the PR list
+git diff --stat $BASE..dev
+```
+
+### Step 3 — Bump the version
+Edit **`versionCode` in `gradle.properties` only** — `versionName` is derived
+(`1932` → `1.93.2`) and must never be set by hand. The bump and the notes belong in the
+**same commit**.
+
+### Step 4 — Write the three files
+Sort every change into *user-visible*, *project-visible* and *internal* first. A commit prefixed
+`fix(` that only touched comments or KDoc is **internal** — check the diff, not the subject. Users
+should never be told about dependency bumps or documentation.
+
+```
+release-notes/v<version>/{playstore.txt,telegram.md,github.md}
+```
+
+### Step 5 — Propagate `playstore.txt` to the other two channels
+```bash
+cp release-notes/v<version>/playstore.txt \
+   fastlane/metadata/android/en-US/changelogs/<versionCode>.txt   # F-Droid + Play
+.github/scripts/sync-shizu-changelog.sh                          # Shizu Store manifest
+```
+`sync-shizu-changelog.sh` reads `versionCode` from `gradle.properties`, derives the version name,
+and writes `playstore.txt` into `shizu_store.json`'s `changelog` with `jq`. Run it **after** Step 3
+or it will look for the wrong directory. CI never runs it: the `master` ruleset requires a PR and a
+status check, and a `GITHUB_TOKEN`-authored PR does not trigger `pull_request` workflows, so no bot
+can land that commit.
+
+### Step 6 — Verify before committing
+```bash
+# sizes
+wc -m release-notes/v<version>/playstore.txt            # must be < 500
+python3 -c "t=open('release-notes/v<version>/telegram.md',encoding='utf-8').read(); \
+print(sum(2 if ord(c)>0xFFFF else 1 for c in t))"       # must be < ~870
+
+# the three copies agree, and the manifest still describes reality
+diff release-notes/v<version>/playstore.txt fastlane/metadata/android/en-US/changelogs/<versionCode>.txt
+.github/scripts/check-shizu-manifest.sh                 # add --network for the URL tier
+```
+
+### Step 7 — Stage explicitly
+```bash
+git add release-notes/v<version>/ \
+        fastlane/metadata/android/en-US/changelogs/<versionCode>.txt \
+        shizu_store.json gradle.properties
 ```

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -21,8 +21,15 @@ release-notes/v<version>/
 ```
 
 **`playstore.txt` is the single source for three channels.** All three copies must stay
-byte-identical — the audit in `.github/scripts/check-shizu-manifest.sh` compares them and the
-F-Droid build reads its own copy from `fastlane/`. Write the text once, then propagate it (Step 5).
+byte-identical, because each consumer reads its own copy: F-Droid reads `fastlane/`, the Shizu store
+reads `shizu_store.json`. Write the text once, then propagate it (Step 5).
+
+Only one of those copies is audited. `.github/scripts/check-shizu-manifest.sh` compares
+`shizu_store.json`'s `.changelog` against `playstore.txt`, and `pr-ci.yml:82` runs it on **every**
+PR — deliberately un-path-filtered, since `on.pull_request.paths` would gate the whole workflow
+including the required `build-and-test` check. So a forgotten `sync-shizu-changelog.sh` is a red
+`shizu-manifest` check, not a silent store regression. The **`fastlane/` copy is checked by
+nothing** — the `diff` in Step 6 is its only gate, which is why Step 6 is not optional.
 
 Who reads what, exactly:
 
@@ -58,7 +65,10 @@ Use the `v` form; the fallback exists only for old directories.
 
 * **Format**: punchy markdown, emoji-led bullets, mobile-first.
 * **Size**: **under ~870 UTF-16 code units.** ⚠️ **Exceeding this fails silently — see the trap
-  below.** Measure UTF-16 units, not characters: most emoji count as **2**.
+  below.** Measure UTF-16 units, not characters: most emoji count as **2**. The budget is the 1024
+  cap minus the wrapper the workflow adds, measured at **149** units (`dev-check.yml`, the longer of
+  the two) and **141** (`telegram-release.yml`) for v1.93.2. The wrapper is not fixed — it carries
+  the branch name, the actor and the track label — so keep the margin.
 * **Line breaks**: **MANDATORY** blank line between bullets, or Telegram's mobile client squeezes
   the whole thing into a dense block.
 
@@ -66,7 +76,9 @@ Use the `v` form; the fallback exists only for old directories.
 
 * **Format**: full markdown, no size limit, as detailed as the release deserves.
 * **Content**: `## ✨ Highlights`, then `## What's Changed` with one `###` section per theme
-  carrying PR numbers, then `## 🛠 Build & Dependencies`, then a commits log.
+  carrying PR numbers, then a project/internal section for the work users never see (name it for
+  what the release actually contained — v1.93.2 used `## 🌐 Project: the site, the stores, the
+  build`), then `## 🛠 Commits Log`.
 * Include real short commit hashes (e.g. `(5f3d34d)`) — this file is the open-source accountability
   record. Internal work (docs, CI, tests) belongs here too, in a lower section.
 
@@ -140,11 +152,19 @@ cp release-notes/v<version>/playstore.txt \
 ```
 `sync-shizu-changelog.sh` reads `versionCode` from `gradle.properties`, derives the version name,
 and writes `playstore.txt` into `shizu_store.json`'s `changelog` with `jq`. Run it **after** Step 3
-or it will look for the wrong directory. CI never runs it: the `master` ruleset requires a PR and a
-status check, and a `GITHUB_TOKEN`-authored PR does not trigger `pull_request` workflows, so no bot
-can land that commit.
+or it will look for the wrong directory. CI never runs *this* script: the `master` ruleset requires
+a PR and a status check, and a `GITHUB_TOKEN`-authored PR does not trigger `pull_request` workflows,
+so no bot can land that commit. Do not read that as "nothing checks the result" — its counterpart
+`check-shizu-manifest.sh` runs on every PR (see the note under the diagram above).
+
+The `cp` writes a **trailing newline** the manifest does not carry: `jq` stores the changelog
+stripped, by design, so `check-shizu-manifest.sh` passing while a naive byte comparison of the two
+says "different" is the expected state, not a defect.
 
 ### Step 6 — Verify before committing
+Nothing in CI checks either size, so this step is the only gate on both — see
+`docs/follow-ups/telegram-caption-length-guard.md` for why the Telegram one is not yet automated.
+
 ```bash
 # sizes
 wc -m release-notes/v<version>/playstore.txt            # must be < 500

--- a/release-notes/v1.93.2/github.md
+++ b/release-notes/v1.93.2/github.md
@@ -1,0 +1,260 @@
+# Thor v1.93.2 Release Notes
+
+A **data-safety and correctness** release on top of the v1.93.1 pre-release. The headline is that
+**freezing a preinstalled app no longer destroys its data** — under any privilege mode — and that
+the paths which used to report a success they never checked now read the platform back and tell you
+what actually happened.
+
+> **Pre-release.** v1.93.2 is a dev build, like v1.93.1 was. The current **stable** release is still
+> **v1.93.0**.
+
+*100 commits and 28 merged pull requests since `v1.93.1-dev-103`. Roughly two thirds of them are the
+new marketing site, documentation and CI; the app changes are below.*
+
+## ✨ Highlights
+
+* 🧊 **A system-app freeze keeps the app's data** — disable first, and a `-k` removal only where the
+  platform actually refused (#314, #332, for GH#316).
+* ⚠️ **A freeze Thor cannot perform now fails and says why**, instead of quietly uninstalling the app
+  for your user (#314, #332).
+* 📱 **The app list no longer collapses to a single entry** on Chinese-market ROMs (#329).
+* ❄️ **Removing an app from the Freezer really unfreezes it**, from every screen that can remove it
+  (#308, #331, for GH#310).
+* ⏸️ **Unsuspend stops reporting a success it never earned**, and names the privilege still holding
+  the app (#330).
+* 🤖 **Dhizuku is usable on a device**, and the Privilege Check dialog's Refresh actually re-probes
+  privileges (#333).
+* 💜 **GitHub Sponsors** in the Support sheet (#311).
+
+## What's Changed
+
+### 🧊 System-app freeze: disable first, `-k` second (#314, #332 — for GH#316)
+
+* Every build before this one ran `pm uninstall --user N` with **no `-k`** as the first and only
+  mechanic, on every privilege mode. The package was removed for the current user and `installd`
+  destroyed `/data/user/N/<pkg>`, so unfreezing brought the app back factory-fresh — logins,
+  settings and local content gone — while the UI reported an ordinary, reversible freeze
+  (`b59c1f64`).
+* **Rung 1 is now a disable.** Root runs `pm disable --user N`; Shizuku tries
+  `IPackageManager.setApplicationEnabledSetting` through `:bypass`, then `pm disable-user --user N`,
+  then the unprivileged `PackageManager`. Every rung is judged by re-reading `ApplicationInfo`, not
+  by a shell exit code — `pm` prints `Success` for a no-op (`b59c1f64`).
+* **Rung 2 keeps the data.** The uninstall fallback now carries `-k` (`DELETE_KEEP_DATA`). Measured
+  on the HyperOS device this fallback exists for: `pm uninstall -k --user 0` then
+  `pm install-existing --user 0` returned byte-identical `ceDataInode` and `deDataInode`
+  (`cf739fc0`). A later pass measured that runtime permission grants survive the round trip too, at
+  uid 2000 on a stock API 36 emulator — one permission, one build, recorded for the scope it has
+  (`4524387d`). What the rung still costs unconditionally is `FLAG_INSTALLED`, which is why every
+  query on the freeze path passes `MATCH_UNINSTALLED_PACKAGES`.
+* **Rung 2 is gated on a refusal, not on an Android version.** The first cut of the gate was
+  `sdkInt >= 36`; measurement killed it. `pm disable-user --user 0` at uid 2000 succeeds on stock
+  API 36 *and* API 37, AOSP's shell guard in `PackageManagerService.setEnabledSettings` is
+  byte-identical across android14- through android16-qpr2-release, and the refusal users actually
+  hit is Xiaomi's vendor `PackageManagerServiceImpl.shouldRestrictEnabledSettingsChange` — first
+  reported on HyperOS running **Android 14**, a year before Android 16 shipped. Reproduced on
+  `25053PC47G`, HyperOS OS3.0, build `BP2A.250605.031.A3` (`6ebdaa17`).
+* ⚠️ **Behaviour change: a freeze can now fail where it used to "work".** `uninstallFreezeFallbackAllowed`
+  returns `false` for `PrivilegeMode.ROOT`, so a root user on a ROM that protects the package now
+  sees *"Root freeze of X failed"* where the old build "succeeded" by removing the app for the user.
+  A non-zero exit, a binder timeout or an unreadable read never counts as a refusal — only a real
+  `SecurityException` does (`6ebdaa17`).
+* **The fallback does not exist at shell uid on Android 17.** The identical command that succeeds on
+  API 36 answers `Failure [only root can delete system app for a particular user]` on API 37
+  (`CP31.260623.005`). The package is left untouched, so the chain ends in an honest failure, and
+  Shizuku users get a new dialog (`freeze_system_app_requires_root`) naming Thor's Root mode instead
+  of the old, wrong *"reflection is blocked or shell lacks permissions"* (`4524387d`, `af37e1f4`).
+* **Dhizuku joined the chain.** #314 deliberately left the Dhizuku gateway on the old unconditional
+  uninstall; #332 converted it. Dhizuku now tries `setApplicationEnabledSetting` through the device
+  owner, then `pm disable-user`, then `pm uninstall -k` — and hardware testing found that PMS
+  **refuses rung 1 for the device-owner identity** where the shell uid succeeds on the same device
+  (`af37e1f4`, `c997124e`).
+* **Unfreeze learned both shapes.** Every system app frozen by v1.93.1 or earlier is
+  uninstalled-for-user, and a package can be disabled *and* uninstalled at once. Unfreeze now runs
+  `install-existing` → `enable` in that order and verifies the end state is installed **and**
+  enabled; the old root path ran `pm enable` first and skipped it entirely for an uninstalled
+  package, so such an app stayed disabled after "unfreeze" (`b59c1f64`, `af37e1f4`).
+* **Extensions no longer bypass the freeze-tier gate.** `ExtensionOpsProvider` handed each
+  extension-supplied package to the raw `ManageAppUseCase.setAppDisabled`, whose own KDoc says it
+  carries no `FreezeTier` check — while `FreezeAppUseCase`'s KDoc already named "an extension
+  trigger" as the caller it exists to backstop. Signature attestation does not close this: a
+  legitimately pinned extension still supplies an arbitrary package list, and freezing a
+  UAD-"Unsafe" system app can leave the device unable to boot. Unfreeze deliberately stays on
+  `forceUnfreeze` — a block there would trap the app it protects (`f48c2874`).
+* **Freezing acted on the wrong user in a work profile or Second Space.** `am get-current-user`
+  returns the *foreground* user, not the user Thor runs as, so rung 1 disabled the app for the
+  profile while the `-k` fallback removed it for the parent. Both paths now read
+  `Process.myUserHandle()` in process — `thorUserId`: no shell, no permission, no binder
+  (`86dd7afa`, `0bbf9e96`).
+* **Two visible UI changes you will notice on first launch.** The Freezer's *"you have disabled apps
+  that aren't in the Freezer — import them?"* prompt lost its blanket `!isSystem` filter
+  (`disabledAppsNotInFreezer`), so system apps Thor itself froze are now offered — BLOCKED-tier
+  packages excluded. And the app list/grid badge is unified: a system app frozen by removal used to
+  draw a red "Uninstalled" danger icon and now shows the same Frozen snowflake as any other frozen
+  app (the `cd_uninstalled` string was removed from all five locales) (`b59c1f64`).
+
+### 📱 The app list collapsing to one entry (#329)
+
+* **Cause:** `com.android.permission.GET_INSTALLED_APPS`, a non-AOSP runtime permission from
+  T/TAF 108-2022 that MIUI/HyperOS, ColorOS, OriginOS and MagicOS implement as three-state
+  (allow / while-in-use / deny) **in addition to** `QUERY_ALL_PACKAGES`. Granted *"while in use"* —
+  which is what those ROMs default to — `getInstalledPackages()` empties the moment Thor is
+  backgrounded, and the cache prune then deleted the Room rows **and the cached icon PNGs** under
+  `filesDir/app_icons/` for nearly every app on the device (`6c010067`).
+* **New permission declared in the manifest:** `com.android.permission.GET_INSTALLED_APPS`.
+  `QUERY_ALL_PACKAGES` is untouched and still required. On AOSP the declaration is a silent no-op —
+  the permission is not defined there.
+* `scanVerdict()` in `domain/model/InstalledAppsVisibility.kt` refuses to prune against a scan it
+  cannot believe — empty, missing the platform package `android`, more than half the cache lost, or
+  a permission gate that explains the loss — and `AppRepositoryImpl` re-emits the cached rows so the
+  UI still shows them. Only with no permission gate to explain it does `SUSPECT_SCAN_TOLERANCE = 2`
+  apply.
+* A **Grant** banner appears on the Apps tab while the permission reads `Denied`, and only on a
+  device that actually defines it — probed with `getPermissionInfo`, not with
+  `shouldShowRequestPermissionRationale`, which returns a hard `false` for a ROM-undefined
+  permission and would have nagged every Pixel forever. A transient probe failure is no longer
+  cached as "unsupported" (`1128ed84`).
+
+### ⏸️ Unsuspend and suspension ownership (#330)
+
+* Android records *who* suspended a package, and from API 30 only that identity may lift it. The
+  platform API returns an **empty failure array** when it removes nothing — which every caller read
+  as total success. Thor's suspender identity is not stable across modes: root records
+  `com.valhalla.thor`, Shizuku/Dhizuku record `com.android.shell`, a device owner records `android`,
+  and pre-GH#239 builds recorded the literal string `root` (`3124b93b`).
+* `parseSuspendingPackages()` reads the owner set out of `dumpsys package <pkg>`, handling all four
+  line shapes including API 35+'s `<0>com.android.shell` prefix. An unreadable dump **fails closed**
+  — never as "nothing to do". 17 parser unit tests.
+* Root issues one removal per recorded owner, under that owner's name, and reads the record back —
+  `PackageManagerService.enforceCanSetPackagesSuspendedAsUser` unconditionally early-returns for
+  `Process.ROOT_UID` before any suspender-name validation, unchanged from API 28 to main. Shell is
+  not exempt, so this rescue path exists in the root daemon and nowhere else. A shell-uid Shizuku
+  facing a root-recorded suspension on API 30+ now says so and names the owner instead of returning
+  success.
+* Two methods were **appended** — never inserted — to `IThorRootService` (`setAppSuspendedAs`,
+  `dumpPackage`), with the interface's new class KDoc explaining why: AIDL derives transaction codes
+  from declaration order, and a root daemon outlives the app update that started it. A stale daemon
+  reads back an empty parcel, which fails closed.
+* ⚠️ Implemented and unit-tested, but **not yet verified on a device** — see
+  `docs/follow-ups/cross-privilege-suspend-ownership.md`.
+
+### ❄️ Freezer removal (#308, #331 — for GH#310)
+
+* All three surfaces that can drop an app from the watchlist — the Freezer screen, the Apps tab and
+  the app-info sheet — now **restore first and delete the row only on success**. Previously only
+  `FreezerViewModel` restored at all, and even it discarded the `Result` and reported success
+  unconditionally; from the Apps tab and the sheet the row was deleted while the app stayed disabled
+  or suspended, which stranded it out of reach of Unfreeze-all (`9d5eb970`, `1a5e5f13`, `445b63a3`).
+* **Bulk removal counts what actually left.** A single failure shows the gateway's own words — which
+  after #330 name the privilege still holding the app — and a partial run gets a new
+  `removed_from_freezer_partial_failure` string, translated into all five locales. Failed apps keep
+  their watchlist rows and stay selected, so a retry is one more tap (`445b63a3`).
+* **The manage-sheet switch stopped planning from a stale snapshot.** It restored using flags from
+  `allInstalledApps`, which the suspend-freeze path never patches, so switching an app on and
+  straight back off planned nothing, made zero privileged calls, deleted the row and left the app
+  suspended. Both watchlist-removal paths now call `forceUnfreeze` unconditionally (`445b63a3`).
+* **Crash fix:** a throw out of the Room delete or `ShortcutManagerCompat` took the process — `:app`
+  installs no `CoroutineExceptionHandler`, so an escaping throw was not a toast. Both branches of
+  `toggleManaged` are now guarded, with `CancellationException` rethrown first (`41eda1d9`).
+
+### 🤖 Privilege UX (#333)
+
+* **Refresh never re-probed privileges.** `PrivilegeManager.refresh()` had **zero call sites**; the
+  Privilege Check dialog's confirm button called `loadDashboardData()`, which reloads the app list
+  and nothing else. It looked Dhizuku-only because `PrivilegeManager` owns Shizuku's binder and
+  permission listeners and self-heals — root and Dhizuku publish no such callback, so a grant made
+  while Thor was running stayed invisible until the process was killed. When one privilege mode
+  alone looks broken, the other modes may be hiding a shared defect (`86dd7afa`).
+* **Dhizuku re-binds from the probe.** `DhizukuHelper` latched the `Dhizuku.init` result from
+  `ThorApplication.onCreate` — on a first run, before the user had authorised anything — so every
+  later probe asked an unbound client whether it had permission. Dhizuku 2.6.0 publishes no
+  connection callback, so the retry is *pulled* from `probeDhizuku`, which keeps a successful bind
+  and re-reads the grant each time so a revocation shows up at once (`86dd7afa`, 7 new tests).
+* `am get-current-user` is denied to the device-owner identity (no `INTERACT_ACROSS_USERS`), which
+  killed every `--user`-scoped Dhizuku command before it ran. Replaced with the in-process
+  `thorUserId`, device-proven to resolve to 0 (`86dd7afa`); moved to
+  `data/source/local/ThorUser.kt` so the Dhizuku package does not depend on the Shizuku one
+  (`0bbf9e96`).
+* The Privilege Check dialog now **names Dhizuku**, in all five locales — `privilege_check_desc` said
+  "Root or Shizuku" while the warning string beside it already listed three (`86dd7afa`).
+* Verified on `emulator-5558` (Android 17, Dhizuku device owner). Rung 2's hardware answer, which
+  #332 had left open: `pm uninstall -k --user 0 com.android.egg` →
+  `Failure [only root can delete system app for a particular user]`, package untouched
+  (`b7eda9c0`).
+
+### 💜 Support (#311)
+
+* GitHub Sponsors is offered in the Support Developer sheet, on both the FOSS and store flavours
+  (`b150c151`, `4b197ced`).
+
+## 🌐 Project: the site, the stores, the build
+
+* **Thor has a website** — <https://thor.trinadhthatakula.com>, an Astro static site under `web/`
+  (#313, #319). Deployment went through three iterations before it worked: a GitHub Actions job via
+  the Vercel CLI (#321), a correction pass on those instructions (#322), then the discovery that the
+  project had been imported from the Vercel portal and therefore deploys from **Vercel's own Git
+  integration** — blocked all along by `git.deploymentEnabled: false` committed in both
+  `vercel.json` files (#327, #328). Branch model: **`master` publishes, `dev` stages** (#323).
+* **Play uploads moved up one track** — the `master` lane now goes to Closed testing and the
+  `production` lane to Open testing, with a hardened track guard (#320, `977bb95a`, `53752885`).
+* **F-Droid preparation** (#309): a fresh clone with no signing keys can build a release APK again,
+  an F-Droid submission guide was added, and the changelog directory gets a "What's New" entry for
+  the first time since v1.60.0 (`9a9e4426`, `6035f373`). Thor is **not** on F-Droid yet and cannot be
+  submitted until a stable release lands.
+* **`:vm-runtime` aligned to Java 21** (#307), which stops the IDE rewriting `.idea/compiler.xml` on
+  every sync — one project gets one language level, so the lowest module wins.
+* Documentation: the cold-start contention measurements (#305, #306), a stale freeze-mechanic
+  comment corrected (#318), root freeze comments (#315), and `docs/site-content/` excluded from git
+  (#312).
+* Dependabot: GitHub Actions and npm bumps (#304, #317, #324, #325).
+* **Unit tests: 376 → 497**, 0 failures. Lint stays an enforced gate.
+
+## 🛠 Commits Log (`v1.93.1-dev-103...HEAD`)
+
+**Merged pull requests**
+
+* `38f6effa` — #333 Dhizuku user id, re-init and Refresh
+* `c997124e` — #332 Dhizuku freeze rungs
+* `a78b2255` — #331 freezer bulk removal failures
+* `9f487d3a` — #330 suspend ownership readback
+* `2aaa45f3` — #329 installed-apps visibility on Chinese-market ROMs
+* `8035db3e` — #328 web: system-environment behaviour confirmed
+* `17008c7c` — #327 Vercel Git auto-deploy
+* `42630d54` — #326 dev/master sync
+* `61ca876b` — #325 Dependabot: GitHub Actions
+* `ff7681e3` — #324 Dependabot: npm (web)
+* `0f255e21` — #323 web on master
+* `7dca86f3` — #322 web deploy corrections
+* `23bad00a` — #321 web deploy from Actions
+* `7adb5955` — #320 Play tracks moved up one
+* `1f418e95` — #319 the landing page
+* `015f0831` — #318 stale freeze-mechanic doc
+* `7bd109e9` — #317 Dependabot: GitHub Actions
+* `99eb889b` — #315 root freeze comments
+* `d8137191` — #314 system-app disable chain
+* `bfa6df75` — #313 landing page design spec
+* `ddebf315` — #312 ignore site-content drafts
+* `4b197ced` — #311 GitHub Sponsors in-app
+* `daaea68e` — #309 F-Droid preparation
+* `c8c0502a` — #308 freezer removal restores the app
+* `8c34824e` — #307 `:vm-runtime` JVM target 21
+* `ded1039a` — #306 cold-start contention
+* `1b60fbeb` — #305 cold-start config 1 measured
+* `ec49853e` — #304 Dependabot: GitHub Actions
+
+**Key commits**
+
+* `b59c1f64` fix(freezer): freeze system apps by disabling them, not by uninstalling
+* `cf739fc0` fix(freezer): keep app data on the uninstall fallback with `pm uninstall -k`
+* `6ebdaa17` fix(freezer): gate the destructive freeze on refusal, not on Android 16
+* `4524387d` fix(freezer): correct the `-k` permission claim and record the API 37 limit
+* `f48c2874` fix(extensions): route extension freezes through the FreezeTier gate
+* `af37e1f4` fix(freezer): freeze preinstalled apps by disabling, not by uninstalling (Dhizuku)
+* `86dd7afa` / `0bbf9e96` fix(privilege): make Dhizuku usable on device — user id, re-init, Refresh
+* `3124b93b` fix(suspend): stop reporting success when an unsuspend removed nothing
+* `9d5eb970` / `1a5e5f13` fix(freezer): removing an app from the watchlist always restores it
+* `445b63a3` fix(freezer): stop bulk removal reporting a success it never checked
+* `41eda1d9` fix(freezer): guard `toggleManaged`'s durable steps against a throw
+* `6c010067` / `1128ed84` fix(apps): keep the app list intact when a ROM revokes package visibility
+* `b150c151` feat(support): offer GitHub Sponsors alongside Patreon and PayPal
+* `9a9e4426` chore(build): let a keystore-less clone build a release, and add the F-Droid guide
+* `977bb95a` / `53752885` chore(ci): move both Play uploads up one track

--- a/release-notes/v1.93.2/github.md
+++ b/release-notes/v1.93.2/github.md
@@ -41,8 +41,10 @@ new marketing site, documentation and CI; the app changes are below.*
   by a shell exit code — `pm` prints `Success` for a no-op (`b59c1f64`).
 * **Rung 2 keeps the data.** The uninstall fallback now carries `-k` (`DELETE_KEEP_DATA`). Measured
   on the HyperOS device this fallback exists for: `pm uninstall -k --user 0` then
-  `pm install-existing --user 0` returned byte-identical `ceDataInode` and `deDataInode`
-  (`cf739fc0`). A later pass measured that runtime permission grants survive the round trip too, at
+  `pm install-existing --user 0` returned **unchanged** `ceDataInode` and `deDataInode` values, so
+  the CE and DE data directories were never recreated — which is exactly what `DELETE_KEEP_DATA`
+  promises. The bytes inside them were not compared; the inodes were (`cf739fc0`). A later pass
+  measured that runtime permission grants survive the round trip too, at
   uid 2000 on a stock API 36 emulator — one permission, one build, recorded for the scope it has
   (`4524387d`). What the rung still costs unconditionally is `FLAG_INSTALLED`, which is why every
   query on the freeze path passes `MATCH_UNINSTALLED_PACKAGES`.

--- a/release-notes/v1.93.2/playstore.txt
+++ b/release-notes/v1.93.2/playstore.txt
@@ -1,0 +1,11 @@
+• 🧊 Freezing a preinstalled app no longer wipes its data — Thor disables it, and keeps the data if it must remove it.
+
+• ❄️ Removing an app from the Freezer unfreezes it first, on every screen — and says so if it can't.
+
+• 📱 Fixed the app list collapsing to one entry on Chinese-market ROMs.
+
+• ⏸️ Thor no longer claims success when it couldn't unsuspend an app.
+
+• 🔄 Privilege Check's Refresh re-checks Root, Shizuku and Dhizuku.
+
+• 💖 New: more ways to support Thor's development.

--- a/release-notes/v1.93.2/telegram.md
+++ b/release-notes/v1.93.2/telegram.md
@@ -1,0 +1,19 @@
+🚀 **Thor v1.93.2 — a much safer freeze.**
+
+**Fixed:**
+
+• 🧊 **Freezing a preinstalled app no longer wipes its data.** Thor disables it in place; if your phone refuses, it removes the app but keeps the data.
+
+• ⚠️ **A freeze Thor can't do now fails and says why**, instead of quietly uninstalling.
+
+• 📋 **App list shrinking to one entry** on MIUI/HyperOS and similar — Thor won't prune its cache against a scan it can't trust, and offers a grant where the ROM allows one.
+
+• ❄️ **Removing an app from the Freezer unfreezes it now**, on every screen. A failed thaw says so instead of stranding it.
+
+• ⏸️ **Unsuspend stops claiming a success it didn't earn** — Thor names who holds the app.
+
+• 🤖 **Dhizuku reconnects** once you authorise it, and **Refresh** re-probes privileges.
+
+**New:**
+
+• 💜 **Sponsor on GitHub** in the Support sheet.

--- a/release-notes/v1.93.2/telegram.md
+++ b/release-notes/v1.93.2/telegram.md
@@ -2,13 +2,13 @@
 
 **Fixed:**
 
-• 🧊 **Freezing a preinstalled app no longer wipes its data.** Thor disables it in place; if your phone refuses, it removes the app but keeps the data.
+• 🧊 **Freezing a preinstalled app no longer wipes its data.** Thor disables it in place; where your phone refuses that, it can remove the app and keep the data instead.
 
 • ⚠️ **A freeze Thor can't do now fails and says why**, instead of quietly uninstalling.
 
-• 📋 **App list shrinking to one entry** on MIUI/HyperOS and similar — Thor won't prune its cache against a scan it can't trust, and offers a grant where the ROM allows one.
+• 📋 **App list shrinking to one entry** on MIUI/HyperOS and similar — Thor keeps the list when a scan looks wrong, and offers a grant where the ROM allows one.
 
-• ❄️ **Removing an app from the Freezer unfreezes it now**, on every screen. A failed thaw says so instead of stranding it.
+• ❄️ **Removing an app from the Freezer unfreezes it now**, on every screen — and a failed thaw says so.
 
 • ⏸️ **Unsuspend stops claiming a success it didn't earn** — Thor names who holds the app.
 

--- a/shizu_store.json
+++ b/shizu_store.json
@@ -23,7 +23,7 @@
   ],
   "repo_url": "https://github.com/trinadhthatakula/Thor",
   "download_url": "https://github.com/trinadhthatakula/Thor/releases/latest/download/foss-release.apk",
-  "changelog": "• 🧊 New: Freeze Profiles — save named groups of apps, freeze or unfreeze in one tap.\n\n• 💾 New: export several apps at once, to a folder you pick.\n\n• 📦 New: export as .xapk, alongside .apk and .apks.\n\n• 🔎 New: filter your apps by permission — Camera, Mic, Location and more.\n\n• 📱 App info is now one sheet, with the full details built in.\n\n• 🧊 Freezer rework: the tile and shortcuts are far more reliable.\n\n• 🔒 App lock can no longer lock you out.",
+  "changelog": "• 🧊 Freezing a preinstalled app no longer wipes its data — Thor disables it, and keeps the data if it must remove it.\n\n• ❄️ Removing an app from the Freezer unfreezes it first, on every screen — and says so if it can't.\n\n• 📱 Fixed the app list collapsing to one entry on Chinese-market ROMs.\n\n• ⏸️ Thor no longer claims success when it couldn't unsuspend an app.\n\n• 🔄 Privilege Check's Refresh re-checks Root, Shizuku and Dhizuku.\n\n• 💖 New: more ways to support Thor's development.",
   "store_issue_number": 279,
   "category": "Tools",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## What

Bumps `versionCode` 1931 → 1932 (**v1.93.2**) and writes the release notes for all five channels.
Another pre-release dev build; the current **stable** is still v1.93.0.

## Range

Baselined on the tag **`v1.93.1-dev-103`**, not on `master` — `master` runs ahead of its own release
tag, so `master..dev` undercounts. **100 commits, 28 merged pull requests, #304–#333.** Roughly two
thirds of that is the new `web/` site, documentation and CI, so the user-visible surface is much
smaller than the commit count suggests.

## Five channels, three files

`playstore.txt` is the single source for Play, F-Droid and the Shizu Store, so it is written once
and propagated:

```bash
cp release-notes/v1.93.2/playstore.txt fastlane/metadata/android/en-US/changelogs/1932.txt
.github/scripts/sync-shizu-changelog.sh
```

| Channel | File | Status |
|---|---|---|
| Google Play "What's new" | `release-notes/v1.93.2/playstore.txt` | 482 chars / 486 UTF-16 (limit 500) |
| F-Droid changelog | `fastlane/…/changelogs/1932.txt` | byte-identical ✅ |
| Shizu CoreFetch | `shizu_store.json` → `.changelog` | matches (manifest holds it without the trailing newline, by design) ✅ |
| Telegram broadcast | `release-notes/v1.93.2/telegram.md` | 826 UTF-16 units (budget ~870) |
| GitHub Release body | `release-notes/v1.93.2/github.md` | present |

The *writer* is the manual half: no workflow runs `sync-shizu-changelog.sh`, because the `master`
ruleset needs a PR plus a status check and a `GITHUB_TOKEN`-authored PR does not trigger
`pull_request` workflows — so no bot can land that commit. Without this one, Shizu CoreFetch would
have gone on advertising v1.93.1's feature list ("New: Freeze Profiles", "export as .xapk") under
v1.93.2.

The *checker* is the automated half: `pr-ci.yml:82` runs `check-shizu-manifest.sh` on every PR,
deliberately un-path-filtered, so forgetting the sync is a red `shizu-manifest` check rather than a
silent store regression. The green `shizu-manifest` check on this PR **is** that gate agreeing the
three copies match — including *"changelog matches release-notes/v1.93.2/playstore.txt (versionCode
1932 -> v1.93.2)"*.

`github.md` exists for the same class of reason: `dev-check.yml:166` falls back to a raw
`git log --oneline` dump when it is missing, which for this range would have published 100
unfiltered commit subjects — mostly docs and Dependabot bumps — as the release body, while CI went
green.

## Verification

```
playstore.txt   482 chars / 486 UTF-16 units      (Play rejects >= 500)
telegram.md     826 UTF-16 units                  (budget ~870)
  → dev-check.yml final caption      974 units    (cap 1024, 50 spare)
  → telegram-release.yml caption     966 units    (cap 1024, 58 spare)
closing keywords in release-notes/v1.93.2/*       clean
blank line between every bullet                   both files
diff playstore.txt vs fastlane/…/1932.txt         identical
check-shizu-manifest.sh                           all checks passed
every commit hash cited in github.md              50/50 resolve, subjects match
@Test methods under app/src/test                  497 (matches the notes' claim)
```

The telegram budget is the one that fails **silently**: the notes go out as a `sendDocument`
*caption*, Telegram caps captions at 1024 UTF-16 units and **rejects** an oversized one outright
(no truncation), and the `curl` has no `--fail` — so the step goes green having broadcast nothing.
The file is only one of the caption's inputs, so the numbers above are the **assembled** captions,
with the wrapper measured at 149 units (dev) and 141 (release) rather than estimated.

## Claims were checked against the code, not the commit subjects

Corrections made while verifying the first draft:

* **The data-safety headline was mis-scoped.** "Thor disables it instead" is *false* on exactly the
  devices that motivated the change — HyperOS's vendor `PackageManagerServiceImpl` refuses the
  disable outright, and the fix for those users is that the fallback now carries `-k`. Both consumer
  files now say the data survives either way.
* **Dropped the OPPO and Honor brand names.** Only Xiaomi/HyperOS was ever observed; the rest of the
  ROM list is inference from T/TAF 108-2022. A defect claim about named third-party hardware,
  published verbatim to three stores with no surrounding context, needs evidence behind it.
* **Dropped "Root can rescue apps suspended under Shizuku" from the broadcast.** It is implemented
  and unit-tested but has **not** run on a device — `docs/follow-ups/cross-privilege-suspend-ownership.md`
  says so explicitly. The half a readback does guarantee is kept.
* **Softened the permission-banner claim.** The banner is gated on `InstalledAppsPermission.Denied`,
  and a "while in use" grant reads as `Granted` — i.e. the users most likely to hit the bug will not
  see it.
* **Added the behaviour change nothing mentioned:** a system-app freeze can now *fail* where it used
  to appear to succeed, because root no longer escalates to an uninstall and the fallback does not
  exist at shell uid on API 37. That is the likeliest source of "1932 broke system-app freezing"
  reports.
* Vocabulary: "unpause" → "unsuspend" (the app's own string is `action_unsuspend`), 🔥 → ❄️ on a thaw
  bullet, and dropped the self-deprecating "really".

Every commit hash cited in `github.md` was verified to exist in the range; the test counts
(376 → 497) and the PR count (28, not the 32 raw merges — four are branch syncs) were measured.

## Note

No GitHub closing keywords in any of the three notes files — `master` is the default branch, so a
`dev` → `master` PR body triggers auto-close. `release-notes/README.md` is rewritten in this commit
to document the pipeline, the four traps and the propagation/verification steps.

Part of GH#316 and GH#310, which their own PRs already handled.
