### PR TITLE
fix(preferences): stop an unreadable settings file from crash-looping the app

### DIFF
--- a/app/src/main/java/com/valhalla/thor/HomeActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/HomeActivity.kt
@@ -83,11 +83,13 @@ class HomeActivity : ComponentActivity() {
             ) {
                 val authState by securityViewModel.authState.collectAsStateWithLifecycle()
 
-                // The only place SecurityViewModel speaks: it disarms a lock this device can never
-                // open, and that must not happen silently — the user set that lock deliberately and
-                // is entitled to know Thor took it off. Collected here rather than in a screen
-                // because the disarm lands *before* any screen: it is what decides which of the
-                // branches below composes at all.
+                // The two things SecurityViewModel says, both about the app lock going away without
+                // the user asking: it disarms a lock this device can never open, and it reports a
+                // settings file it could not read — which drops the lock preference to `false` the
+                // same way. Neither may happen silently; the user set that lock deliberately and is
+                // entitled to know. Collected here rather than in a screen because both land
+                // *before* any screen: they are what decides which of the branches below composes
+                // at all.
                 ObserveAsEvents(securityViewModel.events) { event ->
                     Toast.makeText(
                         this@HomeActivity,

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -5,6 +5,7 @@ package com.valhalla.thor.data.repository
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -22,12 +23,55 @@ import com.valhalla.thor.domain.model.SortOrder
 import com.valhalla.thor.domain.model.ThemeMode
 import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.retryWhen
 import org.koin.core.annotation.Single
+import java.io.IOException
 
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "thor_preferences")
+private const val TAG = "PreferenceRepository"
+
+/**
+ * Latches — for the life of the process — once the settings file has been thrown away and replaced.
+ *
+ * File-scoped rather than a field on [PreferenceRepositoryImpl] because the handler below is
+ * captured by the `preferencesDataStore` delegate, which is a property of `Context` and has no way
+ * to reach the repository instance. Nothing resets it: the replacement has already happened, and
+ * every read afterwards succeeds, so the fact that the values are not the user's is only knowable
+ * from here.
+ */
+private val settingsFileReplaced = MutableStateFlow(false)
+
+/**
+ * The settings store — the one in the Auto Backup allowlist.
+ *
+ * [ReplaceFileCorruptionHandler] rather than the default handler, which is `NoOpCorruptionHandler`
+ * and *rethrows*. Nothing ever rewrites the file after that, so an unreadable
+ * `thor_preferences.preferences_pb` rethrows on every read for the life of the install — and since
+ * this file is the one that travels in cloud backup and device transfer, a partial restore can put
+ * a brand-new device into that state before the user has opened Thor once. Replacing the bad file
+ * with an empty one costs the user their settings; not replacing it costs them the app.
+ *
+ * What makes that trade acceptable rather than merely cheaper is [settingsFileReplaced]: one of the
+ * settings in this file is the app lock, and a replacement drops it to `false`. Dropping a lock the
+ * user deliberately armed *silently* is precisely what `SecurityViewModel` is written not to do, so
+ * the loss is recorded here, carried on [UserPreferences.settingsLost], and said out loud.
+ */
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "thor_preferences",
+    corruptionHandler = ReplaceFileCorruptionHandler {
+        Logger.e(TAG, "thor_preferences was unreadable; replacing it with an empty file", it)
+        settingsFileReplaced.value = true
+        emptyPreferences()
+    }
+)
 
 /**
  * The second store, for state that describes **this install** rather than what the user chose.
@@ -46,8 +90,20 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
  *
  * A user *setting* does not belong here, however local it feels — settings are what the backup is
  * for.
+ *
+ * Corruption-handled for the same reason as [dataStore]: this file cannot arrive corrupted from a
+ * restore, but an interrupted write or a bad block can still leave it unreadable, and the default
+ * handler would then rethrow forever. No equivalent of [settingsFileReplaced] here — the one flag
+ * this file holds falls back to "we have not offered yet", which re-offers the recovery prompt
+ * rather than withholding anything.
  */
-private val Context.localState: DataStore<Preferences> by preferencesDataStore(name = "thor_local_state")
+private val Context.localState: DataStore<Preferences> by preferencesDataStore(
+    name = "thor_local_state",
+    corruptionHandler = ReplaceFileCorruptionHandler {
+        Logger.e(TAG, "thor_local_state was unreadable; replacing it with an empty file", it)
+        emptyPreferences()
+    }
+)
 
 @Single(binds = [PreferenceRepository::class])
 class PreferenceRepositoryImpl(
@@ -117,9 +173,7 @@ class PreferenceRepositoryImpl(
     }
 
     override val userPreferences: Flow<UserPreferences> =
-        combine(context.dataStore.data, context.localState.data) { prefs, local ->
-            prefs.toUserPreferences(local)
-        }
+        userPreferencesFlow(context.dataStore.data, context.localState.data)
 
     // --- App List ---
 
@@ -279,6 +333,83 @@ class PreferenceRepositoryImpl(
         return if (userPreferences.first().autoReinstallEnabled) " -i com.android.vending" else ""
     }
 }
+
+/**
+ * The [PreferenceRepository.userPreferences] stream, with the two store flows passed in so the
+ * composition is reachable from a plain JVM test.
+ *
+ * Each side is guarded **before** the [combine], not after: a `catch` downstream of the combine
+ * would end the whole stream on the first failure, taking the healthy store down with the broken
+ * one. Guarded individually, an unreadable settings file degrades to defaults while `localState`
+ * keeps emitting, and vice versa.
+ *
+ * [settingsFileReplaced] is read at map time rather than combined in as a third flow. It can only
+ * be set by the corruption handler, which runs *while producing* the first `settings` emission, so
+ * by the time this transform runs the answer is already final — and combining it would open a race
+ * where the first snapshot claims the settings are intact and a second one immediately corrects it.
+ */
+internal fun userPreferencesFlow(
+    settings: Flow<Preferences>,
+    local: Flow<Preferences>,
+    settingsReplaced: StateFlow<Boolean> = settingsFileReplaced
+): Flow<UserPreferences> =
+    combine(
+        settings.guardedRead("thor_preferences"),
+        local.guardedRead("thor_local_state")
+    ) { prefs, localPrefs ->
+        prefs.preferences.toUserPreferences(localPrefs.preferences)
+            .copy(settingsLost = prefs.degraded || settingsReplaced.value)
+    }
+
+/**
+ * One snapshot out of a store, and whether it is the user's or something this file made up.
+ *
+ * The two cannot be told apart from the [Preferences] alone — an empty store and a store that could
+ * not be read look identical — and one of the values in there is the app lock, so "made up" has to
+ * survive as far as [UserPreferences.settingsLost].
+ */
+internal data class StoreRead(val preferences: Preferences, val degraded: Boolean)
+
+/** Retries before a read is written off. Backs off over about half a second in total. */
+private const val READ_RETRIES = 3L
+private const val READ_RETRY_DELAY_MS = 100L
+
+/**
+ * Degrade a store's `.data` to an empty snapshot when the read fails, rather than letting it reach
+ * the ~20 places that collect [PreferenceRepository.userPreferences].
+ *
+ * The `corruptionHandler` on each store above is the primary fix and the one that actually heals
+ * the install; this covers what it cannot. It only fires for `CorruptionException` — an
+ * unparseable file — so a read that fails for any other IO reason still throws, and a corrupt file
+ * the handler could not *replace* (no space, a read-only volume) rethrows the original by design.
+ *
+ * Retry first, because degrading is **terminal**: `catch` emits once and the upstream is then
+ * complete, and none of the collectors re-subscribe — `SecurityViewModel` shares this with
+ * `SharingStarted.Eagerly`, which does not restart a finished upstream, and the rest are plain
+ * `collect` loops that simply end. So a single transient failure — low storage, an EIO, a read
+ * attempted before credential-encrypted storage is unlocked — would pin the whole process to values
+ * the user never chose while the file on disk is perfectly intact. Three re-reads cost nothing on a
+ * healthy store and are free on a permanently broken one, where the corruption handler has already
+ * had its go by the time the first attempt fails.
+ *
+ * Only [IOException] is swallowed. Anything else, `CancellationException` above all, is rethrown:
+ * a cancelled collector must not be handed a fabricated defaults emission on its way out. That
+ * distinction is what the tests aim at, which is why this is `internal` rather than private —
+ * asserted through [userPreferencesFlow] it would be asserted through `combine`'s own handling of
+ * a cancelled child instead.
+ */
+internal fun Flow<Preferences>.guardedRead(storeName: String): Flow<StoreRead> =
+    retryWhen { cause, attempt ->
+        (cause is IOException && attempt < READ_RETRIES).also { retrying ->
+            if (retrying) delay(READ_RETRY_DELAY_MS * (attempt + 1))
+        }
+    }
+        .map { StoreRead(it, degraded = false) }
+        .catch { e ->
+            if (e !is IOException) throw e
+            Logger.e(TAG, "$storeName could not be read; falling back to the defaults", e)
+            emit(StoreRead(emptyPreferences(), degraded = true))
+        }
 
 /**
  * Pure mapping from already-read [Preferences] snapshots to [UserPreferences].

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -58,7 +58,19 @@ data class UserPreferences(
     val autoReinstallEnabled: Boolean = false,
 
     // Export destination (persisted SAF tree URI; null = default Downloads/Thor)
-    val exportDirUri: String? = null
+    val exportDirUri: String? = null,
+
+    /**
+     * True when the values above are Thor's defaults rather than the user's, because the settings
+     * store could not be read or had to be thrown away and replaced after corruption.
+     *
+     * Not a preference — nothing writes it and it is never persisted — but it belongs on the
+     * snapshot rather than beside it, because it is the only thing that distinguishes "the user
+     * turned everything off" from "we could not find out what the user chose". [biometricLockEnabled]
+     * is why that distinction has to travel: `false` there is both the common case and, after a
+     * failed read, a silently disarmed app lock.
+     */
+    val settingsLost: Boolean = false
 )
 
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -15,7 +15,18 @@ import kotlinx.coroutines.flow.Flow
 
 interface PreferenceRepository {
 
-    // Observe all preferences as a single stream
+    /**
+     * Observe all preferences as a single stream.
+     *
+     * Never fails on a read: an unreadable store is retried and then degrades to the defaults
+     * instead of throwing, so a collector does not need its own `catch`. That is a promise of this
+     * interface, not an accident of the implementation — around twenty call sites collect this,
+     * several of them during startup, and a throw from any of them is an unrecoverable crash loop.
+     *
+     * When it does degrade it says so, on [UserPreferences.settingsLost]. Read that before treating
+     * a `false` as the user's answer: after a failed read every boolean here is `false`, and one of
+     * them arms the app lock.
+     */
     val userPreferences: Flow<UserPreferences>
 
     // --- App List ---

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -15,7 +15,6 @@ import com.valhalla.thor.domain.model.MultiAppAction
 import com.valhalla.thor.domain.model.PermissionIndex
 import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
-import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.model.filterApps
 import com.valhalla.thor.domain.model.freezeTier
 import com.valhalla.thor.domain.model.sortApps
@@ -333,11 +332,7 @@ class AppListViewModel(
             // time prepended to the scan rather than overlapped with it. A deliberate
             // pull-to-refresh has no transition to protect and must not pay for it.
             if (deferForTransition) {
-                // catch: userPreferences is dataStore.data, which throws IOException on a failed
-                // read. Fall back to the defaults rather than letting a preference read failure
-                // take down the whole app list. (Flow.catch stays transparent to cancellation.)
                 val intensity = preferenceRepository.userPreferences
-                    .catch { emit(UserPreferences()) }
                     .first()
                     .animationIntensity
                 // LOW resolves to ZERO, which delay() returns from without suspending.

--- a/app/src/main/java/com/valhalla/thor/presentation/security/SecurityViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/SecurityViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -49,6 +50,19 @@ class SecurityViewModel(
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     /**
+     * Whether the preference above is the user's answer or a stand-in for one Thor could not read.
+     *
+     * The settings file is the one in the Auto Backup allowlist, so a partial restore can hand a
+     * brand-new device an unreadable copy; `PreferenceRepositoryImpl` replaces it and carries the
+     * loss out on this flag. Everything else in that file degrades to a default the user can see
+     * and put back — the theme is wrong on screen, the language is wrong on screen. The app lock
+     * degrades to *off*, which looks exactly like a user who never set one.
+     */
+    private val _settingsLost = preferenceRepository.userPreferences
+        .map { it.settingsLost }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    /**
      * Whether a prompt could succeed at all. Seeded synchronously rather than refreshed into
      * place, so the very first composition already knows: seeding it optimistically would show
      * the lock screen, fire a prompt that fails instantly, and only then correct itself. One
@@ -75,15 +89,27 @@ class SecurityViewModel(
      *  - Whether the user has authenticated this session
      *  - Whether this device can authenticate at all
      *  - Whether the last auth attempt produced an error
+     *  - Whether the preference was readable at all
      */
     val authState = combine(
         _biometricEnabled,
         _isSessionAuthenticated,
         _canAuthenticate,
-        _authError
-    ) { enabled, authenticated, capable, error ->
+        _authError,
+        _settingsLost
+    ) { enabled, authenticated, capable, error, settingsLost ->
+        // A settings file Thor could not read cannot answer whether the lock was armed, and `false`
+        // is not a safe guess: on a freshly restored device — the one place this happens — it opens
+        // Thor for a user who deliberately closed it, and the replaced file makes that permanent.
+        // So an unreadable store arms the lock too.
+        //
+        // Only where a prompt could actually succeed, though. Inventing an *unopenable* gate for a
+        // lock the user may never have set is the worse of the two mistakes, so with `capable`
+        // false this stays out of the way entirely and the branches below see the same state they
+        // always did. The user is told either way — see `init`.
+        val required = enabled || (settingsLost && capable)
         when {
-            !enabled -> AuthState.NotRequired
+            !required -> AuthState.NotRequired
             authenticated -> AuthState.Unlocked
             // Above Error on purpose. The prompt fails the instant it opens on a device that
             // cannot authenticate, so `error` is always populated here a moment later — and an
@@ -124,6 +150,10 @@ class SecurityViewModel(
         // read asynchronously: `_biometricEnabled` seeds `false` and the restored `true` lands a
         // moment later, which is precisely the case this exists for. Writing `false` flips that
         // flow, so this settles after one pass instead of looping.
+        //
+        // `_settingsLost` is deliberately *not* an input: this branch writes to the store, and
+        // writing a lock state Thor is only guessing at would turn a failed read into a permanent
+        // answer of its own.
         viewModelScope.launch {
             combine(_biometricEnabled, _canAuthenticate) { enabled, capable ->
                 enabled && !capable
@@ -132,6 +162,19 @@ class SecurityViewModel(
                 preferenceRepository.setBiometricLock(false)
                 _events.send(UiText.StringResource(R.string.biometric_lock_disabled_no_biometric))
             }
+        }
+
+        // And say so when the settings could not be read at all, for the same reason the disarm
+        // above does: Thor is running on values the user did not choose, one of which is the app
+        // lock, and on the branch where no prompt can succeed the lock is not even re-armed. Told
+        // from here rather than from a settings screen because the flag decides what the user sees
+        // first, and because this is where the channel that survives that early already exists.
+        //
+        // `first { it }` completes on the first true and the flag never goes back, so this is one
+        // notice per process however many times the stream re-emits.
+        viewModelScope.launch {
+            _settingsLost.first { it }
+            _events.send(UiText.StringResource(R.string.settings_lost_using_defaults))
         }
     }
 
@@ -166,7 +209,10 @@ class SecurityViewModel(
      * user can choose to retry or exit.
      */
     fun onAuthError(message: String) {
-        if (_biometricEnabled.value && !_isSessionAuthenticated.value) {
+        // `_settingsLost` for the same reason `authState` takes it: on that branch the prompt is
+        // armed without the preference being `true`, and gating the error on the preference alone
+        // would leave a cancelled prompt sitting on the lock screen with nothing said and no Retry.
+        if ((_biometricEnabled.value || _settingsLost.value) && !_isSessionAuthenticated.value) {
             _authError.value = message
         }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -453,6 +453,7 @@
     <string name="biometric_not_enrolled_toast_biometric_only">لا توجد بصمة مُسجَّلة — في أندرويد 9 لا يفتح قفل الشاشة تطبيق ثور، فسجّل بصمة أولاً</string>
     <string name="biometric_lock_unavailable_toast">لا يمكن تفعيل قفل التطبيق: لا توجد في هذا الجهاز مقاييس حيوية لإلغاء قفله</string>
     <string name="biometric_lock_disabled_no_biometric">تم إيقاف قفل التطبيق: لا توجد في هذا الجهاز مقاييس حيوية لإلغاء قفله</string>
+    <string name="settings_lost_using_defaults">تعذّر على Thor قراءة إعداداتك، ويستخدم الآن الإعدادات الافتراضية: تحقّق من قفل التطبيق في الإعدادات</string>
     <string name="open_security_settings">فتح إعدادات الأمان</string>
     <string name="unlock">إلغاء القفل</string>
     <string name="thank_you_support_desc">اشتراكك نشط الآن. شكرًا لك على المساعدة في دعم تطوير Thor!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -419,6 +419,7 @@
     <string name="biometric_not_enrolled_toast_biometric_only">Ninguna huella registrada: en Android 9 un bloqueo de pantalla no desbloquea Thor, así que registra una huella primero</string>
     <string name="biometric_lock_unavailable_toast">No se puede activar el bloqueo de la app: este dispositivo no tiene biometría con la que desbloquearlo</string>
     <string name="biometric_lock_disabled_no_biometric">Bloqueo de la app desactivado: este dispositivo no tiene biometría con la que desbloquearlo</string>
+    <string name="settings_lost_using_defaults">Thor no pudo leer tus ajustes y está usando los predeterminados: revisa el bloqueo de la app en Ajustes</string>
     <string name="open_security_settings">Abrir ajustes de seguridad</string>
     <string name="unlock">Desbloquear</string>
     <string name="thank_you_support_desc">Tu suscripción está activa. ¡Gracias por ayudar a apoyar el desarrollo de Thor!</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -419,6 +419,7 @@
     <string name="biometric_not_enrolled_toast_biometric_only">Aucune empreinte enregistrée — sous Android 9, un verrouillage d\'écran ne déverrouille pas Thor : enregistrez d\'abord une empreinte</string>
     <string name="biometric_lock_unavailable_toast">Impossible d\'activer le verrouillage de l\'application : cet appareil n\'a aucune biométrie pour le déverrouiller</string>
     <string name="biometric_lock_disabled_no_biometric">Verrouillage de l\'application désactivé : cet appareil n\'a aucune biométrie pour le déverrouiller</string>
+    <string name="settings_lost_using_defaults">Thor n\'a pas pu lire vos paramètres et utilise ceux par défaut : vérifiez le verrouillage de l\'application dans les Paramètres</string>
     <string name="open_security_settings">Ouvrir les paramètres de sécurité</string>
     <string name="unlock">Déverrouiller</string>
     <string name="thank_you_support_desc">Votre abonnement est actif. Merci d\'aider à soutenir le développement de Thor !</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -411,6 +411,7 @@
     <string name="biometric_not_enrolled_toast_biometric_only">未录入指纹 — 在 Android 9 上屏幕锁无法解锁 Thor，请先录入指纹</string>
     <string name="biometric_lock_unavailable_toast">无法开启应用锁：此设备没有可用来解锁的生物识别方式</string>
     <string name="biometric_lock_disabled_no_biometric">已关闭应用锁：此设备没有可用来解锁的生物识别方式</string>
+    <string name="settings_lost_using_defaults">Thor 无法读取你的设置，正在使用默认设置：请在“设置”中检查应用锁</string>
     <string name="open_security_settings">打开安全设置</string>
     <string name="unlock">解锁</string>
     <string name="thank_you_support_desc">您的订阅已生效。感谢您支持 Thor 的开发！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,6 +565,8 @@
     <string name="biometric_lock_unavailable_toast">App lock can\'t be turned on: this device has no biometrics to unlock it with</string>
     <!-- Shown once when Thor turns its own app lock off, because this device can never open it. -->
     <string name="biometric_lock_disabled_no_biometric">App lock turned off: this device has no biometrics to unlock it with</string>
+    <!-- Shown once when the settings file could not be read, so every setting - the app lock included - fell back to its default. -->
+    <string name="settings_lost_using_defaults">Thor couldn\'t read your settings and is using the defaults — check the app lock in Settings</string>
     <string name="open_security_settings">Open security settings</string>
     <string name="unlock">Unlock</string>
     <string name="thank_you_support_desc">Your subscription is active. Thank you for helping support the development of Thor!</string>

--- a/app/src/test/java/com/valhalla/thor/data/repository/PreferenceReadGuardTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/PreferenceReadGuardTest.kt
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.preferencesOf
+import com.valhalla.thor.data.repository.PreferenceRepositoryImpl.Keys
+import com.valhalla.thor.data.repository.PreferenceRepositoryImpl.LocalKeys
+import com.valhalla.thor.domain.model.ThemeMode
+import com.valhalla.thor.domain.model.UserPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+
+/**
+ * What a collector of `PreferenceRepository.userPreferences` sees when a store cannot be read.
+ *
+ * DataStore's `.data` throws `IOException` on a failed read, and its default corruption handler is
+ * `NoOpCorruptionHandler`, which rethrows. Nothing rewrites the file afterwards, so an unreadable
+ * `thor_preferences.preferences_pb` throws on *every* read for the life of the install — and that
+ * file is the one included in cloud backup and device transfer, so a partial restore can produce
+ * exactly that state on a device the user has never opened Thor on. Around twenty places collect
+ * this stream, several during startup, which makes the failure an unrecoverable crash loop whose
+ * only cure is clearing app data — which in turn destroys the freezer watchlist, deliberately not
+ * backed up and therefore not coming back.
+ *
+ * So the claim under test is not "reads are correct" (that is `ToUserPreferencesTest`) but "a read
+ * that fails is retried, then degrades to the defaults, says which of the two happened, and stays
+ * transparent to everything that is not IO".
+ *
+ * `runTest` skips the retry backoff rather than waiting it out, so nothing here costs the half a
+ * second the production path would spend.
+ */
+class PreferenceReadGuardTest {
+
+    /** The crash loop itself, at the shape the collectors actually use. */
+    @Test
+    fun `an unreadable settings store yields the defaults instead of throwing`() = runTest {
+        val unreadable = flow<Preferences> { throw IOException("failed to read preferences file") }
+
+        val prefs = userPreferencesFlow(unreadable, flowOf(emptyPreferences()), intact()).first()
+
+        assertEquals(UserPreferences(settingsLost = true), prefs)
+    }
+
+    /**
+     * The restore case specifically: a truncated `.preferences_pb` surfaces as `CorruptionException`,
+     * which is an `IOException` subclass — so the guard covers it even when the store's own
+     * corruption handler could not replace the file (a read-only volume, a full disk), where
+     * DataStore rethrows the original by design.
+     */
+    @Test
+    fun `a corrupt preferences file yields the defaults`() = runTest {
+        val corrupt = flow<Preferences> { throw CorruptionException("unreadable proto") }
+
+        val prefs = userPreferencesFlow(corrupt, flowOf(emptyPreferences()), intact()).first()
+
+        assertEquals(UserPreferences(settingsLost = true), prefs)
+    }
+
+    /**
+     * The other half of the corruption case, and the common one: the handler *did* replace the
+     * file, so every read from here on succeeds and returns an empty store. Nothing in the stream
+     * can tell that apart from a user who has changed no settings, which is why the replacement is
+     * recorded outside it — `biometricLockEnabled` reads `false` either way, and only one of those
+     * two is a disarmed app lock.
+     */
+    @Test
+    fun `a replaced settings file reads clean but still reports the loss`() = runTest {
+        val replaced = MutableStateFlow(true)
+
+        val prefs = userPreferencesFlow(
+            flowOf(emptyPreferences()),
+            flowOf(emptyPreferences()),
+            replaced
+        ).first()
+
+        assertTrue("the replacement has to survive into the snapshot", prefs.settingsLost)
+    }
+
+    /** A store that reads is not accused of anything. */
+    @Test
+    fun `a healthy read does not claim the settings were lost`() = runTest {
+        val settings = flowOf(preferencesOf(Keys.BIOMETRIC_LOCK to true))
+
+        val prefs = userPreferencesFlow(settings, flowOf(emptyPreferences()), intact()).first()
+
+        assertFalse(prefs.settingsLost)
+        assertTrue(prefs.biometricLockEnabled)
+    }
+
+    /**
+     * Each store is guarded on its own, before the combine. A single `catch` downstream of the
+     * combine would end the whole stream on the first failure and hand back defaults for *both*
+     * files, silently discarding a perfectly readable settings file.
+     */
+    @Test
+    fun `a failure in one store does not discard the other`() = runTest {
+        val settings = flowOf(preferencesOf(Keys.THEME_MODE to ThemeMode.DARK.name))
+        val unreadableLocal = flow<Preferences> { throw IOException("local state unreadable") }
+
+        val prefs = userPreferencesFlow(settings, unreadableLocal, intact()).first()
+
+        assertEquals("the readable store still answers", ThemeMode.DARK, prefs.themeMode)
+        assertFalse("the unreadable one falls back", prefs.hasShownDisabledAppsPrompt)
+        // The per-install store holds no setting the user chose, so losing it is not the loss the
+        // security path is warned about.
+        assertFalse("and it is not reported as a settings loss", prefs.settingsLost)
+    }
+
+    /** And the same the other way round, since the two sides are not symmetric in what they hold. */
+    @Test
+    fun `an unreadable settings store leaves the per-install one readable`() = runTest {
+        val unreadable = flow<Preferences> { throw IOException("settings unreadable") }
+        val local = flowOf(preferencesOf(LocalKeys.HAS_SHOWN_DISABLED_APPS_PROMPT to true))
+
+        val prefs = userPreferencesFlow(unreadable, local, intact()).first()
+
+        assertTrue("the per-install store still answers", prefs.hasShownDisabledAppsPrompt)
+        assertEquals("the unreadable one falls back", ThemeMode.SYSTEM, prefs.themeMode)
+        assertTrue("and this side *is* reported", prefs.settingsLost)
+    }
+
+    // The rest assert the guard directly rather than through userPreferencesFlow. `combine`
+    // collects each side in a child coroutine and conflates, so a rethrow from inside it would be
+    // observed as combine's handling of a cancelled child rather than as the guard's own decision,
+    // and an emission count would be observing conflation rather than the guard.
+
+    /**
+     * The reason the guard retries at all. Degrading is terminal — `catch` emits once and the
+     * upstream is complete — and nothing re-subscribes: `SecurityViewModel` shares the stream with
+     * `SharingStarted.Eagerly`, which does not restart a finished upstream, and the other collectors
+     * are plain `collect` loops that just end. So without the retry a single transient failure (low
+     * storage, an EIO, a read before credential-encrypted storage is unlocked) pins the whole
+     * process to values the user never chose, with the real ones sitting intact on disk.
+     */
+    @Test
+    fun `a read that fails once and then works delivers the real preferences`() = runTest {
+        val real = preferencesOf(Keys.BIOMETRIC_LOCK to true)
+        var attempts = 0
+        val flaky = flow<Preferences> {
+            if (attempts++ == 0) throw IOException("EIO, once")
+            emit(real)
+        }
+
+        val read = flaky.guardedRead("thor_preferences").first()
+
+        assertEquals(real, read.preferences)
+        assertFalse("a recovered read is not a degraded one", read.degraded)
+    }
+
+    /** A failure that outlasts the retries still degrades rather than reaching the collectors. */
+    @Test
+    fun `a read that never recovers degrades after the retries`() = runTest {
+        var attempts = 0
+        val unreadable = flow<Preferences> {
+            attempts++
+            throw IOException("failed to read")
+        }
+
+        val read = unreadable.guardedRead("thor_preferences").toList()
+
+        assertEquals(listOf(StoreRead(emptyPreferences(), degraded = true)), read)
+        assertEquals("first attempt plus the retries", 4, attempts)
+    }
+
+    /**
+     * A store that fails part way through keeps what it already delivered, then degrades — and the
+     * retries re-deliver it, because a retry re-collects from the start. Harmless here: every
+     * collector of this stream treats an emission as state to hold rather than as an event, and
+     * DataStore re-emits the current snapshot to a new subscriber anyway.
+     */
+    @Test
+    fun `a mid-stream read failure degrades rather than terminating the collector`() = runTest {
+        val good = preferencesOf(Keys.THEME_MODE to ThemeMode.DARK.name)
+        val failsAfterOne = flow<Preferences> {
+            emit(good)
+            throw IOException("the file went away")
+        }
+
+        val read = failsAfterOne.guardedRead("thor_preferences").toList()
+
+        assertEquals(
+            "the last good snapshot survives",
+            good,
+            read.first { !it.degraded }.preferences
+        )
+        assertEquals(
+            "and the stream ends on the fallback rather than on the throw",
+            StoreRead(emptyPreferences(), degraded = true),
+            read.last()
+        )
+    }
+
+    /**
+     * The guard must not become a blanket `catch`. A programming error in the mapping, a
+     * `SecurityException`, an `OutOfMemoryError` — turning any of those into "the user has no
+     * settings" hides a real fault behind a plausible-looking default screen. It must not be
+     * retried either: a non-IO failure will not read differently the second time.
+     */
+    @Test
+    fun `a non-IO failure is not swallowed`() = runTest {
+        var attempts = 0
+        val broken = flow<Preferences> {
+            attempts++
+            throw IllegalStateException("not an IO problem")
+        }
+
+        val thrown = runCatching { broken.guardedRead("thor_preferences").toList() }
+            .exceptionOrNull()
+
+        assertTrue("expected the original failure, got $thrown", thrown is IllegalStateException)
+        assertEquals("and no retry", 1, attempts)
+    }
+
+    /**
+     * Cancellation above all. A collector being torn down must not be handed a fabricated defaults
+     * emission on its way out — for `MainViewModel` or `PrivilegeManager` that would be a state
+     * write during shutdown, and it would break structured concurrency besides.
+     */
+    @Test
+    fun `a cancellation is not mistaken for a read failure`() = runTest {
+        val cancelled = flow<Preferences> { throw CancellationException("collector went away") }
+
+        val thrown = runCatching { cancelled.guardedRead("thor_preferences").toList() }
+            .exceptionOrNull()
+
+        assertTrue("expected the cancellation to propagate, got $thrown", thrown is CancellationException)
+    }
+
+    /** A healthy store is passed through untouched — the guard is not a filter. */
+    @Test
+    fun `a readable store is unaffected`() = runTest {
+        val readable: Flow<Preferences> = flowOf(
+            emptyPreferences(),
+            preferencesOf(Keys.THEME_MODE to ThemeMode.DARK.name)
+        )
+
+        val read = readable.guardedRead("thor_preferences").toList()
+
+        assertEquals(2, read.size)
+        assertTrue("nothing was degraded", read.none { it.degraded })
+    }
+
+    /** The state of a settings file that was never replaced. */
+    private fun intact() = MutableStateFlow(false)
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/security/SecurityViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/security/SecurityViewModelTest.kt
@@ -245,6 +245,91 @@ class SecurityViewModelTest {
         }
     }
 
+    // ── Settings that could not be read ─────────────────────────────────────────────────────────
+    //
+    // `UserPreferences.settingsLost` means the values in the snapshot are Thor's defaults rather
+    // than the user's, because `thor_preferences.preferences_pb` was unreadable — the partial-restore
+    // case the corruption handler exists for. Every other setting degrades to something the user can
+    // see and put back; this one degrades to an app lock that is off, which is indistinguishable
+    // from a user who never set one.
+
+    @Test
+    fun `settings that could not be read hold the lock closed rather than opening it`() = runTest {
+        val vm = SecurityViewModel(
+            FakePreferenceRepository(UserPreferences(settingsLost = true)),
+            FakeAuthCapability()
+        )
+
+        // The preference itself reads `false` here — that is the whole problem. Taking it at face
+        // value opens Thor for a user who deliberately closed it, on the one device where that is
+        // most likely to have happened, and the replaced file makes it permanent.
+        assertEquals(AuthState.Locked, vm.authState.value)
+    }
+
+    @Test
+    fun `an unreadable store does not invent a gate this device could not open`() = runTest {
+        val vm = SecurityViewModel(
+            FakePreferenceRepository(UserPreferences(settingsLost = true)),
+            FakeAuthCapability(capable = false)
+        )
+
+        // Failing closed is only the safer guess while a prompt can succeed. Here it would hand a
+        // user who may never have armed the lock the Unavailable screen and send them off to enrol
+        // a screen lock for a gate Thor invented.
+        assertEquals(AuthState.NotRequired, vm.authState.value)
+    }
+
+    @Test
+    fun `a lock held closed by an unreadable store still reports its own errors`() = runTest {
+        val vm = SecurityViewModel(
+            FakePreferenceRepository(UserPreferences(settingsLost = true)),
+            FakeAuthCapability()
+        )
+
+        vm.onAuthError("Fingerprint operation cancelled")
+
+        // onAuthError is gated on the lock being armed, and on this branch the preference says it
+        // is not. Without settingsLost in that gate the user sits on the lock screen after a
+        // cancelled prompt with no message and no Retry.
+        assertEquals(AuthState.Error("Fingerprint operation cancelled"), vm.authState.value)
+    }
+
+    @Test
+    fun `losing the settings says so`() = runTest {
+        val vm = SecurityViewModel(
+            FakePreferenceRepository(UserPreferences(settingsLost = true)),
+            FakeAuthCapability()
+        )
+
+        vm.events.test {
+            // The prompt alone would not explain itself, and on the incapable branch above there is
+            // no prompt at all — the lock is simply gone. Either way Thor is running on settings the
+            // user did not choose and has to say so.
+            assertEquals(
+                UiText.StringResource(R.string.settings_lost_using_defaults),
+                awaitItem()
+            )
+        }
+    }
+
+    @Test
+    fun `an unreadable store is not mistaken for a lock this device cannot open`() = runTest {
+        val prefs = FakePreferenceRepository(UserPreferences(settingsLost = true))
+        val vm = SecurityViewModel(prefs, FakeAuthCapability(capable = false, hardware = false))
+
+        vm.events.test {
+            // The settings notice, and only the settings notice. The disarm above writes `false`
+            // for a lock it has decided cannot work; this branch has decided nothing — it does not
+            // know what the user chose — and feeding settingsLost into it would turn a failed read
+            // into a permanent answer of Thor's own, told to the user as a lock it took off.
+            assertEquals(
+                UiText.StringResource(R.string.settings_lost_using_defaults),
+                awaitItem()
+            )
+            expectNoEvents()
+        }
+    }
+
     @Test
     fun `a lock the user could enrol their way into is left alone`() = runTest {
         val prefs = locked()


### PR DESCRIPTION
Branch 1 of 8 from the 2026-08-04 dev-branch audit.

## The crash

`PreferenceRepositoryImpl.userPreferences` was `combine(dataStore.data, localState.data)` with no
guard. DataStore's `.data` throws `IOException` on a failed read, and **22 call sites across 18
files** collect this flow — including `ThorApplication:106`, `HomeActivity:70` and
`PrivilegeManager:70`, all on the startup path. One unreadable preferences file took the whole app
down, on every launch, with no recovery short of clearing app data.

Exactly one collector knew: `AppListViewModel:336` had a local `.catch { emit(UserPreferences()) }`
with a comment explaining precisely why it was needed. That is the audit's **dominant theme** — a
fix applied where the bug was found and never swept across its class — so the guarantee moves onto
the interface and that local catch is deleted, its comment's premise now being false.

## Two layers, because neither is sufficient alone

| | Covers | Misses |
|---|---|---|
| `ReplaceFileCorruptionHandler` | an unparseable file — and *heals* it, so the install recovers | fires only for `CorruptionException` |
| `guardedRead` on each flow | every other IO failure: SELinux denial, EIO, a read before credential-encrypted storage unlocks | doesn't repair anything |

The default handler is `NoOpCorruptionHandler`, which **rethrows and never rewrites** — so today a
corrupt file rethrows for the life of the install. The guard also covers the case where the
replacement write *itself* fails (no space, read-only volume): DataStore rethrows the original by
design there, which is exactly the state a device that just restored a broken backup can be in.

**Guarded per-flow, before the `combine`.** A catch downstream of the combine would end the whole
stream on the first failure and take the healthy store down with the broken one.

**Retry before degrading, because degrading is terminal.** `Flow.catch` emits once and completes
the upstream, and nothing re-subscribes — `SharingStarted.Eagerly` does not restart a finished
upstream, and the remaining collectors are plain `collect` loops. Without the retry, one transient
failure would pin the whole process to values the user never chose while the file on disk is
perfectly intact. Three re-reads over ~600 ms cost nothing on a healthy store.

**Only `IOException` is swallowed, and it is logged.** `CancellationException` and everything else
propagate — a cancelled collector must not be handed a fabricated defaults emission on its way out.
There is a test for each half of that.

## The part that isn't just a crash fix

After a failed read every boolean is `false`, and one of them arms the app lock. **"Could not read
your settings" and "the user turned everything off" were indistinguishable** — the audit's second
theme, "not yet known encoded as a safe-looking default".

The route that matters: the settings store is the one in the Auto Backup allowlist, so a partial
restore can hand a brand-new device an unreadable copy. Thor would open, silently unlocked, for a
user who had deliberately locked it — and the corruption handler then writes the empty file, making
it permanent.

So `UserPreferences.settingsLost` carries the distinction out, `SecurityViewModel` treats an
unreadable store as **lock-armed**, and the user is told.

Two guards on that, both deliberate:

- **Only where a prompt could succeed.** Inventing an *unopenable* gate for a lock the user may
  never have set is the worse of the two mistakes, so with `canAuthenticate` false this stays out
  of the way entirely.
- **`settingsLost` is not an input to the self-heal write in `init`.** That branch writes to the
  store, and writing a lock state Thor is only guessing at would turn a failed read into a
  permanent answer of its own.

It self-clears: the replaced file reads cleanly, so the next process sees `settingsLost = false`.

## Verification

- **514 unit tests, 0 failed, 0 skipped** (+17 over `dev`'s 497). `PreferenceReadGuardTest` is 12 of
  them, `SecurityViewModelTest` grew to 20.
- `lintFossRelease`: **0 errors, 0 warnings**, 5 hints. New string added to all five locales.
- The three Kotlin warnings in the build log are pre-existing (`ExtensionManager`, Koin plugin
  version), not from this change.

## Reviewer's attention, please

1. **Arming the lock on an unreadable store is a behaviour change**, not just a crash fix. It is
   fail-closed for a security feature and gated on `capable`, but it is the judgement call in here.
2. `settingsFileReplaced` is a **file-scoped** `MutableStateFlow`. It has to be — the handler is
   captured by the `preferencesDataStore` delegate, which is a `Context` property and cannot reach
   the repository instance. `userPreferencesFlow` takes it as a parameter so tests inject their own.
3. **The write path is still unguarded.** `edit {}` throws `IOException` the same way `.data` does,
   and there are ~25 setters with no guard. The corruption handler helps them, but a non-corruption
   write failure still propagates into the caller's scope. Deliberately left — wrapping 25 setters
   is a separate change — and filed as a follow-up rather than silently dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when app settings are unreadable or corrupted by retrying and safely restoring defaults.
  * Preserved app-lock protection when settings cannot be recovered and device authentication is available.
  * Added clear notifications when default settings are being used, including Arabic, Chinese, French, and Spanish translations.
  * Clarified security handling for devices that cannot support app locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->