### PR TITLE
ci: run R8 on every PR, so the first minified build isn't the one that ships

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -76,6 +76,72 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+      # The only place R8 runs BEFORE a merge. It does run elsewhere — dev-check.yml:147,
+      # production-deploy.yml:145 and manual-build.yml:52 all shell out to fastlane, which
+      # assembles release — but every one of those triggers on a push to an already-merged
+      # branch. On the PR itself nothing minified was ever built: assembleFossDebug above does
+      # not minify (app/build.gradle.kts: `debug { isMinifyEnabled = false }`), lintStoreRelease
+      # analyses unminified classes, and codeql.yml builds with `build-mode: none`. So the first
+      # minified build of any change was the build that published it, and a shrinker break was
+      # discovered by the release rather than by review. gradle.properties runs R8 in full mode
+      # with android.r8.strictFullModeForKeepRules=true, which is exactly the configuration where
+      # a keep that used to be implied quietly stops being one.
+      #
+      # Needs no secrets: the release build type assigns signingConfig only when jks.properties
+      # or KEY_ALIAS exists (`hasSigningCredentials` in app/build.gradle.kts, added so a fresh
+      # clone can still build), so this produces an unsigned release APK rather than dying in
+      # validateSigningFossRelease. Nothing here exports the keystore env vars, so the result is
+      # the same for a fork PR and for a branch PR.
+      #
+      # Both flavours, on every PR, deliberately. The two are not redundant: foss is the
+      # reproducibility-critical one and the only consumer of proguard-rules-foss.pro, while
+      # store is the only place the Play Billing dependency, its consumer keep rules and the
+      # app/src/store sources are shrunk at all — a store-only R8 break is invisible to a foss
+      # run. Gating store on `base_ref == 'master'` would defer exactly that check to the
+      # release PR, which is the one place a red check is most expensive. The marginal cost is
+      # small: lintStoreRelease above has already compiled the store release variant, so this
+      # adds shrink/dex/package for store rather than a second full Kotlin compile.
+      - name: Assemble minified release (R8)
+        id: r8
+        run: ./gradlew assembleFossRelease assembleStoreRelease --stacktrace
+
+      # R8 writes missing_rules.txt into the mapping directory when it cannot resolve a class
+      # something references, and the contents are the rules it wants. AGP fails the build in the
+      # same breath today, so this is a second lock rather than the only one — but it is the lock
+      # that survives the first being relaxed (a blanket -dontwarn added to quiet the symptom, or
+      # a future AGP demoting missing classes to a warning), and it names the file in the log
+      # instead of leaving it to be found inside an artifact.
+      - name: Check R8 missing rules
+        id: missing_rules
+        # Runs even when the assemble failed, because if R8 is what failed then this is the step
+        # that says so. Skipped along with the assemble if an earlier step went red.
+        if: ${{ !cancelled() && steps.r8.outcome != 'skipped' }}
+        run: |
+          missing=0
+          for rules in app/build/outputs/mapping/*/missing_rules.txt; do
+            [ -f "$rules" ] || continue
+            missing=1
+            echo "::error::R8 could not resolve every class the code references. $rules holds the -dontwarn rules R8 suggests to proceed anyway; copying them in silences the symptom, so reach for that only once you have established the class is genuinely absent at runtime. Prefer the actual fix — a missing dependency, a compileOnly that should be implementation, or a real -keep in app/proguard-rules.pro (or the flavour's own file)."
+            cat "$rules"
+          done
+          exit "$missing"
+
+      # configuration.txt is the fully merged rule set, every consumer rule from every dependency
+      # included, and usage.txt is what R8 removed — between them a shrinker failure is readable
+      # from the PR without rerunning the build locally on a variant nobody assembles by hand.
+      # Failure-only, like the lint report above: on a green run the APK is unsigned and thrown
+      # away, and its mapping.txt describes nothing that will ever ship.
+      - name: Upload R8 outputs
+        if: failure() && steps.r8.outcome != 'skipped'
+        uses: actions/upload-artifact@v7
+        with:
+          # One directory per variant inside, so the archive names the variant even when the
+          # master-only store run above is part of it.
+          name: r8-outputs
+          path: app/build/outputs/mapping/
+          if-no-files-found: warn
+          retention-days: 14
+
   # Runs on every PR rather than being path-filtered. on.pull_request.paths
   # filters the whole workflow, which would also gate build-and-test — the
   # required status check — leaving unrelated PRs pending forever.

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -121,7 +121,7 @@ jobs:
           for rules in app/build/outputs/mapping/*/missing_rules.txt; do
             [ -f "$rules" ] || continue
             missing=1
-            echo "::error::R8 could not resolve every class the code references. $rules holds the -dontwarn rules R8 suggests to proceed anyway; copying them in silences the symptom, so reach for that only once you have established the class is genuinely absent at runtime. Prefer the actual fix — a missing dependency, a compileOnly that should be implementation, or a real -keep in app/proguard-rules.pro (or the flavour's own file)."
+            echo "::error::R8 could not resolve every class the code references. The fix is on the classpath, not in the keep rules: add the dependency that supplies the class, or correct its scope (a compileOnly that should be implementation). A -keep cannot help here — it preserves a class R8 can already see, it does not supply one it cannot. $rules holds the -dontwarn rules R8 suggests so the build can proceed regardless; those silence the diagnostic rather than fix it, so add them to app/proguard-rules.pro (or the flavour's own file) only once you have established the class is genuinely absent at runtime too. If that code path does run, -dontwarn buys a ClassNotFoundException instead of a build failure."
             cat "$rules"
           done
           exit "$missing"

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -25,7 +25,8 @@ byte-identical, because each consumer reads its own copy: F-Droid reads `fastlan
 reads `shizu_store.json`. Write the text once, then propagate it (Step 5).
 
 Only one of those copies is audited. `.github/scripts/check-shizu-manifest.sh` compares
-`shizu_store.json`'s `.changelog` against `playstore.txt`, and `pr-ci.yml:82` runs it on **every**
+`shizu_store.json`'s `.changelog` against `playstore.txt`, and `pr-ci.yml`'s `shizu-manifest` job
+runs it on **every**
 PR — deliberately un-path-filtered, since `on.pull_request.paths` would gate the whole workflow
 including the required `build-and-test` check. So a forgotten `sync-shizu-changelog.sh` is a red
 `shizu-manifest` check, not a silent store regression. The **`fastlane/` copy is checked by


### PR DESCRIPTION
Branch 0 of 8 from the 2026-08-04 dev-branch audit. Infrastructure first, deliberately: the
remaining seven branches all change shippable code, and this is the gate that would catch a
shrinker break in any of them.

## The finding

R8 already runs in CI. `dev-check.yml:147`, `production-deploy.yml:145` and `manual-build.yml:52`
all shell out to fastlane, which assembles release. **Every one of them triggers on a push to an
already-merged branch.**

On the PR itself nothing minified was ever built:

| Existing check | Why it doesn't cover R8 |
|---|---|
| `assembleFossDebug` | `debug { isMinifyEnabled = false }` |
| `lintStoreRelease` | analyses unminified classes |
| `codeql.yml` | `build-mode: none` |
| push to `dev` | nothing builds at all |

So the first minified build of any change was **the build that published it**, and
`gradle.properties` runs the shrinker in full mode with
`android.r8.strictFullModeForKeepRules=true` — precisely the configuration where a keep that used
to be implied quietly stops being one.

## What this adds

Three steps appended to the existing `build-and-test` job:

1. **`Assemble minified release (R8)`** — `assembleFossRelease assembleStoreRelease`
2. **`Check R8 missing rules`** — fails with an `::error::` naming the file and dumping its contents
3. **`Upload R8 outputs`** — `mapping/` on failure only, 14-day retention

Placed last so the cheaper signals still fail first.

## Decisions worth reviewing

**A step, not a job.** `build-and-test` is the only status context the `dev` and `master` rulesets
require. A separate `r8` job would render green-or-red on the PR, but merge would not *wait* on it
until someone also edited both rulesets. Inside this job it is enforced the moment this merges.

**Both flavours, every PR.** The two are not redundant — `foss` is the reproducibility-critical
flavour and the only consumer of `proguard-rules-foss.pro`; `store` is the only place Play Billing,
its consumer keep rules and `app/src/store` are shrunk at all, so a store-only break is invisible
to a foss run. An earlier revision gated store on `base_ref == 'master'`; that deferred the check
to the release PR, which is the worst place to first see it red. Marginal cost is modest because
`lintStoreRelease` has already compiled that variant, so this adds shrink/dex/package rather than a
second full Kotlin compile.

**No secrets needed.** `signingConfig` is assigned only when `jks.properties` or `KEY_ALIAS` exists
(`hasSigningCredentials`, `app/build.gradle.kts:45`), so this produces an *unsigned* release APK
rather than dying in `validateSigningFossRelease`. Fork PRs and branch PRs behave identically.

**The missing-rules check is a second lock, not the only one.** AGP fails the build in the same
breath today. This survives the first being relaxed — a blanket `-dontwarn` added to quiet the
symptom, or a future AGP demoting missing classes to a warning — and it names the file in the log
instead of leaving it to be found inside an artifact. Its message points at the real fix first,
because the rules R8 writes into `missing_rules.txt` *are* `-dontwarn` suggestions, so pasting them
in silences rather than fixes.

## Verification

- `assembleFossRelease assembleStoreRelease` is **green at this commit**, no `missing_rules.txt`
  emitted (re-run commit-exact during the audit rather than trusting 2-day-old mapping artifacts).
- The missing-rules script parses under **both `sh` and `zsh`**. The accumulator is named `missing`
  and not `status` on purpose — `status` is read-only in zsh, which made an earlier draft exit 1
  unconditionally there.
- Workflow YAML parses; both jobs and all nine steps resolve.

## Expect the first red

Nothing has ever built `fossRelease` in CI on a clean machine. If a keep rule is already broken,
**this step is where it surfaces, and that is the finding rather than a regression** — worth
landing on a day when there is room to read the output, not at the end of a release.

Job runtime roughly doubles (~7 min → ~12), and this workflow has no path filter, so docs-only PRs
pay it too. That tradeoff is inherited from the existing file, not introduced here.

## Also

`release-notes/README.md` cited `pr-ci.yml:82` for the `shizu-manifest` job; these steps move it to
line 144. Repointed at the job **by name** — a line number in prose is what drifted in the first
place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added automated validation for release builds to identify missing configuration and unresolved classes before changes are merged.
  - Release build checks now cover both Foss and Store variants.

- **Bug Fixes**
  - Failed validation runs now provide diagnostic reports to help investigate build issues.

- **Documentation**
  - Updated release-notes documentation to reference the current CI validation job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->