### PR TITLE
fix(installer): make the confirmed identity and the installed bytes one set

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -14,122 +14,231 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build
 import androidx.core.graphics.createBitmap
+import com.valhalla.thor.domain.model.AnalyzedPackage
 import com.valhalla.thor.domain.model.AppMetadata
+import com.valhalla.thor.domain.model.StagedPackage
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.util.getDisplayName
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import java.io.File
 import java.io.FileOutputStream
+import java.security.MessageDigest
 import java.util.UUID
+
+/** Sub-directory of cacheDir holding staged installer inputs. */
+private const val STAGING_DIR_NAME = "staged_installs"
 
 @Single(binds = [AppAnalyzer::class])
 class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
 
-    override suspend fun analyze(uri: Uri): Result<AppMetadata> = withContext(Dispatchers.IO) {
+    override suspend fun analyze(uri: Uri): Result<AnalyzedPackage> = withContext(Dispatchers.IO) {
         val displayName = uri.getDisplayName(context)
         // Random, unpredictable temp names (CWE-377): avoids collisions between
         // concurrent analyses and predictable cache paths.
         val token = UUID.randomUUID()
+        val stagingDir = File(context.cacheDir, STAGING_DIR_NAME).apply { mkdirs() }
+        // The staged file outlives analyze() now, so a process death between the analysis and
+        // the install (or the dismissal) would strand a full copy of the input — hundreds of MB
+        // for an XAPK. Nothing else ever revisits this directory, so the sweep happens on the
+        // way in.
+        sweepStaleStagedPackages(stagingDir, System.currentTimeMillis())
         // The whole input is copied to disk once so it can be read with ZipFile
         // (random access via the central directory). ZipInputStream cannot handle
         // APKPure's STORED-with-data-descriptor entries (zero-size local headers) and
         // mis-reads the archive; ZipFile reads the central directory like `unzip`.
-        val bundleFile = File(context.cacheDir, "analysis_bundle_$token")
+        //
+        // That copy is also the ONE read of the caller's URI: the install runs off this file,
+        // so a hostile provider cannot serve a clean APK to the sheet the user approves and
+        // spyware to the `pm install -r -g` that follows. See StagedPackage.
+        val bundleFile = File(stagingDir, "staged_$token")
         val apkFile = File(context.cacheDir, "analysis_$token.apk")
 
-        try {
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                FileOutputStream(bundleFile).use { output -> input.copyTo(output) }
-            } ?: return@withContext Result.failure(
-                Exception("Could not open the selected file.")
-            )
-
-            // Phase 1: Enumerate entries + read sidecar metadata (XAPK manifest.json /
-            // APKMirror info.json) and icon bytes via ZipFile. If the file is not a
-            // readable zip, entryNames stays empty and the monolithic parse below runs.
-            var entryNames: List<String> = emptyList()
-            var manifestBytes: ByteArray? = null
-            var infoBytes: ByteArray? = null
-            var iconBytes: ByteArray? = null
-            try {
-                // Single ZipFile pass for entry names + all sidecar/icon bytes, instead
-                // of re-opening (and re-parsing the central directory of) the archive per
-                // file.
-                val contents = BundleZip.read(
-                    bundleFile,
-                    setOf("manifest.json", "info.json", "icon.png", "icon.jpg", "icon.webp")
-                )
-                entryNames = contents.entryNames
-                manifestBytes = contents.bytes["manifest.json"]
-                infoBytes = contents.bytes["info.json"]
-                iconBytes = contents.bytes["icon.png"]
-                    ?: contents.bytes["icon.jpg"]
-                    ?: contents.bytes["icon.webp"]
-            } catch (_: Exception) {
-                // Not a readable zip — fall through to the monolithic whole-file parse.
-            }
-
-            // Phase 2: Monolithic-APK gate (GH#207). A single installable APK carries
-            // its own top-level AndroidManifest.xml and shows no bundle signal — parse
-            // the whole file as-is and NEVER scan inner .apk assets.
-            if (isMonolithicApk(entryNames, displayName)) {
-                val archiveInfo = parseArchiveSafely(bundleFile)
-                    ?: return@withContext Result.failure(
-                        Exception("Failed to parse APK manifest. The file might be corrupted or encrypted.")
+        val metadata = try {
+            val input = context.contentResolver.openInputStream(uri)
+            if (input == null) {
+                Result.failure(Exception("Could not open the selected file."))
+            } else {
+                // The extraction budget applied at the door. A content provider is not an archive
+                // — there is no compression ratio to bound — but a hostile one can stream forever,
+                // and this copy runs before anything has decided the input is even a zip. Bounding
+                // it here is also what lets the two whole-file copies downstream (stageInstallSet's
+                // monolithic branch, the session's `base.apk` stream) reason about their source:
+                // it is this file, and it cannot grow after this line.
+                val copied = input.use { source ->
+                    FileOutputStream(bundleFile).use { output ->
+                        source.copyAtMostTo(output, MAX_EXTRACTED_TOTAL_BYTES)
+                    }
+                }
+                if (copied == null) {
+                    Result.failure(
+                        Exception(
+                            "The selected file is larger than " +
+                                "${MAX_EXTRACTED_TOTAL_BYTES / (1024 * 1024)} MB and was not read."
+                        )
                     )
-                return@withContext Result.success(metadataFrom(archiveInfo, bundleFile, iconBytes))
-            }
-
-            // Phase 3: Sidecar-metadata hint. The XAPK manifest.json / APKMirror
-            // info.json declares the package; that hint drives base selection so it no
-            // longer depends on a literal `base.apk` name. Tolerant deserialization
-            // (GH#159) keeps a numeric version_code / missing name from nuking it.
-            val manifest = manifestBytes?.let { bytes -> parseXapkManifest(String(bytes)) }
-            val apkmInfo = infoBytes?.let { bytes -> parseApkmInfo(String(bytes)) }
-            val packageHint = manifest?.packageName?.takeIf { it.isNotBlank() }
-                ?: apkmInfo?.packageName?.takeIf { it.isNotBlank() }
-
-            // Phase 4: Base selection (GH#159) — the manifest's declared base first,
-            // then generic candidates (config/splits last). Extract each from the
-            // bundle and return the first that parses as a real, non-split base APK.
-            val baseCandidates = buildList {
-                manifest?.baseApkFile()?.let { add(it) }
-                addAll(selectBaseApkCandidates(entryNames, packageHint))
-            }.distinctBy { it.substringAfterLast('/').lowercase() }
-
-            for (candidate in baseCandidates) {
-                val base = candidate.substringAfterLast('/')
-                if (!BundleZip.extractEntryTo(bundleFile, base, apkFile)) continue
-                val archiveInfo = parseArchiveSafely(apkFile)
-                if (archiveInfo != null && archiveInfo.applicationInfo != null) {
-                    return@withContext Result.success(metadataFrom(archiveInfo, apkFile, iconBytes))
+                } else {
+                    readMetadata(bundleFile, apkFile, displayName)
                 }
             }
-
-            // Phase 4.5: Sidecar-only metadata fallback (GH#159). If no bundled APK
-            // parsed but the bundle declares its own identity, surface that — it is the
-            // bundle's own package (never a nested APK's), so it cannot cause the
-            // GH#207 wrong-identity downgrade, and it lets the (independent) installer
-            // path proceed instead of the whole flow reading as "failed to parse".
-            buildMetadataFromSidecar(manifest, apkmInfo, iconBytes)?.let {
-                return@withContext Result.success(it)
-            }
-
-            // Phase 5: Last resort — parse the whole file as a monolithic APK (only
-            // reachable when it wasn't a readable bundle at all).
-            val archiveInfo = parseArchiveSafely(bundleFile)
-                ?: return@withContext Result.failure(
-                    Exception("Failed to parse APK manifest. The file might be corrupted or encrypted.")
-                )
-            Result.success(metadataFrom(archiveInfo, bundleFile, iconBytes))
         } catch (e: Exception) {
             Result.failure(e)
+        } catch (e: OutOfMemoryError) {
+            // BundleZip bounds what it reads into memory, but decoding a crafted icon or handing
+            // a crafted archive to the platform parser can still exhaust the heap — and an Error
+            // is not an Exception, so it would sail past every catch between here and
+            // viewModelScope and kill the process while the user was only *previewing* a file.
+            Result.failure(Exception("Could not read the selected file.", e))
         } finally {
-            bundleFile.delete()
             apkFile.delete()
         }
+
+        val analyzed = metadata
+            .map { AnalyzedPackage(it, StagedPackage(bundleFile, displayName)) }
+            // Nobody is going to install a file we could not describe, so this is the last
+            // chance to delete it; on success the caller owns it until discard().
+            .onFailure { bundleFile.delete() }
+
+        // Ownership transfers on the RETURN, and a cancelled withContext does not return — it
+        // throws, so the caller never assigns the result and never calls discard(). The copy above
+        // is a blocking, non-cooperative loop that runs to completion regardless, so cancelling the
+        // sheet mid-parse (swiping it away is the ordinary way to leave) stranded a full-size APK
+        // in cacheDir. The sweep on the next analysis reclaims it, but an hour later and only if
+        // there ever is a next analysis.
+        if (!isActive) bundleFile.delete()
+        analyzed
+    }
+
+    override fun discard(analyzed: AnalyzedPackage?) {
+        analyzed?.staged?.file?.delete()
+    }
+
+    /**
+     * Identify the already-staged [bundleFile], using [apkFile] as scratch space for a base APK
+     * extracted out of a bundle. Reads no URI: everything here is the one staged copy.
+     */
+    private fun readMetadata(
+        bundleFile: File,
+        apkFile: File,
+        displayName: String?
+    ): Result<AppMetadata> {
+        // Phase 1: Enumerate entries + read sidecar metadata (XAPK manifest.json /
+        // APKMirror info.json) and icon bytes via ZipFile. If the file is not a
+        // readable zip, entryNames stays empty and the monolithic parse below runs.
+        var entryNames: List<String> = emptyList()
+        var manifestBytes: ByteArray? = null
+        var infoBytes: ByteArray? = null
+        var iconBytes: ByteArray? = null
+        try {
+            // Single ZipFile pass for entry names + all sidecar/icon bytes, instead
+            // of re-opening (and re-parsing the central directory of) the archive per
+            // file.
+            val contents = BundleZip.read(
+                bundleFile,
+                setOf("manifest.json", "info.json", "icon.png", "icon.jpg", "icon.webp")
+            )
+            entryNames = contents.entryNames
+            manifestBytes = contents.bytes["manifest.json"]
+            infoBytes = contents.bytes["info.json"]
+            iconBytes = contents.bytes["icon.png"]
+                ?: contents.bytes["icon.jpg"]
+                ?: contents.bytes["icon.webp"]
+        } catch (_: Exception) {
+            // Not a readable zip — fall through to the monolithic whole-file parse.
+        }
+
+        // Phase 2: Monolithic-APK gate (GH#207). A single installable APK carries
+        // its own top-level AndroidManifest.xml and shows no bundle signal — parse
+        // the whole file as-is and NEVER scan inner .apk assets.
+        //
+        // No iconBytes: this file is an APK, so the authoritative icon is the one its own
+        // application info loads. A root-level `icon.png` in an APK is not a thing APKs have —
+        // it is a thing an archive gets given — and BundleZip.read now only matches at the root,
+        // so this changes nothing for a real APK and removes the icon from what a crafted one
+        // gets to choose. Same reasoning in Phase 5.
+        if (isMonolithicApk(entryNames, displayName)) {
+            val archiveInfo = parseArchiveSafely(bundleFile)
+                ?: return Result.failure(
+                    Exception("Failed to parse APK manifest. The file might be corrupted or encrypted.")
+                )
+            return Result.success(metadataFrom(archiveInfo, bundleFile, iconBytes = null))
+        }
+
+        // Phase 3: Sidecar-metadata hint. The XAPK manifest.json / APKMirror
+        // info.json declares the package; that hint drives base selection so it no
+        // longer depends on a literal `base.apk` name. Tolerant deserialization
+        // (GH#159) keeps a numeric version_code / missing name from nuking it.
+        val manifest = manifestBytes?.let { bytes -> parseXapkManifest(String(bytes)) }
+        val apkmInfo = infoBytes?.let { bytes -> parseApkmInfo(String(bytes)) }
+        val packageHint = manifest?.packageName?.takeIf { it.isNotBlank() }
+            ?: apkmInfo?.packageName?.takeIf { it.isNotBlank() }
+
+        // Phase 3.5: the install plan. Deliberately the SAME call the installer resolves its
+        // install set with (resolveInstallSetFromFile), so identity can only be read out of a file
+        // that install will write. Deriving the two independently is what let one archive show a
+        // signed base.apk on the sheet and install an unrelated payload.apk.
+        //
+        // The plan also filters entry names the writers would refuse (isSafeEntryFileName), which
+        // is what makes "one list" mean one list: a name like `good\base.apk` stayed in the
+        // candidates below and was dropped at extraction time, so the two sides agreed on the plan
+        // and still disagreed on the bytes.
+        val plan = resolveBundlePlan(
+            entryNames,
+            manifest?.splitApkFiles(),
+            manifest?.baseApkFile(),
+            packageHint
+        )
+
+        // Phase 4: Base selection (GH#159) — the manifest's declared base first,
+        // then generic candidates (config/splits last), all of them inside the install
+        // set. Extract each from the bundle and return the first that parses as a real,
+        // non-split base APK.
+        for (candidate in plan.identityCandidates) {
+            val base = candidate.substringAfterLast('/')
+            if (!BundleZip.extractEntryTo(bundleFile, base, apkFile)) continue
+            val archiveInfo = parseArchiveSafely(apkFile)
+            if (archiveInfo != null && archiveInfo.applicationInfo != null) {
+                return Result.success(metadataFrom(archiveInfo, apkFile, iconBytes))
+            }
+        }
+
+        // Phase 5: parse the whole file as a monolithic APK — but ONLY when the installer would
+        // stream the whole file too. `resolveInstallSetFromFile` reads an empty install set as
+        // "monolithic", so that is precisely the condition under which this file's own manifest
+        // describes the bytes `pm` ends up with.
+        //
+        // Behaviour change, deliberate: an archive that is a valid APK *and* carries installable
+        // `.apk` entries used to reach here and lend its own (genuine, signed) identity to an
+        // install of those inner entries. It is now reported unparseable instead. Nothing legitimate
+        // has that shape — GH#207's case is a nested `assets/child.apk`, whose name contains a `/`
+        // and so is never an install candidate — and it is the same substitution as F5, entered
+        // from the other side.
+        if (plan.installSet.isEmpty()) {
+            parseArchiveSafely(bundleFile)?.let {
+                return Result.success(metadataFrom(it, bundleFile, iconBytes = null))
+            }
+        }
+
+        // Phase 6: Sidecar-only metadata fallback (GH#159). If no bundled APK parsed but the bundle
+        // declares its own identity, surface that — it lets a `.apkm` whose payload this device
+        // cannot parse still show a name and an icon instead of reading as "failed to parse".
+        //
+        // LAST, where it used to run before the whole-file parse. Reaching it before meant a single
+        // attacker-added root `manifest.json` — one decisive bundle signal — was enough to stop a
+        // perfectly valid APK ever meeting the platform parser: no `.apk`-suffixed entry exists in
+        // an APK, so the candidate loop above found nothing to parse, and the sheet took its label,
+        // package name, version, permissions and icon from the attacker's JSON while the install
+        // side installed the real thing. Below the parse, a file that parses as an APK always
+        // identifies itself.
+        buildMetadataFromSidecar(manifest, apkmInfo, iconBytes)?.let {
+            return Result.success(it)
+        }
+
+        return Result.failure(
+            Exception("Failed to parse APK manifest. The file might be corrupted or encrypted.")
+        )
     }
 
     /**
@@ -161,14 +270,30 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
      * Build [AppMetadata] purely from bundle sidecar JSON when no bundled APK could
      * be parsed. Returns null if neither sidecar declares a package name. The icon
      * comes from the bundle's own icon bytes (there is no APK to load one from).
+     *
+     * The name is validated first. Every other path gets its package name from the platform
+     * parser; this one gets it from a JSON file inside an archive a stranger's app handed us,
+     * and it goes on to drive the installed-app lookup and the downgrade verdict. Rejecting it
+     * here means the file is reported unparseable — the right answer for a bundle that will not
+     * say honestly what it is.
+     *
+     * Known residual, deliberately left: when the archive DOES hold installable `.apk` entries and
+     * none of them parsed, this still answers, and `pm install-multiple` will then run on entries
+     * whose identity nothing confirmed. Exploiting it needs an APK that `getPackageArchiveInfo`
+     * rejects and PackageManagerService accepts — the same parser on both sides of a binder call —
+     * so the precondition is unproven, whereas refusing outright would take `.apkm` payloads this
+     * device genuinely cannot read (the GH#159 case this fallback exists for) off the sheet
+     * entirely. The cases that ARE reachable without a parser differential — a sidecar overriding a
+     * file that parses, and a sidecar describing an install set drawn from somewhere else — are
+     * closed by the phase order above and by [resolveBundlePlan] respectively.
      */
     private fun buildMetadataFromSidecar(
         manifest: XapkManifestInfo?,
         apkmInfo: ApkmInfo?,
         iconBytes: ByteArray?
     ): AppMetadata? {
-        val pkg = manifest?.packageName?.takeIf { it.isNotBlank() }
-            ?: apkmInfo?.packageName?.takeIf { it.isNotBlank() }
+        val pkg = manifest?.packageName?.takeIf { isValidSidecarPackageName(it) }
+            ?: apkmInfo?.packageName?.takeIf { isValidSidecarPackageName(it) }
             ?: return null
         val label = manifest?.name?.takeIf { it.isNotBlank() }
             ?: apkmInfo?.appName?.takeIf { it.isNotBlank() }
@@ -234,7 +359,13 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
      * absolute path (or null when there is no icon). The domain [AppMetadata] carries only this
      * path — Bitmap decoding stays in the data layer, only the destination changes.
      *
-     * Keyed by packageName AND [versionCode]: Coil keys its File memory cache by the path only
+     * Keyed by [iconCacheKey], which hashes the package name rather than using it: the sidecar
+     * path can reach here with whatever string a `manifest.json` declared, `java.io.File` does not
+     * normalise `..` (the syscall does), and `{"package_name":"../../databases/thor_database"}`
+     * would otherwise drop PNG bytes on the Room file. Hashing means no caller-supplied string
+     * ever reaches File() — the sidecar name is validated too, so this is the second of two locks.
+     *
+     * The key still varies with [versionCode]: Coil keys its File memory cache by the path only
      * (addLastModifiedToFileCacheKey defaults false), so a fixed per-package path would serve a
      * STALE icon after a version bump — a distinct path per version busts that. A null (unknown)
      * version code gets its own `_unknown` key rather than sharing the `_0` slot with a real APK
@@ -250,7 +381,7 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
         if (bitmap == null) return null
         return runCatching {
             val iconDir = File(context.cacheDir, "installer_icons").apply { mkdirs() }
-            val key = "${packageName}_${versionCode ?: "unknown"}"
+            val key = iconCacheKey(packageName, versionCode)
             val dest = File(iconDir, "$key.png")
             val tmp = File(iconDir, "$key.${java.util.UUID.randomUUID()}.png.tmp")
             try {
@@ -278,4 +409,33 @@ class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
         draw(canvas)
         return bitmap
     }
+}
+
+/** How long a staged input may sit unclaimed before the next analysis reclaims its disk. */
+internal const val STAGED_PACKAGE_TTL_MILLIS = 60L * 60L * 1000L
+
+/**
+ * Delete staged inputs under [dir] last touched more than [ttlMillis] before [now], returning how
+ * many went. Only ever reclaims a *stranded* file: the owner deletes its own on every exit path,
+ * and an hour is far longer than any live analyse-then-install, so a file this old belongs to a
+ * process that no longer exists. Returns 0 for a directory that does not exist.
+ */
+internal fun sweepStaleStagedPackages(
+    dir: File,
+    now: Long,
+    ttlMillis: Long = STAGED_PACKAGE_TTL_MILLIS
+): Int = (dir.listFiles() ?: emptyArray())
+    .count { it.isFile && now - it.lastModified() > ttlMillis && it.delete() }
+
+/**
+ * Cache-file key for an icon belonging to [packageName] at [versionCode].
+ *
+ * A hash, not the name: the name can come from an untrusted sidecar and this becomes a path.
+ * Truncated to 128 bits, which is far more collision resistance than a per-package cache slot
+ * needs, and the hex alphabet cannot express a path component.
+ */
+internal fun iconCacheKey(packageName: String, versionCode: Long?): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(packageName.toByteArray())
+    val hex = digest.take(16).joinToString("") { byte -> "%02x".format(byte.toInt() and 0xFF) }
+    return "${hex}_${versionCode ?: "unknown"}"
 }

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleAnalysis.kt
@@ -21,6 +21,29 @@ import kotlinx.serialization.json.Json
  * failure / wrong base pick).
  */
 
+/**
+ * The same shape the privilege gateways demand of a package name before it reaches a shell
+ * (`ShizukuSystemGateway`, `RootSystemGateway`, `DhizukuSystemGateway`).
+ */
+private val PACKAGE_NAME_REGEX = Regex("^[a-zA-Z0-9._]+$")
+
+/**
+ * True when a package name read out of a bundle *sidecar* may be trusted as an identity.
+ *
+ * Unlike the real-APK path, nothing has validated this string: it is whatever
+ * `manifest.json` / `info.json` said, and the archive came from whichever app fired the
+ * ACTION_VIEW intent. It goes on to drive the installed-app lookup, the downgrade verdict and
+ * the icon cache path, so `"../../databases/thor_database"` must not get that far.
+ *
+ * `..` matches the character class on its own, so it is rejected separately — a path component
+ * is exactly what a filename must never be.
+ */
+fun isValidSidecarPackageName(name: String?): Boolean =
+    !name.isNullOrBlank() &&
+        name != "." &&
+        name != ".." &&
+        PACKAGE_NAME_REGEX.matches(name)
+
 /** Tolerant, framework-independent JSON reader for XAPK manifests. */
 private val bundleJson = Json {
     ignoreUnknownKeys = true
@@ -277,7 +300,16 @@ fun selectBaseApkCandidates(entryNames: List<String>, packageName: String?): Lis
  * (which would yield a base-only/partial install). Otherwise we fall back to
  * [selectBaseApkCandidates], which orders every `.apk` base-first.
  *
- * Returns an empty list only when there are no `.apk` entries at all (caller then
+ * Every name in the result has a leaf that satisfies [isSafeEntryFileName]. That is a
+ * *postcondition*, and it is the reason the filter lives here rather than at the writers: this
+ * is the single place both the install set and the identity candidates drawn from it are
+ * decided, so a name the writers would refuse cannot survive into a list a *reader* still acts
+ * on. Applied at the writers instead — which is where the check started — an entry named
+ * `good\base.apk` stayed in the install set and in the identity candidates, was parsed for the
+ * confirmation sheet, and was then silently dropped from the set `pm` received: the sheet
+ * described one file and the device installed another.
+ *
+ * Returns an empty list only when there are no usable `.apk` entries at all (caller then
  * treats the input as monolithic).
  */
 fun resolveBundleInstallSet(
@@ -285,12 +317,20 @@ fun resolveBundleInstallSet(
     manifestSplitFiles: List<String>?,
     packageName: String?
 ): List<String> {
-    val ordered = selectBaseApkCandidates(entryNames, packageName)
+    // The one filter of the untrusted name list. Entry names come out of an archive a stranger's
+    // app handed us; `java.io.File` does not normalise `.`/`..`, and a backslash is a separator
+    // on the JVM's other host platform.
+    val entries = entryNames.filter { isSafeEntryFileName(it.substringAfterLast('/')) }
+    val ordered = selectBaseApkCandidates(entries, packageName)
     if (manifestSplitFiles.isNullOrEmpty()) return ordered
 
-    val available = entryNames.mapTo(HashSet()) { it.substringAfterLast('/') }
+    val available = entries.mapTo(HashSet()) { it.substringAfterLast('/') }
     // A manifest that references files not present is stale/partial: ignore it and
-    // fall back to the entry scan rather than extracting nothing.
+    // fall back to the entry scan rather than extracting nothing. This is also what carries the
+    // leaf-name postcondition onto the manifest's own strings, which are untrusted too and are
+    // returned verbatim below: `available` holds only leaves that passed the filter, so a split
+    // list naming `evil\payload.apk` reads as stale and is discarded whole — never shortened,
+    // because half a bundle is not a smaller install, it is a different one.
     if (!manifestSplitFiles.all { it.substringAfterLast('/') in available }) return ordered
 
     val listed = manifestSplitFiles.mapTo(HashSet()) { it.substringAfterLast('/') }
@@ -301,4 +341,62 @@ fun resolveBundleInstallSet(
         it.substringAfterLast('/') !in listed && isSplitApkName(it, packageName)
     }
     return manifestSplitFiles + extras
+}
+
+/**
+ * The single answer to "which APKs does this archive install, and which of them is the app".
+ *
+ * These used to be two answers reached by two algorithms. The analyzer picked an identity out of
+ * every `.apk` entry in the archive ([selectBaseApkCandidates]); the installer picked an install set
+ * out of the `manifest.json` split list ([resolveBundleInstallSet]), which deliberately drops
+ * standalone APKs the manifest did not list. An archive carrying a genuine, correctly signed
+ * `base.apk` next to a `manifest.json` naming only `payload.apk` therefore got one answer from each:
+ * the sheet described the signed app, `pm` installed the other one. With the set collapsed to a
+ * single APK there is not even the platform's own base/split package-name check left to catch it.
+ *
+ * So [identityCandidates] is drawn from [installSet] rather than from the archive at large. The APK
+ * the user is shown is always one of the files that gets written — and when [installSet] holds more
+ * than one, `install-multiple` puts the rest through the platform's consistency check against it.
+ *
+ * Being drawn from one list is not enough on its own: the list also has to hold only names the
+ * writers will accept, or the two sides diverge again at extraction time rather than at selection
+ * time. [resolveBundleInstallSet] is where that filter runs, and both fields inherit it.
+ *
+ * @param installSet ordered entry names to hand to `install-multiple`, empty when the archive holds
+ *   no installable `.apk` entry — which is how both sides agree to treat the file as monolithic.
+ *   Every name's leaf satisfies [isSafeEntryFileName].
+ * @param identityCandidates the same list re-ordered base-first, best guess first; the analyzer
+ *   parses these in turn and keeps the first that is a real, non-split APK. Same leaf guarantee,
+ *   because every element is one of [installSet]'s.
+ */
+data class BundleInstallPlan(
+    val installSet: List<String>,
+    val identityCandidates: List<String>
+)
+
+/**
+ * Resolve [entryNames] into the one plan both the analyzer and the installer act on.
+ *
+ * [manifestBaseFile] is untrusted like everything else in the sidecar, and it is the only string
+ * here that does not come from [installSet]. It is admitted only when it names one of the install
+ * set's own leaves, which is what gives it the same [isSafeEntryFileName] guarantee as the rest.
+ */
+fun resolveBundlePlan(
+    entryNames: List<String>,
+    manifestSplitFiles: List<String>?,
+    manifestBaseFile: String?,
+    packageName: String?
+): BundleInstallPlan {
+    val installSet = resolveBundleInstallSet(entryNames, manifestSplitFiles, packageName)
+    val installable = installSet.mapTo(HashSet()) { it.substringAfterLast('/').lowercase() }
+    val identity = buildList {
+        // The manifest's own `id == "base"` entry first — but only when it survived install-set
+        // resolution. A manifest that flags a base it then leaves out of `split_apks` is
+        // describing a file nobody installs, and that discrepancy is the attack, not a hint.
+        manifestBaseFile
+            ?.takeIf { it.substringAfterLast('/').lowercase() in installable }
+            ?.let { add(it) }
+        addAll(selectBaseApkCandidates(installSet, packageName))
+    }.distinctBy { it.substringAfterLast('/').lowercase() }
+    return BundleInstallPlan(installSet, identity)
 }

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
@@ -3,8 +3,125 @@
 
 package com.valhalla.thor.data.repository
 
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.MessageDigest
 import java.util.zip.ZipFile
+
+/**
+ * Cap on an entry read wholly into memory (sidecar JSON, bundle icon). Those are kilobytes;
+ * eight megabytes is already absurd for one. Without it a DEFLATE bomb — a few MB compressed,
+ * gigabytes expanded — raises OutOfMemoryError, which is an *Error*: every `catch (Exception)`
+ * up the installer's call chain misses it and the process dies while merely *previewing* a file
+ * a stranger sent. The installer takes a content:// URI from any app on the device, so the
+ * archive is untrusted input.
+ */
+internal const val MAX_METADATA_ENTRY_BYTES = 8L * 1024 * 1024
+
+/**
+ * Budget for everything one extraction writes to disk. APKs are legitimately large, so this is
+ * not a per-file "sane size" so much as the point past which no install could succeed anyway —
+ * it exists to stop a decompression bomb filling the data partition from cacheDir.
+ */
+internal const val MAX_EXTRACTED_TOTAL_BYTES = 4L * 1024 * 1024 * 1024
+
+/**
+ * The archive was refused, not installed.
+ *
+ * Its own type rather than a bare IOException because the mode ladders in InstallerRepositoryImpl
+ * answer a failed rung by trying the next one. That is right for "Shizuku's binder died" and wrong
+ * for "this archive expands to 40 GB": the next rung reads the same bytes, reaches the same verdict,
+ * and re-writes the same gigabytes on the way there. A refusal is a statement about the input, so it
+ * travels past the ladder to the sheet with a message describing what was refused.
+ */
+internal class InstallRefusedException(message: String) : IOException(message)
+
+/** Lowercase hex, the shape `sha256sum` prints and the shell integrity guard compares against. */
+internal fun ByteArray.toLowercaseHex(): String =
+    joinToString("") { byte -> "%02x".format(byte.toInt() and 0xFF) }
+
+/**
+ * One file [BundleZip.extractEntries] wrote, paired with the SHA-256 of the bytes it wrote.
+ *
+ * The digest belongs to the *write*, not to [file]. On the Shizuku/Dhizuku rungs [file] lands in
+ * externalCacheDir, which on API 28-29 (minSdk is 28; /Android/data was not sandboxed until 11) any
+ * app holding WRITE_EXTERNAL_STORAGE can overwrite the instant the stream closes. Re-opening it to
+ * hash it — what this code did before — measured whatever was there by then, so the on-device
+ * `sha256sum` guard ended up comparing the attacker's file against the attacker's own hash and
+ * passing. Taken in flight, the hash is of bytes no other app could ever have touched.
+ */
+data class ExtractedApk(val file: File, val sha256: String)
+
+/**
+ * True when [name] can be used as a leaf file name under an output directory.
+ *
+ * Entry base names come from the untrusted archive, and `java.io.File` does not normalise
+ * `.` / `..` — it hands them to the syscall, which does. A base name is taken after the last
+ * `/` so it cannot itself contain one, but `..` survives that intact, and a backslash is a
+ * separator on the JVM's other host platform. Rejecting those shapes outright is cheaper than
+ * reasoning about which of them the current filesystem happens to make harmless.
+ */
+internal fun isSafeEntryFileName(name: String): Boolean =
+    name.isNotBlank() &&
+        name != "." &&
+        name != ".." &&
+        !name.contains('/') &&
+        !name.contains('\\')
+
+/**
+ * Read at most [limit] bytes, or null if the stream holds more.
+ *
+ * The size in the central directory is a *claim* by whoever built the archive; a bomb can
+ * simply under-declare it. So a pre-check on [java.util.zip.ZipEntry.size] is an optimisation
+ * and this is the actual bound.
+ */
+private fun InputStream.readAtMost(limit: Long): ByteArray? {
+    val out = ByteArrayOutputStream()
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    var total = 0L
+    while (true) {
+        val read = read(buffer)
+        if (read == -1) break
+        total += read
+        if (total > limit) return null
+        out.write(buffer, 0, read)
+    }
+    return out.toByteArray()
+}
+
+/**
+ * Copy at most [limit] bytes into [out] — feeding each one to [digest] when given — and return the
+ * number copied, or null once the source exceeds [limit] (the partial output is the caller's to
+ * discard).
+ *
+ * Internal, not private: every path that writes bytes out of an untrusted archive needs this, and
+ * the branch that introduced it applied it to two of them. The PackageInstaller session path (the
+ * default rung and the last resort of both privileged ladders) and the copy of the caller's URI in
+ * AppAnalyzerImpl were writing unbounded.
+ *
+ * [digest] is here rather than in a wrapper stream so the hash and the write see the same bytes by
+ * construction — see [ExtractedApk] for what re-reading the destination instead cost.
+ */
+internal fun InputStream.copyAtMostTo(
+    out: OutputStream,
+    limit: Long,
+    digest: MessageDigest? = null
+): Long? {
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    var total = 0L
+    while (true) {
+        val read = read(buffer)
+        if (read == -1) break
+        total += read
+        if (total > limit) return null
+        out.write(buffer, 0, read)
+        digest?.update(buffer, 0, read)
+    }
+    return total
+}
 
 /**
  * Random-access ZIP reading for installer bundles (XAPK/.apkm/.apks) and APKs.
@@ -33,11 +150,33 @@ object BundleZip {
     )
 
     /**
-     * Open [zip] ONCE and return every entry name plus the bytes of any entry whose base
-     * name is in [wantedBaseNames] (case-insensitive). Avoids re-opening (and re-parsing
-     * the central directory of) the archive once per metadata file.
+     * Open [zip] ONCE and return every entry name plus the bytes of any **root-level** entry named
+     * in [wantedBaseNames] (case-insensitive). Avoids re-opening (and re-parsing the central
+     * directory of) the archive once per metadata file.
+     *
+     * An entry that declares — or turns out to hold — more than [maxEntryBytes] is skipped,
+     * not read: it is metadata by definition here, and no legitimate one is that large.
+     *
+     * Root-level, unlike the base-name matching [extractEntries] does: every caller of this wants a
+     * bundle sidecar (`manifest.json`, `info.json`) or a bundle icon, and hasXapkManifest /
+     * hasApkmInfoJson — the gate that decides the file even IS a bundle — already require those at
+     * the archive root. Matching a base name anywhere made the two disagree: a plain APK's
+     * `res/mipmap-hdpi/icon.png` became the icon on the confirmation sheet, and a file that
+     * classified as monolithic could still have an `assets/manifest.json` read out of it. Split
+     * APKs legitimately nest, which is why extraction still matches on the base name.
+     *
+     * [BundleContents.entryNames] is deliberately UNfiltered — every name, nested and unusable ones
+     * included. It is the input to the classifiers (`isMonolithicApk`, `hasTopLevelAndroidManifest`,
+     * `isTopLevelApkEntry`), which have to see what the archive actually holds: an entry named
+     * `evil\base.apk` is still a top-level `.apk` sibling, and hiding it here would classify a
+     * bundle as a monolithic APK. Deciding which names may be *acted on* is a different question
+     * and is answered once, in `resolveBundleInstallSet`.
      */
-    fun read(zip: File, wantedBaseNames: Set<String>): BundleContents {
+    fun read(
+        zip: File,
+        wantedBaseNames: Set<String>,
+        maxEntryBytes: Long = MAX_METADATA_ENTRY_BYTES
+    ): BundleContents {
         val wanted = wantedBaseNames.mapTo(HashSet()) { it.lowercase() }
         val names = ArrayList<String>()
         val bytes = HashMap<String, ByteArray>()
@@ -45,9 +184,12 @@ object BundleZip {
             for (entry in zf.entries()) {
                 if (entry.isDirectory) continue
                 names.add(entry.name)
-                val key = entry.name.substringAfterLast('/').lowercase()
+                if (entry.name.contains('/')) continue
+                val key = entry.name.lowercase()
                 if (key in wanted && key !in bytes) {
-                    bytes[key] = zf.getInputStream(entry).use { it.readBytes() }
+                    if (entry.size > maxEntryBytes) continue
+                    zf.getInputStream(entry).use { it.readAtMost(maxEntryBytes) }
+                        ?.let { bytes[key] = it }
                 }
             }
         }
@@ -65,57 +207,145 @@ object BundleZip {
 
     /**
      * Bytes of the first entry whose *base name* equals [baseName] (case-insensitive),
-     * or null if absent. Base-name matching mirrors how installers reference splits.
+     * or null if absent — or larger than [maxEntryBytes], since this reads into memory.
+     * Base-name matching mirrors how installers reference splits.
      */
-    fun readEntry(zip: File, baseName: String): ByteArray? =
+    fun readEntry(
+        zip: File,
+        baseName: String,
+        maxEntryBytes: Long = MAX_METADATA_ENTRY_BYTES
+    ): ByteArray? =
         ZipFile(zip).use { zf ->
             val entry = zf.entries().asSequence().firstOrNull {
                 !it.isDirectory &&
                     it.name.substringAfterLast('/').equals(baseName, ignoreCase = true)
             } ?: return null
-            zf.getInputStream(entry).use { it.readBytes() }
+            if (entry.size > maxEntryBytes) return null
+            zf.getInputStream(entry).use { it.readAtMost(maxEntryBytes) }
         }
 
     /**
      * Extract the first entry whose base name equals [baseName] (case-insensitive)
-     * into [dest]. Returns true on success, false if no such entry exists.
+     * into [dest]. Returns true on success, false if no such entry exists or it expands
+     * past [maxBytes] (in which case the partial [dest] is deleted).
+     *
+     * A false here stays a false rather than becoming an [InstallRefusedException] like the one
+     * [extractEntries] throws: the only caller is the analyzer's base-candidate loop, which is
+     * choosing which entry to *read*, not what to install. "That candidate is a bomb, try the next
+     * one" is the correct answer there, and every attempt is bounded by [maxBytes] on its own. No
+     * digest either — [dest] is app-private scratch that is parsed and deleted, never handed to
+     * `pm`.
+     *
+     * A [baseName] that is not a plain leaf is refused outright — the second lock behind
+     * [resolveBundleInstallSet], which is where the untrusted names are actually filtered. This is
+     * the read that decides the identity on the confirmation sheet, and every writer refuses such a
+     * name, so an identity must not be readable from one either: that gap is exactly how the sheet
+     * ends up describing a file `pm` was never given.
      */
-    fun extractEntryTo(zip: File, baseName: String, dest: File): Boolean =
-        ZipFile(zip).use { zf ->
+    fun extractEntryTo(
+        zip: File,
+        baseName: String,
+        dest: File,
+        maxBytes: Long = MAX_EXTRACTED_TOTAL_BYTES
+    ): Boolean {
+        if (!isSafeEntryFileName(baseName)) return false
+        return ZipFile(zip).use { zf ->
             val entry = zf.entries().asSequence().firstOrNull {
                 !it.isDirectory &&
                     it.name.substringAfterLast('/').equals(baseName, ignoreCase = true)
             } ?: return false
-            zf.getInputStream(entry).use { input ->
-                dest.outputStream().use { output -> input.copyTo(output) }
+            val copied = zf.getInputStream(entry).use { input ->
+                dest.outputStream().use { output -> input.copyAtMostTo(output, maxBytes) }
+            }
+            if (copied == null) {
+                dest.delete()
+                return false
             }
             true
         }
+    }
 
     /**
      * Extract every entry whose base name is in [wantedBaseNames] (compared
      * case-insensitively) into [outDir], one file per entry named by its base name.
      * The first match wins if two entries share a base name. Returns the extracted
      * files (archive order).
+     *
+     * [maxTotalBytes] is a budget for the whole extraction, not per entry: a bundle is a set
+     * of splits that get installed together, so what matters is what the set expands to.
+     *
+     * Every way of coming up short throws [InstallRefusedException] and deletes everything this
+     * call wrote — including the entries that fitted. There are three, and they are one verdict:
+     *
+     *  - the set passes [maxTotalBytes];
+     *  - a wanted name turns out not to be a plain leaf ([isSafeEntryFileName]);
+     *  - a wanted name is not in the archive at all.
+     *
+     * Returning the short list instead (what the budget case did before, and what the leaf-name
+     * case did until the rest of this comment caught up with it) refused only the all-or-nothing
+     * case: a bomb placed *after* base.apk left a non-empty list, `stageInstallSet`'s
+     * `.ifEmpty { null }` read that as success, and `pm install-multiple` ran on a truncated split
+     * set. Half a bundle is not a smaller install, it is a different one.
+     *
+     * The leaf-name case is unreachable through the installer — [resolveBundleInstallSet] filters
+     * those names out of the install set before any caller can want one — and is kept as a
+     * fail-closed second lock, so this function's contract does not depend on its caller's.
      */
-    fun extractEntries(zip: File, wantedBaseNames: Set<String>, outDir: File): List<File> {
+    internal fun extractEntries(
+        zip: File,
+        wantedBaseNames: Set<String>,
+        outDir: File,
+        maxTotalBytes: Long = MAX_EXTRACTED_TOTAL_BYTES
+    ): List<ExtractedApk> {
         outDir.mkdirs()
         val wanted = wantedBaseNames.mapTo(HashSet()) { it.lowercase() }
         val seen = HashSet<String>()
-        val out = mutableListOf<File>()
+        val out = mutableListOf<ExtractedApk>()
+        var remaining = maxTotalBytes
+        fun refuse(message: String): Nothing {
+            out.forEach { it.file.delete() }
+            throw InstallRefusedException(message)
+        }
         ZipFile(zip).use { zf ->
             for (entry in zf.entries()) {
                 if (entry.isDirectory) continue
                 val base = entry.name.substringAfterLast('/')
                 val key = base.lowercase()
-                if (key in wanted && seen.add(key)) {
-                    val dest = File(outDir, base)
-                    zf.getInputStream(entry).use { input ->
-                        dest.outputStream().use { output -> input.copyTo(output) }
-                    }
-                    out.add(dest)
+                // Wantedness first, so an unsafe name nobody asked for is skipped in silence
+                // (archives carry all sorts of junk) while an unsafe name that IS in the install
+                // set is a refusal — that one cannot be dropped, because the identity was drawn
+                // from the same list.
+                if (key !in wanted) continue
+                if (!isSafeEntryFileName(base)) {
+                    refuse("\"$base\" is not a usable file name; refusing to install this archive.")
                 }
+                if (!seen.add(key)) continue
+                val dest = File(outDir, base)
+                val digest = MessageDigest.getInstance("SHA-256")
+                val copied = zf.getInputStream(entry).use { input ->
+                    dest.outputStream().use { output ->
+                        input.copyAtMostTo(output, remaining, digest)
+                    }
+                }
+                if (copied == null) {
+                    dest.delete()
+                    refuse(
+                        "\"$base\" expands past the ${maxTotalBytes / (1024 * 1024)} MB " +
+                            "extraction budget; refusing to install this archive."
+                    )
+                }
+                remaining -= copied
+                out.add(ExtractedApk(dest, digest.digest().toLowercaseHex()))
             }
+        }
+        // Compared against the lowercased set, not [wantedBaseNames]: two wanted names differing
+        // only in case are one file here, and counting the caller's set would refuse a set that
+        // was in fact extracted whole.
+        if (seen.size != wanted.size) {
+            refuse(
+                "this archive does not contain ${(wanted - seen).sorted().joinToString(", ")}; " +
+                    "refusing to install a partial set."
+            )
         }
         return out
     }

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -8,10 +8,8 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInstaller
-import android.database.Cursor
 import android.net.Uri
 import android.os.Build
-import android.provider.OpenableColumns
 import com.valhalla.bypass.Bypass
 import com.valhalla.thor.data.ACTION_INSTALL_STATUS
 import com.valhalla.thor.data.gateway.RootSystemGateway
@@ -22,12 +20,12 @@ import com.valhalla.thor.data.source.local.shizuku.Shizuku as ShizukuHelper
 import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper
 import com.valhalla.thor.domain.InstallState
 import com.valhalla.thor.domain.InstallerEventBus
+import com.valhalla.thor.domain.model.StagedPackage
 import com.valhalla.thor.domain.repository.InstallMode
 import com.valhalla.thor.domain.repository.InstallerRepository
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.R
 import com.valhalla.thor.util.Logger
-import com.valhalla.thor.util.getDisplayName
 import com.valhalla.superuser.utils.escapeForShell
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -39,9 +37,11 @@ import org.koin.core.annotation.Single
 import kotlinx.coroutines.flow.first
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import java.io.File
-import java.io.FileOutputStream
 import java.io.InputStream
+import java.io.OutputStream
+import java.security.MessageDigest
 import java.util.UUID
+import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
 @Single(binds = [InstallerRepository::class])
@@ -66,6 +66,10 @@ class InstallerRepositoryImpl(
      * bundle signal (GH#207); for real bundles we prefer the manifest.json split
      * list (unioned with any present-but-unlisted splits so a stale manifest never
      * drops one) and otherwise order the .apk entries base-first (GH#159).
+     *
+     * Goes through [resolveBundlePlan] rather than [resolveBundleInstallSet] directly, which is
+     * the same call AppAnalyzerImpl reads its identity candidates out of. The two selections have
+     * to come from one function or they are free to disagree — and they did.
      */
     private fun resolveInstallSetFromFile(bundleFile: File, displayName: String?): List<String>? {
         // Single ZipFile pass for entry names + both sidecar files.
@@ -81,11 +85,16 @@ class InstallerRepositoryImpl(
         val packageHint = manifest?.packageName?.takeIf { it.isNotBlank() }
             ?: apkmInfo?.packageName?.takeIf { it.isNotBlank() }
 
-        return resolveBundleInstallSet(contents.entryNames, manifest?.splitApkFiles(), packageHint)
-            .ifEmpty { null }
+        return resolveBundlePlan(
+            contents.entryNames,
+            manifest?.splitApkFiles(),
+            manifest?.baseApkFile(),
+            packageHint
+        ).installSet.ifEmpty { null }
     }
 
     override suspend fun installPackage(
+        staged: StagedPackage,
         uri: Uri,
         mode: InstallMode,
         canDowngrade: Boolean,
@@ -94,15 +103,22 @@ class InstallerRepositoryImpl(
             try {
                 when (mode) {
                     InstallMode.ROOT -> {
-                        installWithRoot(uri, canDowngrade)
+                        installWithRoot(staged, canDowngrade)
                     }
 
                     InstallMode.SHIZUKU -> {
                         // 1. Try Shell command first
                         val shellSuccess = try {
-                            installWithShizuku(uri, canDowngrade)
+                            installWithShizuku(staged, canDowngrade)
                         } catch (e: Throwable) {
                             if (e is CancellationException) throw e
+                            // A refusal is a verdict about the archive, not a failure of this rung.
+                            // Every rung below reads the same staged bytes and reaches it again,
+                            // after re-writing however many gigabytes it took to get there — so it
+                            // goes straight out to the sheet with its own message. The four catches
+                            // that make up the two ladders all do this; ROOT and NORMAL have no
+                            // fallback and already propagate.
+                            if (e is InstallRefusedException) throw e
                             Logger.e("InstallerRepo", "Shizuku shell install failed with exception, trying reflection", e)
                             false
                         }
@@ -122,7 +138,7 @@ class InstallerRepositoryImpl(
                             if (privilegedInstaller != null) {
                                 try {
                                     performPackageInstallerInstall(
-                                        uri,
+                                        staged,
                                         privilegedInstaller,
                                         canDowngrade,
                                         emitErrors = false
@@ -130,6 +146,7 @@ class InstallerRepositoryImpl(
                                     reflectionSuccess = true
                                 } catch (e: Throwable) {
                                     if (e is CancellationException) throw e
+                                    if (e is InstallRefusedException) throw e
                                     Logger.e("InstallerRepo", "Shizuku reflection install failed: ${e.message}")
                                 }
                             }
@@ -138,7 +155,7 @@ class InstallerRepositoryImpl(
                                 Logger.d("InstallerRepo", "Shizuku reflection install failed. Falling back to normal installer...")
                                 // 3. Fallback to Normal
                                 performPackageInstallerInstall(
-                                    uri,
+                                    staged,
                                     defaultInstaller,
                                     canDowngrade,
                                     emitErrors = true
@@ -150,9 +167,10 @@ class InstallerRepositoryImpl(
                     InstallMode.DHIZUKU -> {
                         // 1. Try Shell command first
                         val shellSuccess = try {
-                            installWithDhizuku(uri, canDowngrade)
+                            installWithDhizuku(staged, canDowngrade)
                         } catch (e: Throwable) {
                             if (e is CancellationException) throw e
+                            if (e is InstallRefusedException) throw e
                             Logger.e("InstallerRepo", "Dhizuku shell install failed with exception, trying reflection", e)
                             false
                         }
@@ -172,7 +190,7 @@ class InstallerRepositoryImpl(
                             if (privilegedInstaller != null) {
                                 try {
                                     performPackageInstallerInstall(
-                                        uri,
+                                        staged,
                                         privilegedInstaller,
                                         canDowngrade,
                                         emitErrors = false
@@ -180,6 +198,7 @@ class InstallerRepositoryImpl(
                                     reflectionSuccess = true
                                 } catch (e: Throwable) {
                                     if (e is CancellationException) throw e
+                                    if (e is InstallRefusedException) throw e
                                     Logger.e("InstallerRepo", "Dhizuku reflection install failed: ${e.message}")
                                 }
                             }
@@ -188,7 +207,7 @@ class InstallerRepositoryImpl(
                                 Logger.d("InstallerRepo", "Dhizuku reflection install failed. Falling back to normal installer...")
                                 // 3. Fallback to Normal
                                 performPackageInstallerInstall(
-                                    uri,
+                                    staged,
                                     defaultInstaller,
                                     canDowngrade,
                                     emitErrors = true
@@ -199,7 +218,7 @@ class InstallerRepositoryImpl(
 
                     InstallMode.NORMAL -> {
                         performPackageInstallerInstall(
-                            uri,
+                            staged,
                             defaultInstaller,
                             canDowngrade,
                             emitErrors = true
@@ -207,10 +226,16 @@ class InstallerRepositoryImpl(
                     }
 
                     InstallMode.EXTERNAL -> {
+                        // The only mode that still needs the URI: we install nothing here, we
+                        // hand the job to whichever installer the user picks, and it does its
+                        // own read behind its own confirmation.
                         installWithExternal(uri)
                     }
                 }
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                // Throwable, matching the per-mode catches above: a bounded read still leaves
+                // OutOfMemoryError reachable through the platform parser, and an Error escaping
+                // to viewModelScope kills the process instead of failing the install.
                 if (e is CancellationException) throw e
                 eventBus.emit(InstallState.Error(UiText.DynamicString(e.message ?: "Unknown error during installation")))
             }
@@ -295,47 +320,100 @@ class InstallerRepositoryImpl(
         }
     }
 
-    private fun copyUriToTempFiles(uri: Uri, tempDir: File): List<File>? {
+    /**
+     * Lay the APK(s) [staged] contains out in [tempDir] for a `pm`-based install.
+     *
+     * Reads only the staged copy — the URI is never re-opened, so what gets installed is what
+     * the sheet described (see [StagedPackage]). The staged file itself is left alone: its owner
+     * deletes it, and a failed install may be retried off it.
+     *
+     * Every returned [ExtractedApk] carries the SHA-256 of the bytes THIS call wrote, taken in
+     * flight. tempDir is shared storage on the Shizuku and Dhizuku rungs, so hashing the files
+     * afterwards — the shape this replaces — measured whatever was in them by then, which on API
+     * 28-29 is not necessarily what we put there.
+     */
+    private fun stageInstallSet(staged: StagedPackage, tempDir: File): List<ExtractedApk>? {
         return try {
             tempDir.mkdirs()
-            // Copy the input to disk once, then read it with ZipFile (central
-            // directory). ZipInputStream cannot handle APKPure's
-            // STORED-with-data-descriptor entries and derails on the first one.
-            val bundleFile = File(tempDir, "__bundle__")
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                FileOutputStream(bundleFile).use { output -> input.copyTo(output) }
-            } ?: return null
-
-            val installSet = resolveInstallSetFromFile(bundleFile, uri.getDisplayName(context))
+            val bundleFile = staged.file
+            val installSet = resolveInstallSetFromFile(bundleFile, staged.displayName)
             if (installSet == null) {
-                // Monolithic APK: install the copied file as-is (renamed to base.apk).
+                // Monolithic APK: copy the staged file as-is (named base.apk). A copy, not a
+                // rename: the staged file has to survive for a retry, and on the Shizuku/Dhizuku
+                // paths tempDir is on a different filesystem anyway.
+                //
+                // The budget cannot fire here — the source is Thor's own staged file, which
+                // analyze() already bounded on the way in — but it is spelled out rather than
+                // assumed, because that bound lives in another class and this one would keep
+                // copying either way if it ever moved.
                 val tempApk = File(tempDir, "base.apk")
-                if (!bundleFile.renameTo(tempApk)) {
-                    bundleFile.copyTo(tempApk, overwrite = true)
-                    bundleFile.delete()
-                }
-                listOf(tempApk)
+                val digest = MessageDigest.getInstance("SHA-256")
+                val copied = bundleFile.inputStream().use { input ->
+                    tempApk.outputStream().use { output ->
+                        input.copyAtMostTo(output, MAX_EXTRACTED_TOTAL_BYTES, digest)
+                    }
+                } ?: throw InstallRefusedException(
+                    "The selected file is larger than " +
+                        "${MAX_EXTRACTED_TOTAL_BYTES / (1024 * 1024)} MB; refusing to install it."
+                )
+                Logger.d("InstallerRepo", "Staged $copied bytes as a monolithic base.apk")
+                listOf(ExtractedApk(tempApk, digest.digest().toLowercaseHex()))
             } else {
-                // Genuine bundle: extract exactly the resolved split set via ZipFile.
+                // Genuine bundle: extract exactly the resolved split set via ZipFile. No
+                // `.ifEmpty { null }` any more — extractEntries refuses a set it cannot deliver
+                // whole rather than returning what it managed, so "empty" no longer means
+                // "partially fine", it is unreachable. Reading emptiness as a staging failure was
+                // what turned a truncated set into the caller's generic error and, on the
+                // privileged ladders, into the next rung.
                 val wanted = installSet.mapTo(HashSet()) { it.substringAfterLast('/') }
-                val extracted = BundleZip.extractEntries(bundleFile, wanted, tempDir)
-                bundleFile.delete()
-                extracted.ifEmpty { null }
+                BundleZip.extractEntries(bundleFile, wanted, tempDir)
             }
+        } catch (e: InstallRefusedException) {
+            // Not a staging failure, a verdict on the archive. Returning null here would turn it
+            // into the caller's generic "Failed to extract or copy installation files" — or worse,
+            // into `false`, which sends the ladder down to the next rung to re-read the same bytes.
+            throw e
         } catch (e: Exception) {
-            Logger.e("InstallerRepo", "Failed to copy URI to temp files", e)
+            Logger.e("InstallerRepo", "Failed to stage the install set", e)
             null
         }
     }
 
+    /**
+     * [stageInstallSet], with [tempDir] removed if it throws.
+     *
+     * The three ladder rungs call this before entering the `try`/`finally` that owns [tempDir], so
+     * a throw from staging escapes past the only `deleteRecursively` on the path and strands the
+     * directory. It leaks no bytes — the extractor deletes what it wrote before refusing — but it
+     * leaks one empty directory per refused archive, and this branch makes staging refuse in
+     * strictly more cases than before, so a pre-existing trickle becomes a faster one. Two of the
+     * three rungs stage into `externalCacheDir`, where the residue is visible to the user in a file
+     * manager rather than hidden in app-private storage.
+     *
+     * Cleaning up here rather than moving the call inside the rung's `try` is deliberate: that
+     * `try` ends in `catch (e: Exception)`, which would fold [InstallRefusedException] into a
+     * generic "install error" message *and* stop it propagating — and propagation is what makes
+     * the ladder halt instead of dropping to a rung that would read the same refused bytes.
+     * Rethrowing the original preserves that, and [CancellationException] with it.
+     */
+    private fun stageInstallSetCleaningUpOnFailure(
+        staged: StagedPackage,
+        tempDir: File,
+    ): List<ExtractedApk>? = try {
+        stageInstallSet(staged, tempDir)
+    } catch (e: Throwable) {
+        tempDir.deleteRecursively()
+        throw e
+    }
+
     private suspend fun installWithRoot(
-        uri: Uri,
+        staged: StagedPackage,
         canDowngrade: Boolean,
     ) {
         eventBus.emit(InstallState.Installing(0f))
 
         val tempDir = File(context.cacheDir, "install_root_${UUID.randomUUID()}")
-        val tempFiles = copyUriToTempFiles(uri, tempDir)
+        val tempFiles = stageInstallSetCleaningUpOnFailure(staged, tempDir)
 
         if (tempFiles.isNullOrEmpty()) {
             eventBus.emit(InstallState.Error(UiText.DynamicString("Failed to extract or copy installation files")))
@@ -346,7 +424,12 @@ class InstallerRepositoryImpl(
         eventBus.emit(InstallState.Installing(0.5f))
 
         try {
-            val apkPaths = tempFiles.map { it.absolutePath }
+            // No integrity guard on this rung, and none needed: tempDir is context.cacheDir, which
+            // is app-private on every API level, so there is no window for another app to swap a
+            // file between the write and `pm`'s read. The Shizuku/Dhizuku rungs below are guarded
+            // because they have to stage into shared storage; the session paths read the staged
+            // file directly and never expose it at all. Those are all four write paths.
+            val apkPaths = tempFiles.map { it.file.absolutePath }
             val result = if (apkPaths.size == 1) {
                 rootGateway.installApp(apkPaths[0], canDowngrade)
             } else {
@@ -369,12 +452,18 @@ class InstallerRepositoryImpl(
         }
     }
 
-    private suspend fun installWithShizuku(uri: Uri, canDowngrade: Boolean): Boolean {
+    private suspend fun installWithShizuku(staged: StagedPackage, canDowngrade: Boolean): Boolean {
         eventBus.emit(InstallState.Installing(0f))
 
+        // Shared storage, deliberately: `pm install <path>` has *system_server* open the path,
+        // and it cannot read /data/data. The root gateway sidesteps this by piping the bytes in
+        // over stdin, which is not available here — Shizuku's newProcess feeds the command
+        // itself down stdin and closes it, and the shell uid could not `cat` an app-private file
+        // even if it were free. So the files are exposed, and integrityGuardedInstall re-hashes
+        // them inside the same shell invocation instead. See the digest map below.
         val baseDir = context.externalCacheDir ?: context.cacheDir
         val tempDir = File(baseDir, "install_shizuku_${UUID.randomUUID()}")
-        val tempFiles = copyUriToTempFiles(uri, tempDir)
+        val tempFiles = stageInstallSetCleaningUpOnFailure(staged, tempDir)
 
         if (tempFiles.isNullOrEmpty()) {
             tempDir.deleteRecursively()
@@ -386,18 +475,24 @@ class InstallerRepositoryImpl(
         val installerArg = preferenceRepository.getInstallerArg()
 
         return try {
-            val apkPaths = tempFiles.map { it.absolutePath }
+            val apkPaths = tempFiles.map { it.file.absolutePath }
+            // The digests came out of the copy itself, not out of a read-back of these paths. By
+            // the time this line runs, `eventBus.emit` and a DataStore read have both suspended —
+            // tens of milliseconds during which a co-installed app holding WRITE_EXTERNAL_STORAGE
+            // could have replaced base.apk. Hashing here would have hashed its file and then
+            // confirmed it against itself.
+            val digests = tempFiles.map { it.file.absolutePath to it.sha256 }
             val result = if (apkPaths.size == 1) {
                 val command = "pm install -r -g${if (canDowngrade) " -d" else ""}$installerArg ${
                     apkPaths[0].escapeForShell()
                 }"
-                ShizukuHelper.execute(command)
+                ShizukuHelper.execute(integrityGuardedInstall(digests, command))
             } else {
                 val escapedPaths = apkPaths.joinToString(" ") {
                     it.escapeForShell()
                 }
                 val command = "pm install-multiple -r -g${if (canDowngrade) " -d" else ""}$installerArg $escapedPaths"
-                ShizukuHelper.execute(command)
+                ShizukuHelper.execute(integrityGuardedInstall(digests, command))
             }
 
             if (result.first == 0) {
@@ -417,12 +512,13 @@ class InstallerRepositoryImpl(
         }
     }
 
-    private suspend fun installWithDhizuku(uri: Uri, canDowngrade: Boolean): Boolean {
+    private suspend fun installWithDhizuku(staged: StagedPackage, canDowngrade: Boolean): Boolean {
         eventBus.emit(InstallState.Installing(0f))
 
+        // Shared storage for the same reason as the Shizuku path, and guarded the same way.
         val baseDir = context.externalCacheDir ?: context.cacheDir
         val tempDir = File(baseDir, "install_dhizuku_${UUID.randomUUID()}")
-        val tempFiles = copyUriToTempFiles(uri, tempDir)
+        val tempFiles = stageInstallSetCleaningUpOnFailure(staged, tempDir)
 
         if (tempFiles.isNullOrEmpty()) {
             tempDir.deleteRecursively()
@@ -434,18 +530,20 @@ class InstallerRepositoryImpl(
         val installerArg = preferenceRepository.getInstallerArg()
 
         return try {
-            val apkPaths = tempFiles.map { it.absolutePath }
+            val apkPaths = tempFiles.map { it.file.absolutePath }
+            // Digests from the copy, for the same reason as the Shizuku rung above.
+            val digests = tempFiles.map { it.file.absolutePath to it.sha256 }
             val result = if (apkPaths.size == 1) {
                 val command = "pm install -r -g${if (canDowngrade) " -d" else ""}$installerArg ${
                     apkPaths[0].escapeForShell()
                 }"
-                DhizukuHelper.execute(command)
+                DhizukuHelper.execute(integrityGuardedInstall(digests, command))
             } else {
                 val escapedPaths = apkPaths.joinToString(" ") {
                     it.escapeForShell()
                 }
                 val command = "pm install-multiple -r -g${if (canDowngrade) " -d" else ""}$installerArg $escapedPaths"
-                DhizukuHelper.execute(command)
+                DhizukuHelper.execute(integrityGuardedInstall(digests, command))
             }
 
             if (result.first == 0) {
@@ -467,15 +565,17 @@ class InstallerRepositoryImpl(
 
     @SuppressLint("RequestInstallPackagesPolicy")
     private suspend fun performPackageInstallerInstall(
-        uri: Uri,
+        staged: StagedPackage,
         packageInstaller: PackageInstaller,
         canDowngrade: Boolean,
         emitErrors: Boolean = true
     ) {
-        val totalBytes = getFileSize(uri)
+        // Written before the first entry is copied, once the install set is known; the staged
+        // file's own length is the right answer for a monolithic APK and a decent lower bound
+        // for a bundle until then.
+        var totalBytes = staged.file.length()
         var bytesProcessed = 0L
         var lastProgressEmitted = 0
-        var filesWritten = false
 
         eventBus.emit(InstallState.Parsing)
 
@@ -555,8 +655,14 @@ class InstallerRepositoryImpl(
                         if (currentProgress > lastProgressEmitted) {
                             lastProgressEmitted = currentProgress
                             // Non-blocking hand-off; conflated so only the latest tick
-                            // survives if the drainer is momentarily behind.
-                            progressChannel.trySend(bytesProcessed.toFloat() / totalBytes)
+                            // survives if the drainer is momentarily behind. Clamped because
+                            // totalBytes is derived from sizes the archive declares: an entry
+                            // that says 10 bytes and streams a gigabyte put fractions in the
+                            // millions on the bus, and the write is bounded now but the lie
+                            // still is not.
+                            progressChannel.trySend(
+                                (bytesProcessed.toFloat() / totalBytes).coerceIn(0f, 1f)
+                            )
                         }
                     }
                 }
@@ -564,79 +670,89 @@ class InstallerRepositoryImpl(
         }
 
         try {
-            // Copy the input to disk once (tracking progress), then read it with
-            // ZipFile (central directory). ZipInputStream cannot handle APKPure's
-            // STORED-with-data-descriptor entries and derails on the first one.
-            val bundleFile = File(context.cacheDir, "install_bundle_${UUID.randomUUID()}")
-            try {
-                val copied = coroutineScope {
-                    // Drain progress ticks on a child coroutine so emissions are bound to the
-                    // install job (cancellation stops them) and can never outlive the copy phase.
-                    // Closing the channel ends the drain loop; coroutineScope then awaits this child
-                    // before returning, so the final tick is flushed before we continue. No explicit
-                    // join(): it is redundant here, and a suspending join() in a finally could mask
-                    // the real failure (e.g. an IOException from openInputStream) under cancellation.
-                    launch {
-                        for (fraction in progressChannel) {
-                            eventBus.emit(InstallState.Installing(fraction))
+            // The staged copy IS the input, already on disk — no second read of the URI, and no
+            // second copy either. ZipFile (central directory) reads it; ZipInputStream cannot
+            // handle APKPure's STORED-with-data-descriptor entries and derails on the first one.
+            val bundleFile = staged.file
+            coroutineScope {
+                // Drain progress ticks on a child coroutine so emissions are bound to the
+                // install job (cancellation stops them) and can never outlive the write phase.
+                // Closing the channel ends the drain loop; coroutineScope then awaits this child
+                // before returning, so the final tick is flushed before we continue. No explicit
+                // join(): it is redundant here, and a suspending join() in a finally could mask
+                // the real failure (e.g. an IOException from openWrite) under cancellation.
+                launch {
+                    for (fraction in progressChannel) {
+                        eventBus.emit(InstallState.Installing(fraction))
+                    }
+                }
+                try {
+                    // Genuine bundle: write each resolved split into the session, read via
+                    // ZipFile so STORED-with-data-descriptor entries stream correctly.
+                    val installSet = resolveInstallSetFromFile(bundleFile, staged.displayName)
+                    if (installSet != null) {
+                        val wanted =
+                            installSet.mapTo(HashSet()) { it.substringAfterLast('/').lowercase() }
+                        ZipFile(bundleFile).use { zf ->
+                            // OrRefuse, not the bare selector: an install set that does not
+                            // survive selection is a verdict about the archive, not a licence to
+                            // install something else. An empty selection used to fall through to
+                            // the monolithic branch below and stream the outer container as
+                            // base.apk — a file that by construction is not the one the sheet's
+                            // identity was read from.
+                            val toWrite =
+                                selectEntriesToWriteOrRefuse(zf.entries().asSequence(), wanted)
+                            // Now that the set is known, progress can be measured against what
+                            // actually gets written rather than the archive's compressed length —
+                            // capped, because this sum is the archive's own claim about itself.
+                            val declared = toWrite.sumOf { if (it.size >= 0) it.size else 0L }
+                            if (declared > 0) {
+                                totalBytes = declared.coerceAtMost(MAX_EXTRACTED_TOTAL_BYTES)
+                            }
+                            writeEntriesWithinBudget(
+                                zip = zf,
+                                entries = toWrite,
+                                budget = MAX_EXTRACTED_TOTAL_BYTES,
+                                openSink = { name, length -> session.openWrite(name, 0, length) },
+                                trackProgress = { inner -> getTrackedStream(inner) },
+                                afterEntry = { out -> session.fsync(out) }
+                            )
+                        }
+                    } else {
+                        // Monolithic APK (or not a readable bundle): stream the staged file
+                        // whole as base.apk.
+                        //
+                        // Gated on the ABSENCE of an install set, not on "nothing got written".
+                        // `installSet == null` is resolveInstallSetFromFile's own monolithic
+                        // verdict — the very condition AppAnalyzerImpl checks (plan.installSet
+                        // .isEmpty()) before it lets the whole file identify itself, so this is
+                        // the only state in which the file's own manifest describes the bytes
+                        // `pm` ends up with.
+                        Logger.d("thor", "Treating stream as monolithic base.apk")
+                        // The budget cannot bite here — the source is Thor's own staged copy,
+                        // bounded by analyze() — but it is applied anyway rather than assumed,
+                        // so this path does not depend on an invariant held in another class.
+                        val length = bundleFile.length().takeIf { it in 1..MAX_EXTRACTED_TOTAL_BYTES }
+                            ?: -1L
+                        var copied: Long? = null
+                        session.openWrite("base.apk", 0, length).use { out ->
+                            bundleFile.inputStream().use { inner ->
+                                copied = getTrackedStream(inner)
+                                    .copyAtMostTo(out, MAX_EXTRACTED_TOTAL_BYTES)
+                            }
+                            if (copied != null) session.fsync(out)
+                        }
+                        if (copied == null) {
+                            throw InstallRefusedException(
+                                "The selected file is larger than " +
+                                    "${MAX_EXTRACTED_TOTAL_BYTES / (1024 * 1024)} MB; " +
+                                    "refusing to install it."
+                            )
                         }
                     }
-                    try {
-                        context.contentResolver.openInputStream(uri)?.use { input ->
-                            FileOutputStream(bundleFile).use { output ->
-                                getTrackedStream(input).copyTo(output)
-                            }
-                            true
-                        } ?: false
-                    } finally {
-                        progressChannel.close()
-                    }
+                } finally {
+                    progressChannel.close()
                 }
-
-                if (!copied) {
-                    session.abandon()
-                    Logger.e("thor", "Could not open file stream.")
-                    if (emitErrors) {
-                        eventBus.emit(InstallState.Error(UiText.DynamicString("Could not open file stream.")))
-                        return
-                    } else throw Exception("Could not open file stream.")
-                }
-
-                // Genuine bundle: write each resolved split into the session, read via
-                // ZipFile so STORED-with-data-descriptor entries stream correctly.
-                val installSet = resolveInstallSetFromFile(bundleFile, uri.getDisplayName(context))
-                if (installSet != null) {
-                    val wanted = installSet.mapTo(HashSet()) { it.substringAfterLast('/').lowercase() }
-                    val seen = HashSet<String>()
-                    ZipFile(bundleFile).use { zf ->
-                        for (entry in zf.entries()) {
-                            if (entry.isDirectory) continue
-                            val base = entry.name.substringAfterLast('/')
-                            val key = base.lowercase()
-                            if (key !in wanted || !seen.add(key)) continue
-                            val size = if (entry.size >= 0) entry.size else -1L
-                            session.openWrite(base, 0, size).use { out ->
-                                zf.getInputStream(entry).use { inner -> inner.copyTo(out) }
-                                session.fsync(out)
-                            }
-                            filesWritten = true
-                        }
-                    }
-                }
-
-                // Monolithic APK (or not a readable bundle): stream the copied file
-                // whole as base.apk.
-                if (!filesWritten) {
-                    Logger.d("thor", "Treating stream as monolithic base.apk")
-                    val size = if (bundleFile.length() > 0) bundleFile.length() else -1L
-                    session.openWrite("base.apk", 0, size).use { out ->
-                        bundleFile.inputStream().use { inner -> inner.copyTo(out) }
-                        session.fsync(out)
-                    }
-                    filesWritten = true
-                }
-            } finally {
-                bundleFile.delete()
             }
 
             eventBus.emit(InstallState.Installing(1.0f))
@@ -662,30 +778,183 @@ class InstallerRepositoryImpl(
             session.commit(pendingIntent.intentSender)
             session.close()
 
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
+            // Abandon FIRST, and on every throwable — including CancellationException, which is
+            // the common case: the user swipes the sheet away mid-copy and this coroutine is
+            // cancelled. Rethrowing before the abandon left the session neither committed nor
+            // abandoned, and PackageInstaller caps sessions per app, so a few dozen abandoned
+            // previews used to block every later install until they aged out. The failure path
+            // where openSession() throws already got this right; this one didn't.
+            runCatching { session.abandon() }
             if (e is CancellationException) throw e
-            try {
-                session.abandon()
-            } catch (_: Exception) {
-            }
             Logger.e("thorInstaller", "Install failed", e)
             if (emitErrors) {
                 eventBus.emit(InstallState.Error(UiText.DynamicString(e.message ?: "Unknown installation error")))
             } else throw e
         }
     }
+}
 
-    private fun getFileSize(uri: Uri): Long {
-        var size = -1L
-        val cursor: Cursor? = context.contentResolver.query(uri, null, null, null, null)
-        cursor?.use {
-            if (it.moveToFirst()) {
-                val sizeIndex = it.getColumnIndex(OpenableColumns.SIZE)
-                if (sizeIndex != -1) {
-                    size = it.getLong(sizeIndex)
-                }
-            }
-        }
-        return size
+/** Exit code the integrity guard uses; distinct from anything `pm` itself returns. */
+internal const val INTEGRITY_CHECK_EXIT_CODE = 90
+
+/**
+ * The entries of a bundle that get written into an install session: the first entry per wanted
+ * base name (case-insensitive), in archive order.
+ *
+ * Names come from an untrusted archive and become the session's file names, so anything that is
+ * not a plain leaf name is dropped rather than handed to `openWrite`, which would answer it with
+ * an IllegalArgumentException from inside the platform.
+ *
+ * Dropping is not the same as tolerating. The caller compares this list against the set it asked
+ * for and refuses the install if anything is missing, so a drop costs the archive the install, not
+ * the entry — anything else would let the sheet describe a file the session never received. The
+ * case is unreachable in practice because `resolveBundleInstallSet` filters those names out of the
+ * install set first; this is the second lock, and it is the one that also catches a wanted name
+ * that simply is not in the archive.
+ */
+internal fun selectEntriesToWrite(
+    entries: Sequence<ZipEntry>,
+    wantedLowercaseBaseNames: Set<String>
+): List<ZipEntry> {
+    val seen = HashSet<String>()
+    return entries.filter { entry ->
+        if (entry.isDirectory) return@filter false
+        val base = entry.name.substringAfterLast('/')
+        if (!isSafeEntryFileName(base)) return@filter false
+        val key = base.lowercase()
+        key in wantedLowercaseBaseNames && seen.add(key)
+    }.toList()
+}
+
+/**
+ * [selectEntriesToWrite], refusing the archive unless it yields every wanted name.
+ *
+ * This is the session path's half of the rule `BundleZip.extractEntries` enforces for the
+ * privileged rungs, and it exists for the same reason: a set that came back short was read as
+ * success. There, `.ifEmpty { null }` turned a truncated bundle into an install; here, an empty
+ * selection fell into `performPackageInstallerInstall`'s monolithic branch, which streamed the
+ * *container archive* as `base.apk` — not merely a smaller install, but a file the confirmation
+ * sheet never described. Both shapes are the same mistake: treating "fewer entries than asked for"
+ * as a quantity when it is a verdict.
+ *
+ * Reachable two ways, neither of which should occur once `resolveBundleInstallSet` has filtered the
+ * names: an entry whose leaf `openWrite` could not take, and a wanted name that is not in the
+ * archive at all. Both are refusals, so this stays correct without depending on that filter.
+ */
+internal fun selectEntriesToWriteOrRefuse(
+    entries: Sequence<ZipEntry>,
+    wantedLowercaseBaseNames: Set<String>
+): List<ZipEntry> {
+    val selected = selectEntriesToWrite(entries, wantedLowercaseBaseNames)
+    val got = selected.mapTo(HashSet()) { it.name.substringAfterLast('/').lowercase() }
+    if (got != wantedLowercaseBaseNames) {
+        throw InstallRefusedException(
+            "this archive does not usably contain " +
+                (wantedLowercaseBaseNames - got).sorted().joinToString(", ") +
+                "; refusing to install a partial set."
+        )
     }
+    return selected
+}
+
+/**
+ * Copy [entries] out of [zip] into the sinks [openSink] hands back, refusing the whole install as
+ * soon as the set passes [budget]. Returns the total number of bytes written.
+ *
+ * The budget lives here as well as in `BundleZip.extractEntries` because this is the path
+ * `extractEntries` never sees. `performPackageInstallerInstall` is InstallMode.NORMAL — every user
+ * with no root and no Shizuku — and it is also the last rung of both privileged ladders, so it is
+ * where most installs land; it opens the archive itself and copied each entry with an unbounded
+ * `copyTo`. The name check (`selectEntriesToWrite`) had been applied to it and the size check had
+ * not, which is the classic shape: validate the entry list, then extract in a second pass that
+ * validates nothing. The session's staging directory is `/data/app/vmdl<id>.tmp` — the same data
+ * partition the budget was added to protect, filled the same way.
+ *
+ * [budget] is spent across the set, not per entry, because a bundle installs as a set: what matters
+ * is what the whole thing expands to. An exhausted budget throws rather than committing what fitted.
+ *
+ * The length reaching [openSink] is clamped to what is still allowed to be written. It comes from
+ * the archive's central directory, which is a claim by whoever built the archive; `openWrite`
+ * preallocates against it, so an entry declaring 2 TB would fail the install on an allocation Thor
+ * already knows it will never honour, and -1 ("unknown") is the honest input in that case. An
+ * under-declaration is left alone — it costs nothing now that the copy itself is bounded.
+ *
+ * @param trackProgress wraps each source stream (the caller's byte counter); identity by default.
+ * @param afterEntry runs on a sink that received all its bytes, before it closes (`session.fsync`).
+ */
+internal fun writeEntriesWithinBudget(
+    zip: ZipFile,
+    entries: List<ZipEntry>,
+    budget: Long,
+    openSink: (name: String, declaredLength: Long) -> OutputStream,
+    trackProgress: (InputStream) -> InputStream = { it },
+    afterEntry: (OutputStream) -> Unit = {}
+): Long {
+    var remaining = budget
+    for (entry in entries) {
+        val base = entry.name.substringAfterLast('/')
+        val declared = entry.size.takeIf { it in 0..remaining } ?: -1L
+        var copied: Long? = null
+        openSink(base, declared).use { out ->
+            zip.getInputStream(entry).use { inner ->
+                copied = trackProgress(inner).copyAtMostTo(out, remaining)
+            }
+            if (copied != null) afterEntry(out)
+        }
+        val written = copied ?: throw InstallRefusedException(
+            "\"$base\" expands past the ${budget / (1024 * 1024)} MB install budget; " +
+                "refusing to install this archive."
+        )
+        remaining -= written
+    }
+    return budget - remaining
+}
+
+/**
+ * Prefix [installCommand] with a check that each staged APK still hashes to what it did when we
+ * wrote it, aborting with [INTEGRITY_CHECK_EXIT_CODE] if not.
+ *
+ * The Shizuku/Dhizuku rungs have to stage into shared storage (see installWithShizuku), where on
+ * API 28-29 — minSdk is 28, and Android/data was not sandboxed until 11 — any app holding
+ * WRITE_EXTERNAL_STORAGE can watch the directory with a FileObserver and swap base.apk before
+ * `pm` reads it. `pm install -r -g` would then install the attacker's package, silently and with
+ * every runtime permission granted, while the sheet showed the app the user actually picked.
+ *
+ * Running the check inside the same shell invocation is the point: doing it from Thor's process
+ * would put a binder round trip and a process spawn between the check and the read. A window
+ * remains — `sha256sum` finishes, then `pm` opens the file — but it is microseconds of the same
+ * script rather than the whole staging-to-install span. A device whose toybox has no
+ * `sha256sum` fails the guard, which drops this rung and falls through to the privileged-session
+ * path that reads the app-private staged file directly: safe by construction, so failing closed
+ * costs nothing.
+ *
+ * What makes that true is where the expected hash comes from. It is computed during the copy that
+ * writes the file (see [ExtractedApk]), not from reading the file back afterwards: a read-back
+ * happens after the write has already suspended twice — an eventBus emit and a DataStore read — so
+ * it measured whatever was on disk by then, and an attacker who had already swapped the file simply
+ * got their own bytes hashed and then confirmed. The guard covered the microseconds and missed the
+ * span it was written for.
+ *
+ * @param digests staged absolute path to its expected lowercase SHA-256 hex.
+ */
+internal fun integrityGuardedInstall(
+    digests: List<Pair<String, String>>,
+    installCommand: String
+): String {
+    // Fail closed rather than quietly returning a bare `pm install`: an empty list means the
+    // caller lost track of what it staged, and the throw lands in that caller's catch, which
+    // gives up this rung for the privileged-session path instead of installing unverified bytes.
+    require(digests.isNotEmpty()) { "refusing to build an unguarded privileged install" }
+
+    val sb = StringBuilder()
+    for ((path, expected) in digests) {
+        sb.append("H=$(sha256sum ").append(path.escapeForShell())
+            .append(" 2>/dev/null | cut -d' ' -f1)\n")
+        sb.append("if [ \"\$H\" != \"").append(expected).append("\" ]; then ")
+            .append("echo 'staged APK failed its integrity check' 1>&2; ")
+            .append("exit ").append(INTEGRITY_CHECK_EXIT_CODE).append("; fi\n")
+    }
+    sb.append(installCommand)
+    return sb.toString()
 }

--- a/app/src/main/java/com/valhalla/thor/domain/model/StagedPackage.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/StagedPackage.kt
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import java.io.File
+
+/**
+ * The installer input after it has been copied into app-private storage — the ONE read of the
+ * caller's `content://` URI.
+ *
+ * `PortableInstallerActivity` is exported and takes an ACTION_VIEW URI from any app on the
+ * device, and in a privileged install mode there is no OS confirmation dialog. Reading that URI
+ * twice — once to build the sheet the user approves, once to install — lets the provider serve
+ * two different files: a clean APK for the "4 permissions" the sheet shows, spyware for the
+ * `pm install -r -g` that follows. So the bytes the user was shown are the bytes that get
+ * installed, and the URI is never opened again.
+ *
+ * @param file app-private copy of the input. It OUTLIVES the analysis that produced it — whoever
+ *   asked for the analysis owns it and must delete it on every exit path (installed, failed,
+ *   dismissed).
+ * @param displayName the provider's display name, captured at analysis time. Carried rather than
+ *   re-queried so the bundle-vs-monolithic decision is made about the same file twice.
+ */
+data class StagedPackage(
+    val file: File,
+    val displayName: String?
+)
+
+/**
+ * What an analysis produced: the metadata the sheet renders, and the staged bytes it was read
+ * from. Kept together so a caller cannot show one and install the other.
+ */
+data class AnalyzedPackage(
+    val metadata: AppMetadata,
+    val staged: StagedPackage
+)

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppAnalyzer.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppAnalyzer.kt
@@ -4,11 +4,22 @@
 package com.valhalla.thor.domain.repository
 
 import android.net.Uri
-import com.valhalla.thor.domain.model.AppMetadata
+import com.valhalla.thor.domain.model.AnalyzedPackage
 
 interface AppAnalyzer {
     /**
-     * Extracts metadata from a URI (APK, XAPK, APKS) without installing it.
+     * Copies a URI (APK, XAPK, APKS) into app-private storage exactly once and extracts metadata
+     * from that copy, without installing it.
+     *
+     * The staged file outlives this call so the install can use the very bytes the metadata
+     * describes — see [com.valhalla.thor.domain.model.StagedPackage]. The caller owns it and must
+     * pass it to [discard] on every exit path.
      */
-    suspend fun analyze(uri: Uri): Result<AppMetadata>
+    suspend fun analyze(uri: Uri): Result<AnalyzedPackage>
+
+    /**
+     * Delete the file staged by [analyze]. Idempotent, and a no-op for null, so it is safe to
+     * call from a teardown path that may or may not have staged anything.
+     */
+    fun discard(analyzed: AnalyzedPackage?)
 }

--- a/app/src/main/java/com/valhalla/thor/domain/repository/InstallerRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/InstallerRepository.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.domain.repository
 
 import android.net.Uri
+import com.valhalla.thor.domain.model.StagedPackage
 
 enum class InstallMode {
     NORMAL,
@@ -15,8 +16,22 @@ enum class InstallMode {
 
 /**
  * The Repository Contract.
- * The Domain layer doesn't care about PackageInstaller APIs, only that we can install a URI.
+ * The Domain layer doesn't care about PackageInstaller APIs, only that we can install a package.
  */
 interface InstallerRepository {
-    suspend fun installPackage(uri: Uri, mode: InstallMode, canDowngrade: Boolean = false)
+    /**
+     * Install the already-staged [staged] bytes — the ones the user was shown. The URI is never
+     * re-opened here; see [StagedPackage] for why.
+     *
+     * @param uri the original input, needed ONLY by [InstallMode.EXTERNAL], which hands the job
+     *   to another installer app rather than installing anything itself (that app does its own
+     *   read and shows its own confirmation, so the read-once rule is not ours to enforce there —
+     *   and a private staging path is not something another app could open anyway).
+     */
+    suspend fun installPackage(
+        staged: StagedPackage,
+        uri: Uri,
+        mode: InstallMode,
+        canDowngrade: Boolean = false
+    )
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.domain.InstallState
 import com.valhalla.thor.domain.InstallerEventBus
+import com.valhalla.thor.domain.model.AnalyzedPackage
 import com.valhalla.thor.domain.model.isVersionDowngrade
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.domain.repository.InstallMode
@@ -46,6 +47,13 @@ class InstallerViewModel(
         private set
 
     private var pendingUri: Uri? = null
+
+    // The one copy of the picked file, made by the analyzer and installed as-is. This ViewModel
+    // owns its lifetime: the analyzer stages it and never deletes it again, so every way out of
+    // this screen — a new pick, or teardown — has to discard it or a full-size copy of the file
+    // is stranded in the cache.
+    private var analyzed: AnalyzedPackage? = null
+
     private var isUpdateOperation: Boolean = false
     private var isDowngrade: Boolean = false
 
@@ -75,17 +83,26 @@ class InstallerViewModel(
         // @Single bus) is still showing. The viewModelScope is already cancelled here, so use the
         // synchronous reset() rather than resetState().
         if (ownsInstall) eventBus.reset()
+        // Covers the cancel path this class exists to serve: the user swipes the installer sheet
+        // away, the Activity finishes, and nothing else would ever delete the staged copy.
+        analyzer.discard(analyzed)
+        analyzed = null
     }
 
     fun parsePackage(uri: Uri) {
         pendingUri = uri
         ownsInstall = true
+        // A second pick replaces the first; the first's copy has no further use.
+        analyzer.discard(analyzed)
+        analyzed = null
         viewModelScope.launch {
             eventBus.emit(InstallState.Parsing)
             val result = analyzer.analyze(uri)
 
             result.fold(
-                onSuccess = { meta ->
+                onSuccess = { analysis ->
+                    analyzed = analysis
+                    val meta = analysis.metadata
                     currentPackageName = meta.packageName
 
                     // getPackageInfo() and the privilege checks in checkPrivilegeAndModes()
@@ -153,6 +170,10 @@ class InstallerViewModel(
 
     fun startInstallation() {
         val uri = pendingUri ?: return
+        // No staged copy means no analysis succeeded, and installing would mean reading the URI
+        // a second time — the very thing the staging exists to prevent. There is nothing to
+        // install here: the sheet only offers Install from ReadyToInstall.
+        val staged = analyzed?.staged ?: return
         ownsInstall = true
         val mode = _installMode.value
 
@@ -174,7 +195,7 @@ class InstallerViewModel(
         val allowDowngrade = isDowngrade || (versionCodeUnknown && mode != InstallMode.NORMAL)
 
         viewModelScope.launch {
-            repository.installPackage(uri, mode, allowDowngrade)
+            repository.installPackage(staged, uri, mode, allowDowngrade)
         }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -19,6 +19,7 @@ import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.R
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -53,6 +54,12 @@ class InstallerViewModel(
     // this screen — a new pick, or teardown — has to discard it or a full-size copy of the file
     // is stranded in the cache.
     private var analyzed: AnalyzedPackage? = null
+
+    // The in-flight analyze(), so a superseding pick can cancel it. Without this the discard in
+    // parsePackage() only reclaims a copy that has already been *handed over* — a parse still
+    // running owns a copy this class cannot see, and would assign it to `analyzed` after the
+    // discard had already run.
+    private var analysisJob: Job? = null
 
     private var isUpdateOperation: Boolean = false
     private var isDowngrade: Boolean = false
@@ -92,10 +99,21 @@ class InstallerViewModel(
     fun parsePackage(uri: Uri) {
         pendingUri = uri
         ownsInstall = true
-        // A second pick replaces the first; the first's copy has no further use.
+        // A second pick replaces the first; the first's copy has no further use. Two things can
+        // hold that copy, and both have to be released here.
+        //
+        // The *finished* parse hands its copy over in `analyzed` — discard reclaims it.
+        //
+        // The *still-running* parse does not: `analyzed` is assigned only when analyze() returns,
+        // so a discard that lands mid-parse finds null and reclaims nothing, and the older parse
+        // then completes and overwrites the newer one's `analyzed` — stranding a full-size copy
+        // in the cache until the hourly sweep. Cancelling is what releases that one: analyze()
+        // deletes its own staged file when it observes cancellation (AppAnalyzerImpl `!isActive`),
+        // and a cancelled coroutine never reaches the `analyzed = analysis` assignment below.
+        analysisJob?.cancel()
         analyzer.discard(analyzed)
         analyzed = null
-        viewModelScope.launch {
+        analysisJob = viewModelScope.launch {
             eventBus.emit(InstallState.Parsing)
             val result = analyzer.analyze(uri)
 

--- a/app/src/test/java/com/valhalla/thor/data/repository/BundleZipTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/BundleZipTest.kt
@@ -8,12 +8,15 @@ import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.file.Files
+import java.security.MessageDigest
 import java.util.zip.CRC32
+import java.util.zip.Deflater
 import java.util.zip.ZipInputStream
 
 /**
@@ -135,6 +138,85 @@ class BundleZipTest {
         return file
     }
 
+    /** Raw DEFLATE stream (no zlib wrapper), as a zip entry stores it. */
+    private fun deflate(data: ByteArray): ByteArray {
+        val deflater = Deflater(Deflater.BEST_COMPRESSION, true)
+        deflater.setInput(data)
+        deflater.finish()
+        val out = java.io.ByteArrayOutputStream()
+        val buffer = ByteArray(8192)
+        while (!deflater.finished()) {
+            out.write(buffer, 0, deflater.deflate(buffer))
+        }
+        deflater.end()
+        return out.toByteArray()
+    }
+
+    /**
+     * Write a single DEFLATED entry whose central directory declares [declaredSize] as the
+     * uncompressed size — which is a *claim*, and here a false one. A decompression bomb is
+     * exactly this: a small entry that says it is small and is not.
+     */
+    private fun writeZipDeclaringSize(
+        name: String,
+        content: ByteArray,
+        declaredSize: Long
+    ): File {
+        val file = tempFile("declared.zip")
+        val compressed = deflate(content)
+        val nameBytes = name.toByteArray(Charsets.US_ASCII)
+        val entryCrc = crc(content)
+        file.outputStream().use { out ->
+            var offset = 0
+            fun write(b: ByteArray) { out.write(b); offset += b.size }
+
+            write(le32(0x04034b50))
+            write(le16(20))
+            write(le16(0))                       // no data descriptor
+            write(le16(8))                       // method: DEFLATE
+            write(le16(0))
+            write(le16(0x21))
+            write(le32(entryCrc))
+            write(le32(compressed.size.toLong()))
+            write(le32(declaredSize))            // the lie
+            write(le16(nameBytes.size))
+            write(le16(0))
+            write(nameBytes)
+            write(compressed)
+
+            val cdStart = offset
+            write(le32(0x02014b50))
+            write(le16(20))
+            write(le16(20))
+            write(le16(0))
+            write(le16(8))
+            write(le16(0))
+            write(le16(0x21))
+            write(le32(entryCrc))
+            write(le32(compressed.size.toLong()))
+            write(le32(declaredSize))            // the same lie, where ZipFile reads it
+            write(le16(nameBytes.size))
+            write(le16(0))
+            write(le16(0))
+            write(le16(0))
+            write(le16(0))
+            write(le32(0))
+            write(le32(0))                       // local header offset
+            write(nameBytes)
+            val cdSize = offset - cdStart
+
+            write(le32(0x06054b50))
+            write(le16(0))
+            write(le16(0))
+            write(le16(1))
+            write(le16(1))
+            write(le32(cdSize.toLong()))
+            write(le32(cdStart.toLong()))
+            write(le16(0))
+        }
+        return file
+    }
+
     private val amazonEntries = listOf(
         "com.amazon.mShop.android.shopping.apk" to "BASE-APK-BYTES-payload-0123456789".toByteArray(),
         "config.arm64_v8a.apk" to "ARM64-CONFIG-SPLIT-bytes".toByteArray(),
@@ -174,10 +256,37 @@ class BundleZipTest {
         )
         val extracted = BundleZip.extractEntries(zip, wanted, outDir)
 
-        assertEquals(wanted, extracted.map { it.name }.toSet())
+        assertEquals(wanted, extracted.map { it.file.name }.toSet())
         for ((name, data) in amazonEntries.filter { it.first in wanted }) {
             assertArrayEquals(data, File(outDir, name).readBytes())
         }
+    }
+
+    @Test
+    fun bundleZip_extractEntries_digestsTheBytesItWroteNotTheFileItLeftBehind() {
+        // The property the privileged rungs' integrity guard rests on. Those stage into
+        // externalCacheDir, which any app holding WRITE_EXTERNAL_STORAGE can rewrite on API 28-29
+        // the moment the stream closes — so a digest taken by re-opening the file measures the
+        // attacker's bytes and then dutifully confirms them against themselves. Overwriting the
+        // file here is exactly that swap; the recorded hash must not follow it.
+        val zip = writeStoredDataDescriptorZip(listOf("base.apk" to "genuine-signal-bytes".toByteArray()))
+        val outDir = tempDir()
+
+        val extracted = BundleZip.extractEntries(zip, setOf("base.apk"), outDir).single()
+        val expected = MessageDigest.getInstance("SHA-256")
+            .digest("genuine-signal-bytes".toByteArray())
+            .joinToString("") { b -> "%02x".format(b.toInt() and 0xFF) }
+        assertEquals(expected, extracted.sha256)
+
+        // The swap.
+        extracted.file.writeBytes("attacker-payload".toByteArray())
+        val afterSwap = MessageDigest.getInstance("SHA-256")
+            .digest(extracted.file.readBytes())
+            .joinToString("") { b -> "%02x".format(b.toInt() and 0xFF) }
+
+        assertNotEquals(afterSwap, extracted.sha256)
+        // Which is what makes the on-device `sha256sum "$path" != "$expected"` check fail closed.
+        assertEquals(expected, extracted.sha256)
     }
 
     @Test
@@ -224,6 +333,280 @@ class BundleZipTest {
             "ZipInputStream unexpectedly read the entry correctly",
             viaZis == null || !viaZis.contentEquals(expected)
         )
+    }
+
+    @Test
+    fun bundleZip_read_skipsAMetadataEntryThatLiesAboutItsSize() {
+        // The shape that killed the process: `manifest.json` declares 100 bytes, expands to
+        // megabytes, and the old readBytes() allocated all of it. At the real scale that is an
+        // OutOfMemoryError, which is an Error — every `catch (Exception)` between here and
+        // viewModelScope misses it and Thor dies while merely PREVIEWING the file.
+        val payload = ByteArray(4 * 1024 * 1024) // compresses to a few KB
+        val zip = writeZipDeclaringSize("manifest.json", payload, declaredSize = 100L)
+
+        // The premise: the declared size is a lie, and reading it out really does yield 4 MB.
+        // If this ever fails, the pre-check alone would have been enough and the test below
+        // proves nothing.
+        assertEquals(
+            payload.size,
+            BundleZip.read(zip, setOf("manifest.json"), maxEntryBytes = 8L * 1024 * 1024)
+                .bytes["manifest.json"]!!.size
+        )
+
+        // With a cap the entry cannot honour, it is dropped rather than allocated.
+        val bounded = BundleZip.read(zip, setOf("manifest.json"), maxEntryBytes = 64L * 1024)
+        assertNull(bounded.bytes["manifest.json"])
+        // The archive is still enumerated — only the oversized entry's *bytes* are refused.
+        assertEquals(listOf("manifest.json"), bounded.entryNames)
+    }
+
+    @Test
+    fun bundleZip_read_skipsAnEntryThatDeclaresMoreThanTheCap() {
+        // Honest declaration, still too big: refused without opening the entry at all.
+        val payload = ByteArray(200_000)
+        val zip = writeZipDeclaringSize("icon.png", payload, declaredSize = payload.size.toLong())
+
+        val contents = BundleZip.read(zip, setOf("icon.png"), maxEntryBytes = 1024L)
+
+        assertNull(contents.bytes["icon.png"])
+    }
+
+    @Test
+    fun bundleZip_readEntry_refusesAnEntryLargerThanTheCap() {
+        val payload = ByteArray(200_000)
+        val zip = writeZipDeclaringSize("info.json", payload, declaredSize = 10L)
+
+        assertNull(BundleZip.readEntry(zip, "info.json", maxEntryBytes = 4096L))
+        assertEquals(payload.size, BundleZip.readEntry(zip, "info.json", maxEntryBytes = 1L shl 24)!!.size)
+    }
+
+    @Test
+    fun bundleZip_extractEntries_refusesAtTheBudgetAndLeavesNoPartialFile() {
+        // On-disk extraction has the same problem in a different currency: instead of the heap,
+        // a bomb fills the data partition from cacheDir.
+        val payload = ByteArray(1024 * 1024)
+        val zip = writeZipDeclaringSize("base.apk", payload, declaredSize = 10L)
+        val outDir = tempDir()
+
+        val refusal = assertThrows(InstallRefusedException::class.java) {
+            BundleZip.extractEntries(zip, setOf("base.apk"), outDir, maxTotalBytes = 4096L)
+        }
+
+        assertTrue(
+            "the refusal has to name what was refused: ${refusal.message}",
+            refusal.message!!.contains("base.apk")
+        )
+        assertTrue("partial output left behind", File(outDir, "base.apk").exists().not())
+    }
+
+    @Test
+    fun bundleZip_extractEntries_refusesTheWholeSetWhenALaterSplitBlowsTheBudget() {
+        // The half that the old "stop and return what we have" answer let through. base.apk fits,
+        // the split does not, and the short list came back non-empty — which stageInstallSet's
+        // `.ifEmpty { null }` reads as success, so `pm install-multiple` ran on a bundle missing
+        // one of its splits. Half a bundle is not a smaller install, it is a different one.
+        val zip = writeStoredDataDescriptorZip(
+            listOf(
+                "base.apk" to ByteArray(2048),
+                "split_config.arm64_v8a.apk" to ByteArray(4096),
+            )
+        )
+        val outDir = tempDir()
+
+        assertThrows(InstallRefusedException::class.java) {
+            BundleZip.extractEntries(
+                zip,
+                setOf("base.apk", "split_config.arm64_v8a.apk"),
+                outDir,
+                maxTotalBytes = 3000L
+            )
+        }
+
+        // Including the entry that DID fit: leaving it behind would leave a lone base.apk in the
+        // staging directory for a retry to find.
+        assertTrue("the entry that fitted was left behind", File(outDir, "base.apk").exists().not())
+        assertTrue(File(outDir, "split_config.arm64_v8a.apk").exists().not())
+    }
+
+    @Test
+    fun bundleZip_extractEntries_spendsOneBudgetAcrossTheWholeSet() {
+        // The complement of the test above: the budget is not per entry, so a set that fits inside
+        // it whole is extracted whole. Two 2 KB entries under a 4 KB budget is the boundary case.
+        val zip = writeStoredDataDescriptorZip(
+            listOf(
+                "base.apk" to ByteArray(2048) { 1 },
+                "split_config.xxhdpi.apk" to ByteArray(2048) { 2 },
+            )
+        )
+        val outDir = tempDir()
+
+        val extracted = BundleZip.extractEntries(
+            zip,
+            setOf("base.apk", "split_config.xxhdpi.apk"),
+            outDir,
+            maxTotalBytes = 4096L
+        )
+
+        assertEquals(listOf("base.apk", "split_config.xxhdpi.apk"), extracted.map { it.file.name })
+        assertEquals(2048, File(outDir, "base.apk").length().toInt())
+        assertEquals(2048, File(outDir, "split_config.xxhdpi.apk").length().toInt())
+    }
+
+    @Test
+    fun bundleZip_extractEntryTo_stopsAtTheBudgetAndDeletesThePartialFile() {
+        val payload = ByteArray(1024 * 1024)
+        val zip = writeZipDeclaringSize("base.apk", payload, declaredSize = 10L)
+        val dest = tempFile("out.apk")
+
+        assertTrue(BundleZip.extractEntryTo(zip, "base.apk", dest, maxBytes = 4096L).not())
+        assertTrue("partial output left behind", dest.exists().not())
+    }
+
+    @Test
+    fun bundleZip_extractEntries_refusesAnEntryWhoseBaseNameIsAPathComponent() {
+        // `java.io.File` does not normalise `..`; the syscall does. `substringAfterLast('/')`
+        // strips directories but leaves `..` intact, so "payload/.." arrives as the base name
+        // "..", and File(outDir, "..") is outDir's PARENT.
+        //
+        // Refused, not skipped. Skipping produced the very shape the budget case two tests up
+        // exists to forbid: a short list that `stageInstallSet` read as success, on a set the
+        // identity was drawn from. The name is in the install set or the archive is not installed.
+        val zip = writeStoredDataDescriptorZip(listOf("payload/.." to "evil".toByteArray()))
+        val outDir = tempDir()
+
+        val refusal = assertThrows(InstallRefusedException::class.java) {
+            BundleZip.extractEntries(zip, setOf(".."), outDir)
+        }
+
+        assertTrue(
+            "the refusal has to name what was refused: ${refusal.message}",
+            refusal.message!!.contains("..")
+        )
+        assertEquals("nothing may be written for a refused name", 0, outDir.listFiles()!!.size)
+    }
+
+    @Test
+    fun bundleZip_extractEntries_refusesAPartlyUnsafeBundleInsteadOfTruncatingIt() {
+        // The regression this branch introduced and then had to close: base.apk extracts, the
+        // split's leaf is not a name any writer accepts, and the old `continue` handed back a
+        // one-file "bundle". Same archive, same set, one file short — which is a different app.
+        val zip = writeStoredDataDescriptorZip(
+            listOf(
+                "base.apk" to ByteArray(64) { 1 },
+                "evil\\split_config.arm64_v8a.apk" to ByteArray(64) { 2 },
+            )
+        )
+        val outDir = tempDir()
+
+        assertThrows(InstallRefusedException::class.java) {
+            BundleZip.extractEntries(
+                zip,
+                setOf("base.apk", "evil\\split_config.arm64_v8a.apk"),
+                outDir
+            )
+        }
+
+        // Including the entry that WAS safe: leaving it behind leaves a lone base.apk for a retry.
+        assertTrue("the safe entry was left behind", File(outDir, "base.apk").exists().not())
+    }
+
+    @Test
+    fun bundleZip_extractEntries_refusesAWantedNameTheArchiveDoesNotHold() {
+        // `pm install-multiple` on a set missing one of its splits is the same partial install the
+        // budget case refuses, reached by a set that simply named a file that is not there.
+        val zip = writeStoredDataDescriptorZip(listOf("base.apk" to ByteArray(64)))
+        val outDir = tempDir()
+
+        val refusal = assertThrows(InstallRefusedException::class.java) {
+            BundleZip.extractEntries(zip, setOf("base.apk", "split_config.xxhdpi.apk"), outDir)
+        }
+
+        assertTrue(refusal.message!!.contains("split_config.xxhdpi.apk"))
+        assertTrue(File(outDir, "base.apk").exists().not())
+    }
+
+    @Test
+    fun bundleZip_extractEntries_doesNotCountTwoSpellingsOfOneNameAsTwoFiles() {
+        // The completeness check counts what the archive can actually yield, which is one file per
+        // *lowercased* name. Counting the caller's set instead would refuse a set that came out
+        // whole, because `stageInstallSet` builds its wanted set case-sensitively.
+        val zip = writeStoredDataDescriptorZip(listOf("base.apk" to ByteArray(64)))
+        val outDir = tempDir()
+
+        val extracted = BundleZip.extractEntries(zip, setOf("base.apk", "BASE.APK"), outDir)
+
+        assertEquals(listOf("base.apk"), extracted.map { it.file.name })
+    }
+
+    @Test
+    fun bundleZip_extractEntryTo_refusesABaseNameThatIsNotAPlainLeaf() {
+        // The read that picks the identity on the confirmation sheet. Every writer refuses a name
+        // like this, so an identity must not be readable from one either — that gap is how the
+        // sheet ends up describing a file `pm` was never given. The analyzer reads false as
+        // "try the next candidate", which is the right answer.
+        val zip = writeStoredDataDescriptorZip(
+            listOf("evil\\base.apk" to "attacker-payload".toByteArray())
+        )
+        val dest = tempFile("identity.apk")
+        dest.delete()
+
+        assertTrue(BundleZip.extractEntryTo(zip, "evil\\base.apk", dest).not())
+        assertTrue(BundleZip.extractEntryTo(zip, "..", dest).not())
+        assertTrue("nothing may be written for a refused name", dest.exists().not())
+    }
+
+    @Test
+    fun isSafeEntryFileName_rejectsEveryNameThatIsNotALeaf() {
+        assertTrue(isSafeEntryFileName("base.apk"))
+        assertTrue(isSafeEntryFileName("split_config.arm64_v8a.apk"))
+        assertTrue(isSafeEntryFileName("my app.apk")) // a space is not a traversal
+        assertTrue(isSafeEntryFileName("..").not())
+        assertTrue(isSafeEntryFileName(".").not())
+        assertTrue(isSafeEntryFileName("").not())
+        assertTrue(isSafeEntryFileName("   ").not())
+        assertTrue(isSafeEntryFileName("a/b.apk").not())
+        assertTrue(isSafeEntryFileName("a\\b.apk").not())
+    }
+
+    @Test
+    fun bundleZip_read_ignoresANestedEntryCarryingAWantedName() {
+        // read() serves the bundle *gate* (hasXapkManifest / hasApkmInfoJson), which only counts a
+        // root-level sidecar. Matching a base name anywhere made the two disagree: a plain APK's
+        // res/mipmap-hdpi/icon.png became the icon on the confirmation sheet — an attacker-chosen
+        // picture beside a package name the user is being asked to trust — and a file that
+        // classified as monolithic could still have an assets/manifest.json read out of it.
+        val zip = writeStoredDataDescriptorZip(
+            listOf(
+                "AndroidManifest.xml" to "binary-xml".toByteArray(),
+                "res/mipmap-hdpi/icon.png" to "whatsapp-icon-bytes".toByteArray(),
+                "assets/manifest.json" to """{"package_name":"com.whatsapp"}""".toByteArray(),
+            )
+        )
+
+        val contents = BundleZip.read(zip, setOf("icon.png", "manifest.json"))
+
+        assertNull(contents.bytes["icon.png"])
+        assertNull(contents.bytes["manifest.json"])
+        // The names are still all enumerated — only the *bytes* matching is root-level, because
+        // isMonolithicApk and selectBaseApkCandidates read this list.
+        assertTrue(contents.entryNames.contains("res/mipmap-hdpi/icon.png"))
+        assertTrue(contents.entryNames.contains("assets/manifest.json"))
+    }
+
+    @Test
+    fun bundleZip_read_stillTakesARootLevelSidecarAndIcon() {
+        // The other half: a real .xapk puts both at the root and must keep working.
+        val zip = writeStoredDataDescriptorZip(
+            listOf(
+                "manifest.json" to """{"package_name":"com.amazon.mShop.android.shopping"}""".toByteArray(),
+                "icon.png" to "real-bundle-icon".toByteArray(),
+            )
+        )
+
+        val contents = BundleZip.read(zip, setOf("icon.png", "manifest.json"))
+
+        assertArrayEquals("real-bundle-icon".toByteArray(), contents.bytes["icon.png"])
+        assertNotEquals(null, contents.bytes["manifest.json"])
     }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/data/repository/SidecarIdentityTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/SidecarIdentityTest.kt
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * The package name a *sidecar* declares is the one string in the analyzer that nothing has
+ * validated: `manifest.json` inside a `.xapk` handed to an exported Activity by whichever app
+ * fired the ACTION_VIEW intent. It flows into the installed-app lookup, the downgrade verdict,
+ * and — before this — straight into a `File()` path.
+ *
+ * Two independent locks, tested independently: the name is rejected, and even a name that got
+ * through could not name a file.
+ */
+class SidecarIdentityTest {
+
+    private val temp = mutableListOf<File>()
+
+    private fun tempDir(): File =
+        Files.createTempDirectory("sidecar_icons_").toFile().also { temp.add(it) }
+
+    @After
+    fun tearDown() {
+        temp.forEach { it.deleteRecursively() }
+    }
+
+    @Test
+    fun `a real package name is accepted`() {
+        assertTrue(isValidSidecarPackageName("com.amazon.mShop.android.shopping"))
+        assertTrue(isValidSidecarPackageName("com.valhalla.thor"))
+        assertTrue(isValidSidecarPackageName("a"))
+        assertTrue(isValidSidecarPackageName("com.example.app2"))
+    }
+
+    @Test
+    fun `a traversal dressed as a package name is rejected`() {
+        // The reported payload: PNG bytes land in /data/user/0/com.valhalla.thor/databases/,
+        // and overwriting the Room file yields SQLiteDatabaseCorruptException on next open.
+        assertFalse(isValidSidecarPackageName("../../databases/thor_database"))
+        assertFalse(isValidSidecarPackageName("../files/secret"))
+        assertFalse(isValidSidecarPackageName(".."))
+        assertFalse(isValidSidecarPackageName("."))
+    }
+
+    @Test
+    fun `a name carrying a path separator is rejected`() {
+        assertFalse(isValidSidecarPackageName("com.example/app"))
+        assertFalse(isValidSidecarPackageName("com.example\\app"))
+        assertFalse(isValidSidecarPackageName("/etc/passwd"))
+    }
+
+    @Test
+    fun `an empty or blank name is rejected`() {
+        assertFalse(isValidSidecarPackageName(null))
+        assertFalse(isValidSidecarPackageName(""))
+        assertFalse(isValidSidecarPackageName("   "))
+    }
+
+    @Test
+    fun `a name carrying shell or glob metacharacters is rejected`() {
+        // The same string reaches the privilege gateways as a `pm` argument.
+        assertFalse(isValidSidecarPackageName("com.example;rm -rf /"))
+        assertFalse(isValidSidecarPackageName("com.example\$(id)"))
+        assertFalse(isValidSidecarPackageName("com.example*"))
+        assertFalse(isValidSidecarPackageName("com.example\nnext"))
+    }
+
+    @Test
+    fun `the icon cache key never carries the package name into the path`() {
+        // Second lock: even granting a caller-supplied name past validation, what reaches
+        // File() is hex. java.io.File does not normalise `..` — the syscall does — so the only
+        // safe answer is for the untrusted string not to be in the name at all.
+        val key = iconCacheKey("../../databases/thor_database", 5L)
+
+        assertFalse(key.contains("/"))
+        assertFalse(key.contains(".."))
+        assertTrue(key.matches(Regex("^[0-9a-f]{32}_5$")))
+
+        val dir = tempDir()
+        val dest = File(dir, "$key.png")
+        assertEquals(dir, dest.parentFile)
+        assertEquals(dir.canonicalFile, dest.canonicalFile.parentFile)
+    }
+
+    @Test
+    fun `the icon cache key still busts Coil's per-path cache on a version bump`() {
+        // The property the old `${packageName}_${versionCode}` key existed for: Coil keys its
+        // File cache by path only, so one path per package would serve a stale icon forever.
+        val v1 = iconCacheKey("com.example.app", 1L)
+        val v2 = iconCacheKey("com.example.app", 2L)
+        assertNotEquals(v1, v2)
+
+        // Same package + same version is the same slot (that is what makes it a cache).
+        assertEquals(v1, iconCacheKey("com.example.app", 1L))
+
+        // Different packages do not share a slot.
+        assertNotEquals(v1, iconCacheKey("com.example.other", 1L))
+
+        // An unknown version code keeps its own slot rather than colliding with a genuine 0.
+        assertNotEquals(
+            iconCacheKey("com.example.app", null),
+            iconCacheKey("com.example.app", 0L)
+        )
+    }
+
+    // ---- resolveBundlePlan: the identity and the install set agree ------------------------
+
+    @Test
+    fun `the app that is described is drawn from the files that get installed`() {
+        // The split that made this necessary: the analyzer chose an identity from every `.apk` in
+        // the archive, the installer chose an install set from the manifest's split list — which
+        // deliberately drops standalone APKs it did not name. An archive holding a real, correctly
+        // signed base.apk beside a manifest naming only payload.apk got one answer from each side.
+        val plan = resolveBundlePlan(
+            entryNames = listOf("manifest.json", "icon.png", "base.apk", "payload.apk"),
+            manifestSplitFiles = listOf("payload.apk"),
+            manifestBaseFile = null,
+            packageName = "com.example.app"
+        )
+
+        assertEquals(listOf("payload.apk"), plan.installSet)
+        // base.apk is the better-looking base by every naming heuristic, and it is still not
+        // offered: nothing installs it, so nothing may be identified by it.
+        assertEquals(listOf("payload.apk"), plan.identityCandidates)
+    }
+
+    @Test
+    fun `a manifest cannot flag a base it then leaves out of the install set`() {
+        // The same attack with the manifest being explicit rather than merely selective. An
+        // `id == "base"` pointing at a file that survives no install is describing something
+        // nobody runs, and that discrepancy is the payload, not a hint worth following.
+        val plan = resolveBundlePlan(
+            entryNames = listOf("manifest.json", "base.apk", "payload.apk"),
+            manifestSplitFiles = listOf("payload.apk"),
+            manifestBaseFile = "base.apk",
+            packageName = "com.example.app"
+        )
+
+        assertEquals(listOf("payload.apk"), plan.identityCandidates)
+    }
+
+    @Test
+    fun `a normal XAPK still leads with the base its manifest declares`() {
+        // The common case must not change shape: APKPure writes `{package}.apk` plus config
+        // splits and flags the base explicitly, and that flag is still the first thing tried.
+        val plan = resolveBundlePlan(
+            entryNames = listOf(
+                "manifest.json",
+                "icon.png",
+                "com.example.app.apk",
+                "config.arm64_v8a.apk",
+                "config.xxhdpi.apk",
+            ),
+            manifestSplitFiles = listOf(
+                "com.example.app.apk",
+                "config.arm64_v8a.apk",
+                "config.xxhdpi.apk",
+            ),
+            manifestBaseFile = "com.example.app.apk",
+            packageName = "com.example.app"
+        )
+
+        assertEquals(
+            listOf("com.example.app.apk", "config.arm64_v8a.apk", "config.xxhdpi.apk"),
+            plan.installSet
+        )
+        assertEquals("com.example.app.apk", plan.identityCandidates.first())
+        // Offered once, not twice, even though the manifest flag and the name heuristic agree.
+        assertEquals(plan.identityCandidates.distinct(), plan.identityCandidates)
+    }
+
+    @Test
+    fun `the install set keeps the manifest's order while the identity list is base-first`() {
+        // Two different jobs off one list: `install-multiple` gets the order the producer wrote
+        // (a config split may legitimately come first), while the parse-until-it-works loop has
+        // to start at the entry most likely to BE the app.
+        val plan = resolveBundlePlan(
+            entryNames = listOf("manifest.json", "config.arm64_v8a.apk", "base.apk"),
+            manifestSplitFiles = listOf("config.arm64_v8a.apk", "base.apk"),
+            manifestBaseFile = null,
+            packageName = null
+        )
+
+        assertEquals(listOf("config.arm64_v8a.apk", "base.apk"), plan.installSet)
+        assertEquals(listOf("base.apk", "config.arm64_v8a.apk"), plan.identityCandidates)
+    }
+
+    @Test
+    fun `no identity candidate ever names a file outside the install set`() {
+        // The invariant the whole type exists to hold, asserted on an archive built to break it:
+        // a foreign universal.apk, a split the manifest forgot, and a manifest base that is not
+        // in its own split list.
+        val plan = resolveBundlePlan(
+            entryNames = listOf(
+                "manifest.json",
+                "universal.apk",
+                "base.apk",
+                "split_config.xxhdpi.apk",
+                "split_config.en.apk",
+            ),
+            manifestSplitFiles = listOf("base.apk", "split_config.xxhdpi.apk"),
+            manifestBaseFile = "universal.apk",
+            packageName = "com.example.app"
+        )
+
+        val installable = plan.installSet.map { it.substringAfterLast('/').lowercase() }.toSet()
+        plan.identityCandidates.forEach {
+            assertTrue(
+                "$it is offered as the app's identity but is never installed",
+                it.substringAfterLast('/').lowercase() in installable
+            )
+        }
+        // The omitted *split* is picked up (dropping it would install a broken app); the foreign
+        // standalone APK is not (it would be a second base and fail install-multiple outright).
+        assertTrue(plan.installSet.contains("split_config.en.apk"))
+        assertFalse(plan.installSet.contains("universal.apk"))
+    }
+
+    @Test
+    fun `an archive with no APK entries plans nothing, which is how both sides call it monolithic`() {
+        // The reported attack on the analyzer: append a manifest.json and an icon.png to somebody
+        // else's genuine, signed APK. The sidecar used to win outright, so the sheet showed the
+        // attacker's label, package name, version and permissions while the install shipped the
+        // real thing. An empty plan is what routes both sides back to the platform parser on the
+        // whole file — the one reader an attacker's JSON cannot talk to.
+        val plan = resolveBundlePlan(
+            entryNames = listOf(
+                "AndroidManifest.xml",
+                "classes.dex",
+                "resources.arsc",
+                "manifest.json",
+                "icon.png",
+            ),
+            manifestSplitFiles = emptyList(),
+            manifestBaseFile = null,
+            packageName = "com.attacker.claim"
+        )
+
+        assertTrue(plan.installSet.isEmpty())
+        assertTrue(plan.identityCandidates.isEmpty())
+    }
+
+    @Test
+    fun `an entry whose leaf no writer would accept is in neither list`() {
+        // The door this branch left open after closing the first one. Both sides read one plan,
+        // but the plan still carried names only one side could act on: `good\base.apk` stayed in
+        // the identity candidates — where extractEntryTo happily read it, because a backslash is
+        // nothing special on Linux — and was dropped by every writer, which refuses anything that
+        // is not a plain leaf. Same archive, two answers again, through a different door.
+        //
+        // Dropped from BOTH lists, so `payload.apk` is what the sheet describes and what `pm` gets.
+        val plan = resolveBundlePlan(
+            entryNames = listOf("manifest.json", "good\\base.apk", "payload.apk"),
+            manifestSplitFiles = null,
+            manifestBaseFile = null,
+            packageName = "com.example.app"
+        )
+
+        assertEquals(listOf("payload.apk"), plan.installSet)
+        assertEquals(listOf("payload.apk"), plan.identityCandidates)
+    }
+
+    @Test
+    fun `no plan of any shape offers a name a writer would refuse`() {
+        // Every route a name can take into the plan, in one archive: the entry scan, the manifest's
+        // split list, and the manifest's explicit `id == "base"` flag. `..` is the traversal case
+        // (java.io.File does not normalise it; the syscall does) and the backslash is the
+        // separator-on-the-other-host-platform case.
+        val plan = resolveBundlePlan(
+            entryNames = listOf(
+                "manifest.json",
+                "base.apk",
+                "evil\\split_config.arm64_v8a.apk",
+                "nested/..",
+                "split_config.xxhdpi.apk",
+            ),
+            manifestSplitFiles = listOf("base.apk", "split_config.xxhdpi.apk"),
+            manifestBaseFile = "evil\\split_config.arm64_v8a.apk",
+            packageName = "com.example.app"
+        )
+
+        (plan.installSet + plan.identityCandidates).forEach {
+            assertTrue(
+                "$it reached the plan but no writer would accept it",
+                isSafeEntryFileName(it.substringAfterLast('/'))
+            )
+        }
+        assertEquals(listOf("base.apk", "split_config.xxhdpi.apk"), plan.installSet)
+        assertEquals(listOf("base.apk", "split_config.xxhdpi.apk"), plan.identityCandidates)
+    }
+
+    @Test
+    fun `a manifest split list naming an unusable entry is discarded, never shortened`() {
+        // The manifest's own strings are untrusted too, and resolveBundleInstallSet returns them
+        // verbatim. They inherit the leaf guarantee from the `available` check — a name that was
+        // filtered out of the entries is not available, so the split list reads as stale and is
+        // dropped whole. Silently shortening it would be the truncation the budget case refuses.
+        val plan = resolveBundlePlan(
+            entryNames = listOf("manifest.json", "base.apk", "evil\\payload.apk"),
+            manifestSplitFiles = listOf("base.apk", "evil\\payload.apk"),
+            manifestBaseFile = "base.apk",
+            packageName = "com.example.app"
+        )
+
+        assertEquals(listOf("base.apk"), plan.installSet)
+        assertEquals(listOf("base.apk"), plan.identityCandidates)
+    }
+
+    @Test
+    fun `an archive whose only APK entries are unusable plans nothing, as monolithic does`() {
+        // The empty plan is not a dead end, it is the agreed signal: AppAnalyzerImpl parses the
+        // whole file only when `plan.installSet.isEmpty()`, and resolveInstallSetFromFile answers
+        // null on the same condition and streams the whole file. Both sides land on the same bytes.
+        val plan = resolveBundlePlan(
+            entryNames = listOf("manifest.json", "icon.png", "evil\\base.apk"),
+            manifestSplitFiles = null,
+            manifestBaseFile = null,
+            packageName = "com.example.app"
+        )
+
+        assertTrue(plan.installSet.isEmpty())
+        assertTrue(plan.identityCandidates.isEmpty())
+    }
+
+    @Test
+    fun `a sidecar naming splits the archive does not contain cannot invent an install set`() {
+        // Same archive, but the manifest now declares splits to look more like a bundle. They do
+        // not exist, so the split list is discarded as stale and the entry scan finds no `.apk`
+        // either — the plan stays empty rather than resolving to names nothing can extract.
+        val plan = resolveBundlePlan(
+            entryNames = listOf("AndroidManifest.xml", "classes.dex", "manifest.json"),
+            manifestSplitFiles = listOf("base.apk", "split_config.arm64_v8a.apk"),
+            manifestBaseFile = "base.apk",
+            packageName = "com.attacker.claim"
+        )
+
+        assertTrue(plan.installSet.isEmpty())
+        assertTrue(plan.identityCandidates.isEmpty())
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/repository/StagedInstallTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/StagedInstallTest.kt
@@ -1,0 +1,525 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+
+/**
+ * The pure parts of "read the picked file once, install exactly those bytes": which archive
+ * entries reach an install session, whether the staged bytes are still the staged bytes by the
+ * time `pm` reads them, and who cleans up a copy nobody claimed.
+ */
+class StagedInstallTest {
+
+    private val temp = mutableListOf<File>()
+
+    private fun tempDir(): File =
+        Files.createTempDirectory("staged_install_").toFile().also { temp.add(it) }
+
+    @After
+    fun tearDown() {
+        temp.forEach { it.deleteRecursively() }
+    }
+
+    // ---- sweepStaleStagedPackages --------------------------------------------------------
+
+    @Test
+    fun `a staged copy left behind by a dead process is reclaimed`() {
+        // The analyzer no longer deletes its copy — the ViewModel does, on teardown. Kill the
+        // process before that runs (the OS killing an installer sheet in the background is the
+        // normal case, not the exotic one) and the copy is a full-size APK nothing will ever
+        // claim. This sweep is the only thing that gets it back.
+        val dir = tempDir()
+        val now = System.currentTimeMillis()
+        val stranded = File(dir, "staged_dead").apply { writeText("x") }
+        stranded.setLastModified(now - STAGED_PACKAGE_TTL_MILLIS - 1)
+
+        assertEquals(1, sweepStaleStagedPackages(dir, now))
+        assertFalse(stranded.exists())
+    }
+
+    @Test
+    fun `the copy the user is installing right now survives the sweep`() {
+        // The sweep runs at the START of an analysis, while an earlier sheet may still be sitting
+        // on its own staged file waiting for the user to press Install. Deleting that one turns
+        // the fix into a bug.
+        val dir = tempDir()
+        val now = System.currentTimeMillis()
+        val live = File(dir, "staged_live").apply { writeText("x") }
+        live.setLastModified(now - 1000L)
+        // Exactly at the TTL is still kept; only strictly older goes.
+        val edge = File(dir, "staged_edge").apply { writeText("x") }
+        edge.setLastModified(now - STAGED_PACKAGE_TTL_MILLIS)
+
+        assertEquals(0, sweepStaleStagedPackages(dir, now))
+        assertTrue(live.exists())
+        assertTrue(edge.exists())
+    }
+
+    @Test
+    fun `sweeping a staging directory that was never created is not an error`() {
+        // analyze() sweeps before it stages, so on a first run the directory does not exist yet.
+        // listFiles() answers null there, and null is not an empty array.
+        val missing = File(tempDir(), "never_created")
+
+        assertEquals(0, sweepStaleStagedPackages(missing, System.currentTimeMillis()))
+    }
+
+    @Test
+    fun `the sweep only takes files, never a directory`() {
+        val dir = tempDir()
+        val now = System.currentTimeMillis()
+        val subDir = File(dir, "install_shizuku_1").apply { mkdirs() }
+        subDir.setLastModified(now - STAGED_PACKAGE_TTL_MILLIS - 1)
+
+        assertEquals(0, sweepStaleStagedPackages(dir, now))
+        assertTrue(subDir.isDirectory)
+    }
+
+    // ---- the digest taken during the copy ------------------------------------------------
+
+    private fun digestOfCopy(source: ByteArray, limit: Long = Long.MAX_VALUE): String? {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val sink = ByteArrayOutputStream()
+        ByteArrayInputStream(source).use { it.copyAtMostTo(sink, limit, digest) } ?: return null
+        return digest.digest().toLowercaseHex()
+    }
+
+    @Test
+    fun `the digest taken during the copy matches the published SHA-256 vectors`() {
+        // Pinned against the standard vectors rather than against another call to the same code,
+        // because the shell compares this hex to `sha256sum` output on the device. It is taken on
+        // the way through the copy now — the expected hash has to describe the bytes Thor wrote,
+        // not whatever is in the file by the time anyone gets round to reading it back.
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            digestOfCopy(ByteArray(0))
+        )
+        assertEquals(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            digestOfCopy("abc".toByteArray())
+        )
+    }
+
+    @Test
+    fun `a stream far larger than one read buffer still hashes as one stream`() {
+        // APKs are tens of megabytes; the buffered loop is the whole point, and an off-by-one in
+        // it would produce a hash that no device could ever match — every privileged install
+        // would fail the guard.
+        val bytes = ByteArray(100_000) { i -> (i * 31 % 251).toByte() }
+
+        val oneShot = MessageDigest.getInstance("SHA-256").digest(bytes).toLowercaseHex()
+
+        assertEquals(oneShot, digestOfCopy(bytes))
+    }
+
+    @Test
+    fun `a single flipped byte changes the digest`() {
+        // The property the guard rests on: an attacker who swaps base.apk in shared storage
+        // cannot leave the hash where it was.
+        val before = digestOfCopy(ByteArray(4096) { 7 })
+
+        assertNotEquals(before, digestOfCopy(ByteArray(4096) { i -> if (i == 2048) 8 else 7 }))
+    }
+
+    @Test
+    fun `the copy writes exactly the source bytes it hashed`() {
+        // The digest is only worth anything if it describes what landed on disk, so the two are
+        // asserted against the same call rather than against each other in separate ones.
+        val bytes = ByteArray(70_000) { i -> (i % 256).toByte() }
+        val digest = MessageDigest.getInstance("SHA-256")
+        val sink = ByteArrayOutputStream()
+
+        val copied = ByteArrayInputStream(bytes).use { it.copyAtMostTo(sink, 1L shl 24, digest) }
+
+        assertEquals(bytes.size.toLong(), copied)
+        assertArrayEquals(bytes, sink.toByteArray())
+        assertEquals(
+            MessageDigest.getInstance("SHA-256").digest(sink.toByteArray()).toLowercaseHex(),
+            digest.digest().toLowercaseHex()
+        )
+    }
+
+    @Test
+    fun `a source past the limit yields no byte count, so no caller can mistake it for a copy`() {
+        assertNull(digestOfCopy(ByteArray(5000), limit = 4096L))
+    }
+
+    // ---- writeEntriesWithinBudget (the PackageInstaller session path) ---------------------
+
+    private fun zipOf(vararg entries: Pair<String, ByteArray>): File {
+        val file = File(tempDir(), "bundle.zip")
+        ZipOutputStream(file.outputStream()).use { zos ->
+            for ((name, bytes) in entries) {
+                zos.putNextEntry(ZipEntry(name))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return file
+    }
+
+    /** A stand-in for `session.openWrite`, recording the name and declared length it was given. */
+    private class RecordingSession {
+        val sinks = LinkedHashMap<String, ByteArrayOutputStream>()
+        val declaredLengths = mutableListOf<Pair<String, Long>>()
+
+        fun openSink(name: String, declaredLength: Long): ByteArrayOutputStream {
+            declaredLengths.add(name to declaredLength)
+            return sinks.getOrPut(name) { ByteArrayOutputStream() }
+        }
+    }
+
+    @Test
+    fun `every selected entry reaches the session with its exact bytes`() {
+        val base = ByteArray(3000) { 1 }
+        val split = ByteArray(1500) { 2 }
+        val zip = zipOf("base.apk" to base, "split_config.arm64_v8a.apk" to split)
+        val session = RecordingSession()
+
+        val written = ZipFile(zip).use { zf ->
+            writeEntriesWithinBudget(
+                zip = zf,
+                entries = selectEntriesToWrite(
+                    zf.entries().asSequence(),
+                    setOf("base.apk", "split_config.arm64_v8a.apk")
+                ),
+                budget = 1L shl 20,
+                openSink = session::openSink
+            )
+        }
+
+        assertEquals(4500L, written)
+        assertEquals(listOf("base.apk", "split_config.arm64_v8a.apk"), session.sinks.keys.toList())
+        assertArrayEquals(base, session.sinks["base.apk"]!!.toByteArray())
+        assertArrayEquals(split, session.sinks["split_config.arm64_v8a.apk"]!!.toByteArray())
+    }
+
+    @Test
+    fun `an entry that expands past the budget refuses the install instead of finishing it`() {
+        // The default rung, InstallMode.NORMAL: no root, no Shizuku, so this is where most installs
+        // land — and it copied each entry with a bare copyTo. A single-layer DEFLATE bomb goes to
+        // ~1032:1, so a 100 MB pick wrote ~100 GB into /data/app/vmdl<id>.tmp until write() hit
+        // ENOSPC, taking every other app's and system_server's writes down with it.
+        val zip = zipOf("base.apk" to ByteArray(1024 * 1024))
+        val session = RecordingSession()
+
+        val refusal = assertThrows(InstallRefusedException::class.java) {
+            ZipFile(zip).use { zf ->
+                writeEntriesWithinBudget(
+                    zip = zf,
+                    entries = selectEntriesToWrite(zf.entries().asSequence(), setOf("base.apk")),
+                    budget = 4096L,
+                    openSink = session::openSink
+                )
+            }
+        }
+
+        assertTrue(
+            "the refusal has to name what was refused: ${refusal.message}",
+            refusal.message!!.contains("base.apk")
+        )
+        // Refused, not truncated: the copy stops at the budget instead of running to the entry's
+        // full expanded size, and the caller abandons the session rather than committing what fit.
+        assertTrue(session.sinks["base.apk"]!!.size() < 1024 * 1024)
+    }
+
+    @Test
+    fun `the budget is spent across the whole set, not granted afresh per entry`() {
+        // A bundle installs as a set, so a bomb split behind an innocent base has to stop the whole
+        // thing — and the budget the first entry consumed has to still be gone when the second is
+        // opened, or an archive gets one budget per entry just by adding entries.
+        val zip = zipOf("base.apk" to ByteArray(3000), "split_config.xxhdpi.apk" to ByteArray(3000))
+        val session = RecordingSession()
+
+        assertThrows(InstallRefusedException::class.java) {
+            ZipFile(zip).use { zf ->
+                writeEntriesWithinBudget(
+                    zip = zf,
+                    entries = selectEntriesToWrite(
+                        zf.entries().asSequence(),
+                        setOf("base.apk", "split_config.xxhdpi.apk")
+                    ),
+                    budget = 4096L,
+                    openSink = session::openSink
+                )
+            }
+        }
+
+        // base.apk fitted, which is exactly why the second entry must not get 4096 bytes of its own.
+        assertEquals(3000, session.sinks["base.apk"]!!.size())
+        assertTrue(session.sinks.containsKey("split_config.xxhdpi.apk"))
+    }
+
+    @Test
+    fun `an entry declaring more than may ever be written gets no preallocation hint`() {
+        // openWrite's length argument comes from the archive's central directory — a claim by
+        // whoever built it — and the platform preallocates against it. Handing on a size Thor has
+        // already decided it will not write would fail the install on an allocation instead of on
+        // the budget; -1 is what openWrite documents as "unknown".
+        val zip = zipOf("base.apk" to ByteArray(64), "split_config.xxhdpi.apk" to ByteArray(1024 * 1024))
+        val session = RecordingSession()
+
+        assertThrows(InstallRefusedException::class.java) {
+            ZipFile(zip).use { zf ->
+                writeEntriesWithinBudget(
+                    zip = zf,
+                    entries = selectEntriesToWrite(
+                        zf.entries().asSequence(),
+                        setOf("base.apk", "split_config.xxhdpi.apk")
+                    ),
+                    budget = 8192L,
+                    openSink = session::openSink
+                )
+            }
+        }
+
+        // The honest, in-budget entry keeps its real declared size; the oversized one is opened
+        // with -1 rather than with a megabyte the budget was never going to allow.
+        assertEquals(64L, session.declaredLengths.first { it.first == "base.apk" }.second)
+        assertEquals(
+            -1L,
+            session.declaredLengths.first { it.first == "split_config.xxhdpi.apk" }.second
+        )
+    }
+
+    @Test
+    fun `an empty entry list writes nothing and refuses nothing`() {
+        // A property of the copier alone: handed nothing, it writes nothing rather than treating
+        // an empty budget spend as an error. Deciding whether an empty selection is *allowed* is
+        // not its job — that is selectEntriesToWriteOrRefuse's, three tests down, and the answer
+        // there is no.
+        val zip = zipOf("readme.txt" to ByteArray(16))
+        val session = RecordingSession()
+
+        val written = ZipFile(zip).use { zf ->
+            writeEntriesWithinBudget(
+                zip = zf,
+                entries = emptyList(),
+                budget = 4096L,
+                openSink = session::openSink
+            )
+        }
+
+        assertEquals(0L, written)
+        assertTrue(session.sinks.isEmpty())
+    }
+
+    // ---- selectEntriesToWriteOrRefuse ----------------------------------------------------
+
+    @Test
+    fun `a resolved install set that yields no writable entry refuses instead of falling through`() {
+        // The regression: `filesWritten = toWrite.isNotEmpty()` conflated "this input is
+        // monolithic" with "a bundle resolved and every entry was dropped". The second fell into
+        // the monolithic branch and streamed the CONTAINER archive as base.apk — a file that by
+        // construction is not the one the sheet's identity was read from, which is the substitution
+        // the whole plan exists to close. The archive named files it cannot supply; that is a
+        // verdict about the archive, not a licence to install something else.
+        val zip = zipOf("evil\\base.apk" to ByteArray(16), "manifest.json" to ByteArray(8))
+
+        val refusal = assertThrows(InstallRefusedException::class.java) {
+            ZipFile(zip).use { zf ->
+                selectEntriesToWriteOrRefuse(zf.entries().asSequence(), setOf("evil\\base.apk"))
+            }
+        }
+
+        assertTrue(
+            "the refusal has to name what was refused: ${refusal.message}",
+            refusal.message!!.contains("evil\\base.apk")
+        )
+    }
+
+    @Test
+    fun `a bundle missing one of its splits refuses rather than installing the rest`() {
+        // Same rule as BundleZip.extractEntries applies to the privileged rungs. Half a bundle is
+        // not a smaller install, it is a different one — and this is the rung most users land on.
+        val zip = zipOf("base.apk" to ByteArray(16))
+
+        val refusal = assertThrows(InstallRefusedException::class.java) {
+            ZipFile(zip).use { zf ->
+                selectEntriesToWriteOrRefuse(
+                    zf.entries().asSequence(),
+                    setOf("base.apk", "split_config.xxhdpi.apk")
+                )
+            }
+        }
+
+        assertTrue(refusal.message!!.contains("split_config.xxhdpi.apk"))
+        // Only the missing name is named; the one that was there is not part of the complaint.
+        assertFalse(refusal.message!!.contains("base.apk"))
+    }
+
+    @Test
+    fun `a complete selection passes through untouched`() {
+        // The check must not cost the ordinary case anything: same list, same order.
+        val zip = zipOf(
+            "icon.png" to ByteArray(4),
+            "base.apk" to ByteArray(16),
+            "split_config.arm64_v8a.apk" to ByteArray(16),
+        )
+
+        val selected = ZipFile(zip).use { zf ->
+            selectEntriesToWriteOrRefuse(
+                zf.entries().asSequence(),
+                setOf("base.apk", "split_config.arm64_v8a.apk")
+            ).map { it.name }
+        }
+
+        assertEquals(listOf("base.apk", "split_config.arm64_v8a.apk"), selected)
+    }
+
+    // ---- integrityGuardedInstall ---------------------------------------------------------
+
+    @Test
+    fun `the hash check runs before pm install, not after`() {
+        val expected = "aa".repeat(32)
+        val script = integrityGuardedInstall(
+            listOf("/sdcard/Android/data/x/base.apk" to expected),
+            "pm install -r -g '/sdcard/Android/data/x/base.apk'"
+        )
+
+        val guardAt = script.indexOf("sha256sum")
+        val installAt = script.indexOf("pm install")
+        assertTrue(guardAt >= 0)
+        assertTrue(installAt >= 0)
+        assertTrue("the guard must precede the install", guardAt < installAt)
+        assertTrue(script.contains(expected))
+        assertTrue(script.contains("exit $INTEGRITY_CHECK_EXIT_CODE"))
+    }
+
+    @Test
+    fun `every staged split is checked, not just the first`() {
+        // install-multiple takes the whole set; guarding only base.apk would leave the splits —
+        // which carry code too — swappable.
+        val digests = listOf(
+            "/sdcard/x/base.apk" to "11".repeat(32),
+            "/sdcard/x/split_a.apk" to "22".repeat(32),
+            "/sdcard/x/split_b.apk" to "33".repeat(32),
+        )
+
+        val script = integrityGuardedInstall(digests, "pm install-multiple -r -g /sdcard/x/base.apk")
+
+        assertEquals(3, Regex("sha256sum").findAll(script).count())
+        digests.forEach { (path, expected) ->
+            assertTrue(script.contains(expected))
+            assertTrue(script.contains("'$path'"))
+        }
+        // One abort per check: a mismatch on the third split has to stop the script before the
+        // install command, exactly as a mismatch on the first does.
+        assertEquals(3, Regex("exit $INTEGRITY_CHECK_EXIT_CODE").findAll(script).count())
+    }
+
+    @Test
+    fun `a path holding a quote cannot end the guard's own argument`() {
+        // The staging dir name is ours, but the file names inside come from the picked archive.
+        val script = integrityGuardedInstall(
+            listOf("/sdcard/x/it's;rm -rf /.apk" to "ff".repeat(32)),
+            "pm install -r -g x"
+        )
+
+        assertTrue(script.contains("""'/sdcard/x/it'\''s;rm -rf /.apk'"""))
+        // The raw path never appears: if it did, the apostrophe would have closed the guard's
+        // quoting and left `;rm -rf /` as a command of its own.
+        assertFalse(script.contains("/sdcard/x/it's;rm"))
+    }
+
+    @Test
+    fun `an empty digest list is refused rather than silently unguarded`() {
+        // A future caller that forgets to hash what it staged must not get a bare `pm install`
+        // back; the throw is caught upstream and drops the rung.
+        assertThrows(IllegalArgumentException::class.java) {
+            integrityGuardedInstall(emptyList(), "pm install -r -g /sdcard/x/base.apk")
+        }
+    }
+
+    // ---- selectEntriesToWrite ------------------------------------------------------------
+
+    @Test
+    fun `only the wanted entries are written, in archive order`() {
+        val entries = sequenceOf(
+            ZipEntry("icon.png"),
+            ZipEntry("base.apk"),
+            ZipEntry("manifest.json"),
+            ZipEntry("split_config.arm64_v8a.apk"),
+        )
+
+        val selected = selectEntriesToWrite(entries, setOf("base.apk", "split_config.arm64_v8a.apk"))
+
+        assertEquals(listOf("base.apk", "split_config.arm64_v8a.apk"), selected.map { it.name })
+    }
+
+    @Test
+    fun `a wanted name repeated in the archive is written once`() {
+        // Two entries claiming the same session file name make openWrite overwrite the first with
+        // the second — the install would ship whichever the attacker put last.
+        val entries = sequenceOf(
+            ZipEntry("base.apk"),
+            ZipEntry("BASE.APK"),
+            ZipEntry("nested/base.apk"),
+        )
+
+        val selected = selectEntriesToWrite(entries, setOf("base.apk"))
+
+        assertEquals(listOf("base.apk"), selected.map { it.name })
+    }
+
+    @Test
+    fun `a directory entry is never written`() {
+        val entries = sequenceOf(ZipEntry("base.apk/"), ZipEntry("base.apk"))
+
+        val selected = selectEntriesToWrite(entries, setOf("base.apk"))
+
+        assertEquals(1, selected.size)
+        assertFalse(selected.single().isDirectory)
+    }
+
+    @Test
+    fun `an entry whose leaf name is a traversal is dropped, not handed to openWrite`() {
+        // openWrite("..") throws IllegalArgumentException, which fails the entire install rather
+        // than the one malicious entry — so the archive gets to choose whether Thor can install
+        // anything at all.
+        val entries = sequenceOf(
+            ZipEntry("payload/.."),
+            ZipEntry("base.apk"),
+        )
+
+        val selected = selectEntriesToWrite(entries, setOf("base.apk", ".."))
+
+        assertEquals(listOf("base.apk"), selected.map { it.name })
+    }
+
+    @Test
+    fun `an entry nested in a directory is matched by its leaf name`() {
+        // Real bundles from APKPure and SAI put the APKs at the root, but some nest them; the
+        // pre-existing matching is on the base name and this pins it.
+        val entries = sequenceOf(ZipEntry("apks/base.apk"))
+
+        val selected = selectEntriesToWrite(entries, setOf("base.apk"))
+
+        assertEquals(listOf("apks/base.apk"), selected.map { it.name })
+    }
+
+    @Test
+    fun `an archive with none of the wanted names selects nothing`() {
+        val entries = sequenceOf(ZipEntry("readme.txt"), ZipEntry("icon.png"))
+
+        assertTrue(selectEntriesToWrite(entries, setOf("base.apk")).isEmpty())
+    }
+}


### PR DESCRIPTION
An archive handed to Thor by another app is untrusted input. Two of its strings used to decide different things — the entry the confirmation sheet parsed to name the app, and the entries `pm` was actually given — and nothing held those two to the same answer.

### The identity and the install set are now one set, by construction

An entry named `good\base.apk` could identify the install on screen and then be silently dropped from it: the sheet describing one APK while another was written. `isSafeEntryFileName` was enforced on both *write* paths but not on `extractEntryTo`, the read the **analyzer** uses to pick the identity, nor on plan resolution.

Rather than add the guard at each consumer, the untrusted names are filtered **once**, at plan resolution. `resolveBundleInstallSet` drops any entry whose leaf fails the check, and `resolveBundlePlan` derives `identityCandidates` *from* the surviving `installSet` — so identity is a subset of the install set by construction, and divergence is unrepresentable rather than merely absent. The manifest's own split list inherits the same guarantee for free: it is validated against leaves that already passed, so a list naming an unusable file reads as stale and is discarded **whole**, never shortened.

`extractEntryTo` gets the guard as a second lock. Every writer already refuses such a name; an identity must not be readable from one either.

**`entryNames` itself stays deliberately unfiltered**, and that is the interesting part. The classifiers must see what the archive actually holds — hide a backslash entry from them and the archive classifies as a *monolithic APK* and gets streamed whole, which is the same divergence one layer up. Verified instead that both sides converge on the whole file, which is the honest answer for an archive whose only APK entries are unusable.

### "Nothing was written" no longer means "this input is monolithic"

A resolved install set that selected zero entries fell through to the monolithic branch and streamed the **outer container** as `base.apk` — a file that by construction is not the one the identity was read from. `filesWritten = toWrite.isNotEmpty()` conflated *absent* with *everything was rejected*; empty meant unknown, not fine.

The fallthrough is now gated on the **absence** of an install set — `resolveInstallSetFromFile`'s own monolithic verdict, and the exact condition `AppAnalyzerImpl` checks before letting the whole file identify itself. A non-empty set that yields no writable entry refuses.

### Refusing instead of truncating

`extractEntries` now refuses on the terms its own KDoc already argued for the budget case: *half a bundle is not a smaller install, it is a different one.* Three refusal modes share one verdict — budget overrun, an unsafe wanted leaf, and a wanted name the archive does not hold — each deleting what was already written.

Two ordering details that are load-bearing: wantedness is checked **before** safety, so unrelated junk in an archive is still skipped quietly rather than failing the install; and the completeness check compares against the internally lowercased set, because the caller builds `wanted` case-sensitively and comparing raw sizes would spuriously refuse an archive holding both `base.apk` and `BASE.APK`.

## Riding along

- **A cancelled parse no longer strands its staged copy.** Ownership transfers on `analyze()`'s return, and a cancelled `withContext` *throws* instead of returning, so `analyzed` was never assigned and nothing could discard it — while the copy, a blocking non-cooperative loop, ran to completion anyway. Swiping the sheet away mid-parse is the ordinary way to leave.
- **Staging failures no longer strand their temp directory.** Cleanup is a wrapper rather than a move inside the rung's `try`: that `try` ends in a `catch (e: Exception)` which would fold `InstallRefusedException` into a generic error *and* stop it propagating — and propagation is what makes the ladder halt instead of dropping to a rung that would read the same refused bytes. Two of the three rungs stage into `externalCacheDir`, where the residue is user-visible.

## Verification

- `:app:testFossDebugUnitTest --rerun-tasks` — **578 tests, 0 failures, 0 skipped**
- `lintFossRelease` — clean, 5 hints, no new warnings
- 11 tests added, covering each fix: an unsafe leaf is in *neither* list; no plan of any shape offers a name a writer would refuse (all three routes in one archive); a manifest split list naming an unusable entry is discarded whole; a resolved set yielding no writable entry refuses instead of falling through; a bundle missing one split refuses rather than installing the rest; two spellings of one name are not counted as two files.

Reviewed by a 32-agent, 5-lens adversarial workflow with 3-refuter verification, run against the **post-fix** state. All 7 confirmed findings were regressions or gaps introduced by this branch's own first attempt, not pre-existing bugs — the guard had reached two of its three consumers.

Part of the 2026-08-04 dev-branch audit remediation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installation now uses a staged copy of the selected package for consistent results.
  * Added safer bundle planning and integrity verification.
* **Bug Fixes**
  * Improved cancellation, incomplete package, metadata, temporary-file, and installation failure handling.
  * Added cleanup for partial files and abandoned installation sessions.
* **Security**
  * Added protections against oversized archives, decompression bombs, unsafe filenames, path traversal, and invalid sidecar references.
* **Tests**
  * Expanded coverage for archive limits, cleanup, integrity checks, package selection, and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->