### PR TITLE
fix(locale): make the in-app language picker work below API 33

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,20 @@ if (keystorePropertiesFile.exists()) {
 val hasSigningCredentials: Boolean =
     keystorePropertiesFile.exists() || System.getenv("KEY_ALIAS") != null
 
+// The locales Thor actually translates, and therefore the only ones any variant keeps.
+//
+// Declared once and applied variant-wide in `androidComponents` below, deliberately rather than
+// per-flavour: two copies of this set is how foss and store drift into shipping different
+// languages, and the whole point of the in-app picker is that the answer does not depend on how
+// the user got the app. Adding a `values-xx` directory means adding it here too, or the resources
+// are compiled and then filtered straight back out.
+//
+// `zh-rCN` and not `zh`: the resource directory is `values-zh-rCN`, and `localeFilters` matches on
+// the qualifier as written. The picker's tag is region-less `zh`, which still resolves, because
+// since API 24 ResourcesImpl selects via LocaleList.getFirstMatch with likely-subtag expansion
+// (`zh` -> `zh-Hans` matches `zh-CN` -> `zh-Hans-CN`).
+val translatedLocales: Set<String> = setOf("en", "ar", "es", "fr", "zh-rCN")
+
 // --- VERSIONING HELPERS (Private & Modernized) ---
 
 // 1. Resolve Code: Checks property 'versionCode' first, falls back to 'initialVersionCode'
@@ -219,6 +233,44 @@ android {
         printTextReport = true
     }
 
+    bundle {
+        language {
+            // An in-app language picker and per-locale delivery cannot both be true.
+            //
+            // Play splits an AAB by locale and installs only the ones the device's system languages
+            // ask for. Picking Français then sets a Configuration whose `values-fr` was never
+            // delivered, resources fall back to `values/`, and the picker is a no-op on Play
+            // installs for exactly the languages the user does not already have — which is all of
+            // the ones they would go looking for the picker to get.
+            //
+            // API 33+ is the exception and the reason this was survivable until now:
+            // `LocaleManager.setApplicationLocales` tells `LocaleManagerService`, which has Play
+            // fetch the missing language split. There is no such path below 33, and the only
+            // supported substitute is Play Core's `SplitInstallManager` — a proprietary dependency
+            // the FOSS flavour must not carry. Disabling the split is the documented alternative:
+            // https://developer.android.com/guide/app-bundle/configure-base#handling_language_changes
+            //
+            // Cost: a Play install downloads one base APK carrying every locale it will ever have,
+            // instead of a split carrying its own. That is paid for by the variant-wide
+            // `localeFilters` in `androidComponents` below — the two changes are a pair, and either
+            // one alone is wrong. Splits off without the filter means shipping ~75 locales of
+            // AndroidX/Material strings to every device; the filter without splits off means the
+            // picker still cannot reach `values-fr`.
+            //
+            // Measured on storeRelease (unsigned, 2026-08-04): filtering takes resources.arsc from
+            // 663,672 to 230,132 bytes and the APK from 4,016,164 to 3,582,624 — a 433,540-byte
+            // saving that is *entirely* arsc, the two deltas being equal to the byte and no other
+            // zip entry differing. The residual regression against per-locale delivery is bounded
+            // by an en-only build at 3,439,320, i.e. at most 143,304 bytes (4.00%), and that is an
+            // over-estimate because a real base-plus-one-split download pays split overhead this
+            // single APK does not.
+            //
+            // Applies only to `bundle*` tasks, so the reproducible `assembleFossRelease` APK is
+            // untouched.
+            enableSplit = false
+        }
+    }
+
     packaging {
         dex {
             // Compress dex in generated APKs. dex is otherwise STORED uncompressed (~76% of the
@@ -256,16 +308,29 @@ androidComponents {
         variantBuilder.enable = false
     }
 
-    // 1. Existing FOSS Copy Task
-    onVariants(selector().withFlavor("distribution", "foss")) { variant ->
-        // foss ships as a single universal APK (GitHub direct download), so every locale lands in
-        // one file. Restrict to the locales we actually translate, trimming library-provided strings
-        // (Material/AndroidX) for ~75 unused languages out of resources.arsc.
-        // Deliberately NOT applied to the store flavor: its AAB is delivered by Play as per-locale
-        // splits, so keeping all locales there lets Play serve each device its own library
-        // translations without bloating any single download.
-        variant.androidResources.localeFilters.set(setOf("en", "ar", "es", "fr", "zh-rCN"))
+    // 1. Locale filtering — every variant, one set.
+    //
+    // Both flavours now ship every locale they will ever have in a single file: foss has always
+    // been one universal APK (GitHub direct download), and store became one the moment
+    // `bundle { language { enableSplit = false } }` was set above so that the in-app picker works
+    // below API 33. Read that comment for why the split had to go; this is the other half of that
+    // decision and the two are only correct together.
+    //
+    // Without this filter, disabling the language split would mean every Play install downloading
+    // ~75 locales of AndroidX/Material translations it cannot reach: Thor's own UI is one of five
+    // languages, so those library strings (date pickers, accessibility labels) would render in a
+    // language the app is not being displayed in. The filter is what keeps "no per-locale delivery"
+    // from meaning "pay for all locales".
+    //
+    // The cost is real and bounded: a user whose system language is, say, Polish loses Polish
+    // library strings and gets English ones inside an app whose own UI is already English. That is
+    // the same experience foss users have always had.
+    onVariants { variant ->
+        variant.androidResources.localeFilters.set(translatedLocales)
+    }
 
+    // 2. Existing FOSS Copy Task
+    onVariants(selector().withFlavor("distribution", "foss")) { variant ->
         if (variant.buildType == "release") {
             val apkDir = variant.artifacts.get(SingleArtifact.APK)
             tasks.register<Copy>("copyFossReleaseApk") {
@@ -278,7 +343,7 @@ androidComponents {
         }
     }
 
-    // 2. Store Copy Task
+    // 3. Store Copy Task
     onVariants(selector().withFlavor("distribution", "store")) { variant ->
         if (variant.buildType == "release") {
             val apkDir = variant.artifacts.get(SingleArtifact.APK)

--- a/app/src/main/java/com/valhalla/thor/HomeActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/HomeActivity.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor
 
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -38,6 +39,7 @@ import com.valhalla.thor.presentation.security.BiometricUnavailableScreen
 import com.valhalla.thor.presentation.security.SecurityViewModel
 import com.valhalla.thor.presentation.theme.ThorTheme
 import com.valhalla.thor.presentation.utils.ObserveAsEvents
+import com.valhalla.thor.util.AppLocale
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -53,6 +55,22 @@ class HomeActivity : ComponentActivity() {
 
     private val requestCode = 1001
     private var hasRequestedShizuku = false
+
+    /** The locale tag this instance attached with; see [attachBaseContext]. */
+    private var attachedLocaleTag: String? = null
+
+    /**
+     * Applies the chosen locale on API 28–32, where nothing else will.
+     *
+     * Spelled identically in [com.valhalla.thor.presentation.installer.PortableInstallerActivity]
+     * and [com.valhalla.thor.presentation.launcher.FreezerLaunchActivity]: an entry point that
+     * omits this renders in the system locale while the rest of the app does not, and "the language
+     * picker works" quietly stops being true for whoever arrives through that door.
+     */
+    override fun attachBaseContext(newBase: Context) {
+        attachedLocaleTag = AppLocale.tagFor(newBase)
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
 
     private val shizukuHandler = ShizukuPermissionHandler(
         onPermissionGranted = {
@@ -78,6 +96,10 @@ class HomeActivity : ComponentActivity() {
             securityViewModel.authState.value == AuthState.Loading
         }
         enableEdgeToEdge()
+        // Settings lives inside this activity, so a language change never leaves it: without this
+        // the new locale would only appear on the next cold start. A no-op above API 32, where the
+        // platform relaunches the activity itself.
+        AppLocale.recreateOnChange(this, attachedLocaleTag)
         shizukuHandler.register()
 
         setContent {

--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -22,6 +22,7 @@ import com.valhalla.thor.presentation.utils.AppIconFetcher
 import com.valhalla.thor.presentation.utils.AppIconKeyer
 import com.valhalla.thor.util.AppLocale
 import com.valhalla.thor.util.LocaleManager
+import com.valhalla.thor.util.LocaleRevision
 import com.valhalla.thor.util.LocalizedResources
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.koinLogLevel
@@ -135,17 +136,27 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
         configuration.locales.takeIf { !it.isEmpty }?.get(0)?.toLanguageTag()
 
     /**
-     * Re-resolves the strings that live in someone else's process.
+     * Re-resolves the localised strings that have already been **copied** somewhere [getResources]
+     * cannot reach.
      *
-     * [getResources] fixes every string Thor resolves *on demand*, but a launcher shortcut label is
-     * a copy `ShortcutManager` handed the launcher at publish time and no `Resources` override can
-     * reach it. Only the dynamic Freeze-all / Unfreeze-all pair is re-pushed:
-     * `syncDynamicShortcuts` is idempotent and takes the enabled flag from the preference, so this
-     * publishes nothing a user has turned off. Pinned per-app shortcuts are deliberately left —
-     * re-pushing every pinned id on a language change spends `ShortcutManager`'s background update
-     * budget on cosmetics.
+     * [getResources] fixes every string Thor resolves *on demand*. A copy is a different problem,
+     * and there are two kinds:
+     *
+     * - **In this process.** The app-label cache in Room holds a label per row, resolved at scan
+     *   time. [LocaleRevision] is how the repository hears about the change; see its KDoc for the
+     *   one half of the problem it deliberately leaves to `ACTION_LOCALE_CHANGED`.
+     * - **In someone else's process.** A launcher shortcut label is a copy `ShortcutManager` handed
+     *   the launcher at publish time. Only the dynamic Freeze-all / Unfreeze-all pair is re-pushed:
+     *   `syncDynamicShortcuts` is idempotent and takes the enabled flag from the preference, so this
+     *   publishes nothing a user has turned off. Pinned per-app shortcuts are deliberately left —
+     *   re-pushing every pinned id on a language change spends `ShortcutManager`'s background update
+     *   budget on cosmetics.
+     *
+     * Both call sites below are language changes this process can actually observe, which is why
+     * this is the only place that emits on [LocaleRevision].
      */
     private fun republishLocalisedLabels() {
+        LocaleRevision.bump()
         appScope.launch {
             runCatching {
                 val prefs = preferenceRepository.userPreferences.first()

--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -4,6 +4,9 @@
 package com.valhalla.thor
 
 import android.app.Application
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -17,7 +20,9 @@ import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.presentation.settings.BillingProcessor
 import com.valhalla.thor.presentation.utils.AppIconFetcher
 import com.valhalla.thor.presentation.utils.AppIconKeyer
+import com.valhalla.thor.util.AppLocale
 import com.valhalla.thor.util.LocaleManager
+import com.valhalla.thor.util.LocalizedResources
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.koinLogLevel
 import kotlinx.coroutines.CancellationException
@@ -25,6 +30,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -36,6 +42,120 @@ import org.koin.plugin.module.dsl.startKoin
 
 @KoinApplication
 class ThorApplication : Application(), SingletonImageLoader.Factory {
+
+    /**
+     * The application context's locale, at process start **and afterwards**.
+     *
+     * [attachBaseContext] is the only wrap this object will ever get —
+     * `ContextWrapper.attachBaseContext` throws `IllegalStateException("Base context already set")`
+     * on a second call — so it alone freezes the application context at whatever the mirror said
+     * when the process started. [getResources] is what makes it track a later change; see
+     * [LocalizedResources] for why one `getResources()` override moves every `getString` in the
+     * process.
+     *
+     * ### What tracks a runtime language change, and what does not
+     *
+     * **Tracks it, immediately.** Everything that resolves a string through the Koin
+     * `androidContext()` — which is this object — reads [getResources] at the moment it resolves,
+     * so it is correct from the next call onwards: `ShizukuSystemGateway` and `DhizukuSystemGateway`
+     * (`freeze_system_app_requires_root` and `freeze_system_app_removal_failed`, toasted by
+     * `FreezerViewModel`), `AppBundleFileStoreImpl` (export destination names), the suspended-app
+     * dialog strings in `Shizuku.kt` / `Dhizuku.kt`, `FreezerShortcutManager.disableAppShortcut`,
+     * and `BulkResultNotifier`'s notification title.
+     *
+     * **Tracks it at the next publish, not at the change.** `BulkResultNotifier`'s *channel* name:
+     * `ensureChannel` runs on every `post()` and `createNotificationChannel` updates the name of an
+     * existing channel, so it is corrected the next time a bulk run reports — not the moment the
+     * user picks a language.
+     *
+     * **Only tracks it because something re-publishes.** The Freeze-all / Unfreeze-all *dynamic*
+     * shortcut labels are a copy held by the launcher, and `getResources()` cannot reach a copy. It
+     * is [onCreate]'s `appliedTag` collector that re-runs `syncDynamicShortcuts`, and only for the
+     * dynamic pair. A bulk shortcut the user has **pinned** keeps its old label until they pin it
+     * again: `ShortcutManager` rate-limits background updates and re-pushing every pinned id on a
+     * language change would spend that budget on cosmetics.
+     *
+     * **Never tracks it, on any API level.** The QS tile's manifest `android:label`, read by
+     * SystemUI out of Thor's APK with SystemUI's own resources — see `FreezerTileService`.
+     *
+     * A no-op above API 32, where `ActivityThread` merges the platform's per-app locale into this
+     * context's own configuration and there is nothing left to do — see
+     * [AppLocale.overridesConfiguration].
+     */
+    override fun attachBaseContext(base: Context) {
+        // The RAW base, deliberately, not getBaseContext() afterwards: LocalizedResources must
+        // rebuild from the ContextImpl the framework keeps current, not from a wrap of a wrap.
+        localizedResources = LocalizedResources(base)
+        systemLocaleTag = firstLocaleTag(base.resources.configuration)
+        super.attachBaseContext(AppLocale.wrap(base))
+    }
+
+    /** Rebuilt on a language change; see [attachBaseContext]. Never read before it is assigned. */
+    @Volatile
+    private var localizedResources: LocalizedResources? = null
+
+    /**
+     * The **system** locale as last seen, which is not necessarily the one Thor renders in.
+     *
+     * Seeded from the raw base in [attachBaseContext] so that the first [onConfigurationChanged] —
+     * which may well be a night-mode or font-scale change — is not mistaken for a language change.
+     */
+    @Volatile
+    private var systemLocaleTag: String? = null
+
+    override fun getResources(): Resources =
+        localizedResources?.current() ?: super.getResources()
+
+    /**
+     * Two jobs, both of them consequences of holding a context the framework cannot re-attach.
+     *
+     * `AppLocale.wrap` pins the whole configuration and not only the locale (see its KDoc), so the
+     * cached `Resources` must be dropped whenever the system's configuration moves. Cheap: this
+     * fires on device-language, night-mode, density and font-scale changes, all of them user-driven,
+     * and the rebuild is one `createConfigurationContext`.
+     *
+     * The locale comparison then covers the language changes that [AppLocale.appliedTag] cannot see:
+     * a change made in *system* Settings → Apps → Thor → Language on API 33+, and a device-wide
+     * language change for a user who left Thor on "System default" on any API level. Neither writes
+     * Thor's mirror, and a device-wide language change since API 24 recreates activities without
+     * restarting the process — so without this, the launcher labels would keep the old language
+     * until the next cold start.
+     */
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        localizedResources?.invalidate()
+        val tag = firstLocaleTag(newConfig)
+        if (tag != systemLocaleTag) {
+            systemLocaleTag = tag
+            republishLocalisedLabels()
+        }
+    }
+
+    private fun firstLocaleTag(configuration: Configuration): String? =
+        configuration.locales.takeIf { !it.isEmpty }?.get(0)?.toLanguageTag()
+
+    /**
+     * Re-resolves the strings that live in someone else's process.
+     *
+     * [getResources] fixes every string Thor resolves *on demand*, but a launcher shortcut label is
+     * a copy `ShortcutManager` handed the launcher at publish time and no `Resources` override can
+     * reach it. Only the dynamic Freeze-all / Unfreeze-all pair is re-pushed:
+     * `syncDynamicShortcuts` is idempotent and takes the enabled flag from the preference, so this
+     * publishes nothing a user has turned off. Pinned per-app shortcuts are deliberately left —
+     * re-pushing every pinned id on a language change spends `ShortcutManager`'s background update
+     * budget on cosmetics.
+     */
+    private fun republishLocalisedLabels() {
+        appScope.launch {
+            runCatching {
+                val prefs = preferenceRepository.userPreferences.first()
+                freezerShortcutManager.syncDynamicShortcuts(prefs.addFreezerToLauncher)
+            }.onFailure { throwable ->
+                if (throwable is CancellationException) throw throwable
+                Logger.e("ThorApp", "Shortcut label refresh failed", throwable)
+            }
+        }
+    }
 
     override fun newImageLoader(context: PlatformContext): ImageLoader {
         return ImageLoader.Builder(context)
@@ -104,16 +224,34 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
         appScope.launch {
             runCatching {
                 val prefs = preferenceRepository.userPreferences.first()
-                freezerShortcutManager.syncDynamicShortcuts(prefs.addFreezerToLauncher)
-                withContext(Dispatchers.Main) {
-                    localeManager.applyLocale(prefs.language)
+                // Reconcile BEFORE publishing shortcuts, not after: on the one start where the two
+                // stores disagree — a cloud restore, where the DataStore preference travels and
+                // AppLocale's mirror does not — this is what makes the labels below resolve in the
+                // restored language instead of the device's.
+                val reconciled = withContext(Dispatchers.Main) {
+                    localeManager.reconcileOnStartup(prefs.language)
                 }
+                if (reconciled != prefs.language) {
+                    // Only when the platform's per-app locale won (API 33+). Writing it back is what
+                    // stops the Settings row saying "System default" over a screen the system
+                    // language picker put in French.
+                    preferenceRepository.setLanguage(reconciled)
+                }
+                freezerShortcutManager.syncDynamicShortcuts(prefs.addFreezerToLauncher)
             }.onFailure { throwable ->
                 // runCatching also catches CancellationException; rethrow it so appScope.cancel()
                 // (onTerminate) isn't logged as a failure and cooperative cancellation is preserved.
                 if (throwable is CancellationException) throw throwable
                 Logger.e("ThorApp", "Startup preference sync failed", throwable)
             }
+        }
+
+        // Below API 33 nothing else notices a language change: the platform has no per-app locale to
+        // broadcast, so no configuration change is dispatched and onConfigurationChanged above never
+        // fires for it. AppLocale.appliedTag is the only signal. Inert on 33+, where that flow is
+        // never written and the configuration path covers the same ground.
+        appScope.launch {
+            AppLocale.appliedTag.drop(1).collect { republishLocalisedLabels() }
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/receivers/FreezerShortcutPinnedReceiver.kt
+++ b/app/src/main/java/com/valhalla/thor/data/receivers/FreezerShortcutPinnedReceiver.kt
@@ -8,20 +8,31 @@ import android.content.Context
 import android.content.Intent
 import android.widget.Toast
 import com.valhalla.thor.R
+import com.valhalla.thor.util.AppLocale
 
 /**
  * Fired by the system (via the [android.content.IntentSender] passed to
  * `ShortcutManagerCompat.requestPinShortcut`) ONLY when a shortcut is successfully pinned to the
  * launcher. Android provides no cancel/failure callback, so this confirms success only.
+ *
+ * The `context` is built by the framework, not handed over by Thor: `ActivityThread.handleReceiver`
+ * derives it from the Application's **base** context, so it is neither the wrapped
+ * `ThorApplication` nor reached by that class's `getResources()` override, and on API 28–32 it
+ * resolves `shortcut_added` in the device's language rather than the app's. [AppLocale.wrap] is
+ * applied here for the same reason every other Thor component applies it in `attachBaseContext`; a
+ * `BroadcastReceiver` simply has no such hook to put it in.
  */
 class FreezerShortcutPinnedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
+        val localised = AppLocale.wrap(context)
         val label = intent.getStringExtra(EXTRA_LABEL)
         val message = if (!label.isNullOrEmpty()) {
-            context.getString(R.string.shortcut_added_named, label)
+            localised.getString(R.string.shortcut_added_named, label)
         } else {
-            context.getString(R.string.shortcut_added)
+            localised.getString(R.string.shortcut_added)
         }
+        // The Toast still goes through the application context: a receiver context is dead as soon
+        // as onReceive returns, and the wrapped one above exists only to resolve the string.
         Toast.makeText(context.applicationContext, message, Toast.LENGTH_SHORT).show()
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -10,6 +10,7 @@ import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.res.Resources
 import android.os.Build
+import androidx.core.content.edit
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.source.local.UadHelper
 import com.valhalla.thor.data.source.local.room.AppDao
@@ -21,6 +22,7 @@ import com.valhalla.thor.domain.model.ScanVerdict
 import com.valhalla.thor.domain.model.scanVerdict
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.InstalledAppsPermissionGate
+import com.valhalla.thor.util.LocaleRevision
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -69,6 +71,27 @@ class AppRepositoryImpl(
     }
 
     /**
+     * The locale key the [AppEntity] rows in Room were actually mapped under, or `null` if no scan
+     * has ever recorded one.
+     *
+     * A one-key `SharedPreferences` file, the same shape [com.valhalla.thor.util.AppLocale] uses for
+     * its mirror and for the same reason: it has to be readable before the first scan, without a
+     * suspension point and without a schema migration. It describes the *cache*, not the user, which
+     * is why it does not live in `PreferenceRepository` next to things a backup should carry — a
+     * restored device's Room rows are its own, and a restored key describing someone else's rows
+     * would be worse than no key at all.
+     */
+    private val labelCacheState by lazy {
+        context.getSharedPreferences(LABEL_CACHE_PREFS, Context.MODE_PRIVATE)
+    }
+
+    private fun cachedLabelLocale(): String? = labelCacheState.getString(KEY_LABEL_LOCALE, null)
+
+    private fun recordLabelLocale(key: String) {
+        labelCacheState.edit { putString(KEY_LABEL_LOCALE, key) }
+    }
+
+    /**
      * RUTHLESS OPTIMIZATION V2:
      * We debounce the TRIGGER to prevent heavy package scanning during batch operations.
      */
@@ -93,7 +116,14 @@ class AppRepositoryImpl(
                 mutableMapOf()
             }
 
-            var lastLocale = localeCacheKey()
+            // Seeded from what the cached rows were mapped under, NOT from the locale in force now.
+            // Reading localeCacheKey() here would compare the current key against itself on the
+            // first scan, so `forceRefresh` could never be true on the one scan that most needs it:
+            // a language changed while this process was dead, or before this collection started,
+            // leaves every row in the previous language and no package event to force a re-map.
+            // `null` on a first run differs from every key, so that scan re-maps — which is free,
+            // because it has no cache to reuse anyway.
+            var lastLocale = cachedLabelLocale()
 
             // How many scans in a row scanVerdict() has refused to prune against. Deliberately
             // declared out here, not inside the trigger loop: the whole point of the tolerance is
@@ -116,9 +146,6 @@ class AppRepositoryImpl(
                 try {
                     val currentLocale = localeCacheKey()
                     val forceRefresh = currentLocale != lastLocale
-                    if (forceRefresh) {
-                        lastLocale = currentLocale
-                    }
 
                     val flags = PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
                     val installedPackages =
@@ -254,6 +281,17 @@ class AppRepositoryImpl(
                     // nothing would strand isLoading forever on a fresh collection.
                     producer.send(currentList + retained)
 
+                    // Only now, and only on a scan that was trusted enough to prune against. Moving
+                    // the key up next to the `forceRefresh` read would let a scan that was cancelled
+                    // mid-loop, or one that ran while package visibility was truncated, record a
+                    // language for rows it never re-mapped — and nothing would ever force-refresh
+                    // them again. Re-mapping twice costs a rescan; recording too early costs the
+                    // stale labels this key exists to prevent.
+                    if (forceRefresh && verdict == ScanVerdict.Accept) {
+                        lastLocale = currentLocale
+                        recordLabelLocale(currentLocale)
+                    }
+
                 } catch (e: CancellationException) {
                     // Kotlin's CancellationException is an Exception, so the broad catch below
                     // would otherwise swallow it, log it in debug, and loop straight back round to
@@ -263,6 +301,16 @@ class AppRepositoryImpl(
                     if (BuildConfig.DEBUG) e.printStackTrace()
                 }
             }
+        }
+
+        // A language change is not a package event, so without this nothing in the flow above would
+        // ever pump the channel for one and the locale key could only be consulted when some
+        // unrelated package broadcast happened to arrive — on a device that installs nothing, never.
+        // This covers the *app* half of the key; the system half is ACTION_LOCALE_CHANGED below,
+        // which is a separate signal because it fires in cases this one cannot see (see
+        // [LocaleRevision]).
+        val localeWatcher = launch {
+            LocaleRevision.changes.collect { triggerChannel.trySend(Unit) }
         }
 
         // Receiver for Package-specific changes (requires "package" data scheme)
@@ -292,6 +340,12 @@ class AppRepositoryImpl(
         val generalFilter = IntentFilter().apply {
             addAction(Intent.ACTION_PACKAGES_SUSPENDED)
             addAction(Intent.ACTION_PACKAGES_UNSUSPENDED)
+            // The *system* half of the locale key, and the only signal that carries it. A
+            // third-party app's label is loaded from that app's resources and so follows the device
+            // language, which can move while Thor's own language does not: under an in-app override
+            // the application configuration never changes, so LocaleRevision stays silent and every
+            // cached label is quietly a language behind.
+            addAction(Intent.ACTION_LOCALE_CHANGED)
         }
 
         context.registerReceiver(packageReceiver, packageFilter)
@@ -300,6 +354,7 @@ class AppRepositoryImpl(
         awaitClose {
             context.unregisterReceiver(packageReceiver)
             context.unregisterReceiver(generalReceiver)
+            localeWatcher.cancel()
             worker.cancel()
         }
     }.flowOn(Dispatchers.IO)
@@ -468,5 +523,15 @@ class AppRepositoryImpl(
 
     override suspend fun updateInstallSizes(sizes: Map<String, Long>) {
         appDao.updateInstallSizes(sizes)
+    }
+
+    private companion object {
+        /**
+         * Not in the Auto Backup allowlist, deliberately — it describes rows that live in a
+         * database Auto Backup does not carry either, and restoring one without the other would
+         * assert a language for labels that were never scanned on this device.
+         */
+        const val LABEL_CACHE_PREFS = "app_label_cache"
+        const val KEY_LABEL_LOCALE = "label_locale_key"
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.content.res.Resources
 import android.os.Build
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.source.local.UadHelper
@@ -45,6 +46,29 @@ class AppRepositoryImpl(
     private val pm = context.packageManager
 
     /**
+     * What the cached app labels depend on, as one comparable value.
+     *
+     * **Two** locales, and they can now differ. Thor's own strings follow the *app* language —
+     * `AppLocale`'s configuration override below API 33, the platform's per-app locale above it —
+     * while a third-party app's label is loaded from *that app's* resources and follows the
+     * **system** language. Comparing only the first misses a device-language change made while an
+     * in-app override is active, which is precisely when every cached label in the database is
+     * wrong and nothing else would notice; comparing only the second was what this did before the
+     * app context could disagree with the system at all.
+     *
+     * Over-firing is the safe direction: a miss leaves a stale label on every row until some
+     * unrelated package event happens to force a re-map, while a spurious refresh costs one rescan
+     * immediately after a language change the user just made and was already waiting on.
+     */
+    private fun localeCacheKey(): String {
+        val app = context.resources.configuration.locales
+            .takeIf { !it.isEmpty }?.get(0)?.toString().orEmpty()
+        val system = Resources.getSystem().configuration.locales
+            .takeIf { !it.isEmpty }?.get(0)?.toString().orEmpty()
+        return "$app|$system"
+    }
+
+    /**
      * RUTHLESS OPTIMIZATION V2:
      * We debounce the TRIGGER to prevent heavy package scanning during batch operations.
      */
@@ -69,7 +93,7 @@ class AppRepositoryImpl(
                 mutableMapOf()
             }
 
-            var lastLocale = context.resources.configuration.locales[0].toString()
+            var lastLocale = localeCacheKey()
 
             // How many scans in a row scanVerdict() has refused to prune against. Deliberately
             // declared out here, not inside the trigger loop: the whole point of the tolerance is
@@ -90,7 +114,7 @@ class AppRepositoryImpl(
 
                 // Now Perform the Heavy Fetch ONE time
                 try {
-                    val currentLocale = context.resources.configuration.locales[0].toString()
+                    val currentLocale = localeCacheKey()
                     val forceRefresh = currentLocale != lastLocale
                     if (forceRefresh) {
                         lastLocale = currentLocale

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -82,11 +82,11 @@ import com.valhalla.thor.presentation.theme.firaMonoFontFamily
 import com.valhalla.thor.presentation.utils.AppIconModel
 import com.valhalla.thor.presentation.utils.ObserveAsEvents
 import com.valhalla.thor.presentation.utils.getBloatRecommendationColors
+import com.valhalla.thor.util.AppLocale
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import androidx.compose.ui.platform.ClipEntry
 import java.util.Date
-import java.util.Locale
 
 @OptIn(ExperimentalSharedTransitionApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -1165,13 +1165,27 @@ private data class ComponentLists(
     val providers: List<String>
 )
 
+/**
+ * An install timestamp as a medium date and time.
+ *
+ * The locale comes from [AppLocale.localeOf] — the `Configuration` this very [context] resolves its
+ * resources with — and not from `Locale.getDefault()`. Below API 33 the process default is the
+ * *device's* language regardless of what the in-app picker chose, so the default put an English
+ * date directly beneath the French label produced by the `stringResource` two lines up. On 33+ the
+ * platform merges the per-app locale into the process default and the two agree, so nothing changes
+ * there.
+ *
+ * This is also what makes the row consistent with the APK size beside it, which already goes
+ * through `android.text.format.Formatter.formatShortFileSize(context, …)` and therefore has always
+ * read its locale off the Context.
+ */
 private fun formatTime(timestamp: Long, context: Context): String {
     if (timestamp == 0L) return context.getString(R.string.not_available)
     return try {
         val formatter = DateFormat.getDateTimeInstance(
             DateFormat.MEDIUM,
             DateFormat.MEDIUM,
-            Locale.getDefault()
+            AppLocale.localeOf(context)
         )
         formatter.format(Date(timestamp))
     } catch (_: Exception) {

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstallerActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstallerActivity.kt
@@ -3,6 +3,7 @@
 
 package com.valhalla.thor.presentation.installer
 
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -14,6 +15,7 @@ import com.valhalla.thor.domain.model.ThemeMode
 import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.presentation.theme.ThorTheme
+import com.valhalla.thor.util.AppLocale
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -22,9 +24,28 @@ class PortableInstallerActivity : ComponentActivity() {
     private val installerViewModel: InstallerViewModel by viewModel()
     private val preferenceRepository: PreferenceRepository by inject()
 
+    /** The locale tag this instance attached with; see [attachBaseContext]. */
+    private var attachedLocaleTag: String? = null
+
+    /**
+     * Applies the chosen locale on API 28–32, where nothing else will.
+     *
+     * This activity is a second, independent entry point — users reach it from a file manager via
+     * the `VIEW`/`SEND` filters on `.apk`/`.apks`/`.apkm`/`.apkp` — so it never inherits anything
+     * `HomeActivity` did. Deliberately identical to the override in [com.valhalla.thor.HomeActivity]
+     * and [com.valhalla.thor.presentation.launcher.FreezerLaunchActivity].
+     */
+    override fun attachBaseContext(newBase: Context) {
+        attachedLocaleTag = AppLocale.tagFor(newBase)
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // Reached from outside the app and long-lived enough to still be open when the user changes
+        // the language in a separate task; recreating keeps its strings in step. No-op above API 32.
+        AppLocale.recreateOnChange(this, attachedLocaleTag)
         // Reset the app-scoped installer event bus to Idle on a fresh launch only
         // (savedInstanceState == null). Without this, a leftover Success/ReadyToInstall
         // from a previous install would be replayed by the SharedFlow and suppress the

--- a/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/launcher/FreezerLaunchActivity.kt
@@ -5,6 +5,7 @@ package com.valhalla.thor.presentation.launcher
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -16,6 +17,7 @@ import com.valhalla.thor.data.launcher.FreezerShortcutManager
 import com.valhalla.thor.domain.model.BulkOutcome
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.util.AppLocale
 import com.valhalla.thor.util.bulkResultMessage
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -44,6 +46,23 @@ class FreezerLaunchActivity : Activity() {
     private val manageAppUseCase: ManageAppUseCase by inject()
     private val freezerShortcutManager: FreezerShortcutManager by inject()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    /**
+     * Applies the chosen locale on API 28–32, where nothing else will.
+     *
+     * A third entry point, reached from a launcher shortcut without passing through
+     * [com.valhalla.thor.HomeActivity]. It draws no UI, but every outcome it reports is a
+     * `getString` on **this** context — `tile_grant_privilege_toast`, `tile_no_apps_toast`,
+     * `bulk_run_failed`, `freezer_launch_failed` and [com.valhalla.thor.util.bulkResultMessage] —
+     * so without the wrap those toasts are the one part of Thor still speaking English.
+     *
+     * No `recreateOnChange` counterpart: this activity is `noHistory`, `excludeFromRecents` and
+     * finishes itself within a few hundred milliseconds, so there is no instance alive long enough
+     * for a language change to strand.
+     */
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -25,6 +25,7 @@ import com.valhalla.thor.domain.usecase.ShareAppUseCase
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.presentation.home.AppDestinations
+import com.valhalla.thor.util.AppLocale
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.util.UiTextException
@@ -41,7 +42,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
 import org.koin.core.annotation.Named
-import java.util.Locale
 
 /**
  * Side Effects: One-time events that the UI must handle (Navigation, Intents).
@@ -759,8 +759,13 @@ class MainViewModel(
      * `android.text.format.Formatter.formatShortFileSize` is the usual answer and is what the
      * details screen uses, but it needs a Context and this ViewModel deliberately has none — every
      * other string leaves here as a [UiText] for the screen to resolve. Same SI units the platform
-     * helper has used since O, and the number goes through the default locale so the decimal
-     * separator is the user's.
+     * helper has used since O.
+     *
+     * The locale is [AppLocale.formattingLocale], not `Locale.getDefault()`. Below API 33 nothing
+     * makes the process default follow Thor's in-app language, so the default would put `1.5 GB`
+     * inside `export_bulk_no_space` — a sentence rendered from `values-fr` — where the rest of that
+     * sentence expects `1,5`. On 33+ the platform merges the per-app locale into the process
+     * default and the two answers coincide.
      */
     private fun formatBytes(bytes: Long): String {
         val units = listOf("B", "kB", "MB", "GB", "TB")
@@ -771,7 +776,7 @@ class MainViewModel(
             unit++
         }
         val pattern = if (unit == 0) "%.0f %s" else "%.1f %s"
-        return String.format(Locale.getDefault(), pattern, value, units[unit])
+        return String.format(AppLocale.formattingLocale(), pattern, value, units[unit])
     }
 
     private suspend fun performLoggedMultiAction(

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
@@ -51,6 +52,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -72,6 +74,8 @@ import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.ThemeMode
 import com.valhalla.thor.presentation.utils.ObserveAsEvents
+import com.valhalla.thor.util.AppLanguage
+import com.valhalla.thor.util.displayedLanguage
 import com.valhalla.asgard.components.ConnectedButtonGroup
 import com.valhalla.asgard.components.ConnectedButtonGroupItem
 import org.koin.androidx.compose.koinViewModel
@@ -90,6 +94,25 @@ fun SettingsScreen(
     var showLanguageSheet by remember { mutableStateOf(false) }
     var showUnfreezeConfirmation by remember { mutableStateOf(false) }
     var showSupportSheet by remember { mutableStateOf(false) }
+
+    // The language the row and the picker's checkmark are allowed to name.
+    //
+    // `LocalConfiguration.current` is the Configuration this composition is being drawn with —
+    // `AndroidCompositionLocals` seeds it from `view.context.resources.configuration`, and that
+    // context is the Activity, whose base `AppLocale.wrap` overrode. So this is not what Thor
+    // believes it applied; it is what the screen is rendering in, read back off the screen. If the
+    // override ever fails to take, this reports the locale the user is actually looking at and the
+    // row says so, which is precisely what the old `when (prefs.language)` could not do — it read
+    // the persisted preference and therefore confirmed every change, applied or not.
+    //
+    // Recomposition is automatic on both paths: a locale change recreates the activity (the
+    // platform's on 33+, `AppLocale.recreateOnChange` below it), which rebuilds this composition
+    // with the new Configuration.
+    val shownLanguage = displayedLanguage(
+        persistedTag = prefs.language,
+        appliedTag = LocalConfiguration.current.locales
+            .takeIf { !it.isEmpty }?.get(0)?.toLanguageTag()
+    )
 
     ObserveAsEvents(viewModel.events) { event ->
         android.widget.Toast.makeText(
@@ -254,14 +277,7 @@ fun SettingsScreen(
             SettingsClickRow(
                 icon = R.drawable.settings_backup_restore,
                 title = stringResource(R.string.app_language),
-                subtitle = when (prefs.language) {
-                    "en" -> stringResource(R.string.english)
-                    "zh" -> stringResource(R.string.chinese)
-                    "fr" -> stringResource(R.string.french)
-                    "es" -> stringResource(R.string.spanish)
-                    "ar" -> stringResource(R.string.arabic)
-                    else -> stringResource(R.string.system_default)
-                },
+                subtitle = stringResource(shownLanguage.labelRes),
                 onClick = { showLanguageSheet = true }
             )
         }
@@ -746,9 +762,11 @@ fun SettingsScreen(
 
     if (showLanguageSheet) {
         LanguageBottomSheet(
-            selectedLanguage = prefs.language,
-            onLanguageSelected = { lang ->
-                viewModel.setLanguage(lang)
+            // The same value the row shows, for the same reason: a checkmark against Français on a
+            // screen rendering English is the identical lie in a smaller font.
+            selectedLanguage = shownLanguage,
+            onLanguageSelected = { language ->
+                viewModel.setLanguage(language.tag)
                 showLanguageSheet = false
             },
             onDismiss = { showLanguageSheet = false }
@@ -762,22 +780,30 @@ fun SettingsScreen(
     }
 }
 
+/**
+ * The label for each entry, the only Android-side half of [AppLanguage].
+ *
+ * Split out so the tag list and the label list cannot drift apart: they used to be two hand-written
+ * `when`/`listOf` blocks — one in the row, one in this sheet — and a language added to one but not
+ * the other showed up as a row reading "System default" over a checkmark next to its own name.
+ */
+private val AppLanguage.labelRes: Int
+    @StringRes get() = when (this) {
+        AppLanguage.SystemDefault -> R.string.system_default
+        AppLanguage.English -> R.string.english
+        AppLanguage.Chinese -> R.string.chinese
+        AppLanguage.French -> R.string.french
+        AppLanguage.Spanish -> R.string.spanish
+        AppLanguage.Arabic -> R.string.arabic
+    }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LanguageBottomSheet(
-    selectedLanguage: String?,
-    onLanguageSelected: (String?) -> Unit,
+    selectedLanguage: AppLanguage,
+    onLanguageSelected: (AppLanguage) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val languages = listOf(
-        null to stringResource(R.string.system_default),
-        "en" to stringResource(R.string.english),
-        "zh" to stringResource(R.string.chinese),
-        "fr" to stringResource(R.string.french),
-        "es" to stringResource(R.string.spanish),
-        "ar" to stringResource(R.string.arabic),
-    )
-
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = rememberBottomSheetState(
@@ -802,8 +828,8 @@ private fun LanguageBottomSheet(
                 modifier = Modifier.padding(bottom = 24.dp)
             )
 
-            languages.forEach { (code, label) ->
-                val isSelected = selectedLanguage == code
+            AppLanguage.PICKER_ORDER.forEach { language ->
+                val isSelected = selectedLanguage == language
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -812,12 +838,12 @@ private fun LanguageBottomSheet(
                             if (isSelected) MaterialTheme.colorScheme.primaryContainer
                             else Color.Transparent
                         )
-                        .clickable { onLanguageSelected(code) }
+                        .clickable { onLanguageSelected(language) }
                         .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = label,
+                        text = stringResource(language.labelRes),
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
                         color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer

--- a/app/src/main/java/com/valhalla/thor/presentation/tile/FreezerTileService.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/tile/FreezerTileService.kt
@@ -3,6 +3,9 @@
 
 package com.valhalla.thor.presentation.tile
 
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
 import android.os.Build
 import android.service.quicksettings.TileService
 import com.valhalla.thor.R
@@ -11,6 +14,8 @@ import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.domain.model.BulkOp
 import com.valhalla.thor.domain.model.BulkRequest
 import com.valhalla.thor.domain.model.BulkResult
+import com.valhalla.thor.util.AppLocale
+import com.valhalla.thor.util.LocalizedResources
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.bulkResultMessage
 import kotlinx.coroutines.CancellationException
@@ -43,6 +48,44 @@ class FreezerTileService : TileService() {
 
     /** The [BulkResult] currently displayed in the subtitle; consumed in [onStopListening]. */
     private var shownResult: BulkResult? = null
+
+    /**
+     * Applies the chosen locale on API 28–32 to the strings **this service** resolves.
+     *
+     * `Service` extends `ContextWrapper` and is attached the same way an Activity is, so the same
+     * wrap works here. What it covers is everything [paint] reads: `tile_checking`, `tile_freezing`,
+     * `tile_no_privilege`, `tile_no_apps`, the `freezer` content description and
+     * [com.valhalla.thor.util.bulkResultMessage].
+     *
+     * **What it does not cover, on any API level:** the tile's *label* and *icon*, declared as
+     * `android:label="@string/freezer"` on the `<service>` in the manifest. Those are read by
+     * SystemUI out of Thor's APK using SystemUI's own resources and configuration — Thor's process
+     * is not involved and neither a wrapped context here nor `LocaleManager.setApplicationLocales`
+     * on 33+ reaches it. The tile name therefore follows the **system** locale while its subtitle
+     * follows the app language. That split is a property of how QS tiles load metadata, not
+     * something left undone here.
+     *
+     * The wrap is one-shot — `ContextWrapper.attachBaseContext` refuses a second call — and how long
+     * this instance lives is SystemUI's decision, not Thor's: `TileServiceManager` may hold the
+     * binding across shade sessions rather than unbinding with each one. [getResources] therefore
+     * goes through [LocalizedResources] exactly as `ThorApplication` does, so the subtitle cannot
+     * end up a language behind the app that painted it. On API 33+ that indirection is inert.
+     */
+    override fun attachBaseContext(newBase: Context) {
+        localizedResources = LocalizedResources(newBase)
+        super.attachBaseContext(AppLocale.wrap(newBase))
+    }
+
+    @Volatile
+    private var localizedResources: LocalizedResources? = null
+
+    override fun getResources(): Resources =
+        localizedResources?.current() ?: super.getResources()
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        localizedResources?.invalidate()
+    }
 
     override fun onStartListening() {
         // Cancel any previous scope before replacing it. The framework does not deliver

--- a/app/src/main/java/com/valhalla/thor/presentation/tile/FreezerTileService.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/tile/FreezerTileService.kt
@@ -85,6 +85,14 @@ class FreezerTileService : TileService() {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         localizedResources?.invalidate()
+        // invalidate() only fixes the *next* resource read, and by this point the strings are
+        // already gone: `subtitle`, `stateDescription` and `contentDescription` are copies handed
+        // to SystemUI by the last [paint], and SystemUI is displaying them now. Nothing else would
+        // repaint them — the collector in [onStartListening] fires on privilege and freezer state,
+        // neither of which moves when the language does — so the open shade would keep the previous
+        // language until some unrelated state change happened to come along. [paint] returns
+        // immediately when this service is not listening, so this costs nothing when it is not.
+        paint()
     }
 
     override fun onStartListening() {

--- a/app/src/main/java/com/valhalla/thor/util/AppLocale.kt
+++ b/app/src/main/java/com/valhalla/thor/util/AppLocale.kt
@@ -1,0 +1,346 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.util
+
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.os.Build
+import android.os.LocaleList
+import androidx.activity.ComponentActivity
+import androidx.core.content.edit
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.Locale
+
+private const val TAG = "AppLocale"
+
+/** The mirror file. One key, written only by [AppLocale.record]. */
+private const val MIRROR_FILE = "thor_applied_locale"
+private const val MIRROR_KEY = "language_tag"
+
+/**
+ * Applies Thor's language choice on API 28–32 by wrapping every base context Thor owns.
+ *
+ * ### Why this exists
+ *
+ * On API 33+ the platform does this itself: `android.app.LocaleManager.setApplicationLocales`
+ * records a per-app locale in `system/locale_settings.xml`, and `ActivityThread` merges it into the
+ * configuration of every Context the app is handed, before any Thor code runs. Below 33 there is no
+ * such thing. The previous fallback called `AppCompatDelegate.setApplicationLocales`, which applies
+ * a locale by recreating the AppCompat activities it tracks and wrapping their base context —
+ * `AppCompatDelegateImpl.attachBaseContext2`. Thor has no AppCompat activity for it to track
+ * (`HomeActivity`, `PortableInstallerActivity` and `FreezerTileService` are plain framework
+ * components; `FreezerLaunchActivity` extends `android.app.Activity`), so that call stored a static
+ * `LocaleListCompat` and changed nothing observable. Four of the five shipped translations were
+ * unreachable on Android 9 through 12L.
+ *
+ * ### The synchronous-read problem, and what it costs
+ *
+ * `attachBaseContext` runs on the main thread before `onCreate` and cannot suspend, but the
+ * language preference lives in DataStore behind a `Flow`. Three ways out, and why this is the one:
+ *
+ * - **`runBlocking { userPreferences.first() }`** puts a proto-file open, read and parse on the
+ *   activity-launch path, for every activity and service creation, on the main thread. Rejected:
+ *   Thor already measured cold-start contention on this path (`docs/follow-ups/privilege-manager-cold-start.md`).
+ * - **Read DataStore asynchronously in `ThorApplication.onCreate` and recreate afterwards.** The
+ *   first activity attaches before that read lands, so every cold start with a non-default language
+ *   renders a frame in the wrong language and then visibly recreates. Rejected on flicker.
+ * - **This: a one-key `SharedPreferences` mirror, written in the same call that applies the
+ *   locale.** [record] is the only writer and it is called from `LocaleManager.applyLocale`, so the
+ *   mirror cannot say a locale is applied that was not; it is a cache of *what we did*, not a
+ *   second copy of the user's preference. DataStore remains the source of truth for the preference.
+ *
+ * The cost is one `SharedPreferences` load of a file with at most one key, taken once per process
+ * on the first [wrap] — which is `ThorApplication.attachBaseContext`, the first Context Thor gets.
+ * Every later call is a volatile field read. On API 33+ [overridesConfiguration] is false and the
+ * file is never opened at all, so devices on the majority API levels pay nothing.
+ *
+ * **First launch after install:** the mirror is absent, [read] returns `null`, nothing is wrapped —
+ * which is correct, because a user who has never opened Settings has no language preference either.
+ * "Mirror empty" and "no language chosen" coincide by construction.
+ *
+ * **First launch after a cloud restore** is the one case where they diverge. Thor's backup ruleset
+ * is an allowlist naming exactly `datastore/thor_preferences.preferences_pb` (see
+ * `PreferenceRepositoryImpl`), so the DataStore preference travels to a new device and this mirror
+ * does not. That first cold start renders in the system locale; then `ThorApplication.onCreate`
+ * calls `applyLocale(prefs.language)` as it always has, [record] writes the mirror, and the visible
+ * activity is recreated in the right language. One flicker, once, and it self-heals — the
+ * alternative was adding a `SharedPreferences` file to a backup allowlist whose whole design is
+ * that it names one path.
+ *
+ * ### What is deliberately *not* done
+ *
+ * `Locale.setDefault` / `LocaleList.setDefault` are not called, and the reason is **not** the one
+ * this comment used to give. It claimed `BackupIndex.fileStamp` would start emitting Arabic-Indic
+ * digits into backup file names under an `ar` process default. That is false and was measured
+ * false: `DateTimeFormatter.ofPattern(p)` is built by `DateTimeFormatterBuilder.toFormatter`, which
+ * hard-codes `DecimalStyle.STANDARD` — the locale it captures selects month and era *text*, never
+ * the digits. `DecimalStyle.of(Locale("ar")).zeroDigit` is indeed `U+0660`, but that object is
+ * never reached unless a caller passes it to `withDecimalStyle`, and none does. The file names were
+ * always ASCII. `LocalePolicyTest.backupFileStampsAreAsciiUnderAnArabicDefault` pins it.
+ *
+ * The real reasons are ordinary ones. `Locale.setDefault` is a **process-global** mutation: it
+ * reaches every library in the process, `%d`/`%f` in any `String.format` that omits a locale (both
+ * of which *are* localised — `"%02X"` is not, so the signature-digest paths in `ExtensionTrust` and
+ * `StoreRepositoryImpl` are unaffected either way), and code Thor does not own. And it is not
+ * needed: what the picker is *for* is resources, `createConfigurationContext` covers those, and the
+ * two places that formatted through the process default — `MainViewModel.formatBytes` and
+ * `AppInfoDetailsScreen.formatTime` — now take an explicit locale from [formattingLocale] and
+ * [localeOf]. A scoped argument beats a global mutation for the same result.
+ */
+object AppLocale {
+
+    /**
+     * True only where Thor has to override the configuration itself.
+     *
+     * The `< TIRAMISU` gate is not merely an optimisation. On API 33+ the user can change Thor's
+     * language from **system** Settings → Apps → Thor → Language, which updates the platform's
+     * per-app locale and never touches this mirror. Wrapping on 33+ would therefore let a stale
+     * mirror value silently override a choice the user made in the system UI. Below 33 that screen
+     * does not exist, so the mirror is the only source and cannot be contradicted.
+     */
+    val overridesConfiguration: Boolean
+        get() = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+
+    private val _appliedTag = MutableStateFlow<String?>(null)
+
+    /**
+     * The tag currently being applied by [wrap], for activities that must recreate when it changes.
+     *
+     * Only meaningful when [overridesConfiguration] is true. On API 33+ the platform recreates
+     * activities itself when `setApplicationLocales` is called, so nothing collects this.
+     */
+    val appliedTag: StateFlow<String?> = _appliedTag.asStateFlow()
+
+    @Volatile
+    private var cachedTag: String? = null
+
+    @Volatile
+    private var loaded = false
+
+    /** The tag [wrap] would use for [context] — `null` on API 33+ and when nothing is overridden. */
+    fun tagFor(context: Context): String? = if (overridesConfiguration) read(context) else null
+
+    /**
+     * The base context a Thor component should attach, carrying the chosen locale and its layout
+     * direction.
+     *
+     * `Configuration(base.resources.configuration)` copies the *whole* incoming configuration and
+     * changes only the locale, rather than starting from a blank `Configuration`: everything else
+     * on it — density, screen size, night mode, `screenLayout` size bits — is what the base context
+     * was already resolving with, and a blank one would drop all of it.
+     *
+     * The layout-direction write is what makes `values-ar` render right-to-left rather than merely
+     * translated. `Configuration.setLocales` already calls `setLayoutDirection(locale)` for the
+     * first locale, which routes through `TextUtils.getLayoutDirectionFromLocale` and ICU; this
+     * writes the same two `screenLayout` bits from [isRtl] immediately afterwards so the property
+     * is stated in code a reviewer can see and a JVM test can assert, instead of riding on a side
+     * effect of a setter named for something else.
+     *
+     * Copying the whole configuration has one consequence worth knowing, because
+     * [LocalizedResources] is built on it. `createConfigurationContext` takes a *delta*:
+     * `ResourcesManager.generateConfig` starts from the process configuration and calls
+     * `Configuration.updateFrom(override)`, which applies every field the override has set. A full
+     * copy sets them all, so the returned context pins density, night mode and font scale at the
+     * values they had when it was created, and a later system configuration change does not move
+     * them. That is the right trade anyway — a *blank* `Configuration` is worse, not better,
+     * because `Configuration()` calls `setToDefaults()` and `setToDefaults()` sets `fontScale = 1`,
+     * which `updateFrom` then applies, silently resetting a user's display font size. Callers that
+     * outlive a configuration change re-create the wrap; see [LocalizedResources.invalidate].
+     *
+     * Failure returns [base] unwrapped. This runs inside `ThorApplication.attachBaseContext`,
+     * before `Logger` is even configured — a throw here is an app that cannot start at all, and the
+     * fallback is exactly the pre-fix behaviour rather than a crash loop.
+     */
+    fun wrap(base: Context): Context {
+        if (!overridesConfiguration) return base
+        val locale = localeForTag(read(base)) ?: return base
+        return runCatching {
+            val configuration = Configuration(base.resources.configuration)
+            configuration.setLocales(LocaleList(locale))
+            configuration.screenLayout =
+                (configuration.screenLayout and Configuration.SCREENLAYOUT_LAYOUTDIR_MASK.inv()) or
+                    if (isRtl(locale)) Configuration.SCREENLAYOUT_LAYOUTDIR_RTL
+                    else Configuration.SCREENLAYOUT_LAYOUTDIR_LTR
+            base.createConfigurationContext(configuration)
+        }.getOrDefault(base)
+    }
+
+    /**
+     * The locale [context] is *actually* resolving its resources with.
+     *
+     * Read off the `Configuration` rather than off the mirror, so it cannot disagree with the
+     * strings the same context is producing beside it — which is the whole reason the Settings row
+     * reads `LocalConfiguration` too. This is also what `android.text.format.Formatter`'s own
+     * `formatShortFileSize` does with the Context it is handed, so a date formatted through this
+     * and a size formatted through the platform helper agree by construction.
+     */
+    fun localeOf(context: Context): Locale =
+        context.resources.configuration.locales
+            .takeIf { !it.isEmpty }
+            ?.get(0)
+            ?: Locale.getDefault()
+
+    /**
+     * The same answer for a caller that deliberately holds no `Context`.
+     *
+     * On API 33+ the platform merges the per-app locale into the process default, so
+     * `Locale.getDefault()` is already the app language and [overridesConfiguration] short-circuits
+     * to it. Below 33 nothing does that, so the applied tag is consulted. See [formattingLocale].
+     */
+    fun formattingLocale(): Locale =
+        if (overridesConfiguration) {
+            formattingLocale(_appliedTag.value, Locale.getDefault())
+        } else {
+            Locale.getDefault()
+        }
+
+    /**
+     * Records the tag [wrap] must use from now on, and wakes anything watching [appliedTag].
+     *
+     * The in-memory cache is updated under the same lock that guards [read]'s one-shot load, and
+     * *before* the disk write, so a recreate triggered by [appliedTag] on the very next main-loop
+     * turn attaches with the new value even though the `apply()` has not reached disk yet.
+     *
+     * `apply()` rather than `commit()`: this runs on the main thread (`SettingsViewModel.setLanguage`
+     * is a `viewModelScope` launch, and `ThorApplication` hops to Main for it), where `commit()` is
+     * a disk write on the UI thread and lint's `ApplySharedPref` says so. Durability across a
+     * process death in the window between the two is handled by `QueuedWork`, which the framework
+     * drains at the next `Activity.onPause` / service lifecycle transition.
+     */
+    fun record(context: Context, tag: String?) {
+        synchronized(this) {
+            cachedTag = tag
+            loaded = true
+        }
+        runCatching {
+            context.getSharedPreferences(MIRROR_FILE, Context.MODE_PRIVATE).edit {
+                if (tag == null) remove(MIRROR_KEY) else putString(MIRROR_KEY, tag)
+            }
+        }.onFailure { Logger.e(TAG, "Could not persist the applied locale mirror", it) }
+        _appliedTag.value = tag
+    }
+
+    /**
+     * Recreates [activity] when the applied tag stops matching the one it attached with.
+     *
+     * Both Compose entry points call this with the value [tagFor] returned during their own
+     * `attachBaseContext`, so the comparison is against what this instance is *actually rendering*,
+     * not against a guess. After `recreate()` the new instance attaches with the new tag, the two
+     * agree, and nothing recreates again — the loop terminates on its own.
+     *
+     * A no-op on API 33+, where `LocaleManager.setApplicationLocales` makes the platform relaunch
+     * the activity for us; collecting here as well would race that relaunch.
+     */
+    fun recreateOnChange(activity: ComponentActivity, attachedTag: String?) {
+        if (!overridesConfiguration) return
+        activity.lifecycleScope.launch {
+            appliedTag.collect { tag ->
+                if (tag != attachedTag) activity.recreate()
+            }
+        }
+    }
+
+    /**
+     * The mirror, loaded at most once per process.
+     *
+     * Double-checked against the `@Volatile loaded` flag because [wrap] is called from every
+     * component attach, including ones the system may bring up concurrently (a `TileService` bind
+     * racing an activity launch), and the file is worth opening exactly once.
+     */
+    private fun read(context: Context): String? {
+        if (loaded) return cachedTag
+        return synchronized(this) {
+            if (loaded) return@synchronized cachedTag
+            val tag = runCatching {
+                context.getSharedPreferences(MIRROR_FILE, Context.MODE_PRIVATE)
+                    .getString(MIRROR_KEY, null)
+            }.getOrNull()
+            cachedTag = tag
+            loaded = true
+            _appliedTag.value = tag
+            tag
+        }
+    }
+}
+
+/**
+ * `Resources` that keep following the applied language, for a component that can only attach a
+ * base context **once**.
+ *
+ * ### Why this is needed at all
+ *
+ * `ContextWrapper.attachBaseContext` throws `IllegalStateException("Base context already set")` on
+ * a second call, so the wrap an `Application` or a `Service` performs at process start is the only
+ * one it will ever get. [AppLocale.record] updates the mirror, the cache and
+ * [AppLocale.appliedTag] — it cannot reach back into a context that is already attached. An
+ * Activity does not care, because a language change recreates it and the new instance attaches
+ * afresh (`AppLocale.recreateOnChange`); an Application has no such event.
+ *
+ * That gap was user-visible. Koin's `androidContext()` binds the `Application`, so every `@Single`
+ * taking a bare `Context` — `ShizukuSystemGateway` and `DhizukuSystemGateway` (their
+ * `freeze_system_app_requires_root` refusals, surfaced by `FreezerViewModel` as a toast),
+ * `AppBundleFileStoreImpl` (export destination names), `BulkResultNotifier`,
+ * `FreezerShortcutManager` — resolved strings through a context frozen at the locale the process
+ * started in, for the rest of that process's life. An English sentence toasted over a French
+ * screen. On API 33+ this never happened: `ActivityThread.handleConfigurationChanged` pushes the
+ * new per-app configuration into the Application's own `ResourcesImpl`. Below 33 nothing does, and
+ * that is exactly the range this file exists for.
+ *
+ * ### Shape
+ *
+ * The owner overrides `getResources()` to return [current]. `Context.getString`, `getText`,
+ * `getDrawable` and `getColor` are `final` methods on `Context` that all route through
+ * `getResources()`, and `ContextWrapper` does not override them — so one override moves every
+ * string the component resolves, with no consumer changing anything. The base handed to the
+ * constructor must be the **raw** context the framework passed to `attachBaseContext`, not
+ * `getBaseContext()`: re-wrapping an already-wrapped context compounds the configuration pinning
+ * described on [AppLocale.wrap], while the raw one is the `ContextImpl` the framework keeps
+ * rebased on the current system configuration.
+ *
+ * [invalidate] exists because of that same pinning: the wrap freezes density, night mode and font
+ * scale alongside the locale, so a component that sees `onConfigurationChanged` calls this and the
+ * next [current] rebuilds from a base the framework has already updated.
+ *
+ * On API 33+ this is inert by construction — [AppLocale.appliedTag] is never written there and
+ * [AppLocale.wrap] returns its argument, so [current] hands back the base's own `Resources`, which
+ * is what `getResources()` would have returned anyway.
+ */
+class LocalizedResources(private val base: Context) {
+
+    @Volatile
+    private var cached: Resources? = null
+
+    @Volatile
+    private var cachedTag: String? = null
+
+    /** `Resources` carrying the tag that is in force *now*, rebuilding only when it changes. */
+    fun current(): Resources {
+        val wanted = AppLocale.appliedTag.value
+        cached?.let { if (cachedTag == wanted) return it }
+        return rebuild(wanted)
+    }
+
+    /** Drop the cache; call from `onConfigurationChanged`. The next [current] rebuilds. */
+    fun invalidate() {
+        synchronized(this) { cached = null }
+    }
+
+    /**
+     * Falls back to the base's own `Resources` rather than propagating, for the same reason
+     * [AppLocale.wrap] swallows: this can be reached from `getResources()` during startup, where a
+     * throw is an app that cannot draw a frame. Untranslated beats dead.
+     */
+    private fun rebuild(wanted: String?): Resources = synchronized(this) {
+        cached?.let { if (cachedTag == wanted) return it }
+        val built = runCatching { AppLocale.wrap(base).resources }.getOrElse { base.resources }
+        cached = built
+        cachedTag = wanted
+        built
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/util/LocaleManager.kt
+++ b/app/src/main/java/com/valhalla/thor/util/LocaleManager.kt
@@ -6,51 +6,107 @@ package com.valhalla.thor.util
 import android.content.Context
 import android.os.Build
 import android.os.LocaleList
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.LocaleListCompat
 import org.koin.core.annotation.Single
 import android.app.LocaleManager as AndroidLocaleManager
 
 /**
- * Modern Locale Manager that uses the system LocaleManager on Android 13+ (API 33)
- * and falls back to AppCompatDelegate for older versions.
+ * The one place a language choice becomes an applied locale.
+ *
+ * Two mechanisms, split at API 33:
+ *
+ * - **33+** — `android.app.LocaleManager.setApplicationLocales`. The platform persists the per-app
+ *   locale itself, merges it into every Context the app is handed, and relaunches the running
+ *   activities. Nothing else is needed and nothing else is done here.
+ * - **28–32** — [AppLocale], which records the tag and has each Thor component wrap its own base
+ *   context in a `Configuration` carrying it. This replaces `AppCompatDelegate.setApplicationLocales`,
+ *   which applies a locale only by recreating the AppCompat activities it tracks; Thor has none, so
+ *   that call was a silent no-op and four of the five shipped translations were unreachable below
+ *   Android 13. See [AppLocale] for why the replacement is shaped the way it is.
  */
 @Single
 class LocaleManager(private val context: Context) {
 
     /**
-     * Applies the given language code to the application.
-     * `@param` languageCode The language tag (e.g., "en", "zh-CN"), or null for system default.
+     * Applies [languageCode] — a BCP-47 tag such as `fr`, or `null` for the system default.
+     *
+     * **This is the deliberate-choice path only**: the picker in Settings. A cold start must go
+     * through [reconcileOnStartup] instead, which is the difference between "the user just asked
+     * for this" and "this is what we had written down last time".
+     *
+     * The short-circuit compares on the **language subtag**, via [languageForTag], not on the whole
+     * tag. Below 33, re-recording an equal tag would fire [AppLocale.appliedTag] and recreate the
+     * visible activity for no change. On 33+ it stops a `fr` request from flattening the `fr-FR`
+     * the system language screen handed back, which is a real narrowing — but only that one. It
+     * does **not** protect a *different* language chosen in that screen; a whole-tag comparison and
+     * a language-subtag comparison both report `es` and `fr` as a disagreement, and this method
+     * resolves every disagreement in the preference's favour because that is what its one caller
+     * now means. [reconcileOnStartup] is where the other reading lives.
      */
     fun applyLocale(languageCode: String?) {
+        val tag = languageCode?.trim()?.takeIf { it.isNotEmpty() }
+        if (languageForTag(tag) == languageForTag(appliedLanguageTag())) return
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val localeManager =
-                context.getSystemService(Context.LOCALE_SERVICE) as AndroidLocaleManager
-            localeManager.applicationLocales = if (languageCode == null) {
+            val platform = context.getSystemService(Context.LOCALE_SERVICE) as AndroidLocaleManager
+            platform.applicationLocales = if (tag == null) {
                 LocaleList.getEmptyLocaleList()
             } else {
-                LocaleList.forLanguageTags(languageCode)
+                LocaleList.forLanguageTags(tag)
             }
         } else {
-            val appLocale: LocaleListCompat = if (languageCode == null) {
-                LocaleListCompat.getEmptyLocaleList()
-            } else {
-                LocaleListCompat.forLanguageTags(languageCode)
-            }
-            AppCompatDelegate.setApplicationLocales(appLocale)
+            AppLocale.record(context, tag)
         }
     }
 
     /**
-     * Returns the currently applied application locales.
+     * The tag Thor's own surfaces are currently rendering with, or `null` for the system default.
+     *
+     * Truthful on both paths, which the version this replaced was not: its `< 33` branch returned
+     * `AppCompatDelegate.getApplicationLocales()`, which echoes back the static that
+     * `setApplicationLocales` had just stored — so it reported success for a call that changed
+     * nothing. Here the `< 33` answer is [AppLocale.tagFor], and that value is the *input* to every
+     * `attachBaseContext` wrap in the app; if it says `fr`, the contexts were built from `fr`.
+     *
+     * Used for the short-circuit above, not for the Settings row. The row reads the `Configuration`
+     * it is being composed in (see `SettingsScreen`), because that is the only source that can
+     * *disagree* with what Thor believes it applied — and being able to disagree is exactly what a
+     * row that must not confirm an unapplied change needs.
      */
-    fun getAppliedLocales(): LocaleListCompat {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val localeManager =
-                context.getSystemService(Context.LOCALE_SERVICE) as AndroidLocaleManager
-            LocaleListCompat.wrap(localeManager.applicationLocales)
+    fun appliedLanguageTag(): String? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val platform = context.getSystemService(Context.LOCALE_SERVICE) as AndroidLocaleManager
+            platform.applicationLocales.takeIf { !it.isEmpty }?.get(0)?.toLanguageTag()
         } else {
-            AppCompatDelegate.getApplicationLocales()
+            AppLocale.tagFor(context)
+        }
+
+    /**
+     * The cold-start path. Returns the tag Thor should now have persisted, which the caller stores
+     * if it differs from what it read.
+     *
+     * A startup is not a choice, and treating it as one is what let every cold start overwrite the
+     * platform's per-app locale on API 33+ — reverting a language the user set in Settings → Apps →
+     * Thor → Language, a screen Thor never sees a callback from. [startupLocaleSync] holds the rule
+     * and the argument for it; this method is only the two side effects it selects between.
+     *
+     * Runs on Main like [applyLocale], because below 33 [AppLocale.record] fires
+     * [AppLocale.appliedTag] and the collector on the other end recreates the visible activity.
+     */
+    fun reconcileOnStartup(persistedTag: String?): String? {
+        val persisted = persistedTag?.trim()?.takeIf { it.isNotEmpty() }
+        val action = startupLocaleSync(
+            persistedTag = persisted,
+            inEffectTag = appliedLanguageTag(),
+            // The same predicate, read the same way, as everything else that splits at 33.
+            platformOwnsLocale = !AppLocale.overridesConfiguration,
+        )
+        return when (action) {
+            LocaleSync.InAgreement -> persisted
+            is LocaleSync.AdoptInEffect -> action.tag
+            is LocaleSync.ApplyPreference -> {
+                applyLocale(action.tag)
+                persisted
+            }
         }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/util/LocaleManager.kt
+++ b/app/src/main/java/com/valhalla/thor/util/LocaleManager.kt
@@ -33,18 +33,21 @@ class LocaleManager(private val context: Context) {
      * through [reconcileOnStartup] instead, which is the difference between "the user just asked
      * for this" and "this is what we had written down last time".
      *
-     * The short-circuit compares on the **language subtag**, via [languageForTag], not on the whole
-     * tag. Below 33, re-recording an equal tag would fire [AppLocale.appliedTag] and recreate the
-     * visible activity for no change. On 33+ it stops a `fr` request from flattening the `fr-FR`
-     * the system language screen handed back, which is a real narrowing — but only that one. It
-     * does **not** protect a *different* language chosen in that screen; a whole-tag comparison and
-     * a language-subtag comparison both report `es` and `fr` as a disagreement, and this method
-     * resolves every disagreement in the preference's favour because that is what its one caller
-     * now means. [reconcileOnStartup] is where the other reading lives.
+     * The short-circuit is [isRedundantLanguageRequest], which compares on the **language subtag**
+     * rather than the whole tag. Below 33, re-recording an equal tag would fire
+     * [AppLocale.appliedTag] and recreate the visible activity for no change. On 33+ it stops a `fr`
+     * request from flattening the `fr-FR` the system language screen handed back, which is a real
+     * narrowing — but only that one. It does **not** protect a *different* language chosen in that
+     * screen; a whole-tag comparison and a language-subtag comparison both report `es` and `fr` as a
+     * disagreement, and this method resolves every disagreement in the preference's favour because
+     * that is what its one caller now means. [reconcileOnStartup] is where the other reading lives.
+     *
+     * A request for "System default" is deliberately *not* decided by that comparison — see
+     * [isRedundantLanguageRequest] for why a bare subtag comparison would swallow it.
      */
     fun applyLocale(languageCode: String?) {
         val tag = languageCode?.trim()?.takeIf { it.isNotEmpty() }
-        if (languageForTag(tag) == languageForTag(appliedLanguageTag())) return
+        if (isRedundantLanguageRequest(requestedTag = tag, inEffectTag = appliedLanguageTag())) return
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val platform = context.getSystemService(Context.LOCALE_SERVICE) as AndroidLocaleManager

--- a/app/src/main/java/com/valhalla/thor/util/LocalePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/util/LocalePolicy.kt
@@ -56,6 +56,29 @@ fun languageForTag(tag: String?): AppLanguage {
 }
 
 /**
+ * Whether applying [requestedTag] while [inEffectTag] is already in force would change nothing, so
+ * the caller can return without touching the platform.
+ *
+ * The comparison is on the **language subtag** and nothing else, because the tag that comes back is
+ * rarely the tag that went in: `fr` requested against the `fr-FR` the system language screen
+ * recorded, or `zh` against a resolved `zh-Hans-CN`, is the same language, and re-applying it below
+ * API 33 would fire [AppLocale.appliedTag] and recreate the visible activity for no change. Both
+ * sides go through [localeForTag], so the legacy normalisation applies to each identically — `he`
+ * against `iw` is one language, not two.
+ *
+ * **Not [languageForTag], which is the obvious spelling and the wrong one.** That function degrades
+ * anything Thor does not ship to [AppLanguage.SystemDefault], which is the right conservative
+ * answer for a row that must not claim a language it is not rendering — but it gives the same
+ * answer for "the user asked for no override" and "a language with no translation behind it is
+ * applied right now". Comparing those two answers reports agreement between a request to *clear*
+ * the override and the override still being there, so the request that exists to undo it returns
+ * having done nothing. Comparing subtags keeps `null` distinct from every language while still
+ * treating `de` against `de` as the no-op it is.
+ */
+fun isRedundantLanguageRequest(requestedTag: String?, inEffectTag: String?): Boolean =
+    localeForTag(requestedTag)?.language == localeForTag(inEffectTag)?.language
+
+/**
  * The [Locale] a persisted preference selects, or `null` for "leave the system locale alone".
  *
  * `null` is not a failure value to be substituted for — it is the instruction to wrap nothing, and
@@ -77,9 +100,11 @@ fun localeForTag(tag: String?): Locale? {
 /**
  * Languages written right-to-left, by ISO 639 code as [Locale.getLanguage] reports it.
  *
- * `he`/`id`/`yi` are listed under both their modern and their legacy codes because
- * [Locale.getLanguage] still normalises them to the 1989 forms (`iw`/`in`/`ji`) — a `Locale`
- * built from the tag `he` answers `iw`, so a set holding only `he` would miss it.
+ * `he` and `yi` are listed under both their modern and their legacy codes because
+ * [Locale.getLanguage] still normalises them to the 1989 forms (`iw` and `ji`) — a `Locale`
+ * built from the tag `he` answers `iw`, so a set holding only `he` would miss it. Indonesian
+ * carries the same legacy normalisation (`id` → `in`) and is deliberately **not** here: it is
+ * written left-to-right, so neither of its codes belongs in this set.
  */
 private val RTL_LANGUAGES = setOf(
     "ar", "ckb", "dv", "fa", "he", "iw", "ji", "ps", "sd", "ug", "ur", "yi"

--- a/app/src/main/java/com/valhalla/thor/util/LocalePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/util/LocalePolicy.kt
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.util
+
+import java.util.Locale
+
+/**
+ * The five translations Thor ships, and the one entry that means "do not override anything".
+ *
+ * This list is the Kotlin-side twin of `res/xml/locales_config.xml`, which is what Android 13+
+ * reads to populate its own per-app language screen (Settings → Apps → Thor → Language). The two
+ * must agree: a tag here with no `values-<tag>` directory picks a locale with no translation
+ * behind it, and a `locales_config` entry missing here is a language the in-app picker cannot
+ * reach.
+ *
+ * [tag] is deliberately the *language* subtag alone, with no region, matching what the picker has
+ * always persisted. `values-zh-rCN` is the only shipped directory carrying a region, and plain
+ * `zh` still resolves to it: since API 24 `ResourcesImpl` resolves the requested locale against
+ * the APK's locales with `LocaleList.getFirstMatch`, which expands both sides with likely subtags
+ * (`zh` → `zh-Hans`, `zh-CN` → `zh-Hans-CN`) and matches on script. Region-less tags are therefore
+ * the right thing to persist, not an oversight to correct.
+ */
+enum class AppLanguage(val tag: String?) {
+    SystemDefault(null),
+    English("en"),
+    Chinese("zh"),
+    French("fr"),
+    Spanish("es"),
+    Arabic("ar");
+
+    companion object {
+        /** Picker order: "System default" first, then the shipped translations. */
+        val PICKER_ORDER: List<AppLanguage> = entries.toList()
+    }
+}
+
+/**
+ * Which [AppLanguage] a BCP-47 tag names, matched on the **language subtag only**.
+ *
+ * The tags this has to swallow do not all come from the picker. `LocaleManager.getApplicationLocales`
+ * on API 33+ hands back whatever the platform recorded, and `Configuration.getLocales()[0]` hands
+ * back a fully resolved locale — so `fr` goes in and `fr-FR`, or `zh-Hans-CN`, comes back out.
+ * Comparing whole tags would call those "not French" and "not Chinese".
+ *
+ * An unrecognised language degrades to [AppLanguage.SystemDefault] rather than throwing. That is
+ * the conservative direction: it can only ever under-claim, and the one thing the language row
+ * must never do is claim a language that is not in effect.
+ */
+fun languageForTag(tag: String?): AppLanguage {
+    val language = tag?.takeIf { it.isNotBlank() }
+        ?.let { Locale.forLanguageTag(it).language }
+        ?.takeIf { it.isNotEmpty() }
+        ?: return AppLanguage.SystemDefault
+    return AppLanguage.entries.firstOrNull { it.tag == language } ?: AppLanguage.SystemDefault
+}
+
+/**
+ * The [Locale] a persisted preference selects, or `null` for "leave the system locale alone".
+ *
+ * `null` is not a failure value to be substituted for — it is the instruction to wrap nothing, and
+ * every caller has to honour it rather than fall back to [Locale.getDefault]. Substituting the
+ * default would pin the app to whatever locale the device happened to have the first time the user
+ * opened Settings, which is a different bug wearing the same shape as the one this file exists to
+ * fix.
+ *
+ * A blank or unparseable tag also yields `null`: `Locale.forLanguageTag("")` returns
+ * [Locale.ROOT], whose `language` is the empty string, and a Configuration carrying ROOT resolves
+ * to the default `values/` directory in a way that looks deliberate but never was.
+ */
+fun localeForTag(tag: String?): Locale? {
+    val trimmed = tag?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val locale = Locale.forLanguageTag(trimmed)
+    return locale.takeIf { it.language.isNotEmpty() }
+}
+
+/**
+ * Languages written right-to-left, by ISO 639 code as [Locale.getLanguage] reports it.
+ *
+ * `he`/`id`/`yi` are listed under both their modern and their legacy codes because
+ * [Locale.getLanguage] still normalises them to the 1989 forms (`iw`/`in`/`ji`) — a `Locale`
+ * built from the tag `he` answers `iw`, so a set holding only `he` would miss it.
+ */
+private val RTL_LANGUAGES = setOf(
+    "ar", "ckb", "dv", "fa", "he", "iw", "ji", "ps", "sd", "ug", "ur", "yi"
+)
+
+/**
+ * Whether [locale] lays out right-to-left.
+ *
+ * Duplicates the answer `TextUtils.getLayoutDirectionFromLocale` derives from ICU's
+ * `ULocale.getCharacterOrientation` script data, in a form a JVM test can assert without an
+ * Android runtime. It does not have to be right for every locale on earth — only for the tags in
+ * [AppLanguage], which `LocalePolicyTest` pins — but the extra entries are cheap and stop a future
+ * `values-fa` from shipping silently LTR.
+ *
+ * Kept as a value the wrapper sets explicitly rather than left to `Configuration.setLocales`, which
+ * does call `setLayoutDirection(locale)` for the first locale: relying on that side effect makes
+ * RTL a property nobody can see in the code and nobody can test off-device. See
+ * [com.valhalla.thor.util.AppLocale.wrap].
+ */
+fun isRtl(locale: Locale): Boolean =
+    locale.language.lowercase(Locale.ROOT) in RTL_LANGUAGES
+
+/**
+ * What the Settings language row is allowed to say, given what the user *chose* and what the UI is
+ * actually *being drawn in*.
+ *
+ * This is the finding written as a function. Before it, the row read `prefs.language` alone, so on
+ * API 28–32 — where the old `AppCompatDelegate.setApplicationLocales` call changed nothing, there
+ * being no AppCompat activity for it to recreate — picking Français persisted `fr`, rendered
+ * English, and displayed "Français". The row confirmed a change that had not happened.
+ *
+ * The rule:
+ * - [persistedTag] `null` means the user asked to follow the system. There is no override to fail,
+ *   so the row says "System default" and never names the device's own locale back at them.
+ * - Otherwise the row shows [appliedTag], which callers pass from the rendering `Configuration`,
+ *   not from anything Thor believes it applied. If the override did not take, the two disagree and
+ *   the row sides with the pixels.
+ */
+fun displayedLanguage(persistedTag: String?, appliedTag: String?): AppLanguage =
+    if (persistedTag == null) AppLanguage.SystemDefault else languageForTag(appliedTag)
+
+/**
+ * What a cold start must do when Thor's stored preference and the locale actually in force
+ * disagree.
+ *
+ * There are two stores and only one of them is Thor's. Below API 33 the locale in force is
+ * whatever `AppLocale`'s mirror says, and that mirror is written *only* by Thor — so a
+ * disagreement can only mean the mirror is behind the preference (a cloud restore, a cleared
+ * app-data), and the preference must be pushed out. On API 33+ the locale in force is
+ * `android.app.LocaleManager.getApplicationLocales()`, which the user can change **from outside
+ * Thor** in Settings → Apps → Thor → Language. There, a disagreement usually means the user just
+ * used that screen, and the only safe reading is that the platform is right.
+ */
+sealed interface LocaleSync {
+
+    /** The two name the same language. Touch neither. */
+    data object InAgreement : LocaleSync
+
+    /** Push Thor's stored preference outwards, into whatever applies a locale on this API level. */
+    data class ApplyPreference(val tag: String?) : LocaleSync
+
+    /** Take what is already in force and store it as Thor's preference. */
+    data class AdoptInEffect(val tag: String?) : LocaleSync
+}
+
+/**
+ * Reconciles the two stores at process start.
+ *
+ * ### The bug this exists to stop
+ *
+ * `ThorApplication.onCreate` calls into `LocaleManager` on every cold start. On API 33+ that call
+ * used to be an unconditional `setApplicationLocales(persistedTag)`, which **overwrites** the
+ * platform's per-app locale — so a user who set Thor to French in *system* Settings, having never
+ * touched Thor's own picker, had that choice reverted to "system default" the next time Thor
+ * started, silently and forever. Comparing on the language subtag first (rather than on the whole
+ * tag) narrowed that to "the two name different languages", which is exactly the case where the
+ * user did something deliberate in the system UI — the comparison stopped `fr` from flattening
+ * `fr-FR`, and left the actual overwrite untouched.
+ *
+ * ### The rule
+ *
+ * [platformOwnsLocale] is true on API 33+, where the platform both persists the per-app locale and
+ * offers the user a screen to change it. There Thor's stored preference is a *cache* of a decision
+ * the platform owns, so it loses every disagreement: [AdoptInEffect] writes the platform's answer
+ * back into the preference, which also keeps the Settings row honest — the row reads
+ * [displayedLanguage], and a `null` preference makes it say "System default" no matter what the
+ * screen is actually rendering in.
+ *
+ * Below 33 there is no such screen and no platform store; the preference is the only decision
+ * anyone made, so it is pushed out with [ApplyPreference].
+ *
+ * ### What "platform wins" costs, and why it is still right
+ *
+ * On 33+ a device restored from a cloud backup could in principle arrive with Thor's DataStore
+ * preference restored and the platform's per-app locale not, in which case adopting would discard
+ * the language. It does not, because Android 13 backs the per-app locale up itself — the same
+ * `LocaleManager` that owns it also owns its restore, including the delayed restore for an app
+ * that is installed after the backup lands. The preference is not the only copy on that path, and
+ * treating it as authoritative would trade a rare restore glitch for a reproducible one-tap bug.
+ */
+fun startupLocaleSync(
+    persistedTag: String?,
+    inEffectTag: String?,
+    platformOwnsLocale: Boolean,
+): LocaleSync {
+    val persisted = persistedTag?.trim()?.takeIf { it.isNotEmpty() }
+    if (languageForTag(persisted) == languageForTag(inEffectTag)) return LocaleSync.InAgreement
+    return if (platformOwnsLocale) {
+        LocaleSync.AdoptInEffect(inEffectTag)
+    } else {
+        LocaleSync.ApplyPreference(persisted)
+    }
+}
+
+/**
+ * The [Locale] a user-visible date or number must be formatted with.
+ *
+ * The scoped answer to a problem `Locale.setDefault` would have solved globally and badly. On API
+ * 33+ the platform already merges the per-app locale into the process default, so
+ * [systemDefault] — `Locale.getDefault()` — *is* the app language and there is nothing to do.
+ * Below 33 nothing sets it, which is how "the screen is French but the file size reads `1.5 GB`
+ * instead of `1,5 Go`" happens: the sentence comes from `values-fr` and the number comes from the
+ * device locale, in the same line of text.
+ *
+ * Callers that hold a `Context` should prefer `AppLocale.localeOf(context)`, which reads the locale
+ * off the `Configuration` the caller is actually resolving resources with, and so cannot disagree
+ * with the strings beside it. This overload is for the ones that deliberately hold no Context —
+ * `MainViewModel` formats byte counts into `UiText` arguments and has none by design.
+ *
+ * [appliedTag] `null` means "nothing is overridden", which includes every API 33+ caller, and the
+ * answer is then [systemDefault] rather than any substitute: see [localeForTag] for why `null` has
+ * to survive as `null` here.
+ */
+fun formattingLocale(appliedTag: String?, systemDefault: Locale): Locale =
+    localeForTag(appliedTag) ?: systemDefault

--- a/app/src/main/java/com/valhalla/thor/util/LocaleRevision.kt
+++ b/app/src/main/java/com/valhalla/thor/util/LocaleRevision.kt
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.util
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * "The app language just changed" as one process-wide signal, for the caches that cannot see it any
+ * other way.
+ *
+ * [LocalizedResources] fixes every string Thor resolves *on demand*, but a string already copied
+ * into a database row, a launcher shortcut or a painted tile is beyond its reach. Those holders need
+ * to be told, and the two mechanisms that can change the app language do not share a callback:
+ * below API 33 it is [AppLocale.appliedTag], and on 33+ it is a configuration change delivered to
+ * the `Application`. `ThorApplication` is the one place that already watches both, so it is the one
+ * place that emits here.
+ *
+ * ### What this deliberately does not cover
+ *
+ * A change to the **system** language while an in-app override is active. `ThorApplication` compares
+ * the locale of its own configuration, and under an override that value does not move when the
+ * device language does — yet every third-party app label cached in Room is now stale, because a
+ * label is loaded from *that* app's resources and follows the system language. `ACTION_LOCALE_CHANGED`
+ * is the signal for that half, and it is a broadcast, so the consumer that cares registers for it
+ * directly rather than having it relayed through here. See `AppRepositoryImpl.getAllApps`.
+ *
+ * ### Why `replay = 0` is safe here
+ *
+ * An emission with no subscriber is dropped, which for a `SharedFlow` is usually a bug. It is not
+ * one here: a subscriber only exists while something is actively collecting, and every consumer of
+ * this signal also reconciles from durable state when it *starts* collecting — `AppRepositoryImpl`
+ * seeds its comparison from the locale key persisted alongside the rows. The flow covers the live
+ * case, the persisted key covers the cold one, and neither is asked to do the other's job.
+ */
+object LocaleRevision {
+
+    private val _changes = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /** Emits once per app-language change. Carries no value: the answer is always "re-read it". */
+    val changes: SharedFlow<Unit> = _changes.asSharedFlow()
+
+    /**
+     * Announce that the app language changed.
+     *
+     * `tryEmit` rather than `emit` so this stays callable from the non-suspending framework
+     * callbacks that know about the change. It cannot fail meaningfully: with a buffer of one and
+     * `DROP_OLDEST`, a second change arriving before the first is collected replaces it, and one
+     * "re-read everything" is worth exactly as much as two.
+     */
+    fun bump() {
+        _changes.tryEmit(Unit)
+    }
+}

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -16,9 +16,9 @@
     <!-- The only state worth restoring: DataStore Preferences — theme, sort/filter, privilege
          mode, freezer mode, biometric lock and friends. The store name "thor_preferences" is
          declared in data/repository/PreferenceRepositoryImpl.kt:28, and DataStore writes it to
-         files/datastore/<name>.preferences_pb, so the domain is "file", NOT "sharedpref" — Thor
-         persists nothing through SharedPreferences. A path that matches nothing fails exactly as
-         silently as the empty template this replaced, so it has to track that filename.
+         files/datastore/<name>.preferences_pb, so the domain is "file", NOT "sharedpref". A path
+         that matches nothing fails exactly as silently as the empty template this replaced, so it
+         has to track that filename.
 
          The two device-specific keys in here re-resolve rather than break on a new device:
          export_dir_uri is revalidated by ExportAppUseCase (falls back to Downloads if the SAF
@@ -49,6 +49,15 @@
 
        - cacheDir — APK staging, split bundles, analysis scratch and installer icons, running to
          hundreds of MB. The platform skips it anyway.
+
+       - both SharedPreferences files (domain "sharedpref"). Thor has two, and neither is a
+         setting: AppLocale's one-key language mirror, which exists only so a pre-33 process can
+         read the applied tag before Koin starts, and AppRepositoryImpl's app-label locale key,
+         which records the language the Room rows above were scanned in. Each describes state that
+         is NOT being restored with it — the mirror is re-derived from the backed-up DataStore
+         preference on the first start (ThorApplication reconciles the two), and a locale key
+         restored without its database would claim a language for labels this device never
+         scanned, suppressing the very re-scan that would fix them.
 
        If any of these ever becomes worth backing up, splitting the user-curated freezer watchlist
        out of the derived metadata cache is the prerequisite, not widening this file.

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -32,9 +32,10 @@
         <!-- DataStore Preferences — theme, sort/filter, privilege mode, freezer mode, biometric
              lock and friends. The store name "thor_preferences" is declared in
              data/repository/PreferenceRepositoryImpl.kt:28, and DataStore writes it to
-             files/datastore/<name>.preferences_pb, so the domain is "file", NOT "sharedpref" —
-             Thor persists nothing through SharedPreferences. A path that matches nothing fails
-             exactly as silently as the empty template this replaced.
+             files/datastore/<name>.preferences_pb, so the domain is "file", NOT "sharedpref". A
+             path that matches nothing fails exactly as silently as the empty template this
+             replaced. Thor's two SharedPreferences files are omitted on purpose; see
+             backup_rules.xml.
 
              The two device-specific keys in here re-resolve rather than break on a new device:
              export_dir_uri is revalidated by ExportAppUseCase (falls back to Downloads if the
@@ -55,7 +56,9 @@
            package the new device does not have reads as a frozen app that is not there;
          - everything under cacheDir is in-flight installer scratch, meaningless off-device;
          - thor_local_state describes the database that is not coming with it, so moving it would
-           land a claim about a watchlist that does not exist on the new device.
+           land a claim about a watchlist that does not exist on the new device;
+         - the two SharedPreferences files describe state that is likewise not coming with them —
+           see backup_rules.xml.
        If the watchlist is ever worth transferring, split it out of the metadata cache first
        rather than widening this section.
     -->

--- a/app/src/test/java/com/valhalla/thor/util/LocalePolicyTest.kt
+++ b/app/src/test/java/com/valhalla/thor/util/LocalePolicyTest.kt
@@ -1,0 +1,428 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.util
+
+import com.valhalla.thor.domain.model.BackupIndex
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.format.DateTimeFormatter
+import java.time.format.DecimalStyle
+import java.util.Locale
+
+/**
+ * The decisions behind the in-app language picker, asserted off-device.
+ *
+ * None of the machinery that *applies* a locale is reachable from a JVM test — `AppLocale.wrap`
+ * needs a real `Context`, a `Configuration` and a `SharedPreferences` file, `LocalizedResources`
+ * needs a `Resources`, and there is no Robolectric here — so every judgement those classes make is
+ * lifted into `LocalePolicy.kt` and asserted directly: which language a tag names, which `Locale` a
+ * preference selects, whether that locale is right-to-left, what the Settings row is allowed to
+ * say, which of the two stores wins at cold start, and which locale a date or byte count is
+ * formatted with.
+ *
+ * What that leaves uncovered, stated plainly rather than implied: that `getResources()` on
+ * `ThorApplication` and `FreezerTileService` actually re-resolves after `AppLocale.record`, that
+ * `createConfigurationContext` produces the locale asked for, and that a `BroadcastReceiver`
+ * context is the Application's *base* rather than the wrapped Application. All three are framework
+ * behaviour and need an instrumented test or a device.
+ */
+class LocalePolicyTest {
+
+    /**
+     * The finding, as an assertion.
+     *
+     * On API 28–32 the old fallback called `AppCompatDelegate.setApplicationLocales`, which applies
+     * a locale by recreating the AppCompat activities it tracks. Thor has none, so the call stored
+     * a static and changed nothing — yet the row read `prefs.language` and displayed Français over
+     * an English screen. Any implementation of [displayedLanguage] that lets this pass has
+     * reintroduced the bug.
+     */
+    @Test
+    fun rowShowsTheRenderedLanguage_notThePreference_whenTheOverrideDidNotTake() {
+        assertEquals(
+            AppLanguage.English,
+            displayedLanguage(persistedTag = "fr", appliedTag = "en-US")
+        )
+    }
+
+    /** The same inputs when the override *did* take: the row is then free to say Français. */
+    @Test
+    fun rowShowsFrench_whenTheConfigurationIsActuallyFrench() {
+        assertEquals(
+            AppLanguage.French,
+            displayedLanguage(persistedTag = "fr", appliedTag = "fr")
+        )
+    }
+
+    /**
+     * A user who chose "System default" is told "System default", never the device's own locale.
+     *
+     * Without the `persistedTag == null` branch the row would read the rendering configuration
+     * literally and announce "Français" to a French-phone user who had explicitly asked Thor to
+     * follow the system — technically true, and a change to a row they never touched.
+     */
+    @Test
+    fun systemDefaultStaysSystemDefault_evenOnALocalisedDevice() {
+        assertEquals(
+            AppLanguage.SystemDefault,
+            displayedLanguage(persistedTag = null, appliedTag = "fr-FR")
+        )
+        assertEquals(
+            AppLanguage.SystemDefault,
+            displayedLanguage(persistedTag = null, appliedTag = "ar-EG")
+        )
+    }
+
+    /**
+     * Tags are matched on the language subtag alone.
+     *
+     * `LocaleManager.getApplicationLocales` on API 33+ and `Configuration.getLocales()[0]` both
+     * hand back resolved locales, so what goes in as `fr` comes back as `fr-FR` and `zh` comes back
+     * as `zh-Hans-CN`. Whole-tag equality would call those "not French" and "not Chinese" and drop
+     * the row to "System default" on exactly the devices where the feature is working.
+     */
+    @Test
+    fun regionAndScriptSubtagsDoNotDefeatTheMatch() {
+        assertEquals(AppLanguage.French, languageForTag("fr-FR"))
+        assertEquals(AppLanguage.Chinese, languageForTag("zh-Hans-CN"))
+        assertEquals(AppLanguage.Chinese, languageForTag("zh-CN"))
+        assertEquals(AppLanguage.Spanish, languageForTag("es-419"))
+        assertEquals(AppLanguage.Arabic, languageForTag("ar-EG"))
+        assertEquals(AppLanguage.English, languageForTag("en-GB"))
+    }
+
+    /** Nothing, blank, or a language Thor does not ship degrades to "System default", never throws. */
+    @Test
+    fun unknownAndEmptyTagsDegradeToSystemDefault() {
+        assertEquals(AppLanguage.SystemDefault, languageForTag(null))
+        assertEquals(AppLanguage.SystemDefault, languageForTag(""))
+        assertEquals(AppLanguage.SystemDefault, languageForTag("   "))
+        assertEquals(AppLanguage.SystemDefault, languageForTag("de"))
+        assertEquals(AppLanguage.SystemDefault, languageForTag("not-a-tag-at-all"))
+    }
+
+    /**
+     * `null` means "wrap nothing", and must survive as `null` rather than becoming
+     * [Locale.getDefault].
+     *
+     * `AppLocale.wrap` returns the base context untouched on `null`. Substituting the default here
+     * would instead pin the app to whatever the device's locale happened to be, permanently, which
+     * looks like the feature working right up until the user changes their system language.
+     */
+    @Test
+    fun systemDefaultSelectsNoLocale() {
+        assertNull(localeForTag(null))
+        assertNull(localeForTag(""))
+        assertNull(localeForTag("   "))
+    }
+
+    /** `Locale.forLanguageTag("")` returns ROOT, whose language is empty — that is not a selection. */
+    @Test
+    fun anUnparseableTagSelectsNoLocale_ratherThanRoot() {
+        assertNull(localeForTag("!!"))
+        assertEquals(Locale.ROOT.language, Locale.forLanguageTag("!!").language)
+    }
+
+    /** Every shipped tag parses to a locale carrying the language subtag it was written with. */
+    @Test
+    fun everyShippedTagParses() {
+        for (language in AppLanguage.entries) {
+            val tag = language.tag ?: continue
+            val locale = localeForTag(tag)
+            assertEquals("$language should parse", tag, locale?.language)
+            assertEquals("$language should round-trip", language, languageForTag(tag))
+        }
+    }
+
+    /**
+     * Arabic is right-to-left and the other four are not.
+     *
+     * `AppLocale.wrap` writes `Configuration.screenLayout`'s `SCREENLAYOUT_LAYOUTDIR_*` bits from
+     * [isRtl], the same two bits `Configuration.setLayoutDirection` derives from ICU via
+     * `TextUtils.getLayoutDirectionFromLocale`. A wrong answer here does not fail to translate — it
+     * translates and then lays Arabic out left-to-right.
+     *
+     * The map is keyed by the enum and read with `getValue`, so adding a language to [AppLanguage]
+     * without deciding its direction fails this test with `NoSuchElementException` instead of
+     * shipping silently LTR.
+     */
+    @Test
+    fun onlyArabicIsRightToLeft() {
+        val expected = mapOf(
+            AppLanguage.SystemDefault to false,
+            AppLanguage.English to false,
+            AppLanguage.Chinese to false,
+            AppLanguage.French to false,
+            AppLanguage.Spanish to false,
+            AppLanguage.Arabic to true
+        )
+        for (language in AppLanguage.entries) {
+            val locale = localeForTag(language.tag) ?: continue
+            assertEquals("$language layout direction", expected.getValue(language), isRtl(locale))
+        }
+        assertTrue(isRtl(Locale.forLanguageTag("ar")))
+        assertFalse(isRtl(Locale.forLanguageTag("en")))
+    }
+
+    /**
+     * The legacy ISO 639 codes are covered too.
+     *
+     * [Locale.getLanguage] still normalises `he` to `iw` and `yi` to `ji`, so a set holding only the
+     * modern spellings would report Hebrew as left-to-right. Nothing ships those today; this pins
+     * the trap for whoever adds `values-he`.
+     */
+    @Test
+    fun rtlDetectionSurvivesTheLegacyLanguageCodes() {
+        assertTrue(isRtl(Locale.forLanguageTag("he")))
+        assertTrue(isRtl(Locale.forLanguageTag("iw")))
+        assertTrue(isRtl(Locale.forLanguageTag("fa")))
+        assertTrue(isRtl(Locale.forLanguageTag("ur")))
+    }
+
+    /**
+     * The picker offers "System default" first, then every shipped translation exactly once.
+     *
+     * The row and the sheet are now both driven off this list, so a language present in one and
+     * absent from the other is no longer expressible — this asserts the list itself is whole.
+     */
+    @Test
+    fun pickerOffersSystemDefaultFirstAndEveryShippedLanguageOnce() {
+        assertEquals(AppLanguage.SystemDefault, AppLanguage.PICKER_ORDER.first())
+        assertEquals(AppLanguage.entries.size, AppLanguage.PICKER_ORDER.size)
+        assertEquals(
+            AppLanguage.PICKER_ORDER.size,
+            AppLanguage.PICKER_ORDER.distinct().size
+        )
+        assertEquals(
+            listOf(null, "en", "zh", "fr", "es", "ar"),
+            AppLanguage.PICKER_ORDER.map { it.tag }
+        )
+    }
+
+    /**
+     * Picking a language and having it applied leaves the row saying the same thing it said before
+     * the user opened the sheet — no round-trip through a region-qualified tag changes the answer.
+     */
+    @Test
+    fun everyShippedLanguageRoundTripsThroughTheRow() {
+        for (language in AppLanguage.entries) {
+            val tag = language.tag ?: continue
+            val applied = localeForTag(tag)?.toLanguageTag()
+            assertEquals(language, displayedLanguage(persistedTag = tag, appliedTag = applied))
+        }
+    }
+
+    // --- startupLocaleSync -------------------------------------------------------------------
+
+    /**
+     * The finding: a cold start used to overwrite the platform's per-app locale.
+     *
+     * On API 33+ the user can set Thor's language in **system** Settings → Apps → Thor → Language,
+     * a screen Thor gets no callback from and never writes its own preference for. Thor then
+     * started, read a `null` preference, and pushed `LocaleList.getEmptyLocaleList()` into the
+     * platform — reverting that choice on every single launch. Any rule that answers
+     * [LocaleSync.ApplyPreference] here has reintroduced it.
+     */
+    @Test
+    fun aLanguageSetInSystemSettingsSurvivesTheNextColdStart() {
+        assertEquals(
+            LocaleSync.AdoptInEffect("fr-FR"),
+            startupLocaleSync(
+                persistedTag = null,
+                inEffectTag = "fr-FR",
+                platformOwnsLocale = true,
+            )
+        )
+    }
+
+    /**
+     * The same when Thor's own preference names a *different* language, not merely no language.
+     *
+     * This is the case a whole-tag-versus-language-subtag comparison cannot tell apart from the
+     * one above, and the reason the fix could not be another comparison tweak: `es` and `fr`
+     * disagree under either comparison, so the only question left is which store wins.
+     */
+    @Test
+    fun theSystemScreenBeatsAStalePreference_notJustAnAbsentOne() {
+        assertEquals(
+            LocaleSync.AdoptInEffect("fr"),
+            startupLocaleSync(
+                persistedTag = "es",
+                inEffectTag = "fr",
+                platformOwnsLocale = true,
+            )
+        )
+    }
+
+    /**
+     * Below API 33 the preference is the only decision anyone made, so it is pushed outwards.
+     *
+     * `AppLocale`'s mirror is written *only* by Thor, so a disagreement there cannot mean "the user
+     * changed this somewhere else" — it means the mirror is behind, which is exactly what a cloud
+     * restore leaves (the DataStore preference is in Thor's backup allowlist; the mirror file is
+     * not).
+     */
+    @Test
+    fun below33ARestoredPreferenceIsPushedOutRatherThanDiscarded() {
+        assertEquals(
+            LocaleSync.ApplyPreference("fr"),
+            startupLocaleSync(
+                persistedTag = "fr",
+                inEffectTag = null,
+                platformOwnsLocale = false,
+            )
+        )
+    }
+
+    /**
+     * And the reverse below 33: a preference of "System default" over a mirror still holding `fr`
+     * clears the override rather than adopting it. Adoption would silently convert a stale mirror
+     * into a preference the user never expressed.
+     */
+    @Test
+    fun below33SystemDefaultClearsAStaleMirror() {
+        assertEquals(
+            LocaleSync.ApplyPreference(null),
+            startupLocaleSync(
+                persistedTag = null,
+                inEffectTag = "fr",
+                platformOwnsLocale = false,
+            )
+        )
+    }
+
+    /**
+     * Region and script subtags are not a disagreement.
+     *
+     * `fr` goes into the platform and `fr-FR` comes back out; `zh` comes back as `zh-Hans-CN`.
+     * Treating that as a disagreement would make every cold start either re-apply the preference
+     * (below 33: a pointless activity recreate on every launch) or adopt the resolved tag (33+: the
+     * preference silently narrowing from `fr` to `fr-FR`, which is the flattening the short-circuit
+     * in `LocaleManager.applyLocale` already exists to prevent).
+     */
+    @Test
+    fun aResolvedTagIsNotADisagreement() {
+        for (platformOwnsLocale in listOf(true, false)) {
+            assertEquals(
+                LocaleSync.InAgreement,
+                startupLocaleSync("fr", "fr-FR", platformOwnsLocale)
+            )
+            assertEquals(
+                LocaleSync.InAgreement,
+                startupLocaleSync("zh", "zh-Hans-CN", platformOwnsLocale)
+            )
+            assertEquals(
+                LocaleSync.InAgreement,
+                startupLocaleSync(null, null, platformOwnsLocale)
+            )
+        }
+    }
+
+    /** A blank preference is "System default", not a language, on either side of 33. */
+    @Test
+    fun aBlankPreferenceIsTreatedAsSystemDefault() {
+        assertEquals(LocaleSync.InAgreement, startupLocaleSync("   ", null, true))
+        assertEquals(LocaleSync.InAgreement, startupLocaleSync("", null, false))
+        assertEquals(LocaleSync.ApplyPreference(null), startupLocaleSync("  ", "fr", false))
+    }
+
+    /**
+     * The rule stated as a property, over every pairing of the tags Thor can hold.
+     *
+     * Below 33 nothing may ever be adopted — there is no second store to adopt *from* — and on 33+
+     * nothing may ever be pushed out, which is the whole finding. A future refactor that gets one
+     * disagreement right and another wrong fails here rather than on one device.
+     */
+    @Test
+    fun theStoreThatWinsDependsOnlyOnWhoOwnsTheLocale() {
+        val tags = listOf(null, "en", "fr", "fr-FR", "zh", "ar", "de")
+        for (persisted in tags) {
+            for (inEffect in tags) {
+                val below33 = startupLocaleSync(persisted, inEffect, platformOwnsLocale = false)
+                assertFalse(
+                    "below 33, $persisted/$inEffect must not adopt",
+                    below33 is LocaleSync.AdoptInEffect
+                )
+                val from33 = startupLocaleSync(persisted, inEffect, platformOwnsLocale = true)
+                assertFalse(
+                    "on 33+, $persisted/$inEffect must not overwrite the platform",
+                    from33 is LocaleSync.ApplyPreference
+                )
+            }
+        }
+    }
+
+    // --- formattingLocale --------------------------------------------------------------------
+
+    /**
+     * A date or a byte count follows the picked language, not the device's.
+     *
+     * Below API 33 nothing makes the process default follow the in-app picker, so a screen drawn
+     * from `values-fr` used to carry `1.5 GB` and an English `Aug 4, 2026` inside it. The scoped
+     * answer is this function, deliberately rather than `Locale.setDefault` — see
+     * `AppLocale`'s KDoc for why a process-global mutation was the wrong tool for a
+     * resources-shaped problem.
+     */
+    @Test
+    fun formattingFollowsThePickedLanguage() {
+        val device = Locale.forLanguageTag("en-GB")
+        assertEquals(Locale.forLanguageTag("fr"), formattingLocale("fr", device))
+        assertEquals(Locale.forLanguageTag("ar"), formattingLocale("ar", device))
+    }
+
+    /**
+     * "System default" and API 33+ are the same input — nothing is overridden — and both answer
+     * with the device locale rather than with any substitute.
+     */
+    @Test
+    fun formattingFallsBackToTheDeviceWhenNothingIsOverridden() {
+        val device = Locale.forLanguageTag("en-GB")
+        assertEquals(device, formattingLocale(null, device))
+        assertEquals(device, formattingLocale("", device))
+        assertEquals(device, formattingLocale("   ", device))
+        assertEquals(device, formattingLocale("!!", device))
+    }
+
+    // --- the rationale that was not true -----------------------------------------------------
+
+    /**
+     * `AppLocale` used to justify not calling `Locale.setDefault` by claiming it would put
+     * Arabic-Indic digits into backup file names. It would not, and this is the measurement.
+     *
+     * `DateTimeFormatter.ofPattern(p)` is assembled by `DateTimeFormatterBuilder.toFormatter`,
+     * which hard-codes [DecimalStyle.STANDARD]; the locale it captures selects month and era
+     * *text*, never the digits. The claim was plausible — CLDR really does give `ar` the
+     * Arabic-Indic zero — but that `DecimalStyle` is unreachable without an explicit
+     * `withDecimalStyle`, and nothing in Thor calls it.
+     *
+     * This is pinned rather than deleted because the *conclusion* (do not call `Locale.setDefault`)
+     * is still right for other reasons, and a future reader is entitled to know which of the two
+     * arguments for it actually holds.
+     */
+    @Test
+    fun backupFileStampsAreAsciiUnderAnArabicDefault() {
+        val previous = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.forLanguageTag("ar"))
+
+            val name = BackupIndex.fileNameFor(1_754_300_000_000L)
+            assertTrue("expected ASCII, got $name", name.all { it.code < 128 })
+            assertTrue(name.startsWith(BackupIndex.FILE_NAME_PREFIX))
+            assertTrue(name.endsWith(BackupIndex.FILE_NAME_SUFFIX))
+
+            // Why: the pattern formatter never consults a locale-derived DecimalStyle...
+            assertEquals(
+                '0',
+                DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS").decimalStyle.zeroDigit
+            )
+            // ...even though the locale-derived one really is Arabic-Indic.
+            assertEquals('٠', DecimalStyle.of(Locale.forLanguageTag("ar")).zeroDigit)
+        } finally {
+            Locale.setDefault(previous)
+        }
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/util/LocalePolicyTest.kt
+++ b/app/src/test/java/com/valhalla/thor/util/LocalePolicyTest.kt
@@ -184,6 +184,82 @@ class LocalePolicyTest {
     }
 
     /**
+     * Indonesian is not right-to-left, under either of its two ISO codes.
+     *
+     * `id` normalises to `in` exactly the way `he` normalises to `iw`, which is the trap that put
+     * both members of the Hebrew and Yiddish pairs in the set. Sharing a quirk is not sharing a
+     * layout direction, and a language that renders every Indonesian screen mirrored is a much
+     * louder bug than a missing RTL entry.
+     */
+    @Test
+    fun theLegacyCodeQuirkDoesNotMakeIndonesianRightToLeft() {
+        assertFalse(isRtl(Locale.forLanguageTag("id")))
+        assertFalse(isRtl(Locale.forLanguageTag("in")))
+        assertTrue(isRtl(Locale.forLanguageTag("yi")))
+        assertTrue(isRtl(Locale.forLanguageTag("ji")))
+    }
+
+    /**
+     * Choosing "System default" while a language Thor does not ship is in force actually clears it.
+     *
+     * The short-circuit compares languages, and [languageForTag] answers
+     * [AppLanguage.SystemDefault] for two very different inputs: "the user asked for no override"
+     * and "something is applied that Thor has no translation for". Comparing those two answers
+     * reports agreement between a request to clear the override and the override still being
+     * there, so the request returns without doing anything and the user cannot get back to their
+     * device language. Reachable through `adb shell cmd locale set-app-locales`, through an OEM
+     * language screen that ignores `locales_config`, and through any future release that drops a
+     * translation while a user is still on it.
+     */
+    @Test
+    fun choosingSystemDefaultOverAnUnshippedLanguageIsNotANoOp() {
+        assertFalse(isRedundantLanguageRequest(requestedTag = null, inEffectTag = "de"))
+        assertFalse(isRedundantLanguageRequest(requestedTag = null, inEffectTag = "fr"))
+        // ...but with nothing applied there is genuinely nothing to clear.
+        assertTrue(isRedundantLanguageRequest(requestedTag = null, inEffectTag = null))
+        assertTrue(isRedundantLanguageRequest(requestedTag = null, inEffectTag = "  "))
+    }
+
+    /**
+     * The resolved tag the platform hands back is still the same language, and re-applying it is
+     * the no-op the short-circuit exists for — that is the whole reason it compares subtags.
+     */
+    @Test
+    fun aRequestForTheLanguageAlreadyInForceIsRedundant() {
+        assertTrue(isRedundantLanguageRequest(requestedTag = "fr", inEffectTag = "fr-FR"))
+        assertTrue(isRedundantLanguageRequest(requestedTag = "zh", inEffectTag = "zh-Hans-CN"))
+        assertTrue(isRedundantLanguageRequest(requestedTag = " ar ", inEffectTag = "ar"))
+        assertFalse(isRedundantLanguageRequest(requestedTag = "es", inEffectTag = "fr"))
+        assertFalse(isRedundantLanguageRequest(requestedTag = "fr", inEffectTag = null))
+    }
+
+    /**
+     * Languages Thor does not ship are still told apart from each other.
+     *
+     * They all answer [AppLanguage.SystemDefault], so deciding this on [languageForTag] would call
+     * `de` and `it` the same language and refuse to switch between them — the same collapse that
+     * swallows a request to clear the override, in a different direction. Comparing subtags keeps
+     * them distinct, and still recognises `de` over `de` as the genuine no-op it is rather than
+     * recreating the activity for nothing.
+     */
+    @Test
+    fun unshippedLanguagesAreStillDistinguishedFromEachOther() {
+        assertFalse(isRedundantLanguageRequest(requestedTag = "de", inEffectTag = "it"))
+        assertFalse(isRedundantLanguageRequest(requestedTag = "de", inEffectTag = null))
+        assertTrue(isRedundantLanguageRequest(requestedTag = "de", inEffectTag = "de-AT"))
+    }
+
+    /**
+     * Both sides get the same 1989 normalisation, so a legacy code and its modern twin are one
+     * language rather than a change to apply.
+     */
+    @Test
+    fun theLegacyCodePairsAreNotADisagreement() {
+        assertTrue(isRedundantLanguageRequest(requestedTag = "he", inEffectTag = "iw"))
+        assertTrue(isRedundantLanguageRequest(requestedTag = "id", inEffectTag = "in"))
+    }
+
+    /**
      * The picker offers "System default" first, then every shipped translation exactly once.
      *
      * The row and the sheet are now both driven off this list, so a language present in one and

--- a/web/src/content/claims.mjs
+++ b/web/src/content/claims.mjs
@@ -178,13 +178,16 @@ export const claimRules = [
     unless: NEGATED,
     rationale:
       'One *functional* difference, several others. The foss flavour also sets a `-foss` ' +
-      'versionNameSuffix, adds proguard-rules-foss.pro, and the variant hook narrows ' +
-      'localeFilters to five locales against the store build\'s full set. "One difference" is a ' +
-      'claim a reader can falsify by opening one Gradle file.',
+      'versionNameSuffix and adds proguard-rules-foss.pro, and the benchmark build type is ' +
+      'created only for store. "One difference" is a claim a reader can falsify by opening one ' +
+      'Gradle file. Locales are NOT one of them any more: localeFilters moved from the foss-only ' +
+      'variant hook to onVariants {} once bundle.language.enableSplit was turned off, so both ' +
+      'flavours ship the same five. Any page still saying the store build keeps every locale is ' +
+      'wrong for the opposite reason this rule exists.',
     source:
       "app/build.gradle.kts: productFlavors.create(\"foss\") (versionNameSuffix, " +
-      'proguardFile("proguard-rules-foss.pro")) and the androidComponents variant hook that sets ' +
-      'localeFilters',
+      'proguardFile("proguard-rules-foss.pro")), the store-only benchmark buildType, and the ' +
+      'variant-wide androidComponents onVariants hook that sets localeFilters for every variant',
     allow: [],
   },
 

--- a/web/src/pages/download.mdx
+++ b/web/src/pages/download.mdx
@@ -179,16 +179,19 @@ beside the direct links. Play Billing is scoped to `store` with `storeImplementa
 build never links it: it compiles a no-op billing implementation instead, and its sheet offers
 GitHub Sponsors, Patreon and PayPal and nothing else.
 
-Three others worth knowing, all of them in `app/build.gradle.kts`:
+Two others worth knowing, both of them in `app/build.gradle.kts`:
 
-- **Locales.** The `foss` build ships five — English, Arabic, Spanish, French and Chinese — because
-  it is one universal APK, and trimming the unused library translations out of `resources.arsc`
-  saves real size. The `store` build keeps them all, because Play serves per-locale splits anyway.
-  This is a **flavour** difference and not a Play-versus-GitHub one: the `store-release.apk` on the
-  same GitHub release also carries the full set.
 - **Version string.** The `foss` build carries a `-foss` suffix, which is how you tell the two apart
   on-device.
 - **An extra ProGuard file** for the `foss` flavour.
+
+**Locales are no longer one of them.** Both builds now ship the same five — English, Arabic,
+Spanish, French and Chinese — in a single file, and the Play build no longer uses per-locale
+splits. Splitting an app bundle by locale means Play installs only the languages the device's system
+settings ask for, which is exactly the set the in-app language picker is not needed for: choosing
+Français on a phone that never asked for French would have selected resources Play had not
+delivered. Below Android 13 there is no supported way to fetch that split without Play Core, a
+proprietary library the FOSS build must not carry, so the split is off for both.
 
 Everything else is the same code in both: the same privilege engines, the same app-management
 actions, the same behaviour. Which key an APK carries is a property of the channel, not of the

--- a/web/src/pages/faq.mdx
+++ b/web/src/pages/faq.mdx
@@ -298,9 +298,11 @@ Billing; the `foss` build ships a stub with billing permanently unavailable. Eve
 feature is the same in both.
 
 They are not byte-for-byte twins otherwise — the FOSS flavour also carries a `-foss` suffix in its
-version name and a narrower set of bundled locales — but nothing you can do with one is missing from
-the other. If you are on the FOSS build, or you would simply rather not send a cut to a payment
-processor, [the direct routes are below](#support-development).
+version name and an extra ProGuard rules file — but nothing you can do with one is missing from the
+other. Both now bundle the same five languages: the locale filter that used to apply only to the
+FOSS flavour is applied to every variant, because the Play build no longer uses per-locale splits.
+If you are on the FOSS build, or you would simply rather not send a cut to a payment processor,
+[the direct routes are below](#support-development).
 
 <h3 id="reproducible-builds">Are the builds reproducible?</h3>
 

--- a/web/src/pages/features.mdx
+++ b/web/src/pages/features.mdx
@@ -507,9 +507,11 @@ F-Droid listing is planned. The [download page](/download) has the details for e
 **What differs between `foss` and `store`:** in what the app does, the Support Developer flow. The
 `store` build carries Google Play Billing; the `foss` build ships a no-op stub with billing
 permanently unavailable and opens the donation links in a browser instead. The packaging differs too:
-`foss` takes a `-foss` version-name suffix, an extra ProGuard rules file, and a locale filter
-trimming it to the five languages Thor is translated into, while the benchmark build type exists only
-for `store`. Every app-management feature is the same code in both.
+`foss` takes a `-foss` version-name suffix and an extra ProGuard rules file, while the benchmark
+build type exists only for `store`. The locale filter that used to be one of these is now applied to
+every variant, so both builds carry the same five languages — see the
+[download page](/download#foss-and-store) for why the Play build stopped using per-locale splits. Every
+app-management feature is the same code in both.
 
 <h3 id="reproducible-builds">Reproducible builds</h3>
 


### PR DESCRIPTION
Audit item #6. The picker persisted a language, showed it in the Settings row, and changed nothing on API 28–32. Two independent causes — fixing either alone leaves it broken.

## 1. Non-Activity contexts never got the locale

`attachBaseContext` is the only wrap the Application object will ever get (a second call throws `IllegalStateException("Base context already set")`), so it froze the app context at whatever the locale mirror said when the process started. Everything resolving a string off the Koin `androidContext()` rendered in the **system** language while the UI rendered in the **picked** one: gateway toasts, export destination names, the suspended-app dialog strings, bulk-result notifications, shortcut labels.

A `LocalizedResources` holder plus one `getResources()` override moves every `getString` in the process, invalidated on configuration change.

Three things it *cannot* reach are documented where they are rather than assumed away:

| | behaviour |
|---|---|
| Notification **channel** names | corrected at the next `post()` — `ensureChannel` runs every time and `createNotificationChannel` updates an existing id's name |
| Dynamic shortcut labels | a copy held by the launcher; `onCreate` re-publishes on an `appliedTag` change. **Pinned** shortcuts are deliberately left — re-pushing every id would spend `ShortcutManager`'s background update budget on cosmetics |
| QS tile manifest `android:label` | read by SystemUI with SystemUI's own resources; never tracks a change on any API level |

## 2. Play never delivered the picked locale's resources

The store AAB was split by language, so Play installed only the device's system languages. Picking Français set a Configuration whose `values-fr` had **never been downloaded** — resources fell back silently to `values/`. A no-op for exactly the languages a user would open the picker to get.

API 33+ survived this because `setApplicationLocales` tells `LocaleManagerService` to fetch the missing split. Below 33 there is no such path, and the only supported substitute is Play Core's `SplitInstallManager` — a proprietary dependency the FOSS flavour must not carry. So `bundle { language { enableSplit = false } }`, paired with moving `localeFilters` from foss-only to variant-wide: the un-split base APK would otherwise carry ~75 locales of AndroidX/Material translations Thor's own UI can never reach. **The two halves are only correct together** and the comments say so.

## Testability

Decidable rules extracted into `LocalePolicy.kt` so a JVM test can drive them (this suite has no Robolectric): language-subtag matching, the `AdoptInEffect` vs `ApplyPreference` startup reconciliation — which also stops API 33+ silently reverting a language set in *system* Settings — the RTL table including the legacy ISO codes `Locale.getLanguage` still normalises to (`he`→`iw`, `id`→`in`, `yi`→`ji`), and the Settings-row rule that sides with the pixels over what Thor believes it applied.

## Verification

- **600 tests, 0 failures** (539 on the branch + 61 from #343 after merging `dev`), lint clean on both flavours.
- Adversarial review: 6 lenses × 3 refuters, **60 agents, 0 errors, all 6 lenses returned**. 18 findings raised, **all 18 refuted** (17 at 0/3, one at 1/3). Spot-checked the sweep-completeness finding by hand — root suspends through the same `Shizuku.setAppSuspended` path and the "managed by …" text is platform-rendered, so there was no third copy to sweep.

`versionCode` deliberately untouched — that belongs to a `chore(release)` commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent language support across screens, shortcuts, tiles, notifications, and installer flows.
  * Added English, Arabic, Spanish, French, Chinese, and system-default language options.
  * Improved RTL layout and locale-aware date, number, and filename formatting.

* **Bug Fixes**
  * Improved locale handling across Android versions.
  * App content, labels, shortcuts, and tiles now refresh reliably after language changes.

* **Documentation**
  * Clarified that all builds include the same five translated languages without per-language download splits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->