### PR TITLE
fix(privilege): judge privileged actions by a readback, not by an exit code

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -206,6 +206,10 @@ class RootSystemGateway(
         // caller here treats false as "not proven stopped" and does more work, ending at the
         // failure below; so "could not read" costs a wasted killBackgroundProcesses and a reported
         // failure, never a success that did not happen.
+        //
+        // What it does cost is a *sentence*. "FLAG_STOPPED is clear" and "the package could not be
+        // read" are the same `false` here, so the failure message must not speak for both — see the
+        // last read below, which keeps its `ApplicationInfo` for exactly that.
         fun isStoppedNow(): Boolean = getApplicationInfoCompat(packageName)?.run {
             (flags and android.content.pm.ApplicationInfo.FLAG_STOPPED) != 0
         } ?: false
@@ -241,21 +245,36 @@ class RootSystemGateway(
             am?.killBackgroundProcesses(packageName)
         }
 
-        if (isStoppedNow()) return Result.success(Unit)
+        // The last read is spelled out rather than asked for through [isStoppedNow], because the
+        // failure message below has to say *which* of that function's two `false`s this is, and
+        // re-reading to find out would describe a different moment than the one that decided.
+        val postKillInfo = getApplicationInfoCompat(packageName)
+        if (postKillInfo != null &&
+            (postKillInfo.flags and android.content.pm.ApplicationInfo.FLAG_STOPPED) != 0
+        ) {
+            return Result.success(Unit)
+        }
 
         // Two ways to arrive here now, and a bug report has to be able to tell them apart: the
         // shell command itself failed, or it exited 0 and the app kept running anyway. The old
         // message asserted the first unconditionally, which the guard above has just made false.
         val shellVerdict = if (shellResult.isSuccess) {
-            "`am force-stop` exited 0 but the app never entered the stopped state"
+            "`am force-stop` exited 0"
         } else {
             "the shell command failed"
         }
+        // The same defect one level down, and the reason this is not simply "it is still running":
+        // that claim rests on [isStoppedNow], where an unreadable `ApplicationInfo` and a genuinely
+        // clear FLAG_STOPPED are indistinguishable. A bug report generated from "Thor could not
+        // read the package" must not read as "the kill did not work" — they need different fixes.
+        val stateVerdict = if (postKillInfo == null) {
+            "the package's ApplicationInfo could not be read back after killBackgroundProcesses, " +
+                "so whether it is still running is unknown"
+        } else {
+            "FLAG_STOPPED is still clear after killBackgroundProcesses, so it is still running"
+        }
         return Result.failure(
-            Exception(
-                "Root force stop of $packageName failed: $shellVerdict, and it is still " +
-                    "running after killBackgroundProcesses."
-            )
+            Exception("Root force stop of $packageName failed: $shellVerdict, and $stateVerdict.")
         )
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -196,19 +196,44 @@ class RootSystemGateway(
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
         val escapedPackage = packageName.escapeForShell()
+
+        // What "stopped" means here, asked of the platform rather than of an exit code. All three
+        // rungs below ask this one question, so it is one function: three hand-written copies of a
+        // verifier are how one of them quietly stops matching the others.
+        //
+        // An unreadable package answers false, and that collapse is safe in the one direction that
+        // matters — the opposite of the `null` [readSuspendedFlag] is careful to preserve. Every
+        // caller here treats false as "not proven stopped" and does more work, ending at the
+        // failure below; so "could not read" costs a wasted killBackgroundProcesses and a reported
+        // failure, never a success that did not happen.
+        fun isStoppedNow(): Boolean = getApplicationInfoCompat(packageName)?.run {
+            (flags and android.content.pm.ApplicationInfo.FLAG_STOPPED) != 0
+        } ?: false
+
         // The two halves of this function have to name the same user. Everything below the shell
         // rung is in-process — killBackgroundProcesses and the FLAG_STOPPED reads both answer for
         // Thor's own user — while a bare `am force-stop` reads USER_ALL and kills the package
         // everywhere. Naming [thorUserId] is what makes the post-check evidence about the process
         // the command was aimed at.
         val shellResult = runCommand(forceStopCommand(escapedPackage, thorUserId))
-        if (shellResult.isSuccess) return shellResult
+        // The exit code alone decided this, and it cannot say no:
+        // `ActivityManagerShellCommand.runForceStop` ends in an unconditional `return 0`, so it
+        // reports that the command parsed, never that a process died. `shellResult.isSuccess` was
+        // therefore true on every device for every package, which made the fallback's FLAG_STOPPED
+        // readback — [isStoppedNow], already written, already correct — dead code from the shell
+        // rung's point of view: the verifier existed and was skipped by a rung that could not fail.
+        // Do not simplify this back to `if (shellResult.isSuccess)`; that restores an unfalsifiable
+        // success and takes the only evidence this function has with it.
+        //
+        // The readback is fresh because `am force-stop` is synchronous — AMS has committed the
+        // stopped state before the shell command returns — and it is *about the same app* because
+        // the command names [thorUserId] and `getApplicationInfo` can only ever answer for Thor's
+        // own user. A shell 0 with a package that did not stop now falls through to the
+        // unprivileged rung rather than being reported as done.
+        if (shellResult.isSuccess && isStoppedNow()) return shellResult
 
         // Unprivileged check/fallback
-        val isStopped = getApplicationInfoCompat(packageName)?.run {
-            (flags and android.content.pm.ApplicationInfo.FLAG_STOPPED) != 0
-        } ?: false
-        if (isStopped) return Result.success(Unit)
+        if (isStoppedNow()) return Result.success(Unit)
 
         runCatching {
             val am =
@@ -216,12 +241,22 @@ class RootSystemGateway(
             am?.killBackgroundProcesses(packageName)
         }
 
-        val postCheck = getApplicationInfoCompat(packageName)?.run {
-            (flags and android.content.pm.ApplicationInfo.FLAG_STOPPED) != 0
-        } ?: false
-        if (postCheck) return Result.success(Unit)
+        if (isStoppedNow()) return Result.success(Unit)
 
-        return Result.failure(Exception("Root force stop failed. Shell command failed and app is still running."))
+        // Two ways to arrive here now, and a bug report has to be able to tell them apart: the
+        // shell command itself failed, or it exited 0 and the app kept running anyway. The old
+        // message asserted the first unconditionally, which the guard above has just made false.
+        val shellVerdict = if (shellResult.isSuccess) {
+            "`am force-stop` exited 0 but the app never entered the stopped state"
+        } else {
+            "the shell command failed"
+        }
+        return Result.failure(
+            Exception(
+                "Root force stop of $packageName failed: $shellVerdict, and it is still " +
+                    "running after killBackgroundProcesses."
+            )
+        )
     }
 
     override suspend fun clearCache(packageName: String): Result<Unit> {
@@ -229,6 +264,11 @@ class RootSystemGateway(
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
         val escapedPackage = packageName.escapeForShell()
+        // Deliberately unverified, and deliberately staying that way: as uid 0 `rm -rf` is honest
+        // about its own post-condition — exit 0 means those paths are gone or were never there,
+        // non-zero means a real error — so there is no asynchronous framework call here, and no
+        // IPackageDataObserver to wire up as the reflective cache rungs in the other two gateways
+        // need. A readback would re-`stat` what the shell already reported on.
         val command = "rm -rf ${clearCachePaths(escapedPackage, thorUserId).joinToString(" ")}"
         return runCommand(command)
     }
@@ -247,18 +287,39 @@ class RootSystemGateway(
         // from an older build has no such transaction code and answers false, which lands on the
         // failure below — the right way round for a call that destroys data.
         val service = getRootService()
+        // The failure below now names *which* way the AIDL rung produced nothing. "AIDL failed" —
+        // the whole of what it used to say — folded three different diagnoses into one sentence of
+        // a bug report about data that is still there: no daemon at all (the bind was refused or
+        // timed out), a daemon that could not be reached (dead binder, `:root` killed mid-call),
+        // and a daemon that answered no. The third covers both a PMS refusal and the older-build
+        // case the paragraph above describes — `clearAppDataForUser` hands back a bare boolean, so
+        // this side cannot separate those two and the string does not pretend to.
+        //
+        // What a `true` is, since it still returns a success here: the daemon's reflective
+        // `clearApplicationUserData` is void and reports through an `IPackageDataObserver` that
+        // `ThorRootService.clearAppData` deliberately does not wire up, so `true` means the wipe
+        // was dispatched without throwing — not that the data is gone.
+        val daemonVerdict: String
         if (service != null) {
-            val aidlCleared = runCatching {
+            val aidlCall = runCatching {
                 service.clearAppDataForUser(packageName, thorUserId)
             }.onFailure { e ->
                 Logger.e("RootSystemGateway", "AIDL clearAppData failed", e)
-            }.getOrDefault(false)
-            if (aidlCleared) {
+            }
+            if (aidlCall.getOrDefault(false)) {
                 return@withContext Result.success(Unit)
             }
+            daemonVerdict = aidlCall.fold(
+                onSuccess = { "the root daemon refused the wipe" },
+                onFailure = { "the root daemon could not confirm the wipe (${it.javaClass.simpleName})" },
+            )
+        } else {
+            daemonVerdict = "the root daemon would not bind, so it was never asked"
         }
 
-        return@withContext Result.failure(Exception("Root clear app data failed. Shell command and AIDL both failed."))
+        return@withContext Result.failure(
+            Exception("Root clear app data of $packageName failed: `pm clear` failed and $daemonVerdict.")
+        )
     }
 
     /**
@@ -689,9 +750,36 @@ class RootSystemGateway(
             // user Thor runs as, while [readSuspendedFlag] — the only judge of the result — read
             // Thor's own and saw nothing change. On a single-user device the two commands are the
             // same operation byte for byte; on a secondary user they are two different apps.
+            //
+            // Its exit code is not the judge either, and never was entitled to be:
+            // `PackageManagerShellCommand.runSuspend` returns 0 whenever `setPackagesSuspendedAsUser`
+            // did not throw, discarding the failure array that names the packages it declined to
+            // suspend — an exempt package, or one not installed for this user, comes back as a clean
+            // exit. [readSuspendedFlag] already decides every other branch of this function (the AIDL
+            // suspend above, the early return in [unsuspendPackage]); this rung was the one place a
+            // `pm` exit code still stood in for it.
+            //
+            // `== true` and not a bare call, for the reason the AIDL branch above spells out:
+            // [readSuspendedFlag] answers `null` for "could not read the package at all", and "could
+            // not tell" must never stand in for success. The readback is legitimate here only because
+            // [SUSPEND_USER_ID] is [thorUserId]: `--user` and `getApplicationInfo` — which can answer
+            // for Thor's own user and nothing else — name one user by construction. Pin either back
+            // to 0 and this guard starts asking about a different copy of the app than the command
+            // changed. It is also fresh by the same argument [setAppDisabled] makes, only stronger:
+            // this rung runs on API 28 alone, which has no `ApplicationInfo` cache, so the read is a
+            // plain binder round trip to PMS.
             val shell = runCommand("pm suspend --user $SUSPEND_USER_ID $escapedPackage")
-            return@withContext if (shell.isSuccess) shell
-            else Result.failure(Exception("Root suspend failed for $packageName."))
+            return@withContext if (shell.isSuccess && readSuspendedFlag(packageName) == true) shell
+            else Result.failure(
+                Exception(
+                    if (shell.isSuccess) {
+                        "Root suspend of $packageName is unverified: `pm suspend` exited 0 but " +
+                            "FLAG_SUSPENDED does not read back as set for user $SUSPEND_USER_ID."
+                    } else {
+                        "Root suspend failed for $packageName."
+                    }
+                )
+            )
         }
 
         return@withContext unsuspendPackage(packageName, escapedPackage, hasReflection)

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -158,13 +158,14 @@ class SystemRepositoryImpl(
         }
     }
 
-    override suspend fun aggressiveCleanup(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
-        runGatewayAction { gateway ->
-            gateway.forceStopApp(packageName)
-            gateway.clearCache(packageName)
-            Result.success(Unit)
-        }
-    }
+    // `aggressiveCleanup` used to sit here: force-stop then clear-cache, both `Result`s discarded,
+    // then an unconditional `Result.success(Unit)`. It had no production caller — its only
+    // references were the interface declaration and three interface-forced test overrides — so it
+    // is deleted rather than taught to honour the results it was throwing away. A composite that
+    // reports success no matter what its two steps did is worse than no composite: the caller that
+    // would eventually be written for it inherits a guarantee nothing checks. The two operations
+    // remain available individually as `forceStopApp` and `clearCache`, each returning its own
+    // real `Result`.
 
     override suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
         runGatewayAction { it.reinstallAppWithGoogle(packageName) }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -176,19 +176,38 @@ object DhizukuHelper {
     fun forceStopApp(context: Context, packageName: String): Boolean {
         val pkgs = Packages(context)
         val userId = pkgs.myUserId
-        // 1. Shell first — and its exit code is not evidence of anything. `am force-stop` cannot
-        // fail: `ActivityManagerShellCommand.runForceStop` ends in an unconditional `return 0`, so
-        // exit 0 says the command parsed, never that a process died. The honest verifier was
-        // already written in this function — `pkgs.isAppStopped`, rung 3 below — and sat unreachable
-        // behind this short-circuit, which always won. Do not "simplify" the readback back out.
+        // 1. Shell first — and its exit code is not evidence of anything, in either direction.
+        // `ActivityManagerShellCommand.runForceStop` ends in an unconditional `return 0`, so exit 0
+        // says the command parsed, never that a process died. The honest verifier was already
+        // written in this function — `pkgs.isAppStopped`, rung 3 below — and sat unreachable behind
+        // this short-circuit. Do not "simplify" the readback back out.
         //
-        // Verifying is worth doing *here*, unlike the reflection rungs of [clearCache] and
-        // [clearAppData], which were only made honest: this rung is alive. `execute` runs `am`
-        // inside the device-owner app via `DhizukuAPI.newProcess`, so it reaches
-        // ActivityManagerService for real — the same fact [setAppDisabledDetailed]'s reflection rung
-        // records for `pm`. A readback on a live rung turns a false success into a true one; a
-        // readback on a transport-dead rung turns it into a guaranteed red, which is why those two
-        // sites report failure instead of waiting for an answer that cannot arrive.
+        // **Do not read this rung as the live one.** `execute` runs `am` inside the *Dhizuku* app:
+        // `DhizukuAPI.newProcess` is an AIDL call to `IDhizuku.remoteProcess`, so the child is
+        // spawned by the device-owner app at its own ordinary app uid. AMS gates what that child
+        // then asks for — `ActivityManagerService.forceStopPackage` opens on
+        // `checkCallingPermission(FORCE_STOP_PACKAGES)`, a `signature|privileged` permission that
+        // holding device owner does not confer — so it throws SecurityException,
+        // `ShellCommand.exec` prints that to stderr and leaves its `res` at -1, and `am` exits 255
+        // without `runForceStop` ever reaching its `return 0`. The `&&` below therefore
+        // short-circuits, and `pkgs.isAppStopped` is not called on this rung at all.
+        //
+        // That chain is AOSP-derived rather than measured for `force-stop` itself; its identity
+        // half is measured on device. The same binary at the same Dhizuku uid is recorded further
+        // down this file being refused `am get-current-user` — `Permission Denial … uid=10231`,
+        // exit 255 — which is this exact shape one command over.
+        //
+        // The readback stays anyway: it costs nothing on a rung that short-circuits, and it is the
+        // guard for the one case that would otherwise lie — an exit 0 from a transport that killed
+        // nothing, which is what a ROM or a Dhizuku build that does hold the permission would
+        // produce. Nothing is lost when it never runs, because rung 3 re-reads FLAG_STOPPED
+        // unconditionally: one verifier, reached whichever rung did the work.
+        //
+        // The `newProcess` identity fact lives in [setAppDisabledDetailed]'s **KDoc**, where it is
+        // a caveat — neither of its rungs reaches `PackageManagerService` as uid 2000, which is
+        // precisely why nothing there trusts an exit code — and not in its reflection rung, whose
+        // note says the opposite about *itself*: double-wrapped binder, dead on a Dhizuku-only
+        // device.
         val result = execute("am force-stop --user $userId $packageName")
         if (result.first == 0 && pkgs.isAppStopped(packageName)) return true
 
@@ -1001,9 +1020,16 @@ object DhizukuHelper {
      * a `@StringRes int`). On API 29-30 that lookup threw `NoSuchMethodException` out of the caller's
      * `runCatching` and killed the whole reflection path before it ever reached the suspend call.
      *
-     * The `@StringRes int` overloads are deliberately not used as a pre-31 fallback: the system
-     * resolves such an id against the *suspending* package's resources, which in Dhizuku mode is
-     * `com.android.shell`, not us. A missing title is better than a wrong one.
+     * The `@StringRes int` overloads are deliberately not used as a pre-31 fallback: the system's
+     * `SuspendedAppActivity` resolves such an id against the resources of whichever package the
+     * platform *recorded* as the suspender. This helper's only caller is [setAppSuspended]'s
+     * reflection rung, which names `BuildConfig.APPLICATION_ID`, so the id would ordinarily land on
+     * Thor's own resources — but Dhizuku is the one privilege mode that cannot read the suspension
+     * record back at all (no `DUMP`; see [setAppSuspended]), so "ordinarily" is the strongest claim
+     * this file can make about where it lands. A literal string is right whoever renders it, and a
+     * missing title is better than a wrong one. (`com.android.shell` is
+     * `Shizuku.buildSuspendDialogInfo`'s answer, where the caller really is shell uid 2000; it does
+     * not transfer here.)
      */
     @SuppressLint("PrivateApi")
     private fun buildSuspendDialogInfo(context: Context): Any? = runCatching {
@@ -1138,9 +1164,28 @@ object DhizukuHelper {
      * **Expected to answer `null` on a Dhizuku-only device, and that is not a defect.** This rides
      * the same double-wrapped binder as the reflection rung — `asInterface` puts
      * `ShizukuBinderWrapper` on top of Dhizuku's own wrapper — so where that rung is dead this is
-     * dead with it, and the shell rung's own honest report is what stands. The readback can only
-     * ever *add* confirmation here; it is not load-bearing, which is what makes failing open at the
-     * shell rung safe rather than optimistic.
+     * dead with it.
+     *
+     * What a `null` costs depends on which rung asked, and the two are opposites:
+     * - **Shell rung** — not load-bearing. `appops set` exits non-zero for an unknown package or
+     *   op, so that rung's own report is already honest and a `null` leaves it standing. This
+     *   readback can only *add* confirmation there, which is what makes failing open safe rather
+     *   than optimistic.
+     * - **Reflection rung** — the sole verdict. "The invoke did not throw" is not a mode, so with
+     *   no readback there is nothing left to believe and a `null` forces `false` — which is what
+     *   that rung's own comment says. Fail-closed, as at the clear-data sites.
+     *
+     * **Known blind spot: a uid-level mode hides the package-level one this asks about.**
+     * `AppOpsService.checkOperationUnchecked` consults
+     * `mAppOpsCheckingService.getUidMode(uidState.uid, persistentDeviceId, code)` first and returns
+     * straight away whenever that differs from `AppOpsManager.opToDefaultMode(code)` — before the
+     * package entry is consulted at all. Both write paths in [setAppRestricted] are *package*-level
+     * (`appops set <pkg>` and `IAppOpsService.setMode(op, uid, packageName, mode)`), so wherever a
+     * uid-level mode exists for `OP_RUN_ANY_IN_BACKGROUND` this reports something unrelated to
+     * whether the write landed. `checkOperationRaw` is not the fix: it drops `evalMode`, not the
+     * uid short-circuit. The mechanism is AOSP-verified; what is *not* established is that anything
+     * writes this op at uid level — Settings' Battery ▸ Restricted uses the package-level form — so
+     * this is a known blind spot rather than an observed bug.
      *
      * `checkOperation(int, int, String)` is the signature this project has *not* verified across
      * 28..37 — it has been stable in `IAppOpsService` for as long as anyone has needed it, but that

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -176,27 +176,42 @@ object DhizukuHelper {
     fun forceStopApp(context: Context, packageName: String): Boolean {
         val pkgs = Packages(context)
         val userId = pkgs.myUserId
-        // 1. Try shell first
+        // 1. Shell first — and its exit code is not evidence of anything. `am force-stop` cannot
+        // fail: `ActivityManagerShellCommand.runForceStop` ends in an unconditional `return 0`, so
+        // exit 0 says the command parsed, never that a process died. The honest verifier was
+        // already written in this function — `pkgs.isAppStopped`, rung 3 below — and sat unreachable
+        // behind this short-circuit, which always won. Do not "simplify" the readback back out.
+        //
+        // Verifying is worth doing *here*, unlike the reflection rungs of [clearCache] and
+        // [clearAppData], which were only made honest: this rung is alive. `execute` runs `am`
+        // inside the device-owner app via `DhizukuAPI.newProcess`, so it reaches
+        // ActivityManagerService for real — the same fact [setAppDisabledDetailed]'s reflection rung
+        // records for `pm`. A readback on a live rung turns a false success into a true one; a
+        // readback on a transport-dead rung turns it into a guaranteed red, which is why those two
+        // sites report failure instead of waiting for an answer that cannot arrive.
         val result = execute("am force-stop --user $userId $packageName")
-        if (result.first == 0) return true
+        if (result.first == 0 && pkgs.isAppStopped(packageName)) return true
 
-        // 2. Fallback to reflection
-        val reflectionResult = runCatching {
+        // 2. Fallback to reflection, and nothing reads its result any more. All it could ever report
+        // was that the invoke did not throw, which through `asInterface`'s double-wrapped binder is
+        // not a statement about ActivityManagerService at all — fixing rung 1 and leaving
+        // `if (reflectionResult) return true` underneath it would have been the same defect one line
+        // lower. The line is deleted rather than gated because rung 3 already re-reads FLAG_STOPPED
+        // unconditionally: one verifier, reached whichever rung did the work.
+        runCatching {
             val am = asInterface("android.app.IActivityManager", Context.ACTIVITY_SERVICE)
-                ?: return@runCatching false
-            Bypass.invoke<Any?>(
-                am::class.java, am, "forceStopPackage", packageName, userId
-            )
-            true
-        }.getOrElse {
+            if (am != null) {
+                Bypass.invoke<Any?>(
+                    am::class.java, am, "forceStopPackage", packageName, userId
+                )
+            }
+        }.onFailure {
             Logger.e(
                 "DhizukuHelper",
                 "forceStopApp reflection failed for $packageName",
                 it
             )
-            false
         }
-        if (reflectionResult) return true
 
         // 3. Unprivileged fallback (re-query PM to observe post-mutation state)
         if (pkgs.isAppStopped(packageName)) return true
@@ -609,14 +624,17 @@ object DhizukuHelper {
      * How often this rung runs at all is a separate question, and the answer is probably never:
      * `asInterface` wraps the binder twice — Dhizuku's own wrapper, then `ShizukuBinderWrapper` on
      * top — so on a Dhizuku-only device the call dies in a transport belonging to a privilege mode
-     * the user has not set up. `setAppDisabled` carries that argument in full. It is a reason not to
-     * expect the reorder to change behaviour today, not a reason to keep the order wrong: a rung
-     * that is dead now is still the rung a future transport fix would wake up.
+     * the user has not set up. `setAppDisabledDetailed` carries that argument in full. It is a
+     * reason not to expect the reorder to change behaviour today, not a reason to keep the order
+     * wrong: a rung that is dead now is still the rung a future transport fix would wake up.
      *
-     * **A `true` from this function is not evidence the cache is gone.** Only the shell rung is
-     * honest (`rm -rf` exits 0 or it does not). The reflective call is asynchronous — PMS reports
-     * through the `IPackageDataObserver` that is passed as `null` here — so `true` means only that
-     * the binder call returned without throwing.
+     * **A `true` from this function now comes from the shell rung or from nowhere.** Only that rung
+     * is honest — `rm -rf` exits 0 or it does not — and the reflective one has stopped claiming
+     * otherwise. Its `true` was never evidence: the call is asynchronous, PMS reports through the
+     * `IPackageDataObserver` passed as `null` here, and on a Dhizuku-only device it does not reach
+     * PMS at all. It is still issued, because on a device that also has Shizuku it may genuinely
+     * run; what changed is that "the binder call returned" is no longer allowed to reach the user as
+     * "the cache is gone".
      */
     // SdCardPath: absolute system paths are intentional for privileged/root file ops on app data
     // dirs (not app-scoped storage). PrivateApi: hidden-API reflection is the core privilege
@@ -632,7 +650,23 @@ object DhizukuHelper {
         val shellResult = execute(command)
         if (shellResult.first == 0) return true
 
-        // 2. Fallback to reflection
+        // 2. Fallback to reflection — issued, and deliberately never believed.
+        //
+        // `asInterface` wraps the binder twice, Dhizuku's own wrapper and then
+        // `ShizukuBinderWrapper` on top, so on a Dhizuku-only device this call dies inside a
+        // transport belonging to a privilege mode the user never set up; [setAppDisabledDetailed]'s
+        // reflection rung carries that argument in full. The call stays — it costs nothing, and on a
+        // device that *also* has Shizuku it may genuinely run — but the `false` at the end of the
+        // block replaces a `true` that has never meant the cache was cleared. Even on a live
+        // transport it could not mean that: `deleteApplicationCacheFiles*` reports through the
+        // `IPackageDataObserver` passed as `null` here, so the old `true` only ever said "the binder
+        // call returned".
+        //
+        // An observer is deliberately not wired up in its place. On the device this rung actually
+        // runs on the call never reaches PackageManagerService, so a real observer would buy one
+        // guaranteed timeout per package — an always-red answer that teaches the user nothing and
+        // costs seconds each on a bulk clear. Honest and fast beats verified and impossible. If the
+        // transport is ever fixed, *that* is the change that earns an observer here.
         val reflectionResult = runCatching {
             val pm = asInterface("android.content.pm.IPackageManager", "package") ?: return@runCatching false
             val observerClass = Class.forName("android.content.pm.IPackageDataObserver")
@@ -659,12 +693,33 @@ object DhizukuHelper {
                     null
                 )
             }
-            true
+            Logger.w(
+                "DhizukuHelper",
+                "clearCache($packageName): the reflection rung was issued but can confirm nothing, " +
+                    "so it reports failure — the shell rung above is the only one that clears a cache"
+            )
+            false
         }.getOrDefault(false)
 
         return reflectionResult
     }
 
+    /**
+     * Wipes [packageName]'s data **for [thorUserId]** — `pm clear` first, then a hidden-API
+     * `IPackageManager` call.
+     *
+     * **A `true` from this function comes from the shell rung or from nowhere**, the same contract
+     * [clearCache] states and for the same reasons. `pm clear` blocks on its own observer inside
+     * `PackageManagerShellCommand` and exits non-zero when the wipe fails, so it can be believed;
+     * the reflection rung below can not be, and no longer says otherwise. It used to return `true`
+     * whenever the invoke did not throw, which for the single most destructive operation Thor
+     * performs meant the user was told their data was gone on the strength of a binder call that,
+     * on a Dhizuku-only device, never reached PackageManagerService.
+     *
+     * Reporting failure here is the conservative direction: clearing data twice costs nothing, so a
+     * user who retries loses nothing, while a false "done" loses them the chance to try a privilege
+     * mode that would have worked.
+     */
     // PrivateApi: hidden-API reflection is intentional — the core privilege mechanism, guarded by
     // the :bypass VMRuntime unseal.
     @SuppressLint("PrivateApi")
@@ -676,7 +731,19 @@ object DhizukuHelper {
         val result = execute(clearAppDataCommand(packageName.escapeForShell(), thorUserId))
         if (result.first == 0) return true
 
-        // 2. Fallback to reflection
+        // 2. Fallback to reflection — issued, and deliberately never believed. Same argument as
+        // [clearCache]'s rung 2, one step worse in consequence: `clearApplicationUserData` returns
+        // `void`, so the verdict only ever arrives on the `IPackageDataObserver` that is `null`
+        // here, and `asInterface`'s double-wrapped binder means that on a Dhizuku-only device the
+        // call dies in a Shizuku transport before PackageManagerService sees it — the argument
+        // [setAppDisabledDetailed]'s reflection rung records in full. This rung therefore reported
+        // "your data is gone" for a call that could not have deleted anything, unconditionally, on
+        // every release.
+        //
+        // The call stays because on a device that also has Shizuku it may genuinely run; only the
+        // claim is withdrawn. An observer is not wired up in its place for the reason [clearCache]
+        // gives — a guaranteed 15-second timeout per package on the device this rung actually runs
+        // on is a worse answer than an immediate honest one.
         return runCatching {
             val pm = asInterface("android.content.pm.IPackageManager", "package") ?: return@runCatching false
             val observerClass = Class.forName("android.content.pm.IPackageDataObserver")
@@ -689,7 +756,12 @@ object DhizukuHelper {
                 null,
                 thorUserId
             )
-            true
+            Logger.w(
+                "DhizukuHelper",
+                "clearAppData($packageName): the reflection rung was issued but can confirm nothing, " +
+                    "so it reports failure — `pm clear` above is the only rung that can wipe this data"
+            )
+            false
         }.getOrElse { false }
     }
 
@@ -970,15 +1042,51 @@ object DhizukuHelper {
      * The reflection rung below never had the problem: it resolves the op against the package's own
      * uid, which carries the user in its high bits, so it was already per-user. The two rungs now
      * agree on which app op they are setting for whom.
+     *
+     * Both are also read back now, with `IAppOpsService.checkOperation`, and the two rungs treat an
+     * *unreadable* readback differently on purpose — see [readBackgroundMode]. The shell rung's own
+     * report is already honest, so an unreadable readback leaves it standing; the reflection rung's
+     * never was, so an unreadable readback leaves it with nothing to stand on.
      */
     fun setAppRestricted(context: Context, packageName: String, restricted: Boolean): Boolean {
-        // 1. Try shell first
+        // One expression for the mode both rungs write and the readback compares against, so a
+        // future edit cannot set one thing and check for another. `allow` is `MODE_ALLOWED` and not
+        // `MODE_DEFAULT`, and RUN_ANY_IN_BACKGROUND's platform default is `MODE_ALLOWED` too, so a
+        // lifted restriction reads back as `MODE_ALLOWED` whether AppOpsService kept the entry or
+        // dropped it as redundant.
+        val expectedMode = if (restricted) {
+            android.app.AppOpsManager.MODE_IGNORED
+        } else {
+            android.app.AppOpsManager.MODE_ALLOWED
+        }
+
+        // 1. Try shell first. Unlike the other shell rungs in this file this one is not a liar:
+        // `appops set` returns -1 for an unknown package or op, so a 0 is a real statement about a
+        // real op. The readback is added on top of that rather than in place of it, which is why an
+        // unreadable readback must not sink it — turning "I could not check" into a reported failure
+        // here would be a regression, unlike at the clear-data sites where fail-closed is right.
         val result = execute(
             backgroundRestrictionCommand(packageName.escapeForShell(), thorUserId, restricted)
         )
-        if (result.first == 0) return true
+        if (result.first == 0) {
+            val mode = readBackgroundMode(context, packageName)
+            if (mode == null || mode == expectedMode) return true
+            Logger.w(
+                "DhizukuHelper",
+                "setAppRestricted($packageName, restricted=$restricted): `appops set` exited 0 but " +
+                    "RUN_ANY_IN_BACKGROUND reads mode $mode, not $expectedMode — trying reflection"
+            )
+        }
 
-        // 2. Fallback to reflection
+        // 2. Fallback to reflection. The call is kept for the reason [clearCache]'s rung 2 keeps
+        // its own — `asInterface` double-wraps the binder, so on a Dhizuku-only device this dies in
+        // a Shizuku transport, but on a device that also has Shizuku it may genuinely run. What is
+        // refused is this rung's *self-report*: "the invoke did not throw" is not a mode. Unlike
+        // clearCache and clearAppData, an app op can actually be read back, so this rung reports
+        // what `checkOperation` says rather than a flat `false` — a state the platform confirms is
+        // not a lie, and answering `false` over a confirmed change would strand the user retrying an
+        // operation that already worked. An unreadable readback still means `false` here, because
+        // there is nothing else left to believe.
         return runCatching {
             val appops =
                 asInterface("com.android.internal.app.IAppOpsService", Context.APP_OPS_SERVICE)
@@ -994,17 +1102,76 @@ object DhizukuHelper {
                     String::class.java,
                     Int::class.javaPrimitiveType!!
                 ),
-                Bypass.invoke<Int>(
-                    android.app.AppOpsManager::class.java,
-                    null,
-                    "strOpToOp",
-                    "android:run_any_in_background"
-                ),
+                runAnyInBackgroundOp(),
                 uid,
                 packageName,
-                if (restricted) android.app.AppOpsManager.MODE_IGNORED else android.app.AppOpsManager.MODE_ALLOWED
+                expectedMode
             )
-            true
+            readBackgroundMode(context, packageName) == expectedMode
         }.getOrElse { false }
+    }
+
+    /**
+     * `android:run_any_in_background` resolved to its op code.
+     *
+     * Lifted out of the `setMode` call it used to sit inside so that the rung that writes the op and
+     * the readback that checks it cannot end up naming two different ops — which is the one way a
+     * readback can turn from a verifier into a fabricated verdict. `strOpToOp` throws for a name the
+     * platform does not know rather than answering a wrong code, so both callers' `runCatching`
+     * still see a failure instead of a plausible number.
+     */
+    private fun runAnyInBackgroundOp(): Int = Bypass.invoke(
+        android.app.AppOpsManager::class.java,
+        null,
+        "strOpToOp",
+        "android:run_any_in_background"
+    )
+
+    /**
+     * The mode `IAppOpsService` reports for [packageName]'s RUN_ANY_IN_BACKGROUND op right now, or
+     * `null` for "could not read it".
+     *
+     * `null` is deliberately not "some other mode": the two callers in [setAppRestricted] treat them
+     * differently, and collapsing them is exactly how a readback stops being a verifier and becomes
+     * a second failure mode.
+     *
+     * **Expected to answer `null` on a Dhizuku-only device, and that is not a defect.** This rides
+     * the same double-wrapped binder as the reflection rung — `asInterface` puts
+     * `ShizukuBinderWrapper` on top of Dhizuku's own wrapper — so where that rung is dead this is
+     * dead with it, and the shell rung's own honest report is what stands. The readback can only
+     * ever *add* confirmation here; it is not load-bearing, which is what makes failing open at the
+     * shell rung safe rather than optimistic.
+     *
+     * `checkOperation(int, int, String)` is the signature this project has *not* verified across
+     * 28..37 — it has been stable in `IAppOpsService` for as long as anyone has needed it, but that
+     * is a recollection and not a measurement. A drifted signature arrives as a
+     * `NoSuchMethodException`, which lands here as `null` and therefore costs nothing, and that is
+     * the whole reason the uncertainty is tolerable instead of blocking.
+     */
+    // The type argument is spelled out because the block has two exits of different types — an early
+    // `null` and an `Int` — and an unreadable op must arrive as `null`, never as a mode.
+    private fun readBackgroundMode(context: Context, packageName: String): Int? = runCatching<Int?> {
+        val appops = asInterface("com.android.internal.app.IAppOpsService", Context.APP_OPS_SERVICE)
+            ?: return@runCatching null
+        Bypass.invoke<Int>(
+            appops::class.java,
+            appops,
+            "checkOperation",
+            arrayOf(
+                Int::class.javaPrimitiveType!!,
+                Int::class.javaPrimitiveType!!,
+                String::class.java
+            ),
+            runAnyInBackgroundOp(),
+            Packages(context).packageUid(packageName),
+            packageName
+        )
+    }.getOrElse {
+        Logger.d(
+            "DhizukuHelper",
+            "setAppRestricted($packageName): RUN_ANY_IN_BACKGROUND is unreadable, so the rung's own " +
+                "report stands: $it"
+        )
+        null
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Packages.kt
@@ -3,13 +3,9 @@
 
 package com.valhalla.thor.data.source.local.shizuku
 
-import android.app.ActivityManager
-import android.app.AppOpsManager
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import androidx.core.content.getSystemService
-import com.valhalla.bypass.Bypass
 import com.valhalla.thor.data.source.local.thorUserId
 
 class Packages(private val app: Context) {
@@ -99,51 +95,23 @@ class Packages(private val app: Context) {
     // left for the next caller to find — there is no operation for which the answer "this is not a
     // system app" implies "no user needs naming".
 
-    fun forceStopApp(packageName: String): Boolean = runCatching {
-        app.getSystemService<ActivityManager>()?.let {
-            Bypass.invoke<Any?>(
-                it::class.java,
-                it,
-                "forceStopPackage",
-                packageName
-            )
-        }
-        true
-    }.getOrElse {
-        it.printStackTrace()
-        false
-    }
-
-    fun setAppDisabled(packageName: String, disabled: Boolean): Boolean {
-        getApplicationInfoOrNull(packageName) ?: return false
-        if (disabled) forceStopApp(packageName)
-        runCatching {
-            val newState = when {
-                !disabled -> PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-                else -> PackageManager.COMPONENT_ENABLED_STATE_DISABLED
-            }
-            app.packageManager.setApplicationEnabledSetting(packageName, newState, 0)
-        }.onFailure {
-            it.printStackTrace()
-        }
-        return isAppDisabled(packageName) == disabled
-    }
-
-    fun setAppRestricted(packageName: String, restricted: Boolean): Boolean = runCatching {
-        app.getSystemService<AppOpsManager>()?.let {
-            Bypass.invoke<Any?>(
-                it::class.java,
-                it,
-                "setMode",
-                "android:run_any_in_background",
-                packageUid(packageName),
-                packageName,
-                if (restricted) AppOpsManager.MODE_IGNORED else AppOpsManager.MODE_ALLOWED
-            )
-        }
-        true
-    }.getOrElse {
-        it.printStackTrace()
-        false
-    }
+    // `forceStopApp`, `setAppDisabled` and `setAppRestricted` used to sit here, and were deleted as
+    // one edit because they only made sense as one: `setAppDisabled` was `forceStopApp`'s ONLY
+    // caller, and `setAppDisabled` itself had none, so removing either alone leaves a dangling call
+    // or a still-dead pair.
+    //
+    // All three were unprivileged reflection — `ActivityManager.forceStopPackage` and
+    // `AppOpsManager.setMode` invoked via `Bypass` from Thor's own uid, with no privilege behind
+    // them — wrapped in `runCatching { ...; true }`. That reports **true whenever the call merely
+    // did not throw**, which is the failure mode this class exists to avoid: a `SecurityException`
+    // is not the only way a call can do nothing, and a caller reading `true` cannot tell the
+    // difference between "stopped it" and "was refused quietly". `setAppDisabled` was the only one
+    // that read anything back (`isAppDisabled(...) == disabled`), and it still discarded the
+    // force-stop's answer entirely.
+    //
+    // The real implementations are the privileged ones — `Shizuku`/`Dhizuku`/`RootSystemGateway`,
+    // each of which runs the operation through a shell or a Device Owner binder and verifies it.
+    // What survives on `Packages` is deliberately only the *observers* (`isAppDisabled`,
+    // `isAppStopped`, `isAppUninstalled`, `getApplicationInfoOrNull`), which are what those
+    // privileged paths call this class for. Do not re-add an unprivileged mutator here.
 }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -308,22 +308,35 @@ object Shizuku {
     fun forceStopApp(context: Context, packageName: String): Boolean {
         val pkgs = Packages(context)
         val userId = pkgs.myUserId
-        // 1. Try shell first
+        // 1. Try shell first — but exit 0 is not an answer to "is it stopped?", which is why it is
+        // no longer the whole condition. `ActivityManagerShellCommand.runForceStop` calls
+        // `mInterface.forceStopPackage(pkg, userId)` and then ends in an unconditional `return 0`;
+        // its only non-zero exits are an unknown command-line option and an exception thrown out of
+        // AMS. AMS refuses nothing here — a package nothing is running for, or one not installed
+        // for `--user N` at all, produces exactly the same 0 as a real kill. So this rung reported
+        // success for every force-stop Thor has ever issued, and FLAG_STOPPED re-read from
+        // PackageManager — `Packages.isAppStopped`, the post-condition the caller actually means —
+        // sat twice below, unreachable behind that 0. Do not simplify this back to the exit code.
         val result = execute("am force-stop --user $userId $packageName")
-        if (result.first == 0) return true
+        if (result.first == 0 && pkgs.isAppStopped(packageName)) return true
 
-        // 2. Fallback to reflection
-        val reflectionResult = runCatching {
+        // 2. Fallback to reflection, and nothing reads its result any more. It is the same shape of
+        // claim rung 1 just stopped making: `IActivityManager.forceStopPackage` returns void, so all
+        // the old `if (reflectionResult) return true` could report was that the binder call did not
+        // throw — and verifying rung 1 alone would have moved that false success one rung down
+        // rather than removed it. The line is deleted rather than gated because rung 3 already
+        // re-reads FLAG_STOPPED unconditionally: `reflectionResult && pkgs.isAppStopped(...)` can
+        // only return true where the very next line returns true anyway, at the cost of a second
+        // PackageManager round trip. One verifier, reached whichever rung did the work — the same
+        // shape `DhizukuHelper.forceStopApp` carries.
+        runCatching {
             val am = asInterface("android.app.IActivityManager", Context.ACTIVITY_SERVICE)
             Bypass.invoke<Any?>(
                 am::class.java, am, "forceStopPackage", packageName, userId
             )
-            true
-        }.getOrElse {
+        }.onFailure {
             Logger.e("Shizuku", "forceStopApp reflection failed for $packageName", it)
-            false
         }
-        if (reflectionResult) return true
 
         // 3. Unprivileged fallback (re-query PM to observe post-mutation state)
         if (pkgs.isAppStopped(packageName)) return true
@@ -1008,6 +1021,83 @@ object Shizuku {
     }
 
     fun setAppRestricted(context: Context, packageName: String, restricted: Boolean): Boolean {
+        // `ignore`/MODE_IGNORED restricts and `allow`/MODE_ALLOWED lifts, matching the shell rung's
+        // own pair. This is also what the read-back below expects to find afterwards.
+        val expectedMode =
+            if (restricted) android.app.AppOpsManager.MODE_IGNORED
+            else android.app.AppOpsManager.MODE_ALLOWED
+
+        // The op code and the target uid are resolved once, here, instead of inside the reflection
+        // rung where the `strOpToOp` call used to sit: the read-back needs both, and a write and a
+        // read that each resolve their own op are two chances to name different ones. Null means
+        // "could not resolve", which the read-back answers as "could not tell" rather than as a
+        // disagreement.
+        //
+        // The uid is also what makes the read address the same user as the write:
+        // `Packages.packageUid` goes through Thor's own PackageManager, so it carries Thor's user —
+        // the one the shell rung below spells out as `--user thorUserId`.
+        val opCode = runCatching {
+            Bypass.invoke<Int>(
+                android.app.AppOpsManager::class.java,
+                null,
+                "strOpToOp",
+                "android:run_any_in_background"
+            )
+        }.getOrElse { e ->
+            Logger.e("Shizuku", "strOpToOp(android:run_any_in_background) failed", e)
+            null
+        }
+        val uid = runCatching { Packages(context).packageUid(packageName) }.getOrElse { e ->
+            Logger.e("Shizuku", "packageUid failed for $packageName", e)
+            null
+        }
+
+        // The read-back both rungs are judged by. Three answers, and the third is the point: true
+        // (the op is in the requested mode), false (it is not), null (could not tell) — never false
+        // for "could not tell".
+        //
+        // It reads through the privileged binder rather than the in-process AppOpsManager because
+        // Thor holds no UPDATE_APP_OPS_STATS, and `AppOpsService.verifyIncomingUid` throws
+        // SecurityException at any caller asking about a uid other than its own without it. The
+        // Shizuku identity that performed the write is the one allowed to read it back. What comes
+        // back is the mode actually in force, not a record of what was written.
+        fun opReadsBackAsExpected(): Boolean? {
+            if (opCode == null || uid == null) return null
+            return runCatching {
+                val appops =
+                    asInterface("com.android.internal.app.IAppOpsService", Context.APP_OPS_SERVICE)
+                Bypass.invoke<Int>(
+                    appops::class.java,
+                    appops,
+                    "checkOperation",
+                    arrayOf(
+                        Int::class.javaPrimitiveType!!,
+                        Int::class.javaPrimitiveType!!,
+                        String::class.java
+                    ),
+                    opCode,
+                    uid,
+                    packageName
+                ) == expectedMode
+            }.getOrElse { e ->
+                // Fail OPEN, and the asymmetry with the clear-data sites is deliberate rather than
+                // an oversight. `checkOperation(int, int, String)` has been on IAppOpsService for a
+                // long time, but it has NOT been verified on every release in 28..37; a
+                // NoSuchMethodException here means "this device's signature differs", not "the
+                // restriction failed", so both rungs keep their own verdict when this answers null.
+                //
+                // At the clear-data sites fail-CLOSED is the right call, because there "the
+                // reflective invoke did not throw" is the entire evidence a wipe happened — an
+                // unconfirmable result there really is an unconfirmed wipe. Here the rung being
+                // second-guessed is already honest: `appops set` exits non-zero for an unknown
+                // package or op, and `setMode` throws when it is denied. Turning an unreadable
+                // read-back into a hard failure would therefore report failures for restrictions
+                // that were applied — a regression bought with no new information.
+                Logger.e("Shizuku", "checkOperation read-back unavailable for $packageName", e)
+                null
+            }
+        }
+
         // 1. Try shell first. The user this names is not the `pm` story retold: `appops` seeds
         // UserHandle.USER_CURRENT and system_server resolves it with ActivityManager.getCurrentUser(),
         // so the bare line landed on whoever was in the *foreground* at the moment it ran — the
@@ -1020,13 +1110,19 @@ object Shizuku {
         val result = execute(
             backgroundRestrictionCommand(packageName.escapeForShell(), thorUserId, restricted)
         )
-        if (result.first == 0) return true
+        // `!= false`, not `== true`: null is "could not read the op back" and leaves this rung's
+        // own exit code standing, which is the fail-open rule the read-back documents. Only a
+        // definite disagreement — the op is not in the mode just requested — falls through to
+        // rung 2 rather than reporting a success nobody confirmed.
+        if (result.first == 0 && opReadsBackAsExpected() != false) return true
 
-        // 2. Fallback to reflection
-        return runCatching {
+        // 2. Fallback to reflection. Without an op code or a uid there is nothing to call setMode
+        // with, which is the same `false` the surrounding runCatching used to produce when
+        // `strOpToOp` or `packageUid` threw inside it.
+        if (opCode == null || uid == null) return false
+        val reflectionRan = runCatching {
             val appops =
                 asInterface("com.android.internal.app.IAppOpsService", Context.APP_OPS_SERVICE)
-            val uid = Packages(context).packageUid(packageName)
             Bypass.invoke<Any?>(
                 appops::class.java,
                 appops,
@@ -1037,18 +1133,21 @@ object Shizuku {
                     String::class.java,
                     Int::class.javaPrimitiveType!!
                 ),
-                Bypass.invoke<Int>(
-                    android.app.AppOpsManager::class.java,
-                    null,
-                    "strOpToOp",
-                    "android:run_any_in_background"
-                ),
+                opCode,
                 uid,
                 packageName,
-                if (restricted) android.app.AppOpsManager.MODE_IGNORED else android.app.AppOpsManager.MODE_ALLOWED
+                expectedMode
             )
             true
-        }.getOrElse { false }
+        }.getOrElse { e ->
+            // Logged rather than swallowed: when this rung is the one that has to work, its
+            // SecurityException is the line a bug report needs.
+            Logger.e("Shizuku", "setMode(RUN_ANY_IN_BACKGROUND) failed for $packageName", e)
+            false
+        }
+        // `setMode` returns void, so `reflectionRan` only ever meant "the binder call did not
+        // throw". Same fail-open `!= false` as rung 1.
+        return reflectionRan && opReadsBackAsExpected() != false
     }
 
     // The user id every `--user` below names is [thorUserId], read in process.

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -1056,11 +1056,39 @@ object Shizuku {
         // (the op is in the requested mode), false (it is not), null (could not tell) — never false
         // for "could not tell".
         //
-        // It reads through the privileged binder rather than the in-process AppOpsManager because
-        // Thor holds no UPDATE_APP_OPS_STATS, and `AppOpsService.verifyIncomingUid` throws
-        // SecurityException at any caller asking about a uid other than its own without it. The
-        // Shizuku identity that performed the write is the one allowed to read it back. What comes
-        // back is the mode actually in force, not a record of what was written.
+        // It reads through the privileged binder rather than the in-process AppOpsManager, and the
+        // usual justification for that covers only the bottom of Thor's range.
+        // `AppOpsService.checkOperation` does call `verifyIncomingUid` — which throws
+        // SecurityException at a caller asking about a uid other than its own without
+        // UPDATE_APP_OPS_STATS — but only on API 28, where `checkOperation` calls it directly,
+        // and 29, where `checkOperationImpl` does. API 30 dropped it, and current AOSP states the
+        // split outright: `validateOpRequest(..., shouldVerifyUid, ...)` is passed `false` by
+        // `checkOperation` and `true` by `noteOperation`/`startOperation`. On 30..37 — nearly all
+        // of Thor's range — an in-process read is not refused by that check.
+        //
+        // Routing it here is still right, for reasons that do cover the range. From API 31
+        // `checkOperationImpl` also calls `verifyIncomingPackage`, which refuses a package the
+        // caller cannot see, and a Thor reading across a user boundary is exactly that caller. And
+        // `checkOperationUnchecked` turns its own `verifyAndGetBypass` SecurityException into
+        // `opToDefaultMode(code)`, so a read that goes wrong in process answers a plausible mode
+        // rather than throwing — worse than answering null. Reading with the identity that
+        // performed the write is also what makes this a check of that write and not of some other
+        // caller's view of it.
+        //
+        // What comes back is the mode actually in force, not a record of what was written — with
+        // one blind spot worth naming. `checkOperationUnchecked` consults the *uid*-level mode
+        // before it ever reaches the package entry (`mAppOpsCheckingService.getUidMode(...)` on
+        // recent releases, the `uidState.opModes` lookup on 30..33) and returns it whenever it
+        // differs from the op's default. Both of Thor's writes are package-level — `appops set
+        // <pkg> android:run_any_in_background ...` and `setMode(code, uid, pkg, mode)` — so any
+        // uid-level mode on RUN_ANY_IN_BACKGROUND makes this read report a value unrelated to
+        // whether Thor's write landed. `checkOperationRaw` would not help: `raw` only drops the
+        // foreground evaluation, and the uid branch returns the uid mode either way. The masking is
+        // read straight out of AppOpsService; what is missing is a writer. Settings' battery
+        // "Restricted" setting uses the package-level
+        // `setMode(OP_RUN_ANY_IN_BACKGROUND, uid, packageName, mode)`, and the only uid-level
+        // writer identified is `appops set --uid`, which Thor never issues. Recorded as a known
+        // blind spot, not as an observed bug.
         fun opReadsBackAsExpected(): Boolean? {
             if (opCode == null || uid == null) return null
             return runCatching {
@@ -1080,19 +1108,39 @@ object Shizuku {
                     packageName
                 ) == expectedMode
             }.getOrElse { e ->
-                // Fail OPEN, and the asymmetry with the clear-data sites is deliberate rather than
-                // an oversight. `checkOperation(int, int, String)` has been on IAppOpsService for a
-                // long time, but it has NOT been verified on every release in 28..37; a
-                // NoSuchMethodException here means "this device's signature differs", not "the
-                // restriction failed", so both rungs keep their own verdict when this answers null.
+                // `null` and not `false`: `checkOperation(int, int, String)` has been on
+                // IAppOpsService for a long time, but it has NOT been verified on every release in
+                // 28..37, and a NoSuchMethodException here means "this device's signature differs",
+                // not "the restriction failed".
                 //
-                // At the clear-data sites fail-CLOSED is the right call, because there "the
-                // reflective invoke did not throw" is the entire evidence a wipe happened — an
-                // unconfirmable result there really is an unconfirmed wipe. Here the rung being
-                // second-guessed is already honest: `appops set` exits non-zero for an unknown
-                // package or op, and `setMode` throws when it is denied. Turning an unreadable
-                // read-back into a hard failure would therefore report failures for restrictions
-                // that were applied — a regression bought with no new information.
+                // What each rung does with that null is one rule, stated here once:
+                //
+                //   A rung may fail OPEN on an unreadable read-back only if it has a self-report
+                //   that is evidence independent of the read-back. With no such evidence it fails
+                //   CLOSED.
+                //
+                // Rung 1 has that evidence and so fails open: `appops set` exits non-zero for an
+                // unknown package or op, so its 0 is the platform's own statement about a real op,
+                // and demoting it because a second opinion was unavailable would report failures
+                // for restrictions that were applied.
+                //
+                // Rung 2 has none and so fails closed. `IAppOpsService.setMode` returns void, so
+                // the only thing the reflective call can report is that it did not throw — which
+                // is not a mode, and is not even reliably "not denied". Read across 28..37, the
+                // one refusal that reaches the caller is `enforceManageAppOpsModes` (no
+                // MANAGE_APP_OPS_MODES), which sits ahead of the try on every release. The
+                // "this package is not under that uid" refusal never does: before API 30
+                // `getOpsRawLocked` met a mismatch with `Slog.w("Bad call: specified package … but
+                // it is really …")` and a null, so `setMode` changed nothing and returned
+                // normally; from API 30 the check does throw, but from inside `verifyAndGetBypass`,
+                // where `setMode` catches it (`Slog.e(TAG, "Cannot setMode", e); return;`, and the
+                // same through `logVerifyAndGetBypassFailure` on API 35+). Current AOSP adds a
+                // second silent return ahead of that one for `!isIncomingPackageValid(...)`. So
+                // "setMode throws when it is denied" — the claim this comment used to rest on — is
+                // true nowhere in Thor's range.
+                //
+                // The clear-data sites fail closed under the same rule and for the same reason:
+                // "the reflective invoke did not throw" is their entire evidence too.
                 Logger.e("Shizuku", "checkOperation read-back unavailable for $packageName", e)
                 null
             }
@@ -1110,10 +1158,11 @@ object Shizuku {
         val result = execute(
             backgroundRestrictionCommand(packageName.escapeForShell(), thorUserId, restricted)
         )
-        // `!= false`, not `== true`: null is "could not read the op back" and leaves this rung's
-        // own exit code standing, which is the fail-open rule the read-back documents. Only a
-        // definite disagreement — the op is not in the mode just requested — falls through to
-        // rung 2 rather than reporting a success nobody confirmed.
+        // `!= false`, not `== true`: this is the open side of the rule stated at the read-back, and
+        // the independent evidence it rests on is this rung's own exit code. Null is "could not
+        // read the op back" and leaves that exit code standing. Only a definite disagreement —
+        // the op is not in the mode just requested — falls through to rung 2 rather than reporting
+        // a success nobody confirmed.
         if (result.first == 0 && opReadsBackAsExpected() != false) return true
 
         // 2. Fallback to reflection. Without an op code or a uid there is nothing to call setMode
@@ -1145,9 +1194,26 @@ object Shizuku {
             Logger.e("Shizuku", "setMode(RUN_ANY_IN_BACKGROUND) failed for $packageName", e)
             false
         }
-        // `setMode` returns void, so `reflectionRan` only ever meant "the binder call did not
-        // throw". Same fail-open `!= false` as rung 1.
-        return reflectionRan && opReadsBackAsExpected() != false
+        // The closed side of the rule: this rung's verdict is the read-back and nothing else, so an
+        // unreadable read-back is `false` here where it is survivable at rung 1. `!= false` in this
+        // position was the bug — on API 33 a `setMode` AppOpsService refuses is swallowed there
+        // rather than thrown (`reflectionRan` is still true) and an unreadable `checkOperation`
+        // answers null, so `true && (null != false)` reported a success with nothing restricted.
+        //
+        // `reflectionRan` stays in the expression as a guard, not as evidence: for
+        // `restricted = false` the expected mode is MODE_ALLOWED, which is also
+        // RUN_ANY_IN_BACKGROUND's platform default, so an op nobody ever wrote reads back as
+        // expected. Without the conjunct a `setMode` that threw would be reported as a success by
+        // the default mode alone.
+        //
+        // DhizukuHelper.setAppRestricted's rung 2 lands on the same fail-closed answer by a
+        // different route, and both reasons are load-bearing. There the binder is double-wrapped
+        // — Dhizuku's own wrapper from `DhizukuAPI.binderWrapper`, with `ShizukuBinderWrapper` put
+        // on top of it — so that rung is transport-dead on a Dhizuku-only device and has nothing to
+        // report either way. Here the binder is wrapped once and the call is live; this rung fails
+        // closed because a void return is not evidence, not because it cannot run. A later edit
+        // that "unifies" the two by keeping one reason would leave the wrong one behind.
+        return reflectionRan && opReadsBackAsExpected() == true
     }
 
     // The user id every `--user` below names is [thorUserId], read in process.

--- a/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
@@ -22,7 +22,8 @@ interface SystemRepository {
     suspend fun rebootDevice(reason: String): Result<Unit>
 
     // Composite Actions
-    suspend fun aggressiveCleanup(packageName: String): Result<Unit>
+    // `aggressiveCleanup(packageName)` was declared here and is deliberately gone; see the note at
+    // its old implementation site in `SystemRepositoryImpl`. Do not re-add it without a caller.
     suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit>
     suspend fun copyFileWithRoot(sourcePath: String, destinationPath: String): Result<Unit>
     suspend fun getAppPaths(packageName: String): Result<List<String>>

--- a/app/src/test/java/com/valhalla/thor/data/freezer/BulkFreezeWorkerTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/freezer/BulkFreezeWorkerTest.kt
@@ -161,9 +161,6 @@ private class RecordingSystemRepository(
 
     override suspend fun rebootDevice(reason: String): Result<Unit> = unreachable("rebootDevice")
 
-    override suspend fun aggressiveCleanup(packageName: String): Result<Unit> =
-        unreachable("aggressiveCleanup")
-
     override suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit> =
         unreachable("reinstallAppWithGoogle")
 

--- a/app/src/test/java/com/valhalla/thor/data/source/local/shizuku/PackagesSurfaceTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/shizuku/PackagesSurfaceTest.kt
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local.shizuku
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Method
+
+/**
+ * A lock on what [Packages] is allowed to be: observers only, never an unprivileged mutator.
+ *
+ * `forceStopApp`, `setAppDisabled` and `setAppRestricted` were deleted from this class as one edit,
+ * and they had to be one edit rather than three. `setAppDisabled` was the **only** caller of
+ * `forceStopApp`, and `setAppDisabled` itself had **no** callers anywhere in the repo — so removing
+ * `forceStopApp` alone leaves a dangling call that does not compile, and removing `setAppDisabled`
+ * alone leaves `forceStopApp` dead with nothing pointing at it. Three functions, one deletion.
+ *
+ * *Why* they went matters more than the ordering, and is what this test is really defending. All
+ * three were `Bypass` reflection performed from Thor's own uid with no privilege behind it, wrapped
+ * in `runCatching { ...; true }` — so they answered **true whenever the call merely did not throw**.
+ * A refusal that returns quietly and a stop that actually happened produce the identical `true`, and
+ * a caller has no way to tell them apart. That is precisely the class of lie the privileged gateways
+ * (`Shizuku`, `Dhizuku`, `RootSystemGateway`) exist to avoid by re-reading state after acting, and
+ * it is exactly what a well-meaning future edit would re-introduce here by reaching for the
+ * "obvious" missing setter next to `isAppDisabled`.
+ *
+ * The tombstone comment left in `Packages.kt` says the same thing in prose. This test is the part
+ * that fails a build.
+ */
+class PackagesSurfaceTest {
+
+    /**
+     * The three deleted names, and the reason each one cannot come back on its own.
+     *
+     * Matched on the de-mangled name so that a member re-added with a different visibility — Kotlin
+     * mangles an `internal` member's JVM name with a module suffix, e.g.
+     * `setAppRestricted$app_fossDebug` — cannot slip past a plain string comparison.
+     */
+    @Test
+    fun `the unprivileged mutators are gone`() {
+        val names = declaredNames()
+
+        for (deleted in setOf("forceStopApp", "setAppDisabled", "setAppRestricted")) {
+            assertTrue(
+                "Packages.$deleted is back. It was deleted because unprivileged Bypass reflection " +
+                    "reports success whenever the call did not throw, which is indistinguishable " +
+                    "from a silent refusal — and because these three only ever called each other. " +
+                    "If a caller now needs this operation, it belongs on a privileged gateway that " +
+                    "verifies it by reading the state back, not here. Declared members: $names",
+                deleted !in names
+            )
+        }
+    }
+
+    /**
+     * The anti-vacuity floor under the assertion above, and the only reason to trust it.
+     *
+     * "Assert some names are absent" is the one shape of test that passes perfectly when it is
+     * looking at nothing at all: rename or relocate the class, have `declaredMethods` come back
+     * empty for any reason, and every `deleted !in names` check above is trivially satisfied with a
+     * green tick. Naming members that are known to still exist proves the reflection resolved a real
+     * class with real methods on it.
+     *
+     * `containsAll`, never an equality — adding an observer to [Packages] must not have to be
+     * remembered here. The four named are the ones the privileged paths actually call this class
+     * for: `Shizuku`/`Dhizuku` read `getApplicationInfoOrNull` and `isAppStopped` to judge their own
+     * rungs, `ShizukuReflector` reads `isAppUninstalled`, and `isAppDisabled` is the canonical freeze
+     * predicate shared with `AppFreezeStateReader`.
+     */
+    @Test
+    fun `the reflection actually sees the class`() {
+        val names = declaredNames()
+
+        assertTrue(
+            "the sweep found $names, which is missing observers that are known to exist — it is " +
+                "looking at the wrong class, or declaredMethods returned nothing and the absence " +
+                "assertions above are passing vacuously",
+            names.containsAll(
+                setOf(
+                    "getApplicationInfoOrNull",
+                    "isAppDisabled",
+                    "isAppStopped",
+                    "isAppUninstalled",
+                )
+            )
+        )
+    }
+
+    /**
+     * Every method declared on [Packages], by Kotlin name.
+     *
+     * A class literal rather than a `Class.forName` string, so a rename is a compile error here
+     * instead of a silently empty result set. Synthetic and bridge members are dropped because
+     * Kotlin emits a `$default` bridge for every function with a default argument — both
+     * `getInstalledApplications` and `getApplicationInfoOrNull` have one — and those are a compiler
+     * detail, not this class's surface.
+     */
+    private fun declaredNames(): Set<String> =
+        Packages::class.java.declaredMethods
+            .filterNot { it.isSynthetic || it.isBridge || it.name.contains("\$default") }
+            .map { it.readableName() }
+            .toSet()
+
+    /**
+     * The Kotlin name, with both JVM manglings taken back off: the `$module` suffix `internal` adds
+     * and the `-<hash>` suffix an inline-value-class return type adds. Neither character is legal in
+     * a source-level Kotlin identifier without backticks, so cutting at the first of either cannot
+     * truncate a real method name.
+     *
+     * The second strip is not needed by anything on [Packages] today — every member here returns a
+     * plain type — and is here because the absence assertions above would go silently vacuous the
+     * day one of the three comes back returning `Result`. That is not hypothetical: the sibling
+     * `SystemRepositorySurfaceTest` was written without it and its own anti-vacuity guard caught it
+     * on the first run, where every method is `Result`-returning and de-mangled to nothing that
+     * matched.
+     */
+    private fun Method.readableName(): String = name.substringBefore('$').substringBefore('-')
+}

--- a/app/src/test/java/com/valhalla/thor/data/source/local/shizuku/PackagesSurfaceTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/shizuku/PackagesSurfaceTest.kt
@@ -5,6 +5,7 @@ package com.valhalla.thor.data.source.local.shizuku
 
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 import java.lang.reflect.Method
 
 /**
@@ -27,27 +28,43 @@ import java.lang.reflect.Method
  *
  * The tombstone comment left in `Packages.kt` says the same thing in prose. This test is the part
  * that fails a build.
+ *
+ * It does that from two directions, because neither one is enough alone. Reflection is exact about
+ * what [Packages] declares and inherits, and completely blind to a name that compiles into some
+ * *other* class — which is what an extension function, a companion member and a `@JvmName` rename
+ * all do, while leaving the call site reading `packages.forceStopApp(pkg)` unchanged. So the second
+ * direction reads the source text, where those three are visible and only there. Each direction
+ * carries its own anti-vacuity guard, because "assert this name is absent" is the one test shape
+ * that passes best when it is looking at nothing at all.
  */
 class PackagesSurfaceTest {
 
     /**
-     * The three deleted names, and the reason each one cannot come back on its own.
+     * The three names, hoisted because two tests check for them and a list that can drift between
+     * them is worse than no list at all.
+     */
+    private val deletedNames = setOf("forceStopApp", "setAppDisabled", "setAppRestricted")
+
+    /**
+     * The reflection lock: none of the three is on the class's runtime surface.
      *
      * Matched on the de-mangled name so that a member re-added with a different visibility — Kotlin
      * mangles an `internal` member's JVM name with a module suffix, e.g.
-     * `setAppRestricted$app_fossDebug` — cannot slip past a plain string comparison.
+     * `setAppRestricted$app_fossDebug` — cannot slip past a plain string comparison. See
+     * [readableName] for the second mangling, which nothing on this class exercises today and which
+     * must survive anyway.
      */
     @Test
     fun `the unprivileged mutators are gone`() {
-        val names = declaredNames()
+        val names = surfaceNames()
 
-        for (deleted in setOf("forceStopApp", "setAppDisabled", "setAppRestricted")) {
+        for (deleted in deletedNames) {
             assertTrue(
                 "Packages.$deleted is back. It was deleted because unprivileged Bypass reflection " +
                     "reports success whenever the call did not throw, which is indistinguishable " +
                     "from a silent refusal — and because these three only ever called each other. " +
                     "If a caller now needs this operation, it belongs on a privileged gateway that " +
-                    "verifies it by reading the state back, not here. Declared members: $names",
+                    "verifies it by reading the state back, not here. Visible members: $names",
                 deleted !in names
             )
         }
@@ -57,24 +74,32 @@ class PackagesSurfaceTest {
      * The anti-vacuity floor under the assertion above, and the only reason to trust it.
      *
      * "Assert some names are absent" is the one shape of test that passes perfectly when it is
-     * looking at nothing at all: rename or relocate the class, have `declaredMethods` come back
-     * empty for any reason, and every `deleted !in names` check above is trivially satisfied with a
-     * green tick. Naming members that are known to still exist proves the reflection resolved a real
-     * class with real methods on it.
+     * looking at nothing at all: rename or relocate the class, have the reflection come back empty
+     * for any reason, and every `deleted !in names` check above is trivially satisfied with a green
+     * tick. Naming members that are known to still exist proves the reflection resolved a real class
+     * with real methods on it.
      *
      * `containsAll`, never an equality — adding an observer to [Packages] must not have to be
      * remembered here. The four named are the ones the privileged paths actually call this class
      * for: `Shizuku`/`Dhizuku` read `getApplicationInfoOrNull` and `isAppStopped` to judge their own
      * rungs, `ShizukuReflector` reads `isAppUninstalled`, and `isAppDisabled` is the canonical freeze
      * predicate shared with `AppFreezeStateReader`.
+     *
+     * Where this guard is weaker than its sibling in `SystemRepositorySurfaceTest`, stated plainly
+     * so nobody reads more into a green tick than it earned: all four names return plain types, so
+     * none of them travels through the `-<hash>` strip in [readableName], and this test would still
+     * pass with that strip deleted. There is no member of [Packages] to pin it to — `javap` on the
+     * compiled class shows every method here emitted unmangled. The strip's justification therefore
+     * lives in prose on [readableName] rather than in an assertion, and that is a known limit of
+     * this file, not an oversight.
      */
     @Test
     fun `the reflection actually sees the class`() {
-        val names = declaredNames()
+        val names = surfaceNames()
 
         assertTrue(
             "the sweep found $names, which is missing observers that are known to exist — it is " +
-                "looking at the wrong class, or declaredMethods returned nothing and the absence " +
+                "looking at the wrong class, or the reflection returned nothing and the absence " +
                 "assertions above are passing vacuously",
             names.containsAll(
                 setOf(
@@ -88,19 +113,184 @@ class PackagesSurfaceTest {
     }
 
     /**
-     * Every method declared on [Packages], by Kotlin name.
+     * The source-text lock, covering the three re-adds reflection structurally cannot see.
+     *
+     * `fun Packages.forceStopApp(pkg: String)` compiles to `PackagesKt.forceStopApp`, a different
+     * class entirely, so [surfaceNames] never sees it — while every call site still reads
+     * `packages.forceStopApp(pkg)`, exactly as before the deletion. That is not an exotic dodge; it
+     * is how a helper "next to `isAppStopped`" gets written once the class itself looks closed. Two
+     * more land in the same blind spot: a companion member without `@JvmStatic`, which lands on
+     * `Packages$Companion`, and `@JvmName("stopApp")` on an otherwise straight re-add, where
+     * reflection sees `stopApp` and Kotlin callers still write `forceStopApp`.
+     *
+     * Two patterns, both matched on declaration shape rather than the bare name — the tombstone
+     * comment in `Packages.kt` names all three functions in prose and must not trip this:
+     *  - inside `Packages.kt`, any `fun … <name>(`, which covers a member, a companion member, a
+     *    top-level function in that file, and a `@JvmName`d one, because the Kotlin name survives in
+     *    the source whatever the JVM name becomes;
+     *  - anywhere in the production source sets, any `fun … Packages.<name>(`, which covers an
+     *    extension on the class or on its companion, in any file and any package.
+     *
+     * Comments are deliberately not excluded. A commented-out `fun forceStopApp(` sitting in
+     * `Packages.kt` is a re-add waiting for someone to delete two slashes, and the tombstone there
+     * describes the deletion in prose without quoting a signature — it should stay that way.
+     *
+     * The guards run first and are the whole reason to believe the assertions after them. A sweep
+     * over an empty file list satisfies every absence check it is given, which is the same failure
+     * the reflection guard exists to catch, one layer down: a working directory that is not what
+     * this test assumed, a moved module, a `listFiles()` that came back null. So the corpus must be
+     * more than a handful of files, must contain `Packages.kt` itself, must yield a hit for a
+     * declaration known to be in that file, and the extension pattern must be shown to match the
+     * shape it was written for and to have real extension declarations in the corpus to find.
+     *
+     * The boundary, stated rather than implied. This is a regex over text, not a parse. A name
+     * re-added as a function-typed property (`val forceStopApp: (String) -> Boolean`), reached
+     * through a `typealias` for [Packages], or produced by a compiler plugin, goes straight through
+     * both locks. Those were judged not worth a parser: none of them is how this mistake actually
+     * gets made, and each would be a deliberate act rather than an autocomplete.
+     */
+    @Test
+    fun `no source declaration brings the names back`() {
+        val sources = productionKotlinSources()
+
+        assertTrue(
+            "the sweep read only ${sources.size} Kotlin files, which cannot be Thor's production " +
+                "source tree — the working directory is not what this test assumed, or app/src " +
+                "moved. Every absence check below would pass on a corpus this small",
+            sources.size >= 20
+        )
+
+        val packagesSource = sources.entries
+            .firstOrNull { it.key.invariantSeparatorsPath.endsWith(PACKAGES_KT) }
+            ?.value
+            .orEmpty()
+        assertTrue(
+            "the sweep never read $PACKAGES_KT, so the in-file assertions below are looking at an " +
+                "empty string and pass no matter what that file says",
+            packagesSource.isNotEmpty()
+        )
+        assertTrue(
+            "the declaration pattern cannot find `fun isAppDisabled(` in $PACKAGES_KT, which is " +
+                "certainly there — the pattern no longer matches how this codebase declares a " +
+                "function, so its failure to find the deleted three proves nothing",
+            declarationOf("isAppDisabled").containsMatchIn(packagesSource)
+        )
+        assertTrue(
+            "the extension pattern does not match the declaration it was written for — it can " +
+                "never fire, and the tree-wide assertion below is decoration",
+            deletedNames.all {
+                extensionOnPackages(it).containsMatchIn("fun Packages.$it(pkg: String) = true")
+            }
+        )
+        assertTrue(
+            "no file in the corpus declares an extension function at all, which is not true of " +
+                "this codebase — the corpus is not the source tree, or extensions are no longer " +
+                "written as `fun Receiver.name(` and the tree-wide pattern is looking for a shape " +
+                "that stopped existing",
+            sources.values.any { ANY_EXTENSION.containsMatchIn(it) }
+        )
+
+        for (deleted in deletedNames) {
+            assertTrue(
+                "$PACKAGES_KT declares `fun $deleted(` again. Whether it is a member, a companion " +
+                    "member or renamed on the JVM with @JvmName, Kotlin callers reach it as " +
+                    "Packages.$deleted and it is the unprivileged mutator this class deleted. It " +
+                    "belongs on a privileged gateway that verifies the operation, not here",
+                !declarationOf(deleted).containsMatchIn(packagesSource)
+            )
+
+            val offenders = sources.filterValues { extensionOnPackages(deleted).containsMatchIn(it) }
+                .keys
+                .map { it.invariantSeparatorsPath }
+            assertTrue(
+                "an extension function puts Packages.$deleted back: $offenders. It compiles into a " +
+                    "different class, so the reflection lock in this file cannot see it, but every " +
+                    "call site reads packages.$deleted(...) exactly as it did before the deletion. " +
+                    "An unprivileged mutator is no less unprivileged for being an extension",
+                offenders.isEmpty()
+            )
+        }
+    }
+
+    /**
+     * Every method [Packages] exposes, by Kotlin name: what it declares itself at any visibility,
+     * plus what it inherits.
+     *
+     * `declaredMethods` alone sees only methods declared on this exact class. Moving a name onto a
+     * superclass takes it out of that view entirely while `packages.forceStopApp(pkg)` keeps
+     * compiling at every call site, so `methods` is unioned in to close that. Additive rather than a
+     * replacement, because the two see different things: `methods` is public-only, `declaredMethods`
+     * is visibility-blind, and a `private` or `protected` re-add appears in exactly one of them.
+     *
+     * `java.lang.Object`'s own methods arrive with `methods` on a class and are dropped — they are
+     * not this class's surface and would bury the real names in the failure message. Verified rather
+     * than assumed: on a plain class `getMethods()` returns `equals`, `hashCode`, `toString`,
+     * `getClass`, `notify`, `notifyAll` and three `wait` overloads, all with `declaringClass ==
+     * Object`, and filtering on that leaves exactly the class's own public members.
      *
      * A class literal rather than a `Class.forName` string, so a rename is a compile error here
      * instead of a silently empty result set. Synthetic and bridge members are dropped because
-     * Kotlin emits a `$default` bridge for every function with a default argument — both
-     * `getInstalledApplications` and `getApplicationInfoOrNull` have one — and those are a compiler
-     * detail, not this class's surface.
+     * Kotlin emits a `$default` bridge for every function with a default argument —
+     * `getInstalledApplications`, `getUnhiddenPackageInfoOrNull` and `getApplicationInfoOrNull` each
+     * have one — and those are a compiler detail, not this class's surface.
      */
-    private fun declaredNames(): Set<String> =
-        Packages::class.java.declaredMethods
+    private fun surfaceNames(): Set<String> {
+        val type = Packages::class.java
+        return (type.declaredMethods.asSequence() + type.methods.asSequence())
+            .filterNot { it.declaringClass == Any::class.java }
             .filterNot { it.isSynthetic || it.isBridge || it.name.contains("\$default") }
             .map { it.readableName() }
             .toSet()
+    }
+
+    /**
+     * Every Kotlin file in the production source sets, as text, keyed by file.
+     *
+     * `app/src` minus `test` and `androidTest`, rather than a hardcoded `main` plus flavour list: a
+     * new flavour directory gets swept the day it appears, and — the part that matters — this file
+     * is excluded, which it has to be. Its own KDoc spells out `fun Packages.forceStopApp(...)` as
+     * the example of the thing it is hunting for, and only a production declaration is a defeat
+     * anyway. Widening this to the test source sets would make the sweep fail on its own prose.
+     *
+     * The root is found by walking up from the working directory, because a unit test's working
+     * directory is the Gradle module in one runner and the repository root in another, and neither
+     * is a thing this test should be encoding. `error()` rather than an empty map when the walk
+     * finds nothing: a sweep that cannot locate its own sources has to fail loudly, not quietly
+     * agree that there are no offenders.
+     */
+    private fun productionKotlinSources(): Map<File, String> {
+        var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        while (dir != null) {
+            val src = File(dir, "app/src")
+            if (src.isDirectory) {
+                return src.listFiles().orEmpty()
+                    .filter { it.isDirectory && it.name != "test" && it.name != "androidTest" }
+                    .flatMap { root ->
+                        root.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+                    }
+                    .associateWith { it.readText() }
+            }
+            dir = dir.parentFile
+        }
+        error(
+            "could not locate app/src by walking up from ${System.getProperty("user.dir")}. The " +
+                "source sweep has nothing to read and must not report a clean result"
+        )
+    }
+
+    /**
+     * `fun … <name>(` on a single line: any modifiers, any annotations, any receiver, and no
+     * intervening `(` — which is what keeps `fun other(x) = name(y)` from matching, since the
+     * character class cannot cross the first parenthesis.
+     */
+    private fun declarationOf(name: String) = Regex("""\bfun\b[^(\n]*\b$name\s*\(""")
+
+    /**
+     * `fun … Packages.<name>(` — an extension on the class, and via the second wildcard on
+     * `Packages.Companion` too.
+     */
+    private fun extensionOnPackages(name: String) =
+        Regex("""\bfun\b[^(\n]*\bPackages\s*\.[^(\n]*\b$name\s*\(""")
 
     /**
      * The Kotlin name, with both JVM manglings taken back off: the `$module` suffix `internal` adds
@@ -108,12 +298,33 @@ class PackagesSurfaceTest {
      * a source-level Kotlin identifier without backticks, so cutting at the first of either cannot
      * truncate a real method name.
      *
-     * The second strip is not needed by anything on [Packages] today — every member here returns a
-     * plain type — and is here because the absence assertions above would go silently vacuous the
-     * day one of the three comes back returning `Result`. That is not hypothetical: the sibling
-     * `SystemRepositorySurfaceTest` was written without it and its own anti-vacuity guard caught it
-     * on the first run, where every method is `Result`-returning and de-mangled to nothing that
-     * matched.
+     * **Do not delete the second strip on the grounds that nothing on [Packages] needs it.** Nothing
+     * here does — `javap` on the compiled class shows every member emitted unmangled, because they
+     * all return plain types — which means the guard above cannot pin itself to a mangled member and
+     * this file stays green with the strip removed. That is the reason it has to stay, not a reason
+     * to drop it. The strip is not protecting today's surface; it is protecting the absence
+     * assertions against tomorrow's. The day someone re-adds `forceStopApp` returning
+     * `Result<Boolean>` — the obvious shape for a mutator, and the shape the rest of Thor already
+     * uses — it is emitted as `forceStopApp-gIAlu-s`, `"forceStopApp" !in names` is trivially true,
+     * and this test reports a clean surface while the thing it exists to stop ships.
+     *
+     * That is evidence, not theory. The sibling `SystemRepositorySurfaceTest` was written without
+     * this strip; every method on that interface is `Result`-returning, so every name de-mangled to
+     * nothing that matched, and its own anti-vacuity guard caught it on the first run. Its guard can
+     * pin itself to a mangled member and permanently prove the strip works. This one cannot, so this
+     * paragraph is what stands in for the assertion that file gets to make.
      */
     private fun Method.readableName(): String = name.substringBefore('$').substringBefore('-')
+
+    private companion object {
+        /** Path suffix of the anchor file, matched with `/` so it also holds on Windows. */
+        const val PACKAGES_KT = "com/valhalla/thor/data/source/local/shizuku/Packages.kt"
+
+        /**
+         * Any extension declaration at all, used only as a control: it proves the corpus really is
+         * Kotlin source in which extensions are still written as `fun Receiver.name(`, which is the
+         * shape [extensionOnPackages] pins itself to.
+         */
+        val ANY_EXTENSION = Regex("""\bfun\b[^(\n]*\b\w+\s*\.\s*\w+\s*\(""")
+    }
 }

--- a/app/src/test/java/com/valhalla/thor/domain/repository/SystemRepositorySurfaceTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/repository/SystemRepositorySurfaceTest.kt
@@ -5,6 +5,7 @@ package com.valhalla.thor.domain.repository
 
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 import java.lang.reflect.Method
 
 /**
@@ -26,6 +27,12 @@ import java.lang.reflect.Method
  * The two operations remain available individually — `forceStopApp` and `clearCache` — each
  * returning its own real `Result`, which is what a caller that genuinely wants both should use so it
  * can see which half failed.
+ *
+ * Two locks, because neither is enough alone. Reflection is exact about what the interface declares
+ * and inherits and blind to a name that compiles into some other class — which is what an extension
+ * function does, while `systemRepository.aggressiveCleanup(pkg)` keeps reading the same at every
+ * call site. The source sweep covers that. Each lock carries its own anti-vacuity guard, because
+ * "assert this name is absent" is the one test shape that passes best when it is looking at nothing.
  */
 class SystemRepositorySurfaceTest {
 
@@ -43,14 +50,14 @@ class SystemRepositorySurfaceTest {
      */
     @Test
     fun `aggressiveCleanup is gone`() {
-        val names = declaredNames()
+        val names = surfaceNames()
 
         assertTrue(
             "SystemRepository.aggressiveCleanup is back. It was deleted because it discarded the " +
                 "Results of both operations it composed and then reported unconditional success, " +
                 "and because nothing called it. If a caller now needs force-stop plus clear-cache, " +
                 "it should call forceStopApp and clearCache and decide for itself what a partial " +
-                "failure means. Declared methods: $names",
+                "failure means. Visible methods: $names",
             "aggressiveCleanup" !in names
         )
     }
@@ -58,8 +65,8 @@ class SystemRepositorySurfaceTest {
     /**
      * The anti-vacuity floor under the assertion above.
      *
-     * An absence assertion is the one shape that passes best when it is looking at nothing:
-     * `declaredMethods` coming back empty — a moved interface, a change in how Kotlin emits `suspend`
+     * An absence assertion is the one shape that passes best when it is looking at nothing: the
+     * reflection coming back empty — a moved interface, a change in how Kotlin emits `suspend`
      * members, anything — satisfies `"aggressiveCleanup" !in names` trivially and green. Naming
      * methods that are known to still be declared proves the reflection resolved a real interface
      * with real members on it.
@@ -76,35 +83,204 @@ class SystemRepositorySurfaceTest {
      */
     @Test
     fun `the reflection actually sees the interface`() {
-        val names = declaredNames()
+        val names = surfaceNames()
 
         assertTrue(
             "the sweep found $names, which is missing methods that are known to be declared — it " +
-                "is looking at the wrong type, or declaredMethods returned nothing and the " +
+                "is looking at the wrong type, or the reflection returned nothing and the " +
                 "absence assertion above is passing vacuously",
             names.containsAll(setOf("forceStopApp", "clearCache"))
         )
     }
 
     /**
-     * Every method declared on [SystemRepository], by Kotlin name.
+     * The source-text lock, for the re-add that never appears on this interface at all.
+     *
+     * `fun SystemRepository.aggressiveCleanup(pkg: String): Result<Unit>` compiles into whatever
+     * file-class holds it, so [surfaceNames] cannot see it, while every call site reads
+     * `systemRepository.aggressiveCleanup(pkg)` exactly as it did before the deletion — and an
+     * extension has to have a body, so it would be the same discard-both-`Result`s composite,
+     * written somewhere the interface's own guard cannot reach. The same sweep also catches a
+     * `@JvmName` rename on a re-added declaration, which would show reflection some other name while
+     * Kotlin callers still write this one.
+     *
+     * Two patterns, both matched on declaration shape rather than the bare name — `SystemRepository`
+     * and `SystemRepositoryImpl` both carry tombstone comments naming this method in prose, and
+     * neither must trip it:
+     *  - inside `SystemRepository.kt`, any `fun … aggressiveCleanup(`;
+     *  - anywhere in the production source sets, any `fun … SystemRepository.aggressiveCleanup(`.
+     *
+     * The guards run first and are the whole reason to believe the assertions after them. A sweep
+     * over an empty file list satisfies every absence check it is given — the same failure the
+     * reflection guard exists to catch, one layer down: a working directory that is not what this
+     * test assumed, a moved module, a `listFiles()` that came back null. So the corpus must be more
+     * than a handful of files, must contain `SystemRepository.kt` itself, must yield a hit for a
+     * declaration known to be in that file, and the extension pattern must be shown to match the
+     * shape it was written for and to have real extension declarations in the corpus to find.
+     *
+     * The boundary, stated rather than implied. This is a regex over text, not a parse: the name
+     * re-added as a function-typed property, reached through a `typealias`, or generated by a
+     * compiler plugin goes through both locks untouched. Not worth a parser — none of those is how
+     * an unfinished-looking interface method actually comes back.
+     */
+    @Test
+    fun `no source declaration brings aggressiveCleanup back`() {
+        val sources = productionKotlinSources()
+
+        assertTrue(
+            "the sweep read only ${sources.size} Kotlin files, which cannot be Thor's production " +
+                "source tree — the working directory is not what this test assumed, or app/src " +
+                "moved. Every absence check below would pass on a corpus this small",
+            sources.size >= 20
+        )
+
+        val interfaceSource = sources.entries
+            .firstOrNull { it.key.invariantSeparatorsPath.endsWith(SYSTEM_REPOSITORY_KT) }
+            ?.value
+            .orEmpty()
+        assertTrue(
+            "the sweep never read $SYSTEM_REPOSITORY_KT, so the in-file assertion below is looking " +
+                "at an empty string and passes no matter what that file declares",
+            interfaceSource.isNotEmpty()
+        )
+        assertTrue(
+            "the declaration pattern cannot find `fun forceStopApp(` in $SYSTEM_REPOSITORY_KT, " +
+                "which is certainly there — the pattern no longer matches how this codebase " +
+                "declares a function, so its failure to find aggressiveCleanup proves nothing",
+            declarationOf("forceStopApp").containsMatchIn(interfaceSource)
+        )
+        assertTrue(
+            "the extension pattern does not match the declaration it was written for — it can " +
+                "never fire, and the tree-wide assertion below is decoration",
+            EXTENSION_ON_REPOSITORY.containsMatchIn(
+                "fun SystemRepository.$DELETED(pkg: String) = Result.success(Unit)"
+            )
+        )
+        assertTrue(
+            "no file in the corpus declares an extension function at all, which is not true of " +
+                "this codebase — the corpus is not the source tree, or extensions are no longer " +
+                "written as `fun Receiver.name(` and the tree-wide pattern is looking for a shape " +
+                "that stopped existing",
+            sources.values.any { ANY_EXTENSION.containsMatchIn(it) }
+        )
+
+        assertTrue(
+            "$SYSTEM_REPOSITORY_KT declares `fun $DELETED(` again. Renaming it on the JVM with " +
+                "@JvmName would hide it from reflection and change nothing for Kotlin callers, so " +
+                "the source text is what decides. It was deleted because it swallowed the Results " +
+                "of both operations it composed, and nothing called it",
+            !declarationOf(DELETED).containsMatchIn(interfaceSource)
+        )
+
+        val offenders = sources.filterValues { EXTENSION_ON_REPOSITORY.containsMatchIn(it) }
+            .keys
+            .map { it.invariantSeparatorsPath }
+        assertTrue(
+            "an extension function puts SystemRepository.$DELETED back: $offenders. It compiles " +
+                "into a different class, so the reflection lock in this file cannot see it, but " +
+                "every call site reads systemRepository.$DELETED(...) exactly as it did before. An " +
+                "extension has a body, so it is the discard-both-Results composite all over again",
+            offenders.isEmpty()
+        )
+    }
+
+    /**
+     * Every method [SystemRepository] exposes, by Kotlin name: what it declares itself, plus what it
+     * inherits from a super-interface.
+     *
+     * `declaredMethods` alone sees only methods declared on this exact type, so splitting the
+     * interface into roles and putting `aggressiveCleanup` on a super-interface would take it out of
+     * view while `systemRepository.aggressiveCleanup(pkg)` kept compiling everywhere. `methods` adds
+     * the inherited ones and closes that. Additive rather than a replacement, because the two see
+     * different things: `methods` is public-only and `declaredMethods` is visibility-blind, so a
+     * `private` member appears in exactly one of them.
+     *
+     * The `Object` filter is verified to be a no-op here and is kept as insurance. `getMethods()` on
+     * an *interface* returns nothing from `java.lang.Object` — an interface has no superclass, and
+     * the contract is explicit in `Class.getMethods()`: "if this Class object represents an
+     * interface then the returned array does not contain any implicitly declared methods from
+     * Object". On a class it does return them, and this same filter is what drops them there, so
+     * both files strip on the same rule rather than on a per-type assumption.
      *
      * A class literal rather than a `Class.forName` string, so a rename or a package move is a
      * compile error here instead of a silently empty result set. `suspend` members compile to
      * methods taking a trailing `Continuation`, which changes their signature but not their name, so
      * matching on names alone is stable across that.
      */
-    private fun declaredNames(): Set<String> =
-        SystemRepository::class.java.declaredMethods
+    private fun surfaceNames(): Set<String> {
+        val type = SystemRepository::class.java
+        return (type.declaredMethods.asSequence() + type.methods.asSequence())
+            .filterNot { it.declaringClass == Any::class.java }
             .filterNot { it.isSynthetic || it.isBridge || it.name.contains("\$default") }
             .map { it.readableName() }
             .toSet()
+    }
+
+    /**
+     * Every Kotlin file in the production source sets, as text, keyed by file.
+     *
+     * `app/src` minus `test` and `androidTest`, rather than a hardcoded `main` plus flavour list: a
+     * new flavour directory gets swept the day it appears, and — the part that matters — this file
+     * is excluded, which it has to be. Its own KDoc spells out the extension declaration it is
+     * hunting for as the example of the defeat, and only a production declaration is a defeat
+     * anyway. Widening this to the test source sets would make the sweep fail on its own prose.
+     *
+     * The root is found by walking up from the working directory, because a unit test's working
+     * directory is the Gradle module in one runner and the repository root in another, and neither
+     * is a thing this test should be encoding. `error()` rather than an empty map when the walk
+     * finds nothing: a sweep that cannot locate its own sources has to fail loudly, not quietly
+     * agree that there are no offenders.
+     */
+    private fun productionKotlinSources(): Map<File, String> {
+        var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        while (dir != null) {
+            val src = File(dir, "app/src")
+            if (src.isDirectory) {
+                return src.listFiles().orEmpty()
+                    .filter { it.isDirectory && it.name != "test" && it.name != "androidTest" }
+                    .flatMap { root ->
+                        root.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+                    }
+                    .associateWith { it.readText() }
+            }
+            dir = dir.parentFile
+        }
+        error(
+            "could not locate app/src by walking up from ${System.getProperty("user.dir")}. The " +
+                "source sweep has nothing to read and must not report a clean result"
+        )
+    }
+
+    /**
+     * `fun … <name>(` on a single line: any modifiers, any annotations, any receiver, and no
+     * intervening `(` — which is what keeps `fun other(x) = name(y)` from matching, since the
+     * character class cannot cross the first parenthesis.
+     */
+    private fun declarationOf(name: String) = Regex("""\bfun\b[^(\n]*\b$name\s*\(""")
 
     /**
      * The Kotlin name, with both JVM manglings taken back off: the `$module` suffix `internal` adds
-     * and the `-<hash>` suffix an inline-value-class return type adds. Neither character is legal in
+     * and the `-<hash>` suffix an inline value class return type adds. Neither character is legal in
      * a source-level Kotlin identifier without backticks, so cutting at the first of either cannot
      * truncate a real method name.
      */
     private fun Method.readableName(): String = name.substringBefore('$').substringBefore('-')
+
+    private companion object {
+        const val DELETED = "aggressiveCleanup"
+
+        /** Path suffix of the anchor file, matched with `/` so it also holds on Windows. */
+        const val SYSTEM_REPOSITORY_KT = "com/valhalla/thor/domain/repository/SystemRepository.kt"
+
+        /** `fun … SystemRepository.aggressiveCleanup(`, in any file and any package. */
+        val EXTENSION_ON_REPOSITORY =
+            Regex("""\bfun\b[^(\n]*\bSystemRepository\s*\.[^(\n]*\b$DELETED\s*\(""")
+
+        /**
+         * Any extension declaration at all, used only as a control: it proves the corpus really is
+         * Kotlin source in which extensions are still written as `fun Receiver.name(`, which is the
+         * shape [EXTENSION_ON_REPOSITORY] pins itself to.
+         */
+        val ANY_EXTENSION = Regex("""\bfun\b[^(\n]*\b\w+\s*\.\s*\w+\s*\(""")
+    }
 }

--- a/app/src/test/java/com/valhalla/thor/domain/repository/SystemRepositorySurfaceTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/repository/SystemRepositorySurfaceTest.kt
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Method
+
+/**
+ * A lock on the one method [SystemRepository] is not allowed to grow back.
+ *
+ * `aggressiveCleanup(packageName)` was declared here and implemented in `SystemRepositoryImpl` as
+ * force-stop followed by clear-cache. It discarded **both** `Result`s and returned
+ * `Result.success(Unit)` unconditionally — a composite that reports success no matter what either of
+ * its two steps did. It had zero production callers: the only references in the whole repo were this
+ * declaration, that implementation, and three test overrides which existed purely because the
+ * interface forced them. Not one of them exercised the behaviour.
+ *
+ * It was deleted rather than fixed, and the interface declaration went with it. An interface method
+ * with no implementations and no callers is not a harmless stub — it is a shape that reads like an
+ * unfinished feature, and the next sweep implements it. This test is cheap insurance against the
+ * cheapest way for it to return: an IDE autocomplete on a repository that "obviously" ought to have
+ * a cleanup composite.
+ *
+ * The two operations remain available individually — `forceStopApp` and `clearCache` — each
+ * returning its own real `Result`, which is what a caller that genuinely wants both should use so it
+ * can see which half failed.
+ */
+class SystemRepositorySurfaceTest {
+
+    /**
+     * Matched on the de-mangled name, and there are **two** manglings in play here — the second one
+     * is why the guard below exists and it caught this on the first run.
+     *
+     * Kotlin mangles an `internal` member's JVM name with a module suffix
+     * (`aggressiveCleanup$app_fossDebug`), so a raw `Method.name` comparison could be dodged by
+     * re-adding the method with a narrower visibility. It *also* mangles any function returning an
+     * inline value class with a `-<hash>` suffix, and `Result` is one: every method on this
+     * interface is emitted as `forceStopApp-gIAlu-s`, `setAppDisabled-0E7RQCE` and so on.
+     * `aggressiveCleanup` returned `Result<Unit>` too, so against raw names the assertion below was
+     * green whether or not the method was there.
+     */
+    @Test
+    fun `aggressiveCleanup is gone`() {
+        val names = declaredNames()
+
+        assertTrue(
+            "SystemRepository.aggressiveCleanup is back. It was deleted because it discarded the " +
+                "Results of both operations it composed and then reported unconditional success, " +
+                "and because nothing called it. If a caller now needs force-stop plus clear-cache, " +
+                "it should call forceStopApp and clearCache and decide for itself what a partial " +
+                "failure means. Declared methods: $names",
+            "aggressiveCleanup" !in names
+        )
+    }
+
+    /**
+     * The anti-vacuity floor under the assertion above.
+     *
+     * An absence assertion is the one shape that passes best when it is looking at nothing:
+     * `declaredMethods` coming back empty — a moved interface, a change in how Kotlin emits `suspend`
+     * members, anything — satisfies `"aggressiveCleanup" !in names` trivially and green. Naming
+     * methods that are known to still be declared proves the reflection resolved a real interface
+     * with real members on it.
+     *
+     * `containsAll`, never an equality: adding a capability to [SystemRepository] must not have to be
+     * remembered here. The two named are the exact pair `aggressiveCleanup` used to compose, which
+     * makes this double as the record that deleting the composite did not take the parts with it.
+     *
+     * Both of them return `Result`, and that is load-bearing rather than incidental: it is the same
+     * signature shape `aggressiveCleanup` had, so this passing means [readableName] survives the
+     * exact mangling the deleted method would have been hiding behind. Do not swap either for a
+     * plain-returning member — it would still read as an anti-vacuity check while no longer
+     * exercising the one thing that can make the assertion above vacuous.
+     */
+    @Test
+    fun `the reflection actually sees the interface`() {
+        val names = declaredNames()
+
+        assertTrue(
+            "the sweep found $names, which is missing methods that are known to be declared — it " +
+                "is looking at the wrong type, or declaredMethods returned nothing and the " +
+                "absence assertion above is passing vacuously",
+            names.containsAll(setOf("forceStopApp", "clearCache"))
+        )
+    }
+
+    /**
+     * Every method declared on [SystemRepository], by Kotlin name.
+     *
+     * A class literal rather than a `Class.forName` string, so a rename or a package move is a
+     * compile error here instead of a silently empty result set. `suspend` members compile to
+     * methods taking a trailing `Continuation`, which changes their signature but not their name, so
+     * matching on names alone is stable across that.
+     */
+    private fun declaredNames(): Set<String> =
+        SystemRepository::class.java.declaredMethods
+            .filterNot { it.isSynthetic || it.isBridge || it.name.contains("\$default") }
+            .map { it.readableName() }
+            .toSet()
+
+    /**
+     * The Kotlin name, with both JVM manglings taken back off: the `$module` suffix `internal` adds
+     * and the `-<hash>` suffix an inline-value-class return type adds. Neither character is legal in
+     * a source-level Kotlin identifier without backticks, so cutting at the first of either cannot
+     * truncate a real method name.
+     */
+    private fun Method.readableName(): String = name.substringBefore('$').substringBefore('-')
+}

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
@@ -65,8 +65,6 @@ private class RecordingSystemRepository : SystemRepository {
         error("off the freeze path")
 
     override suspend fun rebootDevice(reason: String): Result<Unit> = error("off the freeze path")
-    override suspend fun aggressiveCleanup(packageName: String): Result<Unit> =
-        error("off the freeze path")
 
     override suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit> =
         error("off the freeze path")

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -115,9 +115,6 @@ class FakeSystemRepository(private val trace: CallTrace? = null) : SystemReposit
 
     override suspend fun rebootDevice(reason: String) = record("rebootDevice:$reason")
 
-    override suspend fun aggressiveCleanup(packageName: String) =
-        record("aggressiveCleanup:$packageName")
-
     override suspend fun reinstallAppWithGoogle(packageName: String) =
         record("reinstallAppWithGoogle:$packageName")
 


### PR DESCRIPTION
Item 3a of the 2026-08-04 dev-branch audit remediation. Eight sites across the three gateways reported success on evidence that could not fail — and in most cases the honest verifier was **already written in the same function**, sitting unreachable behind the short-circuit that always won.

## Why the old evidence was worthless

| Fact | Consequence |
|---|---|
| `ActivityManagerShellCommand.runForceStop` ends in an unconditional `return 0` | `am force-stop` exits 0 for a package nothing is running for, and for one not installed for `--user N` at all |
| `PackageManagerShellCommand.runSuspend` returns 0 whenever `setPackagesSuspendedAsUser` did not throw | the failure array naming packages it declined to suspend is discarded; an exempt package is a clean exit |
| `IActivityManager.forceStopPackage` and `IAppOpsService.setMode` return `void` | a reflective call can only report that the binder did not throw |

## What changed

**Shizuku** — `forceStopApp` rungs 1 and 2 answer to `isAppStopped`; `setAppRestricted` gained a `checkOperation` readback, with the op code and uid resolved once and shared.
**Dhizuku** — the same for `forceStopApp`, plus a background-mode readback; `clearCache`/`clearAppData`'s reflection rungs now report failure rather than claiming a wipe they cannot see.
**Root** — `forceStopApp` gained a shared `isStoppedNow()` (three hand-written copies of one verifier is how one of them stops matching the others); the API 28 suspend rung is judged by `readSuspendedFlag`; `clearAppData` now names *which* of three ways the daemon produced nothing instead of folding them into "AIDL failed".

### Two readback policies, deliberately not unified

Where the rung's own error reporting is honest — `appops set` exits non-zero for an unknown package or op, `setMode` throws on denial — an unreadable state **fails open**, so a restriction that really was applied is not reported as a failure. Where "did not throw" is the whole of the evidence, and on Dhizuku's double-wrapped transport is not even a statement about the target service, it **fails closed**. Every readback is tri-state: `null` means "could not tell" and never stands in for success.

## Deleted as unfixable rather than left unfixed

- `SystemRepository.aggressiveCleanup` — force-stop then clear-cache, **both** `Result`s discarded, then unconditional `Result.success(Unit)`. Zero production callers; its only references were the declaration and three interface-forced test overrides, none of which exercised it.
- `Packages.forceStopApp` / `setAppDisabled` / `setAppRestricted` — unprivileged `Bypass` reflection from Thor's own uid, wrapped in `runCatching { ...; true }`. Deleted as one edit because they only ever called each other: `setAppDisabled` was `forceStopApp`'s only caller and itself had none.

Both are locked by surface tests. **The anti-vacuity guard on the repository one paid for itself on its first run**: methods returning `Result` are JVM-mangled to `forceStopApp-gIAlu-s`, and `aggressiveCleanup` returned `Result<Unit>` too — so the absence assertion was green whether or not the method was there, until the de-mangler learned to strip the inline-value-class suffix as well as the `internal` one.

## Correction to my own earlier reasoning

An adversarial review of the audit killed the Dhizuku overload-order finding as "transport-dead, therefore unreachable". That is an argument about **impact**, not about **correctness** — a rung that is dead today is still the rung a future transport fix would wake up. The order is fixed here, with the transport argument recorded next to it so the next reader gets both halves.

## Verification

- `:app:testFossDebugUnitTest --rerun-tasks` — **673 pass** (+4 new)
- `:app:lintFossDebug` — clean

## Not covered here, and why

The two `IPackageDataObserver` sites (`Shizuku.kt` clear-cache/clear-data, `ThorRootService`) are held back for a separate PR. They need a vendored AIDL and a real `Stub` subclass, and if the callback never arrives on a device, clears that *did* work would newly report failure — so that change is merge-blocked on hardware testing that this one is not.

Residual, unchanged by this PR and stated rather than buried: `forceStopApp`'s reliance on `FLAG_STOPPED` being readable promptly after the call returns, and `checkOperation` reporting the mode *in force* rather than a record of the write, are both device-observable and unmeasured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - System actions now verify that force-stop, app suspension, restriction, cache clearing, and data clearing actually succeeded.
  - Improved error reporting distinguishes command failures, refusals, binding issues, and unconfirmed state changes.
  - Privileged operations use more reliable fallback behavior and state checks.

- **Refactor**
  - Removed the obsolete aggressive cleanup operation while retaining individual force-stop and cache-clearing actions.

- **Tests**
  - Added regression coverage to ensure removed operations stay unavailable and supported operations remain present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->