### PR TITLE
fix(gateway): name the user on every privileged command, per that command's own AOSP default

### DIFF
--- a/app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl
+++ b/app/src/main/aidl/com/valhalla/thor/rootservice/IThorRootService.aidl
@@ -13,8 +13,8 @@ package com.valhalla.thor.rootservice;
  * back as an empty reply parcel -- false for a boolean, null for a String. A stale daemon therefore
  * degrades into an honest failure rather than a mis-dispatch.
  *
- * <p>That is why setAppSuspended below keeps its two-argument shape even though setAppSuspendedAs
- * supersedes it.
+ * <p>That is why setAppSuspended below keeps its two-argument shape, and setAppSuspendedAs its
+ * three-argument one, even though setAppSuspendedAsForUser supersedes both.
  */
 interface IThorRootService {
     boolean setAppSuspended(String packageName, boolean suspended);
@@ -59,4 +59,59 @@ interface IThorRootService {
      * as "unknown", never as "not suspended".
      */
     @nullable String dumpPackage(String packageName);
+
+    /**
+     * {@link #clearAppData} for a named Android user, which is the only shape of it that is safe to
+     * call from a secondary user.
+     *
+     * <p>The daemon cannot work the user out for itself. It runs as uid 0 in user 0, so
+     * {@code Process.myUserHandle()} answers 0 there no matter which user the app that bound it
+     * belongs to -- and IPackageManager.clearApplicationUserData takes the user id as an argument,
+     * so the one-argument {@link #clearAppData} above could only ever pass 0. For Thor in a work
+     * profile or a Xiaomi Second Space that wipes the *primary* user's copy of the package, which is
+     * irreversible and reported as a success.
+     *
+     * <p>Appended rather than added as a third argument to {@link #clearAppData}, per the rule at the
+     * top of this file: a daemon left over from an older build has no transaction code for this and
+     * returns false, so the caller reports a failure instead of destroying the wrong user's data.
+     * {@link #clearAppData} therefore stays, and stays user-0, for that stale-daemon case alone.
+     */
+    boolean clearAppDataForUser(String packageName, int userId);
+
+    /**
+     * {@link #setAppSuspendedAs} for a named Android user -- the only shape of it whose outcome the
+     * app process can actually judge.
+     *
+     * <p>One operation used to name three different users. The daemon's reflection wrote user 0,
+     * because it cannot work the user out for itself: it runs as uid 0 in user 0, so
+     * {@code Process.myUserHandle()} answers 0 there whichever user the app that bound it belongs to
+     * -- the same blindness {@link #clearAppDataForUser} exists for. The dumpsys readback that
+     * decides this method's return value parsed user 0 to match. But the gateway's own judge of
+     * success is {@code ApplicationInfo.FLAG_SUSPENDED}, read in-process, and that can only ever
+     * answer for *Thor's* user.
+     *
+     * <p>With Thor in a work profile or a Xiaomi Second Space, those two numbers differ and the
+     * mismatch is a false success in both directions. A suspend pauses the personal profile's copy
+     * of an app the user never selected, verifies it against a user-0 dump, and reports success. The
+     * unsuspend that should undo it reads FLAG_SUSPENDED for Thor's user, finds it false because
+     * nothing was ever suspended there, and returns success having run no rung at all -- so the
+     * suspension it created cannot be lifted from inside Thor.
+     *
+     * <p>{@code userId} is therefore both the user written and the user parsed back:
+     * setPackagesSuspendedAsUser's suspendingUserId and targetUserId, and the {@code User N:} section
+     * parseSuspendingPackages is asked to read. Root may name a user it does not itself belong to for
+     * the same reason it may name an arbitrary suspending package --
+     * PackageManagerService.enforceCanSetPackagesSuspendedAsUser early-returns for Process.ROOT_UID
+     * before either check (android-17.0.0_r1 PackageManagerService.java:3354-3358).
+     *
+     * <p>Appended rather than added as a fourth argument to {@link #setAppSuspendedAs}, per the rule
+     * at the top of this file: a daemon left over from an older build has no transaction code for
+     * this and returns false, so the caller reports a failure instead of pausing another user's app
+     * behind a dialog only this daemon can lift. {@link #setAppSuspended} and
+     * {@link #setAppSuspendedAs} therefore stay, and stay user-0, for that stale-daemon case alone.
+     *
+     * @param suspendingPackage as on {@link #setAppSuspendedAs}: the identity to act as, or null to
+     *   let the daemon apply its own fallback order.
+     */
+    boolean setAppSuspendedAsForUser(String packageName, boolean suspended, in @nullable String suspendingPackage, int userId);
 }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -11,6 +11,8 @@ import com.valhalla.thor.data.source.local.dhizuku.DhizukuReflector
 import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
+import com.valhalla.thor.data.source.local.installCommand
+import com.valhalla.thor.data.source.local.pmPathCommand
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
@@ -332,13 +334,29 @@ class DhizukuSystemGateway(
         return Result.failure(Exception("Dhizuku: Uninstall failed — ${removal.displayLine()}"))
     }
 
+    /**
+     * Install a single APK already on disk, for the user Thor runs as.
+     *
+     * Naming the user is what stops this installing for all of them. `makeInstallParams` leaves
+     * `params.userId` at `UserHandle.USER_ALL` when the option loop sees no `--user`, and the
+     * session is then created with `USER_SYSTEM` plus `INSTALL_ALL_USERS`: the bare command this
+     * replaces installed the package for **every user on the device** and exited 0, the same
+     * all-users widening `DhizukuHelper.uninstallApp` avoids from the removal side.
+     *
+     * Running as the Device Owner does not change that. `DhizukuAPI.newProcess` decides which
+     * process `pm` runs in; the missing `--user` is interpreted by `PackageManagerService`, which
+     * neither knows nor cares who invoked the command.
+     */
     override suspend fun installApp(apkPath: String, canDowngrade: Boolean): Result<Unit> {
         val installerArg = preferenceRepository.getInstallerArg()
-        
+
         val result = DhizukuHelper.execute(
-            "pm install -r -g${if (canDowngrade) " -d" else ""}$installerArg ${
-                apkPath.escapeForShell()
-            }"
+            installCommand(
+                escapedApkPaths = listOf(apkPath.escapeForShell()),
+                userId = thorUserId,
+                canDowngrade = canDowngrade,
+                installerArg = installerArg,
+            )
         )
         return if (result.first == 0) {
             Result.success(Unit)
@@ -357,8 +375,18 @@ class DhizukuSystemGateway(
 
         return try {
             val escapedPackageName = packageName.escapeForShell()
-            // 1. Get the APK path(s)
-            val pathResult = DhizukuHelper.execute("pm path $escapedPackageName")
+
+            // 1. The user this whole operation is about — Thor's own, matching every other `--user`
+            // here, and read before the first command rather than between the two. `pm path` used
+            // to run bare, and `PackageManagerShellCommand.runPath` seeds USER_SYSTEM, so the read
+            // half answered for user 0 while the write half below already named Thor's user. The
+            // APK bytes are device-wide, so both commands exit 0 either way and the mismatch is
+            // invisible: what a user id selects here is whether the package is *visible*, which is
+            // how a work-profile-only app came back with no paths at all.
+            val currentUser = thorUserId
+
+            // 2. Get the APK path(s) as that user sees them
+            val pathResult = DhizukuHelper.execute(pmPathCommand(escapedPackageName, currentUser))
             val paths = pathResult.second?.lines()
                 ?.filter { it.isNotBlank() }
                 ?.map { it.removePrefix("package:").trim() } ?: emptyList()
@@ -368,9 +396,6 @@ class DhizukuSystemGateway(
             }
 
             val combinedPath = paths.joinToString(" ") { it.escapeForShell() }
-
-            // 2. The user to install for — Thor's own, matching every other `--user` here.
-            val currentUser = thorUserId
 
             // 3. Execute the reinstallation command
             val command =

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -26,7 +26,6 @@ import com.valhalla.thor.domain.repository.PreferenceRepository
 import kotlinx.coroutines.flow.first
 
 private val PACKAGE_NAME_REGEX = Regex("^[a-zA-Z0-9._]+$")
-private val USER_ID_REGEX = Regex("^\\d+$")
 
 @Single
 class DhizukuSystemGateway(

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -15,7 +15,15 @@ import com.valhalla.thor.rootservice.IThorRootService
 import com.valhalla.superuser.ktx.ShellRepository
 import com.valhalla.superuser.ktx.ShellResult
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
+import com.valhalla.thor.data.source.local.clearAppDataCommand
+import com.valhalla.thor.data.source.local.clearCachePaths
+import com.valhalla.thor.data.source.local.forceStopCommand
+import com.valhalla.thor.data.source.local.pmPathCommand
+import com.valhalla.thor.data.source.local.setAppEnabledCommand
 import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
+import com.valhalla.thor.data.source.local.thorUserId
+import com.valhalla.thor.data.source.local.uninstallCommand
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.parseSuspendingPackages
@@ -34,22 +42,35 @@ import java.io.File
 import kotlin.coroutines.resume
 
 private val PACKAGE_NAME_REGEX = Regex("^[a-zA-Z0-9._]+$")
-private val USER_ID_REGEX = Regex("^\\d+$")
 
 // Upper bound for the RootService bind handshake. A null binder or a callback that never
 // arrives must not pin connectionMutex forever and deadlock every later privileged op (H2).
 private const val ROOT_SERVICE_BIND_TIMEOUT_MS = 10_000L
 
 /**
- * The Android user every suspend and unsuspend in this gateway writes to and verifies against.
+ * The Android user every suspend and unsuspend in this gateway writes, verifies, and reads the
+ * platform's suspension record for — Thor's own, and no longer a pinned 0.
  *
- * It has to be the number `ThorRootService.TARGET_USER_ID` writes with, or the readback would
- * confirm a state nobody set: the daemon suspends user 0, and parsing user 10's section of the same
- * dump reports an empty suspender set for a package that is very much suspended. Deliberately not
- * `getCurrentUserId()` for exactly that reason — on a work-profile device the foreground user is the
- * parent (0) while the profile's packages live in 10, and the daemon would still be writing 0.
+ * One operation used to name three different users, and the third is the one that made the pinning
+ * indefensible. The *write* was user 0 (`ThorRootService`'s own constant, plus an API-28 `pm suspend`
+ * that named no user at all, which `PackageManagerShellCommand.runSuspend` seeds to
+ * `UserHandle.USER_SYSTEM`). [readSuspenders] parsed user 0 to match it, so those two agreed. But
+ * [readSuspendedFlag] is `context.packageManager.getApplicationInfo`, an in-process query that can
+ * only ever answer for **Thor's** user — and it is what decides the outcome on all four paths below,
+ * including the early return that skips the unsuspend entirely.
+ *
+ * With Thor in a work profile or a Xiaomi Second Space those numbers differ, and the result was a
+ * false success in both directions. A suspend paused the personal profile's copy of an app the user
+ * never selected, verified it against a user-0 dump, and reported success while the copy they were
+ * looking at stayed running. The unsuspend that should have undone it read `FLAG_SUSPENDED` for
+ * Thor's user, found it false because nothing was ever suspended there, and returned success having
+ * run no rung — leaving the suspension it had made unliftable from inside Thor.
+ *
+ * The user id crosses the binder now ([IThorRootService.setAppSuspendedAsForUser]), so write, dump
+ * parse and flag read finally name one user. It keeps its own symbol rather than being spelled
+ * [thorUserId] at each site so that the set of places which must agree stays one grep.
  */
-private const val SUSPEND_USER_ID = 0
+private val SUSPEND_USER_ID: Int get() = thorUserId
 
 /**
  * Modern implementation of SystemGateway using the reactive ShellRepository.
@@ -121,10 +142,6 @@ class RootSystemGateway(
 
                         override fun onServiceDisconnected(name: ComponentName?) {
                             rootService = null
-                            // A dead service can no longer answer '--user <id>'; drop the cached
-                            // user id so a reconnect re-reads the (possibly switched) user (#34).
-                            cachedUserId = null
-                            userIdGeneration++
                             if (activeConnection === this) {
                                 activeConnection = null
                             }
@@ -179,7 +196,12 @@ class RootSystemGateway(
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
         val escapedPackage = packageName.escapeForShell()
-        val shellResult = runCommand("am force-stop $escapedPackage")
+        // The two halves of this function have to name the same user. Everything below the shell
+        // rung is in-process — killBackgroundProcesses and the FLAG_STOPPED reads both answer for
+        // Thor's own user — while a bare `am force-stop` reads USER_ALL and kills the package
+        // everywhere. Naming [thorUserId] is what makes the post-check evidence about the process
+        // the command was aimed at.
+        val shellResult = runCommand(forceStopCommand(escapedPackage, thorUserId))
         if (shellResult.isSuccess) return shellResult
 
         // Unprivileged check/fallback
@@ -207,7 +229,7 @@ class RootSystemGateway(
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
         val escapedPackage = packageName.escapeForShell()
-        val command = "rm -rf /data/data/$escapedPackage/cache /sdcard/Android/data/$escapedPackage/cache"
+        val command = "rm -rf ${clearCachePaths(escapedPackage, thorUserId).joinToString(" ")}"
         return runCommand(command)
     }
 
@@ -216,14 +238,18 @@ class RootSystemGateway(
             return@withContext Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
         val escapedPackage = packageName.escapeForShell()
-        val shellResult = runCommand("pm clear $escapedPackage")
+        val shellResult = runCommand(clearAppDataCommand(escapedPackage, thorUserId))
         if (shellResult.isSuccess) return@withContext shellResult
 
-        // Fallback to ThorRootService AIDL daemon
+        // Fallback to ThorRootService AIDL daemon. `clearAppDataForUser` and not the older
+        // `clearAppData`: the daemon runs as uid 0 in user 0, so it cannot read Thor's user for
+        // itself and the one-argument entry point wipes user 0 unconditionally. A daemon left over
+        // from an older build has no such transaction code and answers false, which lands on the
+        // failure below — the right way round for a call that destroys data.
         val service = getRootService()
         if (service != null) {
             val aidlCleared = runCatching {
-                service.clearAppData(packageName)
+                service.clearAppDataForUser(packageName, thorUserId)
             }.onFailure { e ->
                 Logger.e("RootSystemGateway", "AIDL clearAppData failed", e)
             }.getOrDefault(false)
@@ -238,8 +264,36 @@ class RootSystemGateway(
     /**
      * Freeze ([isDisabled] = true) or unfreeze a package.
      *
-     * **User apps** keep the single `pm disable` / `pm enable` rung they always had, with the
-     * unprivileged `setApplicationEnabledSetting` as a last resort. It works; it is untouched.
+     * **User apps** run the single `pm disable` / `pm enable` rung they always had, with the
+     * unprivileged `setApplicationEnabledSetting` as a last resort. Two things about it are new, and
+     * the second can report a failure where this path used to report a success, so both are worth
+     * stating rather than leaving to be rediscovered:
+     *
+     *  - The rung now names [thorUserId]. That changes nothing on a single-user device — `pm
+     *    disable` seeds `UserHandle.USER_SYSTEM`, so the bare command and `--user 0` are the same
+     *    operation, byte for byte — and everything on a secondary user, where the bare form moved
+     *    the parent profile's copy while the re-read below, which can only see Thor's own user,
+     *    watched a package that never changed.
+     *  - The rung is now verified by re-reading `ApplicationInfo`, which is this function's own
+     *    stated rule (see the last paragraph) finally applied to the one path that never followed
+     *    it. `pm` exits 0 for a command it accepted and did not act on, and that is not theoretical
+     *    at user 0: an app some other freezer removed with `pm uninstall -k --user N` still has a
+     *    `PackageSetting`, so `pm enable` on it exits 0, writes an enabled-setting nothing consults
+     *    and leaves `FLAG_INSTALLED` clear. The app stays frozen and the old code called that
+     *    success. A **null** read is not evidence in either direction — the package could not be
+     *    resolved at all — so it keeps the exit code's answer instead of manufacturing a failure.
+     *
+     * The read is fresh, and the evidence for that is not an argument: it is the same
+     * `getApplicationInfo(…, MATCH_UNINSTALLED_PACKAGES)` call, in the same process, that two
+     * already-shipped paths depend on for exactly this — [freezeSystemApp]'s rung-1 short-circuit,
+     * device-tested for GH#316, and `Shizuku.setAppDisabledDetailed`, whose
+     * `firstRungThatSticks { isDisabledNow() == disabled }` has been the *only* judge of a freeze in
+     * that gateway since it shipped, for ordinary user apps as well as preinstalled ones — the same
+     * kind of package this rung handles. Mechanically, `ApplicationPackageManager` answers from a
+     * cache keyed on a nonce system_server bumps when it commits a package-state change, so a read
+     * issued after the shell command has returned cannot be served from a pre-command entry; on API
+     * 28, which has no such cache, the call is a plain binder round trip to PMS and there is nothing
+     * to be stale.
      *
      * **System apps** run a two-rung chain, in this order — the order matters because the two rungs
      * have wildly different consequences for the user's data:
@@ -276,10 +330,9 @@ class RootSystemGateway(
         val isSystem = appInfo != null && (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_SYSTEM) != 0
         val escapedPackage = packageName.escapeForShell()
 
+        val currentUser = thorUserId
+
         if (isSystem) {
-            // Only the system path needs a user id, so the `am get-current-user` round trip stays
-            // off the user-app path entirely.
-            val currentUser = getCurrentUserId()
             return if (isDisabled) {
                 freezeSystemApp(packageName, escapedPackage, currentUser)
             } else {
@@ -287,10 +340,16 @@ class RootSystemGateway(
             }
         }
 
-        val state = if (isDisabled) "disable" else "enable"
-        val shellResult = runCommand("pm $state $escapedPackage")
+        val shellResult = runCommand(setAppEnabledCommand(escapedPackage, currentUser, isDisabled))
 
-        if (shellResult.isSuccess) return shellResult
+        // Not a bare `if (isSuccess) return it` — the exit code is not the judge here; see the KDoc.
+        // `enabled != isDisabled` reads oddly and is the whole test: it is "the state we asked for
+        // was reached", since reaching it means `enabled == !isDisabled`. A null read is neither, so
+        // the exit code keeps its answer.
+        if (shellResult.isSuccess) {
+            val enabled = readEffectivelyEnabled(packageName)
+            if (enabled == null || enabled != isDisabled) return shellResult
+        }
 
         // Check if already in the target state
         if (appInfo != null) {
@@ -337,7 +396,7 @@ class RootSystemGateway(
     private suspend fun freezeSystemApp(
         packageName: String,
         escapedPackage: String,
-        currentUser: String,
+        currentUser: Int,
     ): Result<Unit> {
         // Already frozen — by us, by an older build, or by another tool. Short-circuit before any
         // rung runs: re-freezing a package that is merely disabled must never walk down into the
@@ -351,7 +410,7 @@ class RootSystemGateway(
         // The result is kept rather than discarded because the gate below turns on *why* a rung
         // failed: runCommand folds stderr into the exception message, which is where a
         // PackageManagerService SecurityException lands.
-        val disableResult = runCommand("pm disable --user $currentUser $escapedPackage")
+        val disableResult = runCommand(setAppEnabledCommand(escapedPackage, currentUser, isDisabled = true))
         when (readEffectivelyEnabled(packageName)) {
             false -> {
                 Logger.i(
@@ -451,7 +510,7 @@ class RootSystemGateway(
     private suspend fun unfreezeSystemApp(
         packageName: String,
         escapedPackage: String,
-        currentUser: String,
+        currentUser: Int,
     ): Result<Unit> {
         val tried = mutableListOf<String>()
 
@@ -479,7 +538,7 @@ class RootSystemGateway(
         // restored above with its old disabled enabled-setting intact. install-existing does not
         // clear that setting, which is why this runs *after* rung 1 rather than instead of it.
         if (step == RootFreezeChain.UnfreezeStep.ENABLE) {
-            runCommand("pm enable --user $currentUser $escapedPackage")
+            runCommand(setAppEnabledCommand(escapedPackage, currentUser, isDisabled = false))
             tried += "pm enable --user $currentUser"
             step = readUnfreezeStep(packageName) ?: return unreadable()
         }
@@ -539,6 +598,11 @@ class RootSystemGateway(
      * `FLAG_SUSPENDED` is a public `ApplicationInfo` flag, so unlike the suspender *names* (which
      * need `dumpsys` and `android.permission.DUMP`) it can be read from the app process. It answers
      * "is this app still paused" but never "who owns it", which is why both reads exist.
+     *
+     * It is also the one read here that cannot be told which user to answer for: `getApplicationInfo`
+     * answers for the process's own, always. That made it the reader which silently disagreed with
+     * the writer for as long as the write was pinned to user 0 — see [SUSPEND_USER_ID], which is now
+     * the same number by construction rather than by luck.
      */
     private fun readSuspendedFlag(packageName: String): Boolean? =
         getApplicationInfoCompat(packageName)?.let {
@@ -592,14 +656,21 @@ class RootSystemGateway(
             // ("IllegalArgumentException: Package root does not exist"). We never fall back to the
             // shell for suspend — a broken suspension is worse than a reported failure. GH#239.
             //
-            // The identity stays Thor's own applicationId, chosen by the daemon: the system builds
-            // the user-visible "managed by Thor" line out of the recorded suspender name, so what
-            // this writes is deliberately unchanged. Only the read and unsuspend paths moved.
+            // The identity is still left to the daemon — hence the null third argument: the system
+            // builds the user-visible "managed by Thor" line out of the recorded suspender name, so
+            // what this writes as *who* is deliberately unchanged.
+            //
+            // What this writes as *where* is not. `setAppSuspendedAsForUser` and not the userless
+            // `setAppSuspended`: the daemon runs as uid 0 in user 0 and cannot read Thor's user for
+            // itself, so the old entry point suspended the primary user's copy while
+            // [readSuspendedFlag] below — the only thing that can contradict the daemon — asked
+            // Thor's. A daemon left over from an older build has no transaction code for this and
+            // answers false, which lands on the failure below rather than on another user's app.
             if (hasReflection) {
                 val service = getRootService()
                 if (service != null) {
                     val taskResult = runCatching {
-                        service.setAppSuspended(packageName, true)
+                        service.setAppSuspendedAsForUser(packageName, true, null, SUSPEND_USER_ID)
                     }.onFailure { e ->
                         Logger.e("RootSystemGateway", "AIDL suspend failed", e)
                     }.getOrDefault(false)
@@ -612,8 +683,13 @@ class RootSystemGateway(
                 }
                 return@withContext Result.failure(Exception("Root suspend failed via AIDL for $packageName."))
             }
-            // API < 29 has no SuspendDialogInfo reflection path.
-            val shell = runCommand("pm suspend $escapedPackage")
+            // API < 29 has no SuspendDialogInfo reflection path, so the shell is the whole rung and
+            // it has to name the user itself. `PackageManagerShellCommand.runSuspend` seeds
+            // `UserHandle.USER_SYSTEM`, so the bare form this replaces suspended user 0 whichever
+            // user Thor runs as, while [readSuspendedFlag] — the only judge of the result — read
+            // Thor's own and saw nothing change. On a single-user device the two commands are the
+            // same operation byte for byte; on a secondary user they are two different apps.
+            val shell = runCommand("pm suspend --user $SUSPEND_USER_ID $escapedPackage")
             return@withContext if (shell.isSuccess) shell
             else Result.failure(Exception("Root suspend failed for $packageName."))
         }
@@ -626,9 +702,9 @@ class RootSystemGateway(
      *
      * Two shapes, picked by whether the platform's record could be read at all:
      *
-     *  1. **Record readable** — one `setAppSuspendedAs(…, owner)` per recorded owner, then a second
-     *     read that has to come back empty. This is the rescue path for the user's Shizuku-era
-     *     suspensions and the only one that can name an identity Thor never wrote.
+     *  1. **Record readable** — one `setAppSuspendedAsForUser(…, owner, …)` per recorded owner, then
+     *     a second read that has to come back empty. This is the rescue path for the user's
+     *     Shizuku-era suspensions and the only one that can name an identity Thor never wrote.
      *  2. **Record unknown, empty included** — sweep the identities Thor could have written and let
      *     `FLAG_SUSPENDED` be the sole judge. Reached when the daemon will not bind, when the dump
      *     is denied or in a shape the parser has never seen, and on API 28, where there is no
@@ -668,10 +744,12 @@ class RootSystemGateway(
         if (service != null && recorded != null) {
             // One removal per recorded owner, and deliberately no break on the first accepted call:
             // from API 30 `PackageUserState.suspendParams` is a map, so a package can carry several
-            // entries at once and stays suspended while any one of them survives.
+            // entries at once and stays suspended while any one of them survives. Each removal names
+            // the user the owners were read for, so what is lifted is what [readSuspenders] listed
+            // rather than user 0's same-named entries.
             for (owner in recorded) {
                 val accepted = runCatching {
-                    service.setAppSuspendedAs(packageName, false, owner)
+                    service.setAppSuspendedAsForUser(packageName, false, owner, SUSPEND_USER_ID)
                 }.onFailure { e ->
                     Logger.e("RootSystemGateway", "AIDL unsuspend of $packageName as $owner failed", e)
                 }.getOrDefault(false)
@@ -712,20 +790,23 @@ class RootSystemGateway(
             return Result.success(Unit)
         }
 
-        // Unknown record. Sweep rather than guess: the daemon's two-argument entry point clears
-        // every identity Thor has written across its history, and the root shell's `pm unsuspend`
-        // clears the "root" entry left by a pre-GH#239 build or by the API-28 suspend path above
+        // Unknown record. Sweep rather than guess: passing a null identity asks the daemon to clear
+        // every name Thor has written across its history, and the root shell's `pm unsuspend` clears
+        // the "root" entry left by a pre-GH#239 build or by the API-28 suspend path above
         // (PackageManagerShellCommand passes "root" as the calling package for uid 0). Neither is
         // allowed to *report* anything — an exit code of 0 is what the no-op returns — so the flag
-        // read below is the only judge.
+        // read below is the only judge, and both rungs therefore have to act on the user that flag
+        // answers for. That is what `--user $SUSPEND_USER_ID` and the fourth argument below are
+        // doing; `runSuspend` would otherwise seed `USER_SYSTEM` and the daemon would otherwise
+        // default to 0, neither of which is Thor's user in a work profile.
         if (service != null) {
             runCatching {
-                service.setAppSuspended(packageName, false)
+                service.setAppSuspendedAsForUser(packageName, false, null, SUSPEND_USER_ID)
             }.onFailure { e ->
                 Logger.e("RootSystemGateway", "AIDL unsuspend failed", e)
             }
         }
-        runCommand("pm unsuspend $escapedPackage")
+        runCommand("pm unsuspend --user $SUSPEND_USER_ID $escapedPackage")
         return when (readSuspendedFlag(packageName)) {
             false -> {
                 Logger.i(
@@ -803,8 +884,12 @@ class RootSystemGateway(
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
         val escapedPackage = packageName.escapeForShell()
-        val state = if (isRestricted) "ignore" else "allow"
-        return runCommand("appops set $escapedPackage RUN_ANY_IN_BACKGROUND $state")
+        // Not the `pm` trap: `appops` seeds USER_CURRENT and resolves it, inside system_server, to
+        // the *foreground* user. So the bare form did not land on user 0 and did not fan out to
+        // every user — it landed on whoever happened to be in the foreground when the shell ran,
+        // which on a work-profile device is the parent while Thor and the app it is restricting
+        // live in the profile. See [backgroundRestrictionCommand] for the AOSP path.
+        return runCommand(backgroundRestrictionCommand(escapedPackage, thorUserId, isRestricted))
     }
 
     override suspend fun rebootDevice(reason: String): Result<Unit> {
@@ -817,9 +902,13 @@ class RootSystemGateway(
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
-        val currentUser = getCurrentUserId()
         val escapedPackage = packageName.escapeForShell()
-        return runCommand("pm uninstall --user $currentUser $escapedPackage")
+        // Through the shared builder rather than the byte-identical string this used to hold: the
+        // `DELETE_ALL_USERS` trap a bare `pm uninstall` falls into is documented once, on
+        // [uninstallCommand], and `Shizuku.uninstallApp` already reaches it the same way. Two
+        // gateways spelling the destructive command themselves is how one of them keeps the `--user`
+        // and the other loses it.
+        return runCommand(uninstallCommand(escapedPackage, thorUserId))
     }
 
     override suspend fun installApp(apkPath: String, canDowngrade: Boolean): Result<Unit> {
@@ -855,7 +944,7 @@ class RootSystemGateway(
         apkPaths.firstOrNull { File(it).length() == 0L }?.let {
             return Result.failure(Exception("APK file is missing or empty: $it"))
         }
-        val currentUser = getCurrentUserId()
+        val currentUser = thorUserId
         val downgrade = if (canDowngrade) " -d" else ""
         
         val installerArg = preferenceRepository.getInstallerArg()
@@ -904,7 +993,10 @@ class RootSystemGateway(
         }
         return try {
             val escapedPackage = packageName.escapeForShell()
-            val result = shellRepository.exec("du -s /data/data/$escapedPackage/cache")
+            // The credential-encrypted cache dir for Thor's own user. `/data/data/<pkg>` is an alias
+            // of this path *for user 0* — from a secondary user it sizes the wrong copy — and at
+            // user 0 the two name the same directory, so nothing changes on a single-user device.
+            val result = shellRepository.exec("du -s /data/user/$thorUserId/$escapedPackage/cache")
             val outputLine = (if (result.isSuccess) result.stdout.firstOrNull() else null) ?: return 0L
 
             // Output format is usually "12345   /path/to/file"
@@ -941,8 +1033,8 @@ class RootSystemGateway(
 
                 val combinedPath = paths.joinToString(" ") { it.escapeForShell() }
 
-                // 2. Get Current User ID
-                val currentUser = getCurrentUserId()
+                // 2. The user to reinstall for — Thor's own, matching every other `--user` here.
+                val currentUser = thorUserId
 
                 // 3. Execute the reinstallation command
                 val command =
@@ -970,14 +1062,23 @@ class RootSystemGateway(
     }
 
     /**
-     * Retrieves all APK paths (Base + Splits) for a package.
+     * Every APK path (base + splits) of [packageName] **as [thorUserId] sees it**, or an empty list
+     * when the package has no record for that user.
+     *
+     * The user id is not decoration. `pm path` seeds `UserHandle.USER_SYSTEM`, so the bare form
+     * answered for user 0's record whichever user Thor runs as, and [reinstallAppWithGoogle] — this
+     * function's only in-app caller — feeds the answer straight into a `pm install … --user
+     * $thorUserId`. Read one user, write another, and every command in the chain exits 0: Fix Store
+     * would reinstall a secondary user's app off the primary user's record and report success. An
+     * empty list now means "this user has no such package", which is what the caller already
+     * assumed it meant when it turns it into "Could not find APK path".
      */
     suspend fun getAppPaths(packageName: String): List<String> {
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
             return emptyList()
         }
         val escapedPackage = packageName.escapeForShell()
-        val result = shellRepository.exec("pm path $escapedPackage")
+        val result = shellRepository.exec(pmPathCommand(escapedPackage, thorUserId))
         val lines = if (result.isSuccess) result.stdout else emptyList()
 
         return lines
@@ -1082,34 +1183,17 @@ class RootSystemGateway(
         }
     }.getOrNull()
 
-    // @Volatile guarantees safe publication across threads: getCurrentUserId() runs on the IO
-    // dispatcher while onServiceDisconnected() invalidates the cache on the main thread, so a
-    // '--user <id>' read always sees a consistent value and a foreground-user switch is picked up
-    // after the next reconnect (#34).
-    @Volatile
-    private var cachedUserId: String? = null
-
-    // Bumped on every cache invalidation (onServiceDisconnected). getCurrentUserId() captures it
-    // before the shell read and only commits the result if it is unchanged, so an invalidation that
-    // races an in-flight lookup can't be silently overwritten by the stale value the lookup read.
-    @Volatile
-    private var userIdGeneration = 0
-
-    private suspend fun getCurrentUserId(): String {
-        cachedUserId?.let { return it }
-        val gen = userIdGeneration
-        val userResult = shellRepository.exec("am get-current-user")
-        val currentUser = if (userResult.isSuccess) userResult.stdout.firstOrNull()?.trim() else null
-        return if (currentUser != null && currentUser.matches(USER_ID_REGEX)) {
-            // Only cache a *successfully* resolved id (caching the "0" fallback would let a transient
-            // shell/daemon blip persist the wrong user, so later '--user' commands would target user
-            // 0 on multi-user devices), AND only if no invalidation raced this lookup — a user switch
-            // that fired onServiceDisconnected mid-read must not re-cache the stale value.
-            currentUser.also { if (userIdGeneration == gen) cachedUserId = it }
-        } else {
-            "0"
-        }
-    }
+    // getCurrentUserId(), its @Volatile cache and the generation counter that guarded the cache all
+    // lived here. Every one of them existed to make `am get-current-user` — a shell round trip whose
+    // answer can change while the process runs — safe to reuse. It answered the wrong question:
+    // the *foreground* user, which on a work-profile device is the parent (0) while Thor and the
+    // packages it lists live in 10. So `pm uninstall --user 0` deleted the personal profile's copy
+    // of a package the user never selected, and `pm disable --user 0` disabled a copy the verifying
+    // re-read (which looks at Thor's user) could never see change. Its "0" fallback made a failed
+    // read indistinguishable from a real answer.
+    //
+    // [thorUserId] is a process-lifetime constant read in-process, so there is nothing left to cache
+    // and nothing left to invalidate — which is why onServiceDisconnected no longer resets anything.
 }
 
 /**

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -13,6 +13,8 @@ import com.valhalla.thor.data.source.local.shizuku.ShizukuReflector
 import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
+import com.valhalla.thor.data.source.local.installCommand
+import com.valhalla.thor.data.source.local.pmPathCommand
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
@@ -341,13 +343,26 @@ class ShizukuSystemGateway(
         }
     }
 
+    /**
+     * Install a single APK already on disk, for the user Thor runs as.
+     *
+     * The `--user` is not cosmetic here. `PackageManagerShellCommand.makeInstallParams` opens with
+     * `params.userId = UserHandle.USER_ALL` and leaves it there when the option loop never sees a
+     * `--user`, after which the session is created with `USER_SYSTEM` plus `INSTALL_ALL_USERS` — so
+     * the bare command this replaces installed the package for **every user on the device** and
+     * exited 0, the mirror image of the `DELETE_ALL_USERS` trap `uninstallCommand` documents. Every
+     * other privileged command in this gateway already named a user; the install path did not.
+     */
     override suspend fun installApp(apkPath: String, canDowngrade: Boolean): Result<Unit> {
         val installerArg = preferenceRepository.getInstallerArg()
-        
-        val command = "pm install -r -g${if (canDowngrade) " -d" else ""}$installerArg ${
-            apkPath.escapeForShell()
-        }"
-        
+
+        val command = installCommand(
+            escapedApkPaths = listOf(apkPath.escapeForShell()),
+            userId = thorUserId,
+            canDowngrade = canDowngrade,
+            installerArg = installerArg,
+        )
+
         val result = ShizukuHelper.execute(command)
         return if (result.first == 0) {
             Result.success(Unit)
@@ -366,8 +381,19 @@ class ShizukuSystemGateway(
 
         return try {
             val escapedPackageName = packageName.escapeForShell()
-            // 1. Get the APK path(s)
-            val pathResult = ShizukuHelper.execute("pm path $escapedPackageName")
+
+            // 1. The user this whole operation is about — read once, before the first command,
+            // because the read half and the write half have to agree. `pm path` used to run bare,
+            // and `PackageManagerShellCommand.runPath` seeds USER_SYSTEM, so it answered for user
+            // 0's copy while the reinstall below already passed `--user`. Nothing surfaced the
+            // mismatch: the APK bytes are device-wide, so both commands exit 0 whichever user they
+            // name. What differed was visibility — a work-profile-only app answered nothing and
+            // stopped here with "Could not find APK path", and an app installed for user 0 but not
+            // for Thor's user was reinstalled off a record this user does not hold.
+            val currentUser = thorUserId
+
+            // 2. Get the APK path(s) as that user sees them
+            val pathResult = ShizukuHelper.execute(pmPathCommand(escapedPackageName, currentUser))
             val paths = pathResult.second?.lines()
                 ?.filter { it.isNotBlank() }
                 ?.map { it.removePrefix("package:").trim() } ?: emptyList()
@@ -377,9 +403,6 @@ class ShizukuSystemGateway(
             }
 
             val combinedPath = paths.joinToString(" ") { it.escapeForShell() }
-
-            // 2. Get Current User ID
-            val currentUser = thorUserId
 
             // 3. Execute the reinstallation command
             val command =

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -31,7 +31,6 @@ import com.valhalla.thor.domain.repository.PreferenceRepository
 import kotlinx.coroutines.flow.first
 
 private val PACKAGE_NAME_REGEX = Regex("^[a-zA-Z0-9._]+$")
-private val USER_ID_REGEX = Regex("^\\d+$")
 
 @Single
 class ShizukuSystemGateway(

--- a/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/UsageAccessManager.kt
@@ -10,6 +10,9 @@ import android.net.Uri
 import android.os.Build
 import android.os.Process
 import android.provider.Settings
+import com.valhalla.superuser.utils.escapeForShell
+import com.valhalla.thor.data.source.local.thorUserId
+import com.valhalla.thor.data.source.local.usageStatsGrantCommand
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.repository.UsageAccessGate
 import org.koin.core.annotation.Single
@@ -46,7 +49,15 @@ class UsageAccessManager(
         if (isGranted()) return true
         // Harmless if no privilege is active (command just fails); may also be
         // blocked on newer Android — hence we re-verify rather than assume success.
-        systemRepository.executeShellCommand("appops set $pkg GET_USAGE_STATS allow")
+        //
+        // The user id is not decoration. `isGranted()` above reads the op through
+        // AppOpsManager for `Process.myUid()`, which answers for Thor's own user; the bare
+        // `appops set` this replaced was resolved by `AppOpsService.Shell.parseUserPackageOp`
+        // against `USER_CURRENT`, i.e. the foreground user. On a managed profile those are two
+        // different users, so the write and the confirming read never met.
+        systemRepository.executeShellCommand(
+            usageStatsGrantCommand(pkg.escapeForShell(), thorUserId)
+        )
         return isGranted()
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -16,7 +16,9 @@ import com.valhalla.bypass.Bypass
 import com.valhalla.thor.data.ACTION_INSTALL_STATUS
 import com.valhalla.thor.data.gateway.RootSystemGateway
 import com.valhalla.thor.data.receivers.InstallReceiver
+import com.valhalla.thor.data.source.local.installCommand
 import com.valhalla.thor.data.source.local.shizuku.ShizukuPackageInstallerUtils
+import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.data.source.local.shizuku.ShizukuReflector
 import com.valhalla.thor.data.source.local.shizuku.Shizuku as ShizukuHelper
 import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper
@@ -224,12 +226,10 @@ class InstallerRepositoryImpl(
         // on some ROMs / API versions and caused NoSuchMethodError).
         try {
             val iPackageInstaller = ShizukuPackageInstallerUtils.getPrivilegedPackageInstaller()
-            val root = try {
-                rikka.shizuku.Shizuku.getUid() == 0
-            } catch (_: Exception) {
-                false
-            }
-            val userId = if (root) android.os.Process.myUserHandle().hashCode() else 0
+            // Thor's own user, for the reason `ShizukuReflector.getPackageInstaller` gives: which
+            // uid Shizuku holds is a different question from which user the session installs for,
+            // and the old `if (root) … else 0` answered the first one.
+            val userId = thorUserId
             val installerPackageName = context.packageName
 
             return ShizukuPackageInstallerUtils.createPackageInstaller(
@@ -256,11 +256,11 @@ class InstallerRepositoryImpl(
         } catch (_: Exception) {
             -1
         }
-        val isRoot = shizukuUid == 0
         val isShell = shizukuUid == 2000
 
-        // If Shizuku is running as root, set userId to current user; otherwise use 0
-        val userId = if (isRoot) android.os.Process.myUserHandle().hashCode() else 0
+        // Thor's own user, whatever uid Shizuku holds. Shell uid is the normal setup, so the old
+        // `if (isRoot) … else 0` meant a work-profile install landed in the primary user instead.
+        val userId = thorUserId
 
         // For ADB-based Shizuku (shell), using "com.android.shell" often works better
         // than the app's own package name to avoid permission/UID mismatch issues.
@@ -386,19 +386,24 @@ class InstallerRepositoryImpl(
         val installerArg = preferenceRepository.getInstallerArg()
 
         return try {
-            val apkPaths = tempFiles.map { it.absolutePath }
-            val result = if (apkPaths.size == 1) {
-                val command = "pm install -r -g${if (canDowngrade) " -d" else ""}$installerArg ${
-                    apkPaths[0].escapeForShell()
-                }"
-                ShizukuHelper.execute(command)
-            } else {
-                val escapedPaths = apkPaths.joinToString(" ") {
-                    it.escapeForShell()
-                }
-                val command = "pm install-multiple -r -g${if (canDowngrade) " -d" else ""}$installerArg $escapedPaths"
-                ShizukuHelper.execute(command)
-            }
+            // The shell rung, and normally the one that decides the outcome: the PackageInstaller
+            // session rung is only reached when this returns false. Both rungs now name the same
+            // user, which is the whole point — getShizukuPackageInstaller() creates its session for
+            // thorUserId, so a shell rung that installed somewhere else meant one operation landing
+            // in two different places depending on which rung happened to succeed.
+            //
+            // Bare `pm install` was not "install for the shell's user" and was not "install for
+            // user 0" either: makeInstallParams leaves params.userId at USER_ALL when no --user is
+            // parsed, and the session is then created with USER_SYSTEM plus INSTALL_ALL_USERS, so
+            // every install here landed on *every* user of the device and exited 0. From a work
+            // profile that pushes an APK into the personal profile nobody asked to install it into.
+            val command = installCommand(
+                escapedApkPaths = tempFiles.map { it.absolutePath.escapeForShell() },
+                userId = thorUserId,
+                canDowngrade = canDowngrade,
+                installerArg = installerArg,
+            )
+            val result = ShizukuHelper.execute(command)
 
             if (result.first == 0) {
                 eventBus.emit(InstallState.Installing(1.0f))
@@ -434,19 +439,18 @@ class InstallerRepositoryImpl(
         val installerArg = preferenceRepository.getInstallerArg()
 
         return try {
-            val apkPaths = tempFiles.map { it.absolutePath }
-            val result = if (apkPaths.size == 1) {
-                val command = "pm install -r -g${if (canDowngrade) " -d" else ""}$installerArg ${
-                    apkPaths[0].escapeForShell()
-                }"
-                DhizukuHelper.execute(command)
-            } else {
-                val escapedPaths = apkPaths.joinToString(" ") {
-                    it.escapeForShell()
-                }
-                val command = "pm install-multiple -r -g${if (canDowngrade) " -d" else ""}$installerArg $escapedPaths"
-                DhizukuHelper.execute(command)
-            }
+            // Same rung, same seed, same fix as installWithShizuku above — and the same pairing
+            // with the session rung, which getDhizukuPackageInstaller() creates for thorUserId.
+            // Dhizuku's identity does not soften the trap: `pm` runs inside the device-owner app
+            // via DhizukuAPI.newProcess, but the missing --user is parsed by PackageManagerService,
+            // not by whoever invoked it, so the bare form installed for every user here too.
+            val command = installCommand(
+                escapedApkPaths = tempFiles.map { it.absolutePath.escapeForShell() },
+                userId = thorUserId,
+                canDowngrade = canDowngrade,
+                installerArg = installerArg,
+            )
+            val result = DhizukuHelper.execute(command)
 
             if (result.first == 0) {
                 eventBus.emit(InstallState.Installing(1.0f))

--- a/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
@@ -21,6 +21,26 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 
+/**
+ * The flags every permission read in this file uses, single-package and whole-device alike.
+ *
+ * The match half is not optional, and it is not optional *per call site* either — which is how the
+ * two here came apart. A **system** app frozen by removal for the current user (what
+ * `FreezePolicy.uninstallFreezeFallbackAllowed` still permits, and the state every system app frozen
+ * before Thor preferred disabling is already in) is not installed for this user, so a
+ * `getPackageInfo` without MATCH_UNINSTALLED_PACKAGES **throws** for it. The index kept the flag and
+ * the per-app read did not, so Thor listed the app, offered its permission sheet, and then failed to
+ * open it — for exactly the apps Thor itself had frozen.
+ *
+ * A top-level constant rather than two literals: the sweep and the single read have to describe the
+ * same universe of packages, and the only way to keep them from drifting again is to give them one
+ * name to share.
+ */
+internal const val PERMISSION_QUERY_FLAGS =
+    PackageManager.GET_PERMISSIONS or
+            PackageManager.MATCH_UNINSTALLED_PACKAGES or
+            PackageManager.MATCH_DISABLED_COMPONENTS
+
 @Single(binds = [PermissionRepository::class])
 class PermissionRepositoryImpl(
     context: Context,
@@ -33,14 +53,13 @@ class PermissionRepositoryImpl(
     override suspend fun getAppPermissions(packageName: String): Result<List<AppPermission>> =
         withContext(Dispatchers.IO) {
             try {
-                val flags = PackageManager.GET_PERMISSIONS
                 val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     pm.getPackageInfo(
                         packageName,
-                        PackageManager.PackageInfoFlags.of(flags.toLong())
+                        PackageManager.PackageInfoFlags.of(PERMISSION_QUERY_FLAGS.toLong())
                     )
                 } else {
-                    pm.getPackageInfo(packageName, PackageManager.GET_PERMISSIONS)
+                    pm.getPackageInfo(packageName, PERMISSION_QUERY_FLAGS)
                 }
 
                 val requestedPermissions = packageInfo.requestedPermissions ?: emptyArray()
@@ -84,14 +103,15 @@ class PermissionRepositoryImpl(
     /**
      * One pass over every installed package, bucketing them by runtime-permission group.
      *
-     * The match flags mirror `AppRepositoryImpl`'s sweep, and that is not optional. A *system* app
-     * frozen by removal for the current user — what `FreezePolicy.uninstallFreezeFallbackAllowed`
-     * still permits, and what every system app frozen before Thor preferred disabling is already
-     * in — is not installed for this user, and a default `getInstalledPackages` drops it. The
-     * disabled mechanic needs no flag of its own here, which is exactly why the pair must stay
-     * whole: the half that is doing the work is the invisible one. The app list keeps those rows — showing
-     * them is a headline Thor capability — and `filterApps` intersects the list with this index, so
-     * two different package universes would make every frozen app silently fall out of every chip.
+     * [PERMISSION_QUERY_FLAGS] mirrors `AppRepositoryImpl`'s sweep, and that is not optional. A
+     * *system* app frozen by removal for the current user — what
+     * `FreezePolicy.uninstallFreezeFallbackAllowed` still permits, and what every system app frozen
+     * before Thor preferred disabling is already in — is not installed for this user, and a default
+     * `getInstalledPackages` drops it. The disabled mechanic needs no flag of its own here, which is
+     * exactly why the pair must stay whole: the half that is doing the work is the invisible one.
+     * The app list keeps those rows — showing them is a headline Thor capability — and `filterApps`
+     * intersects the list with this index, so two different package universes would make every
+     * frozen app silently fall out of every chip.
      *
      * Two caches make this affordable. `groupOf` memoises the group per *permission name* — a device
      * with 400 apps declares maybe 200 distinct permissions, and without it the same
@@ -105,13 +125,12 @@ class PermissionRepositoryImpl(
     override suspend fun buildPermissionIndex(): Result<PermissionIndex> =
         withContext(Dispatchers.IO) {
             try {
-                val flags = PackageManager.GET_PERMISSIONS or
-                        PackageManager.MATCH_UNINSTALLED_PACKAGES or
-                        PackageManager.MATCH_DISABLED_COMPONENTS
                 val packages = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    pm.getInstalledPackages(PackageManager.PackageInfoFlags.of(flags.toLong()))
+                    pm.getInstalledPackages(
+                        PackageManager.PackageInfoFlags.of(PERMISSION_QUERY_FLAGS.toLong())
+                    )
                 } else {
-                    pm.getInstalledPackages(flags)
+                    pm.getInstalledPackages(PERMISSION_QUERY_FLAGS)
                 }
 
                 // permission name -> its group, or null for "not dangerous / no usable group".

--- a/app/src/main/java/com/valhalla/thor/data/source/local/PerUserCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/PerUserCommands.kt
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import android.annotation.SuppressLint
+
+/**
+ * The privileged commands and data paths that are wrong — silently, and on another user's data —
+ * unless an Android user is named in them.
+ *
+ * `pm` does not default to the caller's user. `PackageManagerShellCommand.runClear` (and the
+ * enable/disable pair beside it) seeds `userId = UserHandle.USER_SYSTEM`, so a bare
+ * `pm clear <pkg>` issued from user 10 wipes **user 0's** copy of that package and still exits 0 —
+ * the same trap `RootSystemGateway.getPackageUserId` already documents for `pm grant`/`pm revoke`.
+ * `/data/data` and `/sdcard` are that trap's filesystem half: both are per-user aliases resolved
+ * against the *shell's* user, so they name user 0's directories no matter which user Thor runs as.
+ *
+ * Shared by all three privilege modes, because all three had the same hole in the same places — and
+ * because the shell rung and the reflection rung of one operation have to name the same user: a
+ * `pm clear` on user 0 followed by a `clearApplicationUserData(…, 10)` fallback is two different
+ * wipes wearing one function name.
+ *
+ * The builders take the user id instead of reading [thorUserId] themselves so that "does this
+ * command name a user at all?" is assertable from a plain JVM test — `Process.myUserHandle()` is not
+ * callable there. The tests pass a work-profile id, where a missing `--user` is visible, and a 0,
+ * where it is not. It also keeps them usable from a privileged process that has to be *told* the
+ * user because it cannot read it: the `:root` daemon runs as uid 0, where [thorUserId] would answer
+ * 0 for a Thor sitting in user 10.
+ *
+ * The seed is not one value, and each builder below names the one it defends against for exactly
+ * that reason. `pm` seeds `USER_SYSTEM` for clear/enable/disable/path and `USER_ALL` for
+ * install/uninstall, which it then widens to *every* user; `am` seeds `USER_ALL` for force-stop;
+ * `appops` seeds `USER_CURRENT` and resolves it inside system_server to the globally foreground
+ * user, which is neither of the other two. "It defaults to user 0" is true of some of these commands
+ * and wrong about the rest, so no builder here inherits another's explanation.
+ */
+
+/** `pm clear`, scoped to [userId] instead of to whatever user the privileged shell belongs to. */
+internal fun clearAppDataCommand(escapedPackage: String, userId: Int): String =
+    "pm clear --user $userId $escapedPackage"
+
+/**
+ * The cache directories of [escapedPackage] **for [userId]**, credential-encrypted first, then
+ * external.
+ *
+ * Deliberately no `/data/data/<pkg>/cache` and no `/sdcard/Android/data/<pkg>/cache`. They are not
+ * extra coverage: they are aliases of the first and second entries *for user 0*, so on a secondary
+ * user (work profile, Xiaomi Second Space) a shell that expands them deletes a different user's
+ * cache and leaves Thor's own untouched. At `userId = 0` — every single-user device — the paths
+ * below resolve to exactly the directories those two aliases pointed at, so nothing changes there.
+ */
+// SdCardPath is suppressed because its advice does not apply: these are not Thor's own directories.
+// getExternalCacheDir/getFilesDir answer for the *calling* app, and the whole point of the function
+// is to name another package's cache — under another user id — for a privileged shell to delete. The
+// literal path is the only way to express that. The same suppression sat on Shizuku.clearCache and
+// Dhizuku.clearCache before these strings were lifted out of them; it is inherited, not new.
+@SuppressLint("SdCardPath")
+internal fun clearCachePaths(escapedPackage: String, userId: Int): List<String> = listOf(
+    "/data/user/$userId/$escapedPackage/cache",
+    "/storage/emulated/$userId/Android/data/$escapedPackage/cache",
+)
+
+/**
+ * `pm uninstall`, scoped to [userId] — the user-facing removal, data and all.
+ *
+ * This one is not merely wrong-user: `PackageManagerShellCommand.runUninstall` seeds
+ * `userId = UserHandle.USER_ALL` and then turns that into `flags |= DELETE_ALL_USERS`. So a bare
+ * `pm uninstall <pkg>` does not remove the package for the shell's user, or for user 0 — it removes
+ * it, and its data, for **every user on the device**, and exits 0. From a work profile that destroys
+ * the personal profile's copy of an app the user never selected, and nothing in the exit code says
+ * so.
+ *
+ * Naming [userId] is also the answer Thor's UI is asking for: the app list is built from packages
+ * installed for Thor's own user, so "uninstall this" means "the entry I am looking at". On a
+ * single-user device the two agree — PMS fully removes a package when no other user still holds it —
+ * so this changes nothing there.
+ *
+ * Deliberately no `-k` variant. `DELETE_KEEP_DATA` belongs to the system-app *freeze* fallback,
+ * which is a different operation behind a different gate, and the three helpers that issue it
+ * already name their user.
+ */
+internal fun uninstallCommand(escapedPackage: String, userId: Int): String =
+    "pm uninstall --user $userId $escapedPackage"
+
+/**
+ * `pm disable` / `pm enable` for a **user** app, scoped to [userId].
+ *
+ * `disable` (COMPONENT_ENABLED_STATE_DISABLED) and not `disable-user`, because the only caller is
+ * the root gateway and uid 0 may set the stronger state. The Shizuku and Dhizuku helpers build
+ * their own `pm disable-user` line rather than calling this — a shell-uid or device-owner caller is
+ * refused the stronger state on every release, which `Shizuku.setAppDisabledDetailed` documents
+ * with the measurement behind it.
+ */
+internal fun setAppEnabledCommand(escapedPackage: String, userId: Int, isDisabled: Boolean): String =
+    "pm ${if (isDisabled) "disable" else "enable"} --user $userId $escapedPackage"
+
+/**
+ * `pm install` / `pm install-multiple`, scoped to [userId] — [uninstallCommand]'s trap entered from
+ * the other side.
+ *
+ * `PackageManagerShellCommand.makeInstallParams` opens with `params.userId = UserHandle.USER_ALL`
+ * and leaves it there when the option loop never sees a `--user`; the session is then created with
+ * `params.userId = UserHandle.USER_SYSTEM; sessionParams.installFlags |= INSTALL_ALL_USERS`. A bare
+ * `pm install <apk>` therefore does not install for the shell's user, and does not install only for
+ * user 0: it installs the package for **every user on the device**, and exits 0. That is the same
+ * `USER_ALL` seed and the same silent widening to all users that [uninstallCommand] documents,
+ * reached from the opposite direction — which is why the two now sit in one file. They are a pair,
+ * and a pair that drifts is how a profile ends up holding an app nobody there chose to install.
+ *
+ * The verb follows `escapedApkPaths.size` rather than being a parameter of its own. The four
+ * installer call sites already branched on that count and built two separate command strings from
+ * it, so `--user` would have had to be added twice per site; one operation reaching `pm` down two
+ * hand-written paths is precisely where a flag ends up present on one of them only.
+ *
+ * [installerArg] arrives pre-formatted from `PreferenceRepository.getInstallerArg` — either empty or
+ * `" -i com.android.vending"` — and is re-spaced here so that a caller passing it untrimmed cannot
+ * emit `-g-i com.android.vending`, which `pm` rejects with a usage error the installer would report
+ * as an install failure. [canDowngrade] is `-d`: permissive-only, it allows a lower versionCode to
+ * replace a higher one and changes nothing otherwise. `-r` and `-g` are constants at all six call
+ * sites, so they are not parameters.
+ *
+ * Deliberately no `--install-reason` and no hard-coded `-i com.android.vending`. That is the Fix
+ * Store line — a different operation, meaning "re-attribute this app to Play" — and all three
+ * gateways already name a user in it.
+ *
+ * An empty [escapedApkPaths] is a programming error, not a runtime condition: every caller returns
+ * early when the copy-to-temp step produced no files, and a command with no APK argument would
+ * otherwise be handed to a privileged shell to fail on.
+ */
+internal fun installCommand(
+    escapedApkPaths: List<String>,
+    userId: Int,
+    canDowngrade: Boolean = false,
+    installerArg: String = "",
+): String {
+    require(escapedApkPaths.isNotEmpty()) { "installCommand needs at least one APK path" }
+    val verb = if (escapedApkPaths.size == 1) "install" else "install-multiple"
+    val downgrade = if (canDowngrade) " -d" else ""
+    val installer = installerArg.trim().let { if (it.isEmpty()) "" else " $it" }
+    return "pm $verb --user $userId -r -g$downgrade$installer ${escapedApkPaths.joinToString(" ")}"
+}
+
+/**
+ * `pm path`, scoped to [userId] — *whose* copy of the package the answer describes.
+ *
+ * `PackageManagerShellCommand.runPath` seeds `UserHandle.USER_SYSTEM` and then asks
+ * `getPackageInfo(pkg, …, userId)`, so a bare `pm path <pkg>` answers for **user 0's** copy no
+ * matter which user the shell belongs to. Its one caller is the Fix Store / reinstall-with-Google
+ * path, which feeds the result straight into a `pm install … --user <thorUserId>`: the two halves of
+ * a single operation read one user and write another, and every command in the chain exits 0 either
+ * way, so nothing in the result says so.
+ *
+ * The APK bytes themselves are device-wide — one `/data/app` copy serves every user — so what a
+ * user id selects here is *visibility*, and that is what makes the mismatch silent in both
+ * directions. A work-profile-only app answers nothing for user 0, so Fix Store stops with "Could not
+ * find APK path" for an app the user is looking at; an app installed for user 0 but not for Thor's
+ * user answers with paths, and Fix Store reinstalls off a record for a copy this user does not have.
+ * Naming [userId] makes the empty answer mean what the caller already assumed it meant.
+ */
+internal fun pmPathCommand(escapedPackage: String, userId: Int): String =
+    "pm path --user $userId $escapedPackage"
+
+/**
+ * `am force-stop`, scoped to [userId].
+ *
+ * `ActivityManagerShellCommand.runForceStop` seeds `UserHandle.USER_ALL`, so a bare
+ * `am force-stop <pkg>` kills the package for **every user on the device** rather than for the
+ * shell's — the same seed and the same unnamed-user class as [uninstallCommand] and
+ * [installCommand].
+ *
+ * The stakes are lower here and this should not pretend otherwise: force-stop destroys no data and
+ * the process returns on the next start, so the cost of the bare form is another profile's app
+ * losing live state — a scheduled alarm, a foreground service, an unsaved draft. It is fixed because
+ * it is the same defect and because the Shizuku and Dhizuku helpers already pass `--user` on this
+ * exact command: root was the odd one out, and one gateway spelling an operation differently from
+ * the other two is how "that is fixed" quietly stops being true.
+ */
+internal fun forceStopCommand(escapedPackage: String, userId: Int): String =
+    "am force-stop --user $userId $escapedPackage"
+
+/**
+ * `appops set … RUN_ANY_IN_BACKGROUND`, scoped to [userId] — the background-restriction toggle.
+ *
+ * `appops` is not `pm`, and none of the reasoning above carries over: nothing here defaults to
+ * user 0 and nothing here fans out to all users. `AppOpsService.Shell.parseUserPackageOp` seeds
+ * `UserHandle.USER_CURRENT` and, once the option loop ends, resolves it with
+ * `ActivityManager.getCurrentUser()` — evaluated inside system_server, so the target is the
+ * **globally foreground user**: not the caller's, and not user 0.
+ *
+ * That is why the bare form failed the way it did. On a managed profile the foreground user is the
+ * parent, so a restriction set from the work profile landed on the personal profile's copy of the
+ * app. In a Xiaomi Second Space the space you switched into *is* the foreground user, so the same
+ * command happened to be right. The defect is therefore not "it targets the wrong user" — it is that
+ * which user it targeted depended on who was in the foreground at the moment the command ran, a
+ * value that changes while Thor is alive and can differ between the write and the read-back that
+ * confirms it.
+ *
+ * `ignore` restricts and `allow` lifts the restriction, matching the three call sites this replaces.
+ * `--user` precedes the package because `parseUserPackageOp` consumes its options before the package
+ * and op positionals.
+ */
+internal fun backgroundRestrictionCommand(
+    escapedPackage: String,
+    userId: Int,
+    restricted: Boolean,
+): String = appOpsCommand(
+    escapedPackage = escapedPackage,
+    userId = userId,
+    op = "RUN_ANY_IN_BACKGROUND",
+    mode = if (restricted) "ignore" else "allow",
+)
+
+/**
+ * `appops set … GET_USAGE_STATS allow`, scoped to [userId] — the silent grant behind
+ * `UsageAccessManager.tryGrantViaPrivilege`.
+ *
+ * The same `USER_CURRENT` seed [backgroundRestrictionCommand] documents, but it went wrong in a
+ * different shape and it is worth saying which, because the two are not interchangeable.
+ *
+ * Here the package is **Thor's own**, and the grant is confirmed by `UsageAccessManager.isGranted`,
+ * an in-process `AppOpsManager.unsafeCheckOpNoThrow` for `Process.myUid()` — which answers for
+ * *Thor's* user, always. So the write went to whoever was in the foreground and the read asked
+ * Thor's own user, and on a managed profile those are different users. The failure is therefore not
+ * a false success: `isGranted()` still returns false and `tryGrantViaPrivilege` still reports
+ * failure, so Thor falls back to the Settings deep-link and the user is not lied to. What it does
+ * instead is grant usage access to the **parent profile's** copy of Thor — a permission nobody
+ * asked for, on a profile the request did not come from — and then leave the work profile's copy
+ * without the op forever, because the retry issues exactly the same command again.
+ *
+ * `maybeAutoGrant` latches only on success, so this was a wasted privileged command on every call
+ * rather than once. Naming [userId] makes the write land where the read is already looking.
+ */
+internal fun usageStatsGrantCommand(escapedPackage: String, userId: Int): String =
+    appOpsCommand(escapedPackage, userId, op = "GET_USAGE_STATS", mode = "allow")
+
+/**
+ * The one place that knows how an `appops set` line is spelled.
+ *
+ * Private on purpose. The file's contract is the *named* operations above, not a generic emitter
+ * that would let a caller pass any op and any mode — an arbitrary-op builder is a per-user command
+ * literal again, with one extra function call in front of it. A third app-op belongs here as a
+ * third named builder, which is also what gets it covered by the reflective sweep in
+ * `PerUserCommandsTest` for free; a private helper is deliberately invisible to that sweep.
+ *
+ * `--user` precedes the package because `parseUserPackageOp` consumes its options before the
+ * package and op positionals: written after the package, `--user` is parsed as the *op* and the
+ * command fails with "Unknown operation string" rather than with a usage error.
+ */
+private fun appOpsCommand(escapedPackage: String, userId: Int, op: String, mode: String): String =
+    "appops set --user $userId $escapedPackage $op $mode"

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -587,6 +587,37 @@ object DhizukuHelper {
         -1 to err.stackTraceToString()
     }
 
+    /**
+     * Deletes [packageName]'s cache directories **for [thorUserId]** — shell first, then a
+     * hidden-API `IPackageManager` call.
+     *
+     * The reflection overloads are tried `…AsUser` first for the same reason as
+     * [com.valhalla.thor.data.source.local.shizuku.Shizuku.clearCache], whose KDoc carries the full
+     * argument: `deleteApplicationCacheFiles(String, IPackageDataObserver)` is declared on every
+     * release this app runs on (28 through 37), so the `NoSuchMethodException` meant to reach the
+     * `…AsUser` branch never fires. Ordered the other way round, the only branch that names a user
+     * is unreachable and the branch that runs names none — `PackageManagerService` implements the
+     * no-user overload as `deleteApplicationCacheFilesAsUser(packageName, getCallingUserId(),
+     * observer)`, resolving the user from the *caller*. Here the caller is the Dhizuku app holding
+     * device owner, so from a work profile the reachable rung cleared the cache of whichever user
+     * Dhizuku itself runs as, for a package the user picked in another profile.
+     *
+     * The fallback is gated on `NoSuchMethodException` alone, never `Exception`: a *refusal* of the
+     * per-user call must not fall through to one that clears a different user's cache and reports it
+     * as this user's success.
+     *
+     * How often this rung runs at all is a separate question, and the answer is probably never:
+     * `asInterface` wraps the binder twice — Dhizuku's own wrapper, then `ShizukuBinderWrapper` on
+     * top — so on a Dhizuku-only device the call dies in a transport belonging to a privilege mode
+     * the user has not set up. `setAppDisabled` carries that argument in full. It is a reason not to
+     * expect the reorder to change behaviour today, not a reason to keep the order wrong: a rung
+     * that is dead now is still the rung a future transport fix would wake up.
+     *
+     * **A `true` from this function is not evidence the cache is gone.** Only the shell rung is
+     * honest (`rm -rf` exits 0 or it does not). The reflective call is asynchronous — PMS reports
+     * through the `IPackageDataObserver` that is passed as `null` here — so `true` means only that
+     * the binder call returned without throwing.
+     */
     // SdCardPath: absolute system paths are intentional for privileged/root file ops on app data
     // dirs (not app-scoped storage). PrivateApi: hidden-API reflection is the core privilege
     // mechanism, guarded by the :bypass VMRuntime unseal.
@@ -610,19 +641,21 @@ object DhizukuHelper {
                 Bypass.invoke<Any?>(
                     pm.javaClass,
                     pm,
-                    "deleteApplicationCacheFiles",
-                    arrayOf(String::class.java, observerClass),
-                    packageName,
-                    null /* IPackageDataObserver */
-                )
-            } catch (_: NoSuchMethodException) {
-                Bypass.invoke(
-                    pm.javaClass,
-                    pm,
                     "deleteApplicationCacheFilesAsUser",
                     arrayOf(String::class.java, Int::class.javaPrimitiveType!!, observerClass),
                     packageName,
                     thorUserId,
+                    null /* IPackageDataObserver */
+                )
+            } catch (_: NoSuchMethodException) {
+                // No user id to give: this overload derives one from the calling uid. Reached only
+                // if a release stops declaring the AsUser variant, which none in 28..37 does.
+                Bypass.invoke<Any?>(
+                    pm.javaClass,
+                    pm,
+                    "deleteApplicationCacheFiles",
+                    arrayOf(String::class.java, observerClass),
+                    packageName,
                     null
                 )
             }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -10,6 +10,9 @@ import android.os.IBinder
 import com.valhalla.bypass.Bypass
 import com.valhalla.superuser.utils.escapeForShell
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
+import com.valhalla.thor.data.source.local.clearAppDataCommand
+import com.valhalla.thor.data.source.local.clearCachePaths
 // The enable/disable rung machinery is privilege-agnostic; it lives in the `shizuku` package
 // because that is where it was first needed, and it is imported rather than re-typed here so the
 // two privilege modes cannot drift apart on "did the platform refuse?" — the one question whose
@@ -589,14 +592,12 @@ object DhizukuHelper {
     // mechanism, guarded by the :bypass VMRuntime unseal.
     @SuppressLint("PrivateApi", "SdCardPath")
     fun clearCache(packageName: String): Boolean {
-        // 1. Try shell first
-        val userId = android.os.Process.myUserHandle().hashCode()
-        val paths = listOf(
-            "/data/data/$packageName/cache",
-            "/data/user/$userId/$packageName/cache",
-            "/sdcard/Android/data/$packageName/cache"
-        )
-        val command = "rm -rf ${paths.joinToString(" ")}"
+        // 1. Try shell first. The `/data/data/<pkg>/cache` and `/sdcard/Android/data/<pkg>/cache`
+        // aliases that used to sit either side of these two are gone: they are not extra coverage,
+        // they are the same directories *for user 0*, so from a secondary user they deleted another
+        // user's cache. At user 0 they resolve to exactly what remains.
+        val command =
+            "rm -rf ${clearCachePaths(packageName.escapeForShell(), thorUserId).joinToString(" ")}"
         val shellResult = execute(command)
         if (shellResult.first == 0) return true
 
@@ -621,7 +622,7 @@ object DhizukuHelper {
                     "deleteApplicationCacheFilesAsUser",
                     arrayOf(String::class.java, Int::class.javaPrimitiveType!!, observerClass),
                     packageName,
-                    userId,
+                    thorUserId,
                     null
                 )
             }
@@ -635,8 +636,11 @@ object DhizukuHelper {
     // the :bypass VMRuntime unseal.
     @SuppressLint("PrivateApi")
     fun clearAppData(packageName: String): Boolean {
-        // 1. Try shell first
-        val result = execute("pm clear $packageName")
+        // 1. Try shell first, naming the same user the reflection rung below hands to
+        // clearApplicationUserData. `pm clear` with no `--user` seeds USER_SYSTEM, so from a work
+        // profile this rung wiped the primary user's copy and exited 0 — and the reflection rung
+        // that would have targeted the right user never ran.
+        val result = execute(clearAppDataCommand(packageName.escapeForShell(), thorUserId))
         if (result.first == 0) return true
 
         // 2. Fallback to reflection
@@ -650,7 +654,7 @@ object DhizukuHelper {
                 arrayOf(String::class.java, observerClass, Int::class.javaPrimitiveType!!),
                 packageName,
                 null,
-                android.os.Process.myUserHandle().hashCode()
+                thorUserId
             )
             true
         }.getOrElse { false }
@@ -916,10 +920,29 @@ object DhizukuHelper {
         )
     }.getOrNull()
 
+    /**
+     * Restricts or unrestricts background execution for [packageName], for the user Thor runs as.
+     *
+     * The `--user` the shell rung now carries is not the `pm` story told elsewhere in this file:
+     * nothing here defaults to user 0 and nothing here fans out to all users.
+     * `AppOpsService.Shell.parseUserPackageOp` seeds `UserHandle.USER_CURRENT` and resolves it with
+     * `ActivityManager.getCurrentUser()` — evaluated inside system_server — so the bare command
+     * targeted the **globally foreground user**, which is neither the caller's user nor user 0. On a
+     * managed profile the foreground user is the parent, so a restriction set from the work profile
+     * landed on the personal profile's copy; in a Xiaomi Second Space the space you switched into
+     * *is* foreground, so the same command happened to be right. The defect was therefore the
+     * dependence on foreground state, not a fixed wrong target, and it could differ between one call
+     * and the next while Thor stayed alive.
+     *
+     * The reflection rung below never had the problem: it resolves the op against the package's own
+     * uid, which carries the user in its high bits, so it was already per-user. The two rungs now
+     * agree on which app op they are setting for whom.
+     */
     fun setAppRestricted(context: Context, packageName: String, restricted: Boolean): Boolean {
         // 1. Try shell first
-        val result =
-            execute("appops set $packageName RUN_ANY_IN_BACKGROUND ${if (restricted) "ignore" else "allow"}")
+        val result = execute(
+            backgroundRestrictionCommand(packageName.escapeForShell(), thorUserId, restricted)
+        )
         if (result.first == 0) return true
 
         // 2. Fallback to reflection

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/PackageManagerExt.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/PackageManagerExt.kt
@@ -8,19 +8,66 @@ import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
 import android.os.Build
 
+/**
+ * [PackageInfo] for [packageName] — including the records whose `PackageUserState.installed` bit is
+ * false for this user.
+ *
+ * The match flags are the load-bearing part, and the reason they are wide is the one caller:
+ * `ShizukuReflector.uninstallApp`'s reflection rung, which exists to cover for the shell rung above
+ * it. Those two rungs used to share a blind spot. `PackageManagerShellCommand.runUninstall`, once a
+ * user is named, first does
+ * `getPackageInfo(pkg, MATCH_STATIC_SHARED_AND_SDK_LIBRARIES, userId)` and prints
+ * `Failure [not installed for N]` with exit 1 when that returns null — flags that carry neither
+ * `MATCH_UNINSTALLED_PACKAGES` nor `MATCH_ARCHIVED_PACKAGES`. With `GET_META_DATA` alone this
+ * lookup answered null on exactly the same condition, so the fallback returned false without ever
+ * reaching `PackageInstaller.uninstall`: one condition, both rungs, no removal and no explanation.
+ *
+ * Thor puts an uninstall button in front of precisely those packages, because its app sweep queries
+ * with `MATCH_UNINSTALLED_PACKAGES`. Two ways in:
+ * - a Play-Store-**archived** app on API 35+ — `PackageArchiver` removes the APK with
+ *   `DELETE_KEEP_DATA | DELETE_ARCHIVE`, which clears the per-user installed bit while the launcher
+ *   entry stays on screen;
+ * - any app another tool removed for this user with `pm uninstall -k`, which is the same state
+ *   Thor's own system-app freeze produces via `freezeSystemAppForUser`.
+ *
+ * Both flags are needed and neither substitutes for the other. `MATCH_UNINSTALLED_PACKAGES` (folded
+ * into `MATCH_KNOWN_PACKAGES`, which is what the availability check actually tests) covers the
+ * second case, where the parsed package still exists and only the user state says otherwise. It
+ * cannot cover the first: an archived package has no `AndroidPackage` left to generate info from, so
+ * only the `MATCH_ARCHIVED_PACKAGES` branch in `Computer.getPackageInfoInternal` can answer for it.
+ *
+ * `MATCH_ARCHIVED_PACKAGES` is a `long` (`1L << 32`), not an `int`, so it does not fit the
+ * `getPackageInfo(String, Int)` overload at all — it can only ride the `PackageInfoFlags` path,
+ * which itself starts at API 33. That is why the two version guards below are separate conditions
+ * rather than one: 33 is where the wide-flag overload exists, 35 is where the constant does.
+ *
+ * Widening this changes nothing else — the uninstall fallback is its only call site — and it does
+ * not weaken the caller: `PackageInstaller.uninstall` carries no "installed for this user"
+ * precondition of its own, so a non-null answer here is enough for the removal to go through for
+ * the session's user. Callers that need "is this installed for me?" must read
+ * `ApplicationInfo.FLAG_INSTALLED` (as `ShizukuReflector.isAppUninstalled` does) rather than read it
+ * out of a null returned by this function.
+ */
 fun PackageManager.getInfoForPackage(
     packageName: String,
 ): PackageInfo? {
     return try {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            var flags = PackageManager.GET_META_DATA.toLong() or
+                PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                flags = flags or PackageManager.MATCH_ARCHIVED_PACKAGES
+            }
             this.getPackageInfo(
                 packageName,
-                PackageManager.PackageInfoFlags.of(PackageManager.GET_META_DATA.toLong())
+                PackageManager.PackageInfoFlags.of(flags)
             )
         } else {
+            // No archived packages to miss here: archiving is an API 35 feature, and every device
+            // on this branch is below API 33.
             this.getPackageInfo(
                 packageName,
-                PackageManager.GET_META_DATA
+                PackageManager.GET_META_DATA or PackageManager.MATCH_UNINSTALLED_PACKAGES
             )
         }
     } catch (e: NameNotFoundException) {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
@@ -93,10 +93,11 @@ class Packages(private val app: Context) {
         (ApplicationInfo::class.java.getField("privateFlags").get(it) as Int) and 8 == 8
     } ?: false
 
-    fun canUninstallNormally(packageName: String): Boolean =
-        getApplicationInfoOrNull(packageName)?.let {
-            (it.flags and ApplicationInfo.FLAG_SYSTEM) == 0
-        } ?: false
+    // `canUninstallNormally` used to sit here: `FLAG_SYSTEM == 0`, one caller, and its only job was
+    // to route ordinary user apps to a `pm uninstall` with no `--user`. That command is
+    // DELETE_ALL_USERS in disguise (see `uninstallCommand`), so the predicate is deleted rather than
+    // left for the next caller to find — there is no operation for which the answer "this is not a
+    // system app" implies "no user needs naming".
 
     fun forceStopApp(packageName: String): Boolean = runCatching {
         app.getSystemService<ActivityManager>()?.let {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -9,7 +9,11 @@ import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import com.valhalla.bypass.Bypass
 import com.valhalla.superuser.utils.escapeForShell
+import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
+import com.valhalla.thor.data.source.local.clearAppDataCommand
+import com.valhalla.thor.data.source.local.clearCachePaths
 import com.valhalla.thor.data.source.local.thorUserId
+import com.valhalla.thor.data.source.local.uninstallCommand
 import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
 import com.valhalla.thor.domain.model.canLiftSuspension
 import com.valhalla.thor.domain.model.parseSuspendingPackages
@@ -877,20 +881,48 @@ object Shizuku {
         null
     }
 
+    /**
+     * Deletes [packageName]'s cache directories **for [thorUserId]** — shell first, then a
+     * hidden-API `IPackageManager` call.
+     *
+     * The two reflection overloads used to be tried in the opposite order, and that order made the
+     * user id decorative. `deleteApplicationCacheFiles(String, IPackageDataObserver)` is declared on
+     * `IPackageManager` on every release this app runs on (28 through 37), so the
+     * `NoSuchMethodException` that was supposed to reach the `…AsUser` branch never fired: the only
+     * branch naming a user was unreachable, and the branch that ran named none. It could not — that
+     * overload takes no user id, and `PackageManagerService`'s implementation of it is
+     * `deleteApplicationCacheFilesAsUser(packageName, UserHandle.getCallingUserId(), observer)`,
+     * which resolves the user from the *caller*. The caller here is the Shizuku server, at shell uid
+     * 2000 in the ordinary setup, so from a work profile the reachable rung cleared **user 0's**
+     * cache for a package the user selected in profile 10. Hence the reorder rather than an extra
+     * argument: `…AsUser` first, and the calling-user overload kept only as the answer to "this
+     * release does not declare the symbol".
+     *
+     * The fallback is deliberately gated on `NoSuchMethodException` alone and not on `Exception`. A
+     * *refusal* of the per-user call must not fall through to a call that clears a different user's
+     * cache and reports it as this user's success — the failure the reorder exists to remove.
+     *
+     * **A `true` from this function is not evidence the cache is gone.** The shell rung is honest:
+     * `rm -rf` exits 0 or it does not. The reflection rung is not — the call is asynchronous
+     * (`PackageManagerService` posts the work to its own handler and reports through the
+     * `IPackageDataObserver`, which is passed as `null` here), so `true` means only that the binder
+     * call returned without throwing. At shell uid PMS also *accepts* cache clears that it then
+     * declines — it logs that it is silently ignoring the request and returns without deleting
+     * anything, and the caller is told none of that. So this Boolean must not be turned into
+     * "N bytes freed"; re-measure the cache if the number matters.
+     */
     // PrivateApi: hidden-API reflection (IPackageDataObserver) is intentional — the core privilege
     // mechanism, guarded by the :bypass VMRuntime unseal.
-    // SdCardPath: the absolute /data and /sdcard paths are intentional for privileged/root file ops,
+    // SdCardPath: the absolute /data and /storage paths are intentional for privileged file ops,
     // not app-scoped storage.
     @SuppressLint("PrivateApi", "SdCardPath")
     fun clearCache(packageName: String): Boolean {
-        // 1. Try shell first
-        val userId = thorUserId
-        val paths = listOf(
-            "/data/data/$packageName/cache",
-            "/data/user/$userId/$packageName/cache",
-            "/sdcard/Android/data/$packageName/cache"
-        )
-        val command = "rm -rf ${paths.joinToString(" ")}"
+        // 1. Try shell first. The `/data/data/<pkg>/cache` and `/sdcard/Android/data/<pkg>/cache`
+        // aliases that used to sit either side of these two are gone: they are not extra coverage,
+        // they are the same directories *for user 0*, so from a secondary user they deleted another
+        // user's cache. At user 0 they resolve to exactly what remains.
+        val command =
+            "rm -rf ${clearCachePaths(packageName.escapeForShell(), thorUserId).joinToString(" ")}"
         val shellResult = execute(command)
         if (shellResult.first == 0) return true
 
@@ -903,19 +935,21 @@ object Shizuku {
                 Bypass.invoke<Any?>(
                     pm.javaClass,
                     pm,
-                    "deleteApplicationCacheFiles",
-                    arrayOf(String::class.java, observerClass),
-                    packageName,
-                    null
-                )
-            } catch (_: NoSuchMethodException) {
-                Bypass.invoke<Any?>(
-                    pm.javaClass,
-                    pm,
                     "deleteApplicationCacheFilesAsUser",
                     arrayOf(String::class.java, Int::class.javaPrimitiveType!!, observerClass),
                     packageName,
-                    userId,
+                    thorUserId,
+                    null
+                )
+            } catch (_: NoSuchMethodException) {
+                // No user id to give: this overload derives one from the calling uid. Reached only
+                // if a release stops declaring the AsUser variant, which none in 28..37 does.
+                Bypass.invoke<Any?>(
+                    pm.javaClass,
+                    pm,
+                    "deleteApplicationCacheFiles",
+                    arrayOf(String::class.java, observerClass),
+                    packageName,
                     null
                 )
             }
@@ -929,8 +963,11 @@ object Shizuku {
     // mechanism, guarded by the :bypass VMRuntime unseal.
     @SuppressLint("PrivateApi")
     fun clearAppData(packageName: String): Boolean {
-        // 1. Try shell first
-        val result = execute("pm clear $packageName")
+        // 1. Try shell first. Both rungs name the same user: the reflection rung below already
+        // passed thorUserId, while this one passed none at all — and `pm clear` with no `--user`
+        // seeds USER_SYSTEM, so from a work profile the shell rung wiped the primary user's copy
+        // and exited 0, and the reflection rung that would have done the right thing never ran.
+        val result = execute(clearAppDataCommand(packageName.escapeForShell(), thorUserId))
         if (result.first == 0) return true
 
         // 2. Fallback to reflection
@@ -971,9 +1008,18 @@ object Shizuku {
     }
 
     fun setAppRestricted(context: Context, packageName: String, restricted: Boolean): Boolean {
-        // 1. Try shell first
-        val result =
-            execute("appops set $packageName RUN_ANY_IN_BACKGROUND ${if (restricted) "ignore" else "allow"}")
+        // 1. Try shell first. The user this names is not the `pm` story retold: `appops` seeds
+        // UserHandle.USER_CURRENT and system_server resolves it with ActivityManager.getCurrentUser(),
+        // so the bare line landed on whoever was in the *foreground* at the moment it ran — the
+        // parent profile for a Thor sitting in a work profile, and a value free to change between
+        // this write and the read-back that is supposed to confirm it. The reflection rung below
+        // never had that problem: it addresses the app by uid, and Packages.packageUid resolves that
+        // through Thor's own PackageManager, so it already carried Thor's user. Naming thorUserId
+        // here is what makes the two rungs of this one operation agree on a target.
+        // The package is escaped for the same reason it is everywhere else in this object (#40).
+        val result = execute(
+            backgroundRestrictionCommand(packageName.escapeForShell(), thorUserId, restricted)
+        )
         if (result.first == 0) return true
 
         // 2. Fallback to reflection
@@ -1019,16 +1065,51 @@ object Shizuku {
     // The same swap on the Dhizuku side fixes an outright failure rather than a latent mismatch;
     // see the note in DhizukuHelper.
 
-    fun uninstallApp(context: Context, packageName: String): Boolean {
+    /**
+     * The user-facing uninstall: removes [packageName] for [thorUserId], data included.
+     *
+     * This used to name the user only for system packages. Ordinary user apps — everything the
+     * uninstall button is normally pressed on — took a bare `pm uninstall`, selected by a
+     * `canUninstallNormally` predicate that read `FLAG_SYSTEM == 0` and nothing else. That was not
+     * the harmless default it looked like: `PackageManagerShellCommand.runUninstall` seeds
+     * `userId = UserHandle.USER_ALL` and converts it to `DELETE_ALL_USERS`, so from a work profile
+     * the line removed the app **and its data for every user on the device** and exited 0.
+     *
+     * Both the predicate and the branch are gone rather than corrected, because there is no version
+     * of "system apps get `--user`, ordinary ones do not" that is right; [uninstallCommand] carries
+     * the reasoning. The root gateway and the Dhizuku helper already named their user on this same
+     * operation — this was the one site of the class that did not.
+     *
+     * **Naming the user is stricter than the bare form, not merely narrower.** [uninstallCommand]'s
+     * "on a single-user device this changes nothing" is a claim about *which users are affected*,
+     * and it does not extend to *whether the command succeeds*. Once `userId != USER_ALL`,
+     * `runUninstall` first does
+     * `getPackageInfo(pkg, MATCH_STATIC_SHARED_AND_SDK_LIBRARIES, userId)` and stops with
+     * `Failure [not installed for N]` and exit 1 when that is null. Those flags carry neither
+     * `MATCH_UNINSTALLED_PACKAGES` nor `MATCH_ARCHIVED_PACKAGES`, so every package whose
+     * `PackageUserState.installed` bit is false for this user is refused here, at user 0, on a
+     * device that has only one user — where the bare form took the `USER_ALL` path and skipped the
+     * precondition altogether. Thor lists exactly those packages, because its app sweep queries
+     * with `MATCH_UNINSTALLED_PACKAGES`: a Play-Store-archived app on API 35+, and anything another
+     * tool (or Thor's own [freezeSystemAppForUser]) removed with `pm uninstall -k`.
+     *
+     * The rung that covers the difference is the reflection fallback in
+     * `ShizukuReflector.uninstallApp`, which reads `false` here as "try `PackageInstaller` instead"
+     * — and `PackageInstaller.uninstall` has no equivalent precondition. That fallback was defeated
+     * by the same condition until its `getInfoForPackage` lookup was widened to the two match flags
+     * `pm` omits; that widening is what makes this trade-off survivable, so the two are one change.
+     * The answer is not to drop `--user` again: that trades a failure the ladder recovers from for
+     * a silent removal on every user of the device.
+     *
+     * Takes no `Context`, unlike its neighbours in this object: the only thing it needed one for
+     * was constructing the `Packages` that answered the predicate.
+     */
+    fun uninstallApp(packageName: String): Boolean {
         // Escape the package identifier before interpolating it into the shell command, mirroring
         // the Dhizuku helper (#40). thorUserId is an Int, so it needs no escaping.
         val escapedPackage = packageName.escapeForShell()
-        val normally = Packages(context).canUninstallNormally(packageName)
-        if (normally) {
-            return execute("pm uninstall $escapedPackage").first == 0
-        }
         return try {
-            execute("pm uninstall --user $thorUserId $escapedPackage").first == 0
+            execute(uninstallCommand(escapedPackage, thorUserId)).first == 0
         } catch (_: Exception) {
             false
         }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
@@ -18,6 +18,8 @@ import android.os.Build
 import com.valhalla.bypass.Bypass
 import com.valhalla.superuser.utils.escapeForShell
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.data.source.local.installCommand
+import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.util.Logger
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
@@ -165,7 +167,7 @@ class ShizukuReflector(
     suspend fun uninstallApp(packageName: String, resetToFactory: Boolean = false): Boolean {
         // 1. Try shell first
         val shellResult = runCatching {
-            Shizuku.uninstallApp(context, packageName)
+            Shizuku.uninstallApp(packageName)
         }.getOrElse {
             if (BuildConfig.DEBUG) {
                 Logger.e("ShizukuReflector", "Shizuku.uninstallApp failed, trying fallbacks", it)
@@ -177,10 +179,19 @@ class ShizukuReflector(
         // 2. Fallback to reflection
         val reflectionResult = runCatching {
             val packageInfo = context.packageManager.getInfoForPackage(packageName) ?: return false
-            val isSystem =
-                (packageInfo.applicationInfo!!.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-            val hasUpdates =
-                (packageInfo.applicationInfo!!.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+            // Read through, don't assert. [getInfoForPackage] now also answers for packages that
+            // are not installed for this user — that widening is the whole reason this rung is
+            // reachable for them — and an *archived* record is synthesised by PackageManager from
+            // the archive state rather than parsed from an APK, so its ApplicationInfo is not the
+            // same guaranteed object an ordinary lookup returns. A `!!` that throws here is caught
+            // by the surrounding runCatching and reported as `false`, which would defeat the rung
+            // on the very packages the widening was for. Absent flags mean "no evidence this is a
+            // system app": isSystem and hasUpdates both read false, and the delete flags below fall
+            // to 0 — a plain removal for the session's user, which is the safe reading of an
+            // unknown.
+            val appFlags = packageInfo.applicationInfo?.flags ?: 0
+            val isSystem = (appFlags and ApplicationInfo.FLAG_SYSTEM) != 0
+            val hasUpdates = (appFlags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
 
             val shouldReset = resetToFactory && isSystem && hasUpdates
             // Namespace the result action + PendingIntent requestCode by the TARGET package so that
@@ -215,10 +226,23 @@ class ShizukuReflector(
             //                not just its installed updates)
             // Reset-to-factory means rolling a system app back to its shipped version, which is a
             // plain removal of the installed updates, so DELETE_SYSTEM_APP must NOT be set there.
+            //
+            // No flag at all for an ordinary user app, where this used to set DELETE_ALL_USERS.
+            // `PackageInstaller.uninstall` passes the installer's own `mUserId` — which
+            // [getPackageInstaller] now binds to [thorUserId] — and DELETE_ALL_USERS overrides it,
+            // so the corrected user id was inert for exactly the packages people uninstall. It also
+            // put this rung at odds with the shell rung above it, which names the user: two rungs of
+            // one operation removing the app for different sets of users depending on which one the
+            // device happened to allow. Zero leaves the session's user in charge. On a single-user
+            // device nothing changes — PMS removes a package outright once no other user holds it.
+            //
+            // DELETE_ALL_USERS stays on the reset path, where it is not a default but the operation:
+            // the update APK it removes lives in /data/app and is shared by every user, so rolling
+            // one user back to the shipped version is not a thing the platform can do.
             val flags = when {
                 shouldReset -> 0x00000002
                 isSystem -> 0x00000004
-                else -> 0x00000002
+                else -> 0
             }
 
             // Fire exactly one async uninstall (previously this ran twice for the reset path) and
@@ -310,8 +334,15 @@ class ShizukuReflector(
     }
 
     /**
-     * Installs an APK using the 'pm install' command via Shizuku.
+     * Installs an APK using the 'pm install' command via Shizuku, **for [thorUserId]**.
      * Note: The file at [apkPath] must be readable by the shell user (e.g. /sdcard/).
+     *
+     * The command is built by `installCommand` rather than written here. This one had no caller
+     * when the user id was swept through the gateways, which is exactly why it is worth naming a
+     * user in: a bare `pm install` is not "install for the shell's user" — `makeInstallParams`
+     * leaves `params.userId = UserHandle.USER_ALL` and the session is created with
+     * `INSTALL_ALL_USERS`, so the first person to call this would have installed the APK for every
+     * user on the device without anything in the exit code saying so.
      *
      * @param apkPath Absolute path to the APK file.
      * @param canDowngrade Whether to allow downgrade.
@@ -319,9 +350,11 @@ class ShizukuReflector(
      */
     fun installPackage(apkPath: String, canDowngrade: Boolean = false): Boolean {
         return try {
-            val command = "pm install -r -g${if (canDowngrade) " -d" else ""} ${
-                apkPath.escapeForShell()
-            }"
+            val command = installCommand(
+                escapedApkPaths = listOf(apkPath.escapeForShell()),
+                userId = thorUserId,
+                canDowngrade = canDowngrade,
+            )
             val result = Shizuku.execute(command)
             result.first == 0
         } catch (e: Exception) {
@@ -391,7 +424,12 @@ class ShizukuReflector(
                     installFlags,
                     installReason,
                     intent.intentSender,
-                    0,
+                    // The userId argument, and the whole point of this rung being reached at all:
+                    // it is the fallback for the `pm install-existing --user N` shell rung, so it
+                    // has to restore the package for the same user that rung named. A literal 0
+                    // here silently restored (and, in the uninstall mirror of this call, removed)
+                    // the primary user's copy whenever Thor runs in a work profile.
+                    thorUserId,
                     null
                 )
             }
@@ -405,12 +443,13 @@ class ShizukuReflector(
 
     fun getPackageInstaller(): PackageInstaller {
         val iPackageInstaller = ShizukuPackageInstallerUtils.getPrivilegedPackageInstaller()
-        val root = try {
-            rikka.shizuku.Shizuku.getUid() == 0
-        } catch (_: Exception) {
-            false
-        }
-        val userId = if (root) android.os.Process.myUserHandle().hashCode() else 0
+        // Thor's own user, unconditionally. This used to be `if (Shizuku.getUid() == 0) <this user>
+        // else 0`, which asked what privilege Shizuku holds when the question is which user the
+        // session acts on — and the two are unrelated. The `else 0` branch is the normal setup
+        // (Shizuku at shell uid 2000), so on a work-profile device every operation this installer
+        // carries was scoped to the primary user: `uninstall` with DELETE_SYSTEM_APP and no
+        // DELETE_ALL_USERS bit removed a system app for user 0, the profile the user never touched.
+        val userId = thorUserId
 
         // The reason for use "com.android.shell" as installer package under adb is that
         // getMySessions will check installer package's owner
@@ -428,12 +467,8 @@ class ShizukuReflector(
      */
     fun createPackageInstallerFor(installerPackageName: String): PackageInstaller {
         val iPackageInstaller = ShizukuPackageInstallerUtils.getPrivilegedPackageInstaller()
-        val root = try {
-            rikka.shizuku.Shizuku.getUid() == 0
-        } catch (_: Exception) {
-            false
-        }
-        val userId = if (root) android.os.Process.myUserHandle().hashCode() else 0
+        // Thor's own user, for the reason [getPackageInstaller] gives.
+        val userId = thorUserId
 
         return ShizukuPackageInstallerUtils.createPackageInstaller(
             iPackageInstaller,

--- a/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
+++ b/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
@@ -17,13 +17,26 @@ import com.valhalla.thor.util.Logger
 import java.lang.reflect.InvocationTargetException
 
 /**
- * The user id every suspend call in this file writes and every readback in it parses.
+ * The user id the two suspend entry points that carry no user of their own fall back to.
  *
- * The two numbers have to be the same one. Suspending user 0 and then verifying against user 10's
- * section of the dump would confirm a state nobody set, so the constant exists to keep the write and
- * the read from drifting apart the next time one of them is edited.
+ * It is no longer what this file writes: the user arrives over the binder
+ * ([IThorRootService.setAppSuspendedAsForUser]) and is threaded through every function below,
+ * because the daemon cannot work it out for itself. This process runs as uid 0 in user 0, so
+ * `Process.myUserHandle()` answers 0 here for a Thor sitting in a work profile just as it does for
+ * one in the primary user — the same blindness that made `clearAppData` take a user id.
+ *
+ * The value survives for [IThorRootService.setAppSuspended] and [IThorRootService.setAppSuspendedAs],
+ * which have no user to pass and are kept at their historical behaviour rather than quietly
+ * re-pointed at the caller's user, exactly as [IThorRootService.clearAppData] is: a method that means
+ * something different depending on which build is answering it is worse than one that means the same
+ * wrong thing every time.
+ *
+ * Whichever number is in play, the write and the readback have to be that one number. Suspending
+ * user 0 and then verifying against user 10's section of the same dump would confirm a state nobody
+ * set, which is why the id below is passed down as a parameter rather than read again from here by
+ * the functions that parse.
  */
-private const val TARGET_USER_ID = 0
+private const val LEGACY_TARGET_USER_ID = 0
 
 /**
  * The platform's own identity — what a device-owner/DPM suspension is recorded under.
@@ -56,7 +69,13 @@ class ThorRootService : RootService() {
         return object : IThorRootService.Stub() {
             override fun setAppSuspended(packageName: String, suspended: Boolean): Boolean {
                 this@ThorRootService.enforceCaller()
-                return this@ThorRootService.setAppSuspendedAs(packageName, suspended, null)
+                // Historical, user-0-only entry point; see [LEGACY_TARGET_USER_ID].
+                return this@ThorRootService.setAppSuspendedAs(
+                    packageName,
+                    suspended,
+                    null,
+                    LEGACY_TARGET_USER_ID
+                )
             }
 
             override fun setAppSuspendedAs(
@@ -65,10 +84,29 @@ class ThorRootService : RootService() {
                 suspendingPackage: String?
             ): Boolean {
                 this@ThorRootService.enforceCaller()
+                // Likewise user-0-only: this overload picked up the *identity* to act as, not the
+                // user to act in. Superseded by setAppSuspendedAsForUser and kept only so a stale
+                // daemon's numbering stays honest.
                 return this@ThorRootService.setAppSuspendedAs(
                     packageName,
                     suspended,
-                    suspendingPackage
+                    suspendingPackage,
+                    LEGACY_TARGET_USER_ID
+                )
+            }
+
+            override fun setAppSuspendedAsForUser(
+                packageName: String,
+                suspended: Boolean,
+                suspendingPackage: String?,
+                userId: Int
+            ): Boolean {
+                this@ThorRootService.enforceCaller()
+                return this@ThorRootService.setAppSuspendedAs(
+                    packageName,
+                    suspended,
+                    suspendingPackage,
+                    userId
                 )
             }
 
@@ -79,14 +117,23 @@ class ThorRootService : RootService() {
 
             override fun clearAppData(packageName: String): Boolean {
                 this@ThorRootService.enforceCaller()
-                return this@ThorRootService.clearAppData(packageName)
+                // The historical, user-0-only entry point. Kept at its old behaviour rather than
+                // quietly re-pointed at the caller's user: this process cannot see the caller's
+                // user, and a method that means something different depending on which build is
+                // answering it is worse than one that means the same wrong thing every time.
+                return this@ThorRootService.clearAppData(packageName, 0)
+            }
+
+            override fun clearAppDataForUser(packageName: String, userId: Int): Boolean {
+                this@ThorRootService.enforceCaller()
+                return this@ThorRootService.clearAppData(packageName, userId)
             }
         }
     }
 
     /**
-     * Suspends or unsuspends [packageName] as [suspendingPackage], and returns whether the
-     * platform's own record agrees afterwards.
+     * Suspends or unsuspends [packageName] **for [userId]** as [suspendingPackage], and returns
+     * whether the platform's own record for that same user agrees afterwards.
      *
      * The return value used to be `runCatching { … }.isSuccess` over a loop that broke as soon as
      * `setPackagesSuspendedAsUser` returned an empty failure array. That array is not evidence:
@@ -96,16 +143,23 @@ class ThorRootService : RootService() {
      * as [SHELL_SUSPENDER_IDENTITY]) therefore removed nothing, reported success, and left the app
      * stuck suspended with no error anywhere. Every success below is now a re-read of the record via
      * [readSuspenders] instead.
+     *
+     * [userId] is threaded all the way down for the same reason the identity is: it is the caller's
+     * knowledge, not this process's. The daemon is uid 0 in user 0 and cannot see which user bound
+     * it, so a hardcoded 0 here wrote the primary user's copy of a package while the gateway's
+     * `FLAG_SUSPENDED` check — an in-process read that answers for Thor's user — judged a copy the
+     * write never touched.
      */
     private fun setAppSuspendedAs(
         packageName: String,
         suspended: Boolean,
-        suspendingPackage: String?
+        suspendingPackage: String?,
+        userId: Int
     ): Boolean {
         Logger.i(
             "Odin",
             "setAppSuspendedAs: packageName=$packageName, suspended=$suspended, " +
-                    "as=${suspendingPackage ?: "<unspecified>"}"
+                    "as=${suspendingPackage ?: "<unspecified>"}, user=$userId"
         )
         return runCatching {
             val binder = Class.forName("android.os.ServiceManager")
@@ -126,12 +180,14 @@ class ThorRootService : RootService() {
                 suspendAsAnyOf(
                     pmClass, pm, dialogInfoClass, packageName,
                     dialogInfo = buildSuspendDialogInfo(),
-                    identities = suspendIdentities(suspendingPackage)
+                    identities = suspendIdentities(suspendingPackage),
+                    userId = userId
                 )
             } else {
                 unsuspendAllOf(
                     pmClass, pm, dialogInfoClass, packageName,
-                    identities = unsuspendIdentities(packageName, suspendingPackage)
+                    identities = unsuspendIdentities(packageName, suspendingPackage, userId),
+                    userId = userId
                 )
             }
         }.onFailure { e ->
@@ -159,13 +215,14 @@ class ThorRootService : RootService() {
         )
 
     /**
-     * The identities to clear when unsuspending [targetPackage].
+     * The identities to clear when unsuspending [targetPackage] for [userId].
      *
      * An explicit [suspendingPackage] is again the only entry touched: the gateway reads the record
      * and calls once per recorded suspender, so each call stays a single well-defined removal.
      *
-     * With none given — the legacy two-argument `setAppSuspended` entry point — the record itself is
-     * the list. Guessing is exactly what caused the bug: a Shizuku-era suspension is recorded as
+     * With none given — the identity-less entry points — the record itself is the list, read for
+     * [userId] so that a work profile's suspenders are never lifted off the primary user's section of
+     * the dump. Guessing is exactly what caused the bug: a Shizuku-era suspension is recorded as
      * [SHELL_SUSPENDER_IDENTITY], and a root-mode Thor that only ever named its own package removed
      * nothing. When the record cannot be read at all we still make a best-effort pass over every name
      * Thor has written across its history, including the pre-GH#239
@@ -174,12 +231,13 @@ class ThorRootService : RootService() {
      */
     private fun unsuspendIdentities(
         targetPackage: String,
-        suspendingPackage: String?
+        suspendingPackage: String?,
+        userId: Int
     ): List<String> {
         if (suspendingPackage != null) return listOf(suspendingPackage)
         // A readable empty set is a real answer — nothing is recorded, so there is nothing to remove
         // and [unsuspendAllOf]'s readback confirms it. Only an unreadable dump falls through.
-        readSuspenders(targetPackage)?.let { return it.toList() }
+        readSuspenders(targetPackage, userId)?.let { return it.toList() }
         return listOf(
             this@ThorRootService.packageName,
             SHELL_SUSPENDER_IDENTITY,
@@ -189,72 +247,84 @@ class ThorRootService : RootService() {
     }
 
     /**
-     * Suspends [targetPackage] as the first of [identities] the platform actually ends up recording.
+     * Suspends [targetPackage] for [userId] as the first of [identities] the platform actually ends
+     * up recording.
      *
      * The loop reads the record back after each attempt rather than trusting
      * [tryCallSetSuspended]'s return value, so "the call was accepted" and "the suspension exists"
-     * stay separate facts. An unreadable record aborts instead of moving on to the next identity:
-     * without knowing whether the previous attempt landed, trying another name risks stacking a
-     * second suspension entry on the package that only a second unsuspend could remove.
+     * stay separate facts. It reads back the same [userId] it just wrote — parsing another user's
+     * section would report an empty suspender set for a package that is very much suspended, and the
+     * loop would then walk on to the next identity and stack a second entry. An unreadable record
+     * aborts for that same reason: without knowing whether the previous attempt landed, trying
+     * another name risks a second suspension entry that only a second unsuspend could remove.
      */
     private fun suspendAsAnyOf(
         pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
-        targetPackage: String, dialogInfo: Any?, identities: List<String>
+        targetPackage: String, dialogInfo: Any?, identities: List<String>, userId: Int
     ): Boolean {
         for (caller in identities) {
             val accepted = tryCallSetSuspended(
-                pmClass, pm, dialogInfoClass, targetPackage, true, dialogInfo, caller
+                pmClass, pm, dialogInfoClass, targetPackage, true, dialogInfo, caller, userId
             )
             if (!accepted) continue
 
-            val recorded = readSuspenders(targetPackage)
+            val recorded = readSuspenders(targetPackage, userId)
             if (recorded == null) {
                 Logger.w(
                     "Odin",
-                    "Cannot read $targetPackage's suspenders after suspending as $caller; " +
-                            "refusing to report a success we did not verify"
+                    "Cannot read $targetPackage's suspenders for user $userId after suspending as " +
+                            "$caller; refusing to report a success we did not verify"
                 )
                 return false
             }
             if (caller in recorded) {
-                Logger.i("Odin", "Suspended $targetPackage; platform recorded suspender $caller")
+                Logger.i(
+                    "Odin",
+                    "Suspended $targetPackage for user $userId; platform recorded suspender $caller"
+                )
                 return true
             }
             Logger.w(
                 "Odin",
                 "setPackagesSuspendedAsUser reported no failure for $targetPackage as $caller, " +
-                        "but the platform records $recorded — that identity owns nothing"
+                        "but the platform records $recorded for user $userId — that identity owns " +
+                        "nothing"
             )
         }
         return false
     }
 
     /**
-     * Removes every one of [identities] from [targetPackage]'s suspension record.
+     * Removes every one of [identities] from [targetPackage]'s suspension record for [userId].
      *
      * Deliberately no break on the first accepted call. From API 30 `PackageUserState.suspendParams`
      * is a map, so a package can carry several suspension entries at once and `suspended` stays true
      * while any of them survives — stopping early is how one gets left behind.
      *
-     * Success means the identities we were asked to remove are gone. A suspension owned by somebody
-     * else is not this call's to lift and is reported at warn level so the caller can name the owner
-     * to the user rather than leaving them with an app that quietly stays paused.
+     * Success means the identities we were asked to remove are gone **from that user's record**. The
+     * removal and the readback name one [userId] on purpose: lifting user 10's entries and then
+     * parsing user 0's section reports an empty set and would call that a success while the app the
+     * caller is looking at stays paused.
+     *
+     * A suspension owned by somebody else is not this call's to lift and is reported at warn level so
+     * the caller can name the owner to the user rather than leaving them with an app that quietly
+     * stays paused.
      */
     private fun unsuspendAllOf(
         pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
-        targetPackage: String, identities: List<String>
+        targetPackage: String, identities: List<String>, userId: Int
     ): Boolean {
         for (caller in identities) {
             tryCallSetSuspended(
-                pmClass, pm, dialogInfoClass, targetPackage, false, null, caller
+                pmClass, pm, dialogInfoClass, targetPackage, false, null, caller, userId
             )
         }
 
-        val recorded = readSuspenders(targetPackage)
+        val recorded = readSuspenders(targetPackage, userId)
         if (recorded == null) {
             Logger.w(
                 "Odin",
-                "Cannot read $targetPackage's suspenders after unsuspending; " +
+                "Cannot read $targetPackage's suspenders for user $userId after unsuspending; " +
                         "refusing to report a success we did not verify"
             )
             return false
@@ -263,20 +333,21 @@ class ThorRootService : RootService() {
         if (remaining.isNotEmpty()) {
             Logger.w(
                 "Odin",
-                "Unsuspend of $targetPackage left $remaining recorded as suspenders"
+                "Unsuspend of $targetPackage left $remaining recorded as suspenders for user $userId"
             )
             return false
         }
         if (recorded.isEmpty()) {
             Logger.i(
                 "Odin",
-                "Unsuspend of $targetPackage verified; nothing is recorded as suspending it"
+                "Unsuspend of $targetPackage verified for user $userId; nothing is recorded as " +
+                        "suspending it"
             )
         } else {
             Logger.w(
                 "Odin",
-                "Removed $identities from $targetPackage, but $recorded still own entries — it " +
-                        "stays suspended until whoever owns those lifts them"
+                "Removed $identities from $targetPackage for user $userId, but $recorded still own " +
+                        "entries — it stays suspended until whoever owns those lifts them"
             )
         }
         return true
@@ -291,16 +362,17 @@ class ThorRootService : RootService() {
      */
     private fun tryCallSetSuspended(
         pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
-        packageName: String, suspended: Boolean, dialogInfo: Any?, caller: String
+        packageName: String, suspended: Boolean, dialogInfo: Any?, caller: String, userId: Int
     ): Boolean = try {
         callSetSuspended(
-            pmClass, pm, dialogInfoClass, packageName, suspended, dialogInfo, caller
+            pmClass, pm, dialogInfoClass, packageName, suspended, dialogInfo, caller, userId
         )
     } catch (e: Exception) {
         val cause = if (e is InvocationTargetException) e.cause else e
         Logger.w(
             "Odin",
-            "setPackagesSuspendedAsUser threw for $packageName as $caller: " + cause?.message
+            "setPackagesSuspendedAsUser threw for $packageName as $caller on user $userId: " +
+                    cause?.message
         )
         false
     }
@@ -318,12 +390,18 @@ class ThorRootService : RootService() {
      */
     private fun callSetSuspended(
         pmClass: Class<*>, pm: Any?, dialogInfoClass: Class<*>,
-        packageName: String, suspended: Boolean, dialogInfo: Any?, caller: String
+        packageName: String, suspended: Boolean, dialogInfo: Any?, caller: String, userId: Int
     ): Boolean {
         // Android 15+ (API 35+): 9-arg signature. Not 34 — the shape itself says so. This overload
         // is where a suspension became cross-user: the suspender key turned into a UserPackage,
         // which is exactly why it carries a suspendingUserId *and* a targetUserId, and that landed
         // in 15. Gating it on 34 would only mean asking a 34 device for a method it does not have.
+        //
+        // Both user arguments are [userId], and they are not the same question: suspendingUserId is
+        // the user [caller] lives in, targetUserId the user [packageName] is paused for. Thor lists
+        // and acts on the packages of its own user, so both are that user — and the API 35 dump
+        // prints the suspender key as `<suspendingUserId>package`, which `parseSuspendingPackages`
+        // filters on, so a mismatch here would read back as no suspender at all.
         try {
             Logger.i("Odin", "Trying API 35+ 9-arg signature with caller=$caller")
             val method = pmClass.getDeclaredMethod(
@@ -340,7 +418,7 @@ class ThorRootService : RootService() {
             )
             val result = method.invoke(
                 pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller,
-                TARGET_USER_ID, TARGET_USER_ID
+                userId, userId
             ) as? Array<*>
             val failedList = result?.filterIsInstance<String>() ?: emptyList()
             Logger.i("Odin", "Successfully invoked API 35+ 9-arg signature. Failed packages: $failedList")
@@ -368,7 +446,7 @@ class ThorRootService : RootService() {
             )
             val result = method.invoke(
                 pm, arrayOf(packageName), suspended, null, null, dialogInfo, 0, caller,
-                TARGET_USER_ID
+                userId
             ) as? Array<*>
             val failedList = result?.filterIsInstance<String>() ?: emptyList()
             Logger.i("Odin", "Successfully invoked API 33 8-arg signature. Failed packages: $failedList")
@@ -390,7 +468,7 @@ class ThorRootService : RootService() {
                 dialogInfoClass, String::class.java, Int::class.javaPrimitiveType
             )
             val result = method.invoke(
-                pm, arrayOf(packageName), suspended, null, null, dialogInfo, caller, TARGET_USER_ID
+                pm, arrayOf(packageName), suspended, null, null, dialogInfo, caller, userId
             ) as? Array<*>
             val failedList = result?.filterIsInstance<String>() ?: emptyList()
             Logger.i("Odin", "Successfully invoked API 29-33 7-arg signature. Failed packages: $failedList")
@@ -402,8 +480,13 @@ class ThorRootService : RootService() {
     }
 
     /**
-     * The identities the platform currently records as suspending [targetPackage] for
-     * [TARGET_USER_ID], or `null` when the dump could not be trusted.
+     * The identities the platform currently records as suspending [targetPackage] for [userId], or
+     * `null` when the dump could not be trusted.
+     *
+     * [userId] is the caller's, never this process's: `dumpsys package` prints every user's section
+     * and `parseSuspendingPackages` picks one, so passing the wrong number here turns a suspension
+     * that exists into an empty set — the exact shape of "unknown" the `null` below is here to keep
+     * separate from "nothing is recorded".
      *
      * The `null` is the entire point of this wrapper. `parseSuspendingPackages` cannot distinguish a
      * package with no suspenders from a dump that was truncated, denied, or in a format nobody has
@@ -416,7 +499,7 @@ class ThorRootService : RootService() {
      * a caller without `android.permission.DUMP` gets a `Permission Denial:` line instead, and a
      * truncated dump gets neither.
      */
-    private fun readSuspenders(targetPackage: String): Set<String>? {
+    private fun readSuspenders(targetPackage: String, userId: Int): Set<String>? {
         val dump = dumpPackage(targetPackage) ?: return null
         if (!dump.contains("Package [$targetPackage]")) {
             Logger.w(
@@ -425,7 +508,7 @@ class ThorRootService : RootService() {
             )
             return null
         }
-        return parseSuspendingPackages(dump, TARGET_USER_ID)
+        return parseSuspendingPackages(dump, userId)
     }
 
     /**
@@ -499,7 +582,18 @@ class ThorRootService : RootService() {
         null
     }
 
-    private fun clearAppData(packageName: String): Boolean {
+    /**
+     * Wipes [packageName]'s data **for [userId]**, which the caller has to name.
+     *
+     * This process runs as uid 0 in user 0, so it cannot ask the platform which user its client
+     * belongs to — `Process.myUserHandle()` here answers 0 for a Thor sitting in a work profile just
+     * as it does for one in the primary user. The user id therefore arrives over the binder
+     * ([IThorRootService.clearAppDataForUser]) and is passed straight through to
+     * `clearApplicationUserData`, whose third argument is exactly this number. It used to be the
+     * literal 0, which is the difference between wiping the app the user tapped and wiping the
+     * primary user's same-named app — irreversibly, and reported as a success.
+     */
+    private fun clearAppData(packageName: String, userId: Int): Boolean {
         return runCatching {
             val pmStub = Class.forName("android.content.pm.IPackageManager\$Stub")
             val serviceManager = Class.forName("android.os.ServiceManager")
@@ -520,7 +614,7 @@ class ThorRootService : RootService() {
             // not wire up. So a clean reflective invocation is the strongest signal available: a
             // thrown SecurityException / missing-package / bad-signature error propagates as
             // failure (via runCatching below), while a successfully dispatched wipe reports success.
-            method.invoke(pm, packageName, null, 0)
+            method.invoke(pm, packageName, null, userId)
         }.onFailure { e ->
             Logger.e("Odin", "Failed to clear app data for $packageName", e)
         }.isSuccess

--- a/app/src/test/java/com/valhalla/thor/data/repository/PermissionQueryFlagsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/PermissionQueryFlagsTest.kt
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import android.content.pm.PackageManager
+import com.valhalla.thor.data.freezer.AppFreezeStateReader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * The flags every permission read shares.
+ *
+ * `PackageManager` cannot be faked in a plain JVM test, so neither `getAppPermissions` nor
+ * `buildPermissionIndex` is reachable here — but the flags are the entire defect and they are
+ * ordinary compile-time ints. This is the same shape, and the same reasoning, as
+ * `FreezeMatchFlagsTest`: the sweep kept the match flags, the single-package read did not, and the
+ * two call sites drifted for exactly as long as nothing named the pair.
+ */
+class PermissionQueryFlagsTest {
+
+    /**
+     * The one that actually broke. A **system** app frozen by removal for this user — the gated
+     * `pm uninstall -k --user N` fallback, plus every system app frozen before Thor preferred
+     * disabling — is not installed for this user, so `getPackageInfo` **throws** for it without
+     * MATCH_UNINSTALLED_PACKAGES. The app list carries the flag and still shows the row, so the user
+     * taps a package Thor itself froze and the permission sheet fails to open.
+     */
+    @Test
+    fun `a package frozen by removal for this user is still readable`() {
+        assertNotEquals(
+            "without MATCH_UNINSTALLED_PACKAGES the read throws for every app Thor froze by removal",
+            0,
+            PERMISSION_QUERY_FLAGS and PackageManager.MATCH_UNINSTALLED_PACKAGES
+        )
+    }
+
+    @Test
+    fun `the permissions themselves are still asked for`() {
+        assertNotEquals(
+            "GET_PERMISSIONS is what populates requestedPermissions; without it the list is empty",
+            0,
+            PERMISSION_QUERY_FLAGS and PackageManager.GET_PERMISSIONS
+        )
+    }
+
+    /**
+     * The permission read has to cover every state Thor's own freeze can leave a package in, so its
+     * match half is the freeze reader's flags in full. Stated as containment rather than as a second
+     * copy of the literal: if `AppFreezeStateReader.MATCH_FLAGS` grows a third mechanic, this fails
+     * until the permission read follows it.
+     */
+    @Test
+    fun `it covers every state the freeze reader knows about`() {
+        assertEquals(
+            AppFreezeStateReader.MATCH_FLAGS,
+            PERMISSION_QUERY_FLAGS and AppFreezeStateReader.MATCH_FLAGS
+        )
+    }
+
+    /**
+     * And nothing else. MATCH_ALL in particular would widen the index to packages the app list never
+     * shows, and `filterApps` intersects the two — a wider universe here silently drops nothing but
+     * a narrower one drops every frozen app from every chip.
+     */
+    @Test
+    fun `and nothing else`() {
+        assertEquals(
+            PackageManager.GET_PERMISSIONS or
+                PackageManager.MATCH_UNINSTALLED_PACKAGES or
+                PackageManager.MATCH_DISABLED_COMPONENTS,
+            PERMISSION_QUERY_FLAGS
+        )
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
@@ -1,0 +1,622 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+/**
+ * The commands and paths that decide *whose* data a privileged operation destroys.
+ *
+ * None of the three gateways is reachable from a JVM test — each needs a live root shell, a Shizuku
+ * binder or a device-owner identity — which is exactly why the strings they issue were extracted:
+ * "does this command name an Android user at all?" is the whole of the bug and it is a plain string
+ * question. Every assertion below uses a **work-profile** id (10, and 11 where two are needed to
+ * tell one user from another), because at user 0 a missing `--user` and a correct one produce the
+ * same effect and the defect is invisible; the handful of tests that pin user 0 exist to prove the
+ * fix changes nothing on a single-user device.
+ *
+ * `Process.myUserHandle()` is not callable here, so [thorUserId] itself is not under test. What is
+ * under test is that the builders spell out whatever number they are given.
+ *
+ * ### Where the reachable boundary is, stated plainly
+ *
+ * The defect this file was written for did **not** live in these builders — they were correct the
+ * moment they were typed. It lived at the call sites, which named the foreground user, or user 0, or
+ * no user at all. Nothing below can see a call site: `RootSystemGateway`, `ShizukuHelper` and
+ * `DhizukuHelper` all reach `android.*` in their constructors and there is no mockk and no
+ * Robolectric on this source set to stand in for them, so "does `installApp` actually call
+ * [installCommand]?" is unanswerable here and is deliberately not faked.
+ *
+ * Two things close as much of that gap as a JVM test honestly can:
+ *
+ *  - the per-builder tests pin the *whole* command, not just its `--user`. A regression that keeps
+ *    the user and drops `-g`, or flips `allow` for `ignore`, is a different bug with the same blast
+ *    radius, and the builder is the one place both are visible at once.
+ *  - `every builder in the file names a user` walks the file's compiled class by reflection instead
+ *    of a hand-kept roster, so a builder added tomorrow is covered without anyone remembering to
+ *    come here. A roster would have been the same defect as the one under repair: a list that has to
+ *    be updated by hand, next to code that compiles fine when it is not.
+ *
+ * What is left uncovered is the wiring, and it is uncovered on purpose. It needs a device.
+ */
+class PerUserCommandsTest {
+
+    private val pkg = "com.example.app"
+
+    /** Two APK paths that are digit-free, so a `10` in an assertion can only be the user id. */
+    private val baseApk = "/data/local/tmp/base.apk"
+    private val splitApk = "/data/local/tmp/split_config.en.apk"
+
+    /** Exactly what `PreferenceRepository.getInstallerArg()` returns when auto-reinstall is on. */
+    private val playInstallerArg = " -i com.android.vending"
+
+    /** The `--user <id>` a command names, or null if it names none — which is the bug. */
+    private fun userArgOf(command: String): Int? =
+        Regex("--user (\\d+)").find(command)?.groupValues?.get(1)?.toIntOrNull()
+
+    // --- pm clear: the irreversible one ---
+
+    /**
+     * `PackageManagerShellCommand.runClear` seeds `userId = UserHandle.USER_SYSTEM`, so a bare
+     * `pm clear <pkg>` issued by a Thor running in user 10 wipes **user 0's** copy — irreversibly,
+     * and with exit code 0, which every caller reads as success.
+     */
+    @Test
+    fun `clearing app data names the user`() {
+        assertEquals(10, userArgOf(clearAppDataCommand(pkg, 10)))
+    }
+
+    /**
+     * The invariant the two rungs of `clearAppData` have to satisfy, in all three privilege modes:
+     * the user named in the shell rung is the number handed to `clearApplicationUserData` in the
+     * reflection rung. Both take the same parameter now — this pins that the shell half actually
+     * spells it out, which is the half that was missing, and is why one function's two rungs used to
+     * wipe two different users' data depending on which one happened to run.
+     */
+    @Test
+    fun `the shell rung names the same user the reflection rung is handed`() {
+        for (userId in listOf(0, 10, 11)) {
+            assertEquals(userId, userArgOf(clearAppDataCommand(pkg, userId)))
+        }
+    }
+
+    // --- pm disable / pm enable ---
+
+    @Test
+    fun `disabling and enabling both name the user`() {
+        assertEquals(10, userArgOf(setAppEnabledCommand(pkg, 10, isDisabled = true)))
+        assertEquals(10, userArgOf(setAppEnabledCommand(pkg, 10, isDisabled = false)))
+    }
+
+    /**
+     * A freeze that names user 0 while the verifying re-read looks at user 10 does not merely fail —
+     * it reports failure *and* disables another profile's copy, and every retry repeats the damage.
+     * So the verb has to be right as well as the user.
+     */
+    @Test
+    fun `the verb follows the requested state`() {
+        assertTrue(setAppEnabledCommand(pkg, 10, isDisabled = true).startsWith("pm disable "))
+        assertTrue(setAppEnabledCommand(pkg, 10, isDisabled = false).startsWith("pm enable "))
+    }
+
+    /**
+     * `disable`, never `disable-user`. Only the root gateway builds this line and uid 0 may set the
+     * stronger COMPONENT_ENABLED_STATE_DISABLED; the Shizuku and Dhizuku helpers build their own
+     * `pm disable-user` because a shell-uid or device-owner caller is refused the stronger state.
+     * `startsWith("pm disable ")` above would pass for `pm disable-user` if the trailing space ever
+     * went missing, so the distinction is asserted rather than implied.
+     */
+    @Test
+    fun `disable is the strong state and not disable-user`() {
+        assertFalse(setAppEnabledCommand(pkg, 10, isDisabled = true).contains("disable-user"))
+    }
+
+    // --- pm uninstall: the one that used to hit every user at once ---
+
+    /**
+     * The worst of the three, because the bare form does not merely target the wrong user.
+     * `PackageManagerShellCommand.runUninstall` seeds `userId = UserHandle.USER_ALL` and then does
+     * `if (userId == UserHandle.USER_ALL) flags |= DELETE_ALL_USERS`, so `pm uninstall <pkg>` removes
+     * the package **and its data for every user on the device** and exits 0. Naming the user is what
+     * stops one profile's uninstall reaching into another's.
+     */
+    @Test
+    fun `uninstalling names the user`() {
+        assertEquals(10, userArgOf(uninstallCommand(pkg, 10)))
+    }
+
+    /**
+     * And it is a plain removal: `-k` is `DELETE_KEEP_DATA`, which belongs to the system-app freeze
+     * fallback. If it ever leaked into this builder the uninstall button would leave the app's data
+     * directories behind, which is the opposite of what the user asked for and invisible until
+     * somebody measured free space.
+     */
+    @Test
+    fun `uninstalling does not keep data`() {
+        assertFalse(uninstallCommand(pkg, 10).contains(" -k"))
+        assertTrue(uninstallCommand(pkg, 10).startsWith("pm uninstall --user "))
+    }
+
+    /** The single-user half of the claim: at user 0 the effect is what it always was. */
+    @Test
+    fun `at user 0 uninstall names 0`() {
+        assertEquals("pm uninstall --user 0 $pkg", uninstallCommand(pkg, 0))
+    }
+
+    // --- cache paths ---
+
+    /**
+     * `/data/data/<pkg>` and `/sdcard` are per-user aliases resolved against the *shell's* user, so
+     * a privileged `rm -rf` expanding them deletes user 0's cache no matter which user Thor runs as.
+     * They used to sit either side of the correct path in all three gateways, so the operation both
+     * missed its target and hit somebody else's.
+     */
+    @Test
+    fun `no cache path is a user-0 alias`() {
+        val paths = clearCachePaths(pkg, 10)
+        assertTrue(paths.isNotEmpty())
+        for (path in paths) {
+            assertFalse("$path is an alias for user 0", path.startsWith("/data/data/"))
+            assertFalse("$path is an alias for user 0", path.startsWith("/sdcard"))
+            assertTrue("$path does not name user 10", path.contains("/10/"))
+        }
+    }
+
+    /**
+     * And the other half of the claim: on a single-user device this changes nothing. These are the
+     * exact directories `/data/data/<pkg>/cache` and `/sdcard/Android/data/<pkg>/cache` resolve to
+     * when the shell belongs to user 0, so the commands issued on the overwhelmingly common device
+     * are byte-for-byte the ones issued before the fix.
+     */
+    @Test
+    fun `at user 0 the paths are what the old aliases pointed at`() {
+        assertEquals(
+            listOf(
+                "/data/user/0/$pkg/cache",
+                "/storage/emulated/0/Android/data/$pkg/cache",
+            ),
+            clearCachePaths(pkg, 0)
+        )
+    }
+
+    /**
+     * The package name is interpolated verbatim: callers pass an already-escaped value, and a
+     * builder that quoted it again would produce a path the shell cannot expand.
+     */
+    @Test
+    fun `the package name is passed through untouched`() {
+        assertTrue(clearAppDataCommand("'weird.pkg'", 10).endsWith(" 'weird.pkg'"))
+        assertTrue(clearCachePaths("'weird.pkg'", 10).all { it.contains("'weird.pkg'") })
+    }
+
+    // --- pm install / install-multiple: uninstall's trap entered from the other side ---
+
+    /**
+     * `makeInstallParams` opens with `params.userId = UserHandle.USER_ALL` and leaves it there when
+     * the option loop never sees a `--user`; the session is then created with `USER_SYSTEM` plus
+     * `INSTALL_ALL_USERS`. So the bare form is not "install for the shell's user" and not "install
+     * for user 0" — it pushes the package onto **every user of the device** and exits 0, which from
+     * a work profile means an APK appearing in the personal profile nobody chose to install it into.
+     */
+    @Test
+    fun `installing names the user`() {
+        assertEquals(10, userArgOf(installCommand(listOf(baseApk), 10)))
+        assertEquals(10, userArgOf(installCommand(listOf(baseApk, splitApk), 10)))
+    }
+
+    /**
+     * The verb follows the path count rather than a parameter of its own, because the four call
+     * sites this replaced each branched on that count and built two separate command strings from
+     * it — and one operation reaching `pm` down two hand-written paths is precisely where a flag
+     * ends up present on one of them only.
+     */
+    @Test
+    fun `the verb follows the number of APKs`() {
+        assertTrue(installCommand(listOf(baseApk), 10).startsWith("pm install --user "))
+        assertTrue(
+            installCommand(listOf(baseApk, splitApk), 10).startsWith("pm install-multiple --user ")
+        )
+    }
+
+    /**
+     * A split install that loses one of its APKs is not a smaller install: `install-multiple`
+     * commits a session that has to contain every split the base declares, so a dropped path fails
+     * the commit outright. Every path given is passed on, in order.
+     */
+    @Test
+    fun `every APK path survives`() {
+        val command = installCommand(listOf(baseApk, splitApk), 10)
+        assertTrue(command.endsWith(" $baseApk $splitApk"))
+    }
+
+    /**
+     * The flags that were constants at all six call sites, and stayed constants. `-r` is what makes
+     * this an update rather than an `INSTALL_FAILED_ALREADY_EXISTS`, and `-g` is what grants the
+     * runtime permissions the installed app declares — losing either turns a working install into a
+     * failure or into an app that silently cannot do anything, neither of which the `--user` fix is
+     * allowed to cost.
+     */
+    @Test
+    fun `the constant install flags survive alongside the user`() {
+        val command = installCommand(listOf(baseApk), 10)
+        assertTrue("-r was dropped: this stops being an update", command.contains(" -r"))
+        assertTrue("-g was dropped: the app installs with no permissions", command.contains(" -g"))
+    }
+
+    /**
+     * `-d` is `--downgrade`: permissive only, so it must appear exactly when it was asked for.
+     * Present unasked it lets a lower versionCode silently replace a higher one; absent when asked
+     * it turns Thor's own "install anyway" confirmation into `INSTALL_FAILED_VERSION_DOWNGRADE`.
+     */
+    @Test
+    fun `downgrade is opt-in`() {
+        assertFalse(installCommand(listOf(baseApk), 10).contains(" -d"))
+        assertTrue(installCommand(listOf(baseApk), 10, canDowngrade = true).contains(" -d"))
+    }
+
+    /**
+     * The installer argument arrives from `getInstallerArg()` already carrying its leading space,
+     * and the builder re-spaces it so that a caller passing it trimmed — or a future
+     * `getInstallerArg` that stops padding — cannot emit `-g-i com.android.vending`. `pm` answers
+     * that with a usage error, which the installer surfaces to the user as a plain install failure
+     * with no hint that the attribution flag is what broke it. Both spellings therefore have to
+     * produce the same command.
+     */
+    @Test
+    fun `the installer attribution cannot fuse onto the preceding flag`() {
+        val padded = installCommand(listOf(baseApk), 10, installerArg = playInstallerArg)
+        val trimmed = installCommand(listOf(baseApk), 10, installerArg = playInstallerArg.trim())
+
+        assertEquals(padded, trimmed)
+        assertFalse("the -i argument fused onto -g", padded.contains("-g-i"))
+        assertTrue(padded.contains(" -i com.android.vending "))
+    }
+
+    /** Auto-reinstall off is the default, and it must add nothing at all — not even a stray space. */
+    @Test
+    fun `no installer argument means no installer argument`() {
+        assertEquals(
+            "pm install --user 10 -r -g $baseApk",
+            installCommand(listOf(baseApk), 10)
+        )
+    }
+
+    /** All four options together, in the order `pm` parses them, spelled out once. */
+    @Test
+    fun `the fully loaded install command`() {
+        assertEquals(
+            "pm install-multiple --user 10 -r -g -d -i com.android.vending $baseApk $splitApk",
+            installCommand(
+                escapedApkPaths = listOf(baseApk, splitApk),
+                userId = 10,
+                canDowngrade = true,
+                installerArg = playInstallerArg,
+            )
+        )
+    }
+
+    /**
+     * `PackageManagerShellCommand` parses options until the first positional and treats everything
+     * after it as an APK path, so a `--user` that drifted behind the paths would not be an error —
+     * it would be read as another file to install, and the install would fall back to the
+     * all-users seed with no diagnostic at all.
+     */
+    @Test
+    fun `the user is named before the APK paths`() {
+        val command = installCommand(listOf(baseApk, splitApk), 10, canDowngrade = true)
+        assertTrue(command.indexOf("--user") < command.indexOf(baseApk))
+    }
+
+    /**
+     * An empty path list is a programming error, not a runtime condition — every caller returns
+     * early when the copy-to-temp step produced no files. Failing here rather than handing
+     * `pm install --user 10 -r -g ` to a privileged shell keeps the mistake in the stack trace of
+     * whoever made it.
+     */
+    @Test(expected = IllegalArgumentException::class)
+    fun `an install with no APK is refused`() {
+        installCommand(emptyList(), 10)
+    }
+
+    // --- pm path: the read half of Fix Store ---
+
+    /**
+     * `PackageManagerShellCommand.runPath` seeds `USER_SYSTEM` and then asks
+     * `getPackageInfo(pkg, …, userId)`, so the bare form answers for **user 0's** record whichever
+     * user the shell belongs to. Its only caller feeds the answer straight into a
+     * `pm install … --user <thorUserId>`, so read and write named different users while every
+     * command in the chain exited 0. The APK bytes are device-wide — what a user id selects here is
+     * visibility — which is why nothing surfaced the mismatch.
+     */
+    @Test
+    fun `asking for a package's APK paths names the user`() {
+        assertEquals("pm path --user 10 $pkg", pmPathCommand(pkg, 10))
+    }
+
+    /** And on a single-user device it is the query it always was. */
+    @Test
+    fun `at user 0 pm path names 0`() {
+        assertEquals("pm path --user 0 $pkg", pmPathCommand(pkg, 0))
+    }
+
+    // --- am force-stop: a different binary with the same USER_ALL seed ---
+
+    /**
+     * `ActivityManagerShellCommand.runForceStop` seeds `UserHandle.USER_ALL`, so the bare form kills
+     * the package on **every user of the device**. The stakes are lower than the `pm` cases —
+     * force-stop destroys no data and the process returns on the next launch — but the cost is
+     * another profile's app losing live state: a scheduled alarm, a foreground service, an unsaved
+     * draft. It is fixed because the Shizuku and Dhizuku helpers already pass `--user` on this exact
+     * command, and one gateway spelling an operation differently from the other two is how "that is
+     * fixed" quietly stops being true.
+     */
+    @Test
+    fun `force-stop names the user`() {
+        assertEquals("am force-stop --user 10 $pkg", forceStopCommand(pkg, 10))
+    }
+
+    /**
+     * And it is `am`, not `pm`. The two shell commands seed different defaults from different
+     * source files, so a builder that drifted onto the wrong binary would not merely fail — `pm`
+     * has no `force-stop` subcommand and answers with a usage dump on stdout and exit 0, which
+     * every caller in this codebase reads as a successful kill.
+     */
+    @Test
+    fun `force-stop goes through am`() {
+        assertTrue(forceStopCommand(pkg, 10).startsWith("am "))
+    }
+
+    // --- appops: neither user 0 nor all users, but whoever is in the foreground ---
+
+    /**
+     * `AppOpsService.Shell.parseUserPackageOp` seeds `UserHandle.USER_CURRENT` and resolves it with
+     * `ActivityManager.getCurrentUser()` *inside system_server*, so the bare form targeted the
+     * globally foreground user. That is why this one failed the way it did: on a managed profile the
+     * foreground user is the parent, so a restriction set from the work profile landed on the
+     * personal profile's copy — while in a Xiaomi Second Space the space you switched into *is* the
+     * foreground user and the same command happened to be right. Which user it hit depended on who
+     * was in the foreground at the instant the command ran, a value that can differ between the
+     * write and the read-back meant to confirm it.
+     */
+    @Test
+    fun `the background restriction names the user`() {
+        assertEquals(10, userArgOf(backgroundRestrictionCommand(pkg, 10, restricted = true)))
+        assertEquals(10, userArgOf(backgroundRestrictionCommand(pkg, 10, restricted = false)))
+    }
+
+    /**
+     * `ignore` restricts, `allow` lifts. Inverted, the freezer's "restrict background" would grant
+     * `RUN_ANY_IN_BACKGROUND` to every app it was pointed at — the exact opposite of the request,
+     * and invisible until somebody read the op's mode back by hand.
+     */
+    @Test
+    fun `ignore restricts and allow lifts`() {
+        assertEquals(
+            "appops set --user 10 $pkg RUN_ANY_IN_BACKGROUND ignore",
+            backgroundRestrictionCommand(pkg, 10, restricted = true)
+        )
+        assertEquals(
+            "appops set --user 10 $pkg RUN_ANY_IN_BACKGROUND allow",
+            backgroundRestrictionCommand(pkg, 10, restricted = false)
+        )
+    }
+
+    /**
+     * `parseUserPackageOp` consumes its options before the package and op positionals, so a `--user`
+     * written after the package name is not a syntax error — it is parsed as the *op* argument, and
+     * the command fails with "Unknown operation string" long after the caller has stopped looking.
+     */
+    @Test
+    fun `the user precedes the package in the appops command`() {
+        val command = backgroundRestrictionCommand(pkg, 10, restricted = true)
+        assertTrue(command.indexOf("--user") < command.indexOf(pkg))
+    }
+
+    /**
+     * The usage-access grant names the user for a reason the other builders do not share, so it is
+     * pinned separately rather than folded into the background-restriction tests.
+     *
+     * Its package is Thor's own, and `UsageAccessManager.isGranted` confirms the grant with an
+     * in-process `unsafeCheckOpNoThrow(…, Process.myUid(), …)` — which answers for *Thor's* user
+     * unconditionally. The bare form was resolved against `USER_CURRENT`, so on a managed profile
+     * the write and the confirming read addressed two different users and the op was granted to the
+     * parent profile's copy of Thor. Unlike the freezer's restriction toggle this never reported a
+     * false success — `isGranted()` simply kept saying no — which is exactly why it survived: a
+     * defect whose only symptom is a feature that never works looks like a feature that is not
+     * supported.
+     */
+    @Test
+    fun `the usage stats grant names the user`() {
+        assertEquals(10, userArgOf(usageStatsGrantCommand(pkg, 10)))
+        assertEquals("appops set --user 10 $pkg GET_USAGE_STATS allow", usageStatsGrantCommand(pkg, 10))
+    }
+
+    /**
+     * `allow`, never `ignore`. Inverted, Thor would issue a privileged command that *denies* itself
+     * the op it is trying to acquire, and `isGranted()` would then report failure — indistinguishable
+     * from "no privilege is active", which is the case this whole path is written to tolerate.
+     */
+    @Test
+    fun `the usage stats grant allows rather than ignores`() {
+        assertTrue(usageStatsGrantCommand(pkg, 10).endsWith(" GET_USAGE_STATS allow"))
+    }
+
+    // --- the shape of the whole file, not one instance of it ---
+
+    /**
+     * Every builder in `PerUserCommands.kt` has to take a user id and has to let that id reach its
+     * output. Asserted over the file's compiled class rather than a list written out here, because a
+     * hand-kept roster is the same defect this whole file exists to repair — a list that has to be
+     * updated by hand, sitting next to code that compiles perfectly well when it is not. A builder
+     * added tomorrow is covered by this test on the day it is written.
+     *
+     * The evidence is a *difference*, not a substring: each builder is rendered twice, once for user
+     * 10 and once for user 11, and the two renderings have to disagree. That works without knowing
+     * any command's syntax, which matters because the file already emits two unrelated shapes —
+     * `--user 10` for the shell commands and `/data/user/10/…` for the cache paths — and a third
+     * would otherwise need this test edited to recognise it. A builder that ignores the user id it
+     * was handed renders identically for both and fails here, which is exactly the regression the
+     * per-builder tests above cannot catch on a builder they do not know about.
+     *
+     * The id is then also required to *appear* as its own token, so a builder that varied its output
+     * with the user by some means other than naming it — hashing it into a session name, say — is
+     * not accepted as per-user. Neither fixture string contains a digit, so a matched `10` can only
+     * have come from the user id.
+     */
+    @Test
+    fun `every builder in the file names a user`() {
+        for (builder in perUserBuilders()) {
+            val forTen = render(builder, userId = 10)
+            val forEleven = render(builder, userId = 11)
+
+            assertNotEquals(
+                "${builder.readableName()} emits the same thing for user 10 and user 11, so the " +
+                    "user id it was handed reaches nothing. That is the bug this file exists to " +
+                    "fix, in a builder that has not been given its own test yet.",
+                forTen,
+                forEleven
+            )
+            assertTrue(
+                "${builder.readableName()} varies with the user id but never names it: $forTen",
+                userTokenTen.containsMatchIn(forTen)
+            )
+        }
+    }
+
+    /**
+     * A floor under the sweep above, and deliberately not a roster of what it covers.
+     *
+     * Reflection that finds nothing passes every assertion in a `for` loop, so a renamed file (the
+     * compiled class is `PerUserCommandsKt`, derived from the file name) or a Kotlin release that
+     * changes how top-level functions are emitted would turn the sweep into a no-op with a green
+     * tick. Naming the eight builders that existed when it was written proves it is looking at the
+     * right class and seeing real methods. It is `containsAll`, never an equality: adding a builder
+     * must not have to be remembered here, which is the entire point of doing this by reflection.
+     */
+    @Test
+    fun `the reflective sweep actually sees the builders`() {
+        val found = perUserBuilders().map { it.readableName() }.toSet()
+
+        assertTrue(
+            "the sweep found $found, which is missing builders that are known to exist — it is " +
+                "looking at the wrong class or filtering out real methods",
+            found.containsAll(
+                setOf(
+                    "clearAppDataCommand",
+                    "clearCachePaths",
+                    "uninstallCommand",
+                    "setAppEnabledCommand",
+                    "installCommand",
+                    "pmPathCommand",
+                    "forceStopCommand",
+                    "backgroundRestrictionCommand",
+                )
+            )
+        )
+    }
+
+    // --- reflection plumbing for the sweep above ---
+
+    /**
+     * `10` as a standalone token. Anchored on non-digits at both ends so it cannot match inside
+     * `101` or `/data/user/100/`, and so it matches equally in `--user 10 ` and in `/10/`.
+     */
+    private val userTokenTen = Regex("(^|\\D)10(\\D|$)")
+
+    /**
+     * Every builder declared in `PerUserCommands.kt`.
+     *
+     * `internal` top-level functions compile to public static methods on the file class, with the
+     * module name mangled onto the end (`installCommand$app_fossDebug`), so the sweep matches on
+     * shape rather than on names it would otherwise have to predict. Synthetic members are dropped
+     * because Kotlin emits a `$default` bridge for every function with a default argument and it
+     * takes a bitmask and a marker this fabricator has no business filling in — the name is checked
+     * as well as the flag, because which of the two carries that bridge is a compiler detail. Private
+     * helpers are dropped because they are not the file's contract.
+     */
+    private fun perUserBuilders(): List<Method> =
+        Class.forName("com.valhalla.thor.data.source.local.PerUserCommandsKt")
+            .declaredMethods
+            .filter { Modifier.isPublic(it.modifiers) && Modifier.isStatic(it.modifiers) }
+            .filterNot { it.isSynthetic || it.isBridge || it.name.contains("\$default") }
+            .sortedBy { it.name }
+
+    /** The Kotlin name, with the `internal` module-mangling suffix taken back off. */
+    private fun Method.readableName(): String = name.substringBefore('$')
+
+    /**
+     * One builder's entire output for [userId], as text.
+     *
+     * Booleans are enumerated rather than defaulted: `setAppEnabledCommand` and
+     * `backgroundRestrictionCommand` both pick between two verbs, and a builder that named the user
+     * on only one branch would slip through a single-value render. The renderings are concatenated
+     * so the caller compares a builder's whole behaviour across two user ids in one assertion.
+     */
+    private fun render(builder: Method, userId: Int): String =
+        booleanCombinations(builder.parameterTypes.count { it == Boolean::class.javaPrimitiveType })
+            .joinToString("\n") { booleans ->
+                when (val output = builder.invoke(null, *argumentsFor(builder, userId, booleans))) {
+                    is String -> output
+                    is List<*> -> output.joinToString(" ")
+                    null -> throw AssertionError(
+                        "${builder.readableName()} returned null. A command builder that can " +
+                            "produce no command is not a shape this sweep can check."
+                    )
+                    else -> throw AssertionError(
+                        "${builder.readableName()} returns a ${output.javaClass.simpleName}, " +
+                            "which this sweep cannot read. Teach render() about it."
+                    )
+                }
+            }
+
+    /**
+     * Plausible arguments for [builder], with every `Int` parameter set to [userId].
+     *
+     * Setting *every* `Int` is the deliberate simplification: a builder with a second numeric
+     * parameter would move both at once, which weakens the difference test into "some number
+     * reaches the output" for that builder alone. No builder has one today, and the alternative —
+     * guessing which parameter is the user from a name reflection does not reliably carry — would be
+     * a worse kind of wrong.
+     *
+     * An unrecognised parameter type is a hard failure rather than a skipped builder. A sweep that
+     * quietly stopped covering a builder because somebody added an enum to it would be the roster
+     * problem again, wearing a `filter`.
+     */
+    private fun argumentsFor(builder: Method, userId: Int, booleans: List<Boolean>): Array<Any?> {
+        if (builder.parameterTypes.none { it == Int::class.javaPrimitiveType }) {
+            throw AssertionError(
+                "${builder.readableName()} takes no user id at all. Everything in " +
+                    "PerUserCommands.kt is a per-user builder by definition; a command that needs " +
+                    "no user belongs beside its caller, not in this file."
+            )
+        }
+        val arguments = arrayOfNulls<Any>(builder.parameterTypes.size)
+        var nextBoolean = 0
+        builder.parameterTypes.forEachIndexed { index, type ->
+            arguments[index] = when {
+                type == Int::class.javaPrimitiveType -> userId
+                type == Boolean::class.javaPrimitiveType -> booleans[nextBoolean++]
+                type == String::class.java -> pkg
+                List::class.java.isAssignableFrom(type) -> listOf(baseApk)
+                else -> throw AssertionError(
+                    "${builder.readableName()} takes a ${type.simpleName}, which argumentsFor() " +
+                        "cannot fabricate. Teach it that type — do not exclude the builder."
+                )
+            }
+        }
+        return arguments
+    }
+
+    /** Every assignment of [count] booleans, in a stable order. `count = 0` yields one empty row. */
+    private fun booleanCombinations(count: Int): List<List<Boolean>> =
+        (0 until (1 shl count)).map { mask ->
+            (0 until count).map { bit -> (mask shr bit) and 1 == 1 }
+        }
+}

--- a/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
@@ -469,24 +469,40 @@ class PerUserCommandsTest {
      * with the user by some means other than naming it — hashing it into a session name, say — is
      * not accepted as per-user. Neither fixture string contains a digit, so a matched `10` can only
      * have come from the user id.
+     *
+     * Each boolean combination is compared against its own counterpart rather than joined into one
+     * blob first. A builder that named the user on only one of its branches still renders two
+     * different joins for users 10 and 11 — the single branch that does vary is enough to make the
+     * whole strings differ — so one assertion over the join accepts it. For the mirrored builder,
+     * the one that names the user only on its `false` branch, joining is *weaker* than the
+     * single-value render this enumeration was written to replace: defaulting the booleans would
+     * have caught it. Branch against matching branch is what makes enumerating them mean what the
+     * rationale in [renderEach] says it means.
      */
     @Test
     fun `every builder in the file names a user`() {
         for (builder in perUserBuilders()) {
-            val forTen = render(builder, userId = 10)
-            val forEleven = render(builder, userId = 11)
+            val forTen = renderEach(builder, userId = 10)
+            val forEleven = renderEach(builder, userId = 11)
 
-            assertNotEquals(
-                "${builder.readableName()} emits the same thing for user 10 and user 11, so the " +
-                    "user id it was handed reaches nothing. That is the bug this file exists to " +
-                    "fix, in a builder that has not been given its own test yet.",
-                forTen,
-                forEleven
-            )
-            assertTrue(
-                "${builder.readableName()} varies with the user id but never names it: $forTen",
-                userTokenTen.containsMatchIn(forTen)
-            )
+            for ((ten, eleven) in forTen.zip(forEleven)) {
+                val branch =
+                    if (ten.booleans.isEmpty()) "" else " on the branch ${ten.booleans}"
+
+                assertNotEquals(
+                    "${builder.readableName()} emits the same thing for user 10 and user 11" +
+                        "$branch, so the user id it was handed reaches nothing. That is the bug " +
+                        "this file exists to fix, in a builder that has not been given its own " +
+                        "test yet.",
+                    ten.text,
+                    eleven.text
+                )
+                assertTrue(
+                    "${builder.readableName()} varies with the user id but never names it" +
+                        "$branch: ${ten.text}",
+                    userTokenTen.containsMatchIn(ten.text)
+                )
+            }
         }
     }
 
@@ -551,29 +567,35 @@ class PerUserCommandsTest {
     /** The Kotlin name, with the `internal` module-mangling suffix taken back off. */
     private fun Method.readableName(): String = name.substringBefore('$')
 
+    /** One boolean combination's rendering, tagged with the combination that produced it. */
+    private data class Rendering(val booleans: List<Boolean>, val text: String)
+
     /**
-     * One builder's entire output for [userId], as text.
+     * One rendering of [builder] per boolean combination, for [userId], in a stable order.
      *
      * Booleans are enumerated rather than defaulted: `setAppEnabledCommand` and
      * `backgroundRestrictionCommand` both pick between two verbs, and a builder that named the user
-     * on only one branch would slip through a single-value render. The renderings are concatenated
-     * so the caller compares a builder's whole behaviour across two user ids in one assertion.
+     * on only one branch would slip through a single-value render. The rows are returned separately
+     * rather than concatenated because a join hands that hole straight back — one varying branch
+     * carries the whole string, and the caller can no longer tell which branch it came from.
      */
-    private fun render(builder: Method, userId: Int): String =
+    private fun renderEach(builder: Method, userId: Int): List<Rendering> =
         booleanCombinations(builder.parameterTypes.count { it == Boolean::class.javaPrimitiveType })
-            .joinToString("\n") { booleans ->
-                when (val output = builder.invoke(null, *argumentsFor(builder, userId, booleans))) {
-                    is String -> output
-                    is List<*> -> output.joinToString(" ")
-                    null -> throw AssertionError(
-                        "${builder.readableName()} returned null. A command builder that can " +
-                            "produce no command is not a shape this sweep can check."
-                    )
-                    else -> throw AssertionError(
-                        "${builder.readableName()} returns a ${output.javaClass.simpleName}, " +
-                            "which this sweep cannot read. Teach render() about it."
-                    )
-                }
+            .map { booleans ->
+                val text =
+                    when (val output = builder.invoke(null, *argumentsFor(builder, userId, booleans))) {
+                        is String -> output
+                        is List<*> -> output.joinToString(" ")
+                        null -> throw AssertionError(
+                            "${builder.readableName()} returned null. A command builder that can " +
+                                "produce no command is not a shape this sweep can check."
+                        )
+                        else -> throw AssertionError(
+                            "${builder.readableName()} returns a ${output.javaClass.simpleName}, " +
+                                "which this sweep cannot read. Teach renderEach() about it."
+                        )
+                    }
+                Rendering(booleans, text)
             }
 
     /**


### PR DESCRIPTION
Audit item 2 of the 2026-08-04 dev-branch sweep.

## The bug

Thor ran most of its `pm` / `am` / `appops` lines with no `--user`, so the user each one acted on
was whatever the AOSP shell command happens to seed. Those seeds are **not the same**, and none of
them is "Thor's user":

| command | seed |
|---|---|
| `pm clear` / `enable` / `disable` / `path` | `USER_SYSTEM` |
| `pm install` / `uninstall` | `USER_ALL`, widened to `INSTALL_ALL_USERS` / `DELETE_ALL_USERS` |
| `am force-stop` | `USER_ALL` |
| `appops` | `USER_CURRENT`, resolved by `ActivityManager.getCurrentUser()` **inside system_server** — the globally foreground user, not the caller's |

On a single-user device these coincide and nothing is visibly wrong. On a work profile they diverge
silently: `UsageAccessManager` wrote the op through `appops` against the foreground user, then
confirmed it by reading `AppOpsManager` for `Process.myUid()`. The write and the read were asking
about two different users and never met.

## The fix

Every command now names `thorUserId` explicitly. The builders live in one new file,
`data/source/local/PerUserCommands.kt`, and each carries KDoc for **its own** seed rather than
inheriting a neighbour's — the seeds differ, so one shared comment would be wrong for most of them.

Things that look mergeable and are not, documented at each site:

- **`appops` needs care beyond the flag.** `parseUserPackageOp` consumes options before positionals,
  so a `--user` written *after* the package name parses as the **op**, and the command fails with
  "Unknown operation string" rather than a usage error. The builder places it first.
- **Two `MATCH_ARCHIVED_PACKAGES` version guards.** The constant is a `long` (`1L shl 32`,
  `since="35"`), so it cannot ride the `getPackageInfo(String, Int)` overload and needs
  `PackageInfoFlags` — API 33+, a different floor from the API 35 the constant itself requires.
- **AIDL methods are appended, never inserted or reordered.** Binder transaction codes are
  positional, so a stale daemon returns `false` rather than misinterpreting a call. Superseded forms
  are retained deliberately for that.
- **`pm set-installer` is left userless, verified:** it takes no `--user` on any supported release.
  Session sub-commands inherit their user from `install-create --user` at the point the session is
  made.

## Review follow-ups (last two commits)

A 43-agent adversarial review over 7 lenses returned no confirmed findings against the main change.
A second, tighter run upheld one, and I found one more myself:

- **Deleted `USER_ID_REGEX` from both gateways.** Declared beside the package-name regex that *is*
  used, and never referenced. The user id reaching those classes is an `Int` and cannot carry a
  shell metacharacter, so a validator that is never called only reads as coverage the callers do
  not have.
- **The reflective sweep compared the wrong thing.** It enumerated every boolean combination of a
  builder, then *joined* the renderings before comparing user 10 against user 11 — which hands back
  the hole the enumeration exists to close. A builder naming the user on only one branch still
  renders two different joins (the varying branch carries the whole string) and still contains the
  `--user 10` token, so both assertions pass. For the mirrored builder, joining is strictly *weaker*
  than the single-value render it replaced.

  Measured, not argued. A builder with exactly that shape, added temporarily:

  ```kotlin
  if (withUser) "pm probe --user $userId $pkg" else "pm probe $pkg"
  ```

  - against the joined sweep: **BUILD SUCCESSFUL**, 669 tests, blind to it
  - against this version: **fails**, naming the branch — `... emits the same thing for user 10 and
    user 11 on the branch [false]`

  The probe was reverted; `PerUserCommands.kt` is untouched by that commit.

## Verification

- `:app:testFossDebugUnitTest --rerun-tasks` → **669 tests, 0 failures, 0 skipped**
  (`PerUserCommandsTest` contributes 32)
- `:app:lintFossDebug` → **0 issues**
- Not device-tested. The work-profile divergence this fixes needs a second user to observe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit user targeting for app installation, uninstallation, suspension, data clearing, cache management, and usage-access permissions.
  * Added support for managing apps across user profiles with improved state verification.
  * Improved visibility of uninstalled and archived apps in package information.

* **Bug Fixes**
  * Prevented package operations from unintentionally affecting other users.
  * Improved service connection cleanup and command failure reporting.
  * Increased reliability when freezing, unfreezing, suspending, and reinstalling apps.

* **Tests**
  * Added comprehensive coverage for user-scoped commands and permission queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->