### PR TITLE
fix(security): close the app lock's cold-start gap, and stop leaking the app list to Recents

### DIFF
--- a/app/src/main/java/com/valhalla/thor/HomeActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/HomeActivity.kt
@@ -8,12 +8,19 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -62,7 +69,14 @@ class HomeActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        installSplashScreen()
+        val splashScreen = installSplashScreen()
+        // Hold the frame until the app lock has answered. The preference comes from DataStore, which
+        // answers a beat after `setContent` returns, so without this the branch the user sees first
+        // is decided by a race rather than by the preference — and the losing outcome is the app,
+        // fully composed, behind a lock that had not finished switching on.
+        splashScreen.setKeepOnScreenCondition {
+            securityViewModel.authState.value == AuthState.Loading
+        }
         enableEdgeToEdge()
         shizukuHandler.register()
 
@@ -83,6 +97,30 @@ class HomeActivity : ComponentActivity() {
             ) {
                 val authState by securityViewModel.authState.collectAsStateWithLifecycle()
 
+                // The app lock promises that nothing inside is visible until you authenticate, and
+                // the Recents card is inside: Android snapshots whatever was on screen when Thor went
+                // to the background — typically the full installed-app list, with which apps are
+                // frozen or hidden — and shows it to anyone who picks the device up, no prompt
+                // involved. FLAG_SECURE is what excludes the window from that capture, and from
+                // screenshots and recorders with it.
+                //
+                // Keyed on `authState`, deliberately, and NOT on `prefs.biometricLockEnabled`:
+                // `prefs` is seeded with `UserPreferences()` until DataStore answers, whose default
+                // is `false`, so keying on it would leave the window capturable for exactly the
+                // window this whole change exists to close — the same "not read yet is
+                // indistinguishable from off" defect, reintroduced one screen later. `authState`
+                // already carries the tri-state, so the condition is inverted to fail closed: every
+                // state is secure *except* the one that means the lock is genuinely off, and an
+                // `AuthState` added later is protected by default rather than by remembering to
+                // amend this line. A user who never armed the lock still keeps their screenshots.
+                LaunchedEffect(authState) {
+                    if (authState == AuthState.NotRequired) {
+                        window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                    } else {
+                        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                    }
+                }
+
                 // The only place SecurityViewModel speaks: it disarms a lock this device can never
                 // open, and that must not happen silently — the user set that lock deliberately and
                 // is entitled to know Thor took it off. Collected here rather than in a screen
@@ -97,6 +135,21 @@ class HomeActivity : ComponentActivity() {
                 }
 
                 when (authState) {
+                    AuthState.Loading -> {
+                        // Deliberately nothing but a backdrop: the splash is still up (its
+                        // keep-on-screen condition reads this same state), and composing MainScreen
+                        // here is the defect this state exists to stop — its first composition
+                        // consumes the restored navigation state, which is then gone by the time the
+                        // user authenticates. Filled rather than empty so that a frame between the
+                        // splash exiting and MainScreen laying out cannot flash the light window
+                        // background of `Theme.Thor` at a dark-theme user.
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(MaterialTheme.colorScheme.background)
+                        )
+                    }
+
                     AuthState.NotRequired,
                     AuthState.Unlocked -> {
                         MainScreen(

--- a/app/src/main/java/com/valhalla/thor/presentation/security/AuthState.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/AuthState.kt
@@ -8,6 +8,20 @@ package com.valhalla.thor.presentation.security
  * The UI tree uses this to decide whether to show BiometricScreen or MainScreen.
  */
 sealed interface AuthState {
+    /**
+     * The lock preference has not been read yet, so it is not yet known whether a gate is needed.
+     *
+     * Its own state because it is neither of the two it could be folded into, and both folds are
+     * wrong. Folded into [NotRequired] — which is what seeding the preference `false` did — the gate
+     * stands open for the frames between `onCreate` and DataStore answering, and that is long enough
+     * to compose the entire app behind the lock. Folded into [Locked] it fires a biometric prompt at
+     * every user who never turned the lock on.
+     *
+     * The UI shows nothing on this state and holds the splash screen up until it resolves, so those
+     * frames belong to no branch at all.
+     */
+    data object Loading : AuthState
+
     /** Biometric lock is disabled — proceed directly to the app. */
     data object NotRequired : AuthState
 

--- a/app/src/main/java/com/valhalla/thor/presentation/security/BiometricScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/BiometricScreen.kt
@@ -33,9 +33,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -238,7 +238,12 @@ private fun BiometricLockView(
             Box(
                 modifier = Modifier
                     .size(110.dp)
-                    .alpha(pulseAlpha)
+                    // graphicsLayer, not Modifier.alpha: the lambda defers the read of the animated
+                    // value to the layer block, so each frame re-records the layer instead of
+                    // invalidating this composable. Read in composition scope it recomposes
+                    // BiometricLockView every frame, forever — on the first screen of a cold start,
+                    // against the main thread the biometric prompt needs.
+                    .graphicsLayer { this.alpha = pulseAlpha }
                     .background(Color.Transparent, CircleShape)
                     .padding(2.dp)
                     .background(greenDark.copy(alpha = 0.2f), CircleShape)
@@ -303,8 +308,14 @@ private fun BiometricLockView(
             Box(
                 modifier = Modifier
                     .size(96.dp)
-                    .scale(scale)
-                    .alpha(0.1f)
+                    // Same reason as the ring above: `scale` is animated, so it is read in the layer
+                    // block rather than in composition. The constant alpha rides along in the same
+                    // layer instead of adding a second one.
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                        alpha = 0.1f
+                    }
                     .background(greenDark, RoundedCornerShape(24.dp))
             )
 

--- a/app/src/main/java/com/valhalla/thor/presentation/security/SecurityViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/SecurityViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -44,9 +45,20 @@ class SecurityViewModel(
     private val _events = Channel<UiText>(Channel.BUFFERED)
     val events: Flow<UiText> = _events.receiveAsFlow()
 
-    private val _biometricEnabled = preferenceRepository.userPreferences
+    /**
+     * Whether the app lock is armed — `null` until the preference has actually been read.
+     *
+     * The nullability is the whole point. The preference arrives from DataStore asynchronously, so
+     * a `false` seed made "not read yet" indistinguishable from "the user turned the lock off", and
+     * `!enabled` is the *first* branch of the `when` below: every cold start reported
+     * [AuthState.NotRequired] until the real value landed, which is a fail-open gate. Long enough to
+     * compose the whole app, too — and MainScreen reads the restored navigation state on its first
+     * composition, which Compose's `SaveableStateRegistry` then drops, so the user who authenticated
+     * a moment later arrived back at the start destination with their place lost.
+     */
+    private val _biometricEnabled: StateFlow<Boolean?> = preferenceRepository.userPreferences
         .map { it.biometricLockEnabled }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     /**
      * Whether a prompt could succeed at all. Seeded synchronously rather than refreshed into
@@ -71,7 +83,7 @@ class SecurityViewModel(
 
     /**
      * The single source of truth for auth state, derived from:
-     *  - Whether biometric lock is enabled in preferences
+     *  - Whether biometric lock is enabled in preferences — `null` until that has been read
      *  - Whether the user has authenticated this session
      *  - Whether this device can authenticate at all
      *  - Whether the last auth attempt produced an error
@@ -83,6 +95,10 @@ class SecurityViewModel(
         _authError
     ) { enabled, authenticated, capable, error ->
         when {
+            // Above everything, including `authenticated`: nothing else in this `when` can be
+            // decided before the preference is known, and each of the other branches would be
+            // asserting something about a lock whose state has not been read yet.
+            enabled == null -> AuthState.Loading
             !enabled -> AuthState.NotRequired
             authenticated -> AuthState.Unlocked
             // Above Error on purpose. The prompt fails the instant it opens on a device that
@@ -106,7 +122,11 @@ class SecurityViewModel(
     }.stateIn(
         viewModelScope,
         SharingStarted.Eagerly,
-        AuthState.Locked
+        // The same value the combine produces first, so the seed cannot describe a different app
+        // than the flow does. `Eagerly` starts the collector but does not make it emit inline — on a
+        // real device this seed is what `HomeActivity` reads when it composes, and `Locked` there
+        // would show the lock screen (and fire a prompt) to every user who never turned it on.
+        AuthState.Loading
     )
 
     init {
@@ -121,12 +141,12 @@ class SecurityViewModel(
         // user can still open would be a security downgrade dressed up as a bug fix.
         //
         // Driven off the preference flow rather than checked once here, because the preference is
-        // read asynchronously: `_biometricEnabled` seeds `false` and the restored `true` lands a
+        // read asynchronously: `_biometricEnabled` seeds `null` and the restored `true` lands a
         // moment later, which is precisely the case this exists for. Writing `false` flips that
         // flow, so this settles after one pass instead of looping.
         viewModelScope.launch {
             combine(_biometricEnabled, _canAuthenticate) { enabled, capable ->
-                enabled && !capable
+                enabled == true && !capable
             }.collect { lockedOut ->
                 if (!lockedOut || enrolmentCanFix) return@collect
                 preferenceRepository.setBiometricLock(false)
@@ -166,7 +186,7 @@ class SecurityViewModel(
      * user can choose to retry or exit.
      */
     fun onAuthError(message: String) {
-        if (_biometricEnabled.value && !_isSessionAuthenticated.value) {
+        if (_biometricEnabled.value == true && !_isSessionAuthenticated.value) {
             _authError.value = message
         }
     }

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -39,9 +39,12 @@ import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.repository.UsageAccessGate
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import java.io.File
@@ -291,14 +294,29 @@ class FakeBulkFreezeController(
  * A real (in-memory) preference store rather than a stub: every setter writes the field it names,
  * so a test can flip a preference mid-run and watch the view model react through its own flow —
  * which is how the preference is delivered in production too.
+ *
+ * [firstReadDelayMs] models the one thing a `MutableStateFlow` cannot: DataStore reads from disk, so
+ * in production a fresh collector gets **no** value at all for the first moments — and a gate that
+ * treats "not read yet" as an answer is open for exactly that long. Left at 0 the flow emits
+ * synchronously as it always has; above 0 it emits nothing until that much virtual time has passed,
+ * then the current value and every later one.
  */
 class FakePreferenceRepository(
-    initial: UserPreferences = UserPreferences()
+    initial: UserPreferences = UserPreferences(),
+    firstReadDelayMs: Long = 0
 ) : PreferenceRepository {
 
     private val prefs = MutableStateFlow(initial)
 
-    override val userPreferences: Flow<UserPreferences> = prefs
+    override val userPreferences: Flow<UserPreferences> =
+        if (firstReadDelayMs == 0L) {
+            prefs
+        } else {
+            flow {
+                delay(firstReadDelayMs)
+                emitAll(prefs)
+            }
+        }
 
     override suspend fun updateAppSort(sortBy: SortBy) {
         prefs.update { it.copy(appSortBy = sortBy) }

--- a/app/src/test/java/com/valhalla/thor/presentation/security/SecurityViewModelColdStartTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/security/SecurityViewModelColdStartTest.kt
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.security
+
+import com.valhalla.thor.domain.model.UserPreferences
+import com.valhalla.thor.presentation.FakeAuthCapability
+import com.valhalla.thor.presentation.FakePreferenceRepository
+import com.valhalla.thor.presentation.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The cold start — the one moment [SecurityViewModelTest] cannot reach.
+ *
+ * Every test in that file hands the view model a `FakePreferenceRepository` backed by a plain
+ * `MutableStateFlow`, whose value is already there, and runs it unconfined so the collector settles
+ * during construction. Production satisfies neither condition: DataStore reads from disk, and
+ * `HomeActivity` composes a branch out of whatever the state is at that instant. The gap between
+ * those two is where the gate stood open, and a test written against a preference that is already
+ * read cannot see it however carefully it asserts.
+ *
+ * So this file is one setup: a preference that answers only after 50ms of virtual time, and a
+ * `StandardTestDispatcher` so nothing runs until the test says so. The assertions are on the whole
+ * *sequence* of states rather than a sampled value — "the gate was never open" is a claim about
+ * every emission, and reading `authState.value` afterwards cannot make it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SecurityViewModelColdStartTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(StandardTestDispatcher())
+
+    /** A preference store that answers the way DataStore does: not yet. */
+    private fun slowRead(lockEnabled: Boolean) = FakePreferenceRepository(
+        UserPreferences(biometricLockEnabled = lockEnabled),
+        firstReadDelayMs = 50
+    )
+
+    /**
+     * Every state the UI would be handed, in order, from construction until the store has answered.
+     *
+     * The collector is a **foreground** `launch` that is cancelled once the clock has run out, not a
+     * `backgroundScope.launch`. That is not a style choice: work in `backgroundScope` is not
+     * guaranteed to have been dispatched by the time `advanceUntilIdle()` returns, so a collector
+     * there records the state flow's initial value and then silently misses every update — this
+     * asserted `[Loading]` against an `authState` whose value had already reached `Locked`. Measured
+     * both ways before it was written this way round; a background collector reported `[Loading]`
+     * with the dispatcher passed explicitly, without it, and with a `runCurrent()` first.
+     *
+     * The cancel is what makes the foreground scope safe here: `authState` is a `StateFlow` and
+     * never completes, so without it `runTest` would hang waiting for a collector that has nothing
+     * left to wait for.
+     */
+    private fun TestScope.states(vm: SecurityViewModel): List<AuthState> {
+        val seen = mutableListOf<AuthState>()
+        val job = launch(mainDispatcherRule.dispatcher) { vm.authState.collect { seen += it } }
+        advanceUntilIdle()
+        job.cancel()
+        return seen
+    }
+
+    @Test
+    fun `the gate is not reported open before the lock preference has been read`() = runTest {
+        val vm = SecurityViewModel(slowRead(lockEnabled = true), FakeAuthCapability())
+
+        // Everything the main thread has to run before the first frame — which on a device is all
+        // that stands between onCreate and setContent picking a branch.
+        runCurrent()
+
+        // NotRequired here is the fail-open, and with the preference seeded `false` it was what
+        // every cold start reported, lock on or off, for as long as the disk read took.
+        assertEquals(AuthState.Loading, vm.authState.value)
+    }
+
+    @Test
+    fun `a cold start with the lock on never passes through an open gate`() = runTest {
+        val vm = SecurityViewModel(slowRead(lockEnabled = true), FakeAuthCapability())
+
+        val seen = states(vm)
+
+        // The whole history, not where it ended up. One NotRequired anywhere in this list is a frame
+        // of MainScreen — the app composed behind its own lock, and the restored navigation state
+        // read and dropped on the way past, so the user who then authenticates lands on the start
+        // destination with their place gone.
+        assertEquals(listOf(AuthState.Loading, AuthState.Locked), seen)
+    }
+
+    @Test
+    fun `a cold start with the lock off never shows the lock screen`() = runTest {
+        val vm = SecurityViewModel(slowRead(lockEnabled = false), FakeAuthCapability())
+
+        val seen = states(vm)
+
+        // The other half of the same rule, and why "not read yet" is a state of its own rather than
+        // just a `Locked` seed: BiometricScreen fires the prompt from a LaunchedEffect the moment it
+        // composes, so a Locked frame here is a fingerprint dialog in the face of a user who never
+        // turned the lock on.
+        assertEquals(listOf(AuthState.Loading, AuthState.NotRequired), seen)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/security/SecurityViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/security/SecurityViewModelTest.kt
@@ -30,6 +30,11 @@ import org.junit.Test
  * No dispatcher is injected here and none is needed: both `stateIn`s are `SharingStarted.Eagerly`,
  * so with a test dispatcher installed as Main the whole chain settles during construction and
  * `authState.value` is readable straight away.
+ *
+ * That settling is also this file's blind spot. Every test below starts from a preference that has
+ * already been read, and the cold start — the window in which it has *not* — is where the gate used
+ * to stand open. It is out of reach here by construction and lives in
+ * [SecurityViewModelColdStartTest].
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SecurityViewModelTest {
@@ -52,8 +57,8 @@ class SecurityViewModelTest {
     fun `with the lock switched on the app starts locked`() = runTest {
         val vm = SecurityViewModel(locked(), FakeAuthCapability())
 
-        // The seed value of the stateIn is Locked as well, so this is only meaningful because the
-        // preference has already been read: fail *open* here and the lock never engages.
+        // Meaningful only because the preference has already been read — the seed is Loading, which
+        // is a different claim entirely: fail *open* on the read and the lock never engages.
         assertEquals(AuthState.Locked, vm.authState.value)
     }
 


### PR DESCRIPTION
Four defects on the path between `onCreate` and the first frame, all of them variants of one mistake: **"not yet known" encoded as a safe-looking default.**

## 1. The app lock reported itself open before the preference had been read

`_biometricEnabled` seeded `false`, and `!enabled -> NotRequired` was the *first* branch of the `when`. So "the preference has not arrived from DataStore yet" and "the user turned the lock off" were the same value, and DataStore answers a beat *after* `setContent` returns. Every cold start therefore reported `NotRequired` until the disk read landed — long enough to compose the entire app behind a lock that had not finished switching on.

Fixed with a tri-state rather than by reseeding: `StateFlow<Boolean?>` seeded `null`, and an explicit `AuthState.Loading` as the first branch.

Reseeding to `Locked` fails the other way. `BiometricScreen` fires the prompt from a `LaunchedEffect(Unit)` on composition, so every user who never armed the lock would get a fingerprint dialog on every launch. The `stateIn` seed moves to `Loading` for the same reason: `Eagerly` starts the collector but does not make `combine` emit inline, so the seed is what `HomeActivity` actually reads at `setContent`, and leaving it `Locked` would just relocate the bug into the seed.

## 2. Restored navigation state was consumed and dropped

`MainScreen`'s first composition reads the restored state, which Compose's `SaveableStateRegistry` then discards. A user who authenticated a moment later landed on the start destination with their place gone.

Closed by (1) plus holding the splash: `core-splashscreen`'s `setKeepOnScreenCondition` installs an `OnPreDrawListener` that cancels the frame, so during `Loading` nothing composes and nothing calls `consumeRestored()`. The restored map has no timeout, so waiting costs nothing.

## 3. The Recents card showed the app list straight through the lock

Android snapshots whatever was on screen when Thor backgrounds — typically the full installed-app list, including which apps are frozen or hidden — and shows it to anyone who picks the device up. No prompt involved. `FLAG_SECURE` excludes the window from that capture, and from screenshots and screen recorders with it.

Keyed on `authState`, **not** on `prefs.biometricLockEnabled`. `prefs` is seeded with `UserPreferences()` until DataStore answers and its default is `false`, so keying on the preference would leave the window capturable for exactly the window this PR exists to close — the same defect one screen later. The condition is inverted to fail closed: every state is secure *except* `NotRequired`, so an `AuthState` added later is protected by default rather than by someone remembering to amend that line. A user who never armed the lock keeps their screenshots.

## 4. AP-C02 in `BiometricScreen`

Both animated reads moved into `graphicsLayer` lambdas.

## Tests

`SecurityViewModelColdStartTest`, with a preference that answers only after 50 ms of virtual time on a `StandardTestDispatcher` — the condition `SecurityViewModelTest` cannot reach, since a `MutableStateFlow` already has its value. Assertions are on the whole *sequence* of states, because "the gate was never open" is a claim about every emission and sampling `.value` afterwards cannot make it.

Its collector is a foreground `launch`, cancelled once the clock runs out, and that is load-bearing: **work in `backgroundScope` is not guaranteed to have been dispatched when `advanceUntilIdle()` returns**, so a collector there records the initial value and misses every update. The first draft did exactly that and asserted `[Loading]` against an `authState` that had already reached `Locked`. Measured four ways before rewriting.

## Reconciliation with #339

Both branches rewrote the same `combine`, because they fix two halves of one defect: this one closes the window where the preference had not been read *yet*, #339 closes the window where it could not be read *at all*. The merge commit keeps both conditions:

```kotlin
val required = enabled == true || (settingsLost && capable)
when {
    enabled == null -> AuthState.Loading
    !required -> AuthState.NotRequired
    ...
```

`enabled == true` rather than leaning on a smart cast from the `Loading` branch above it, so that reordering the `when` cannot silently turn "not read yet" back into "not armed".

## Verification

517 unit tests, 0 failed, 0 skipped. `lintFossRelease` 0 errors, 0 warnings.

**Not covered:** `HomeActivity` has no test — there is no Robolectric or instrumentation harness in this suite — so the splash guard, the `Loading` branch and the `FLAG_SECURE` toggle are unverified by any automated check. Defect 3 in particular wants a device: arm the lock, open the app list, background it, look at the Recents card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup security by keeping the splash screen visible while authentication settings load.
  * Prevented the app from briefly displaying unlocked content before biometric-lock preferences are resolved.
  * Applied screen-capture protection whenever authentication is required.
  * Added an opaque themed loading backdrop for a smoother, more secure startup experience.

* **Tests**
  * Added coverage for delayed preference loading and cold-start authentication transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->