### PR TITLE
fix(privilege): wait for the observer instead of reporting a wipe that was only dispatched

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -51,3 +51,22 @@
 -keep class com.valhalla.thor.rootservice.** { *; }
 -keep interface com.valhalla.thor.rootservice.** { *; }
 
+# --- IPackageDataObserver (framework AIDL callback, shadowed at runtime) --------------------------
+# This file is the one the RELEASE build type wires in (`proguardFiles(..., "proguard-rules.pro")`),
+# so it covers both flavours -- `proguardFile("proguard-rules-foss.pro")` on the foss flavour ADDS to
+# that list rather than replacing it. The rule has to live here and not there: the foss file's only
+# blanket keep, `-keep class com.valhalla.thor.** { *; }`, is commented out, and it would not have
+# covered `android.content.pm.**` anyway.
+#
+# app/src/main/aidl/android/content/pm/IPackageDataObserver.aidl is an AOSP copy that exists only so
+# the Kotlin compiler has a Stub to subclass. At runtime PathClassLoader delegates parent-first and
+# the boot classpath's real framework class wins, so Thor's observer extends the FRAMEWORK Stub and
+# the FRAMEWORK's onTransact dispatches to it -- by the original method name and descriptor, which
+# R8 has no way to know about: nothing in the dex calls onRemoveCompleted, a binder transaction does.
+# Renaming the override would leave onTransact unable to find it, so the callback would never fire,
+# every clear would report "could not confirm" forever, and only in release, because debug is not
+# minified. Same failure shape as the rootservice block above.
+-keep class android.content.pm.IPackageDataObserver { *; }
+-keep class android.content.pm.IPackageDataObserver$Stub { *; }
+-keep class * extends android.content.pm.IPackageDataObserver$Stub { *; }
+

--- a/app/src/main/aidl/android/content/pm/IPackageDataObserver.aidl
+++ b/app/src/main/aidl/android/content/pm/IPackageDataObserver.aidl
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2007 The Android Open Source Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// This file is AOSP's interface definition, not Thor's code, so it deliberately does NOT carry
+// Thor's usual `2025-2026 Trinadh Thatakula` / `GPL-3.0-or-later` pair. Apache-2.0 combined into a
+// GPL-3.0-or-later work is a compatible one-way combination; relabelling it would be a licence
+// claim over someone else's text. There is no CI licence-header gate, so a "fix the SPDX header"
+// reflex is the only thing that can get this wrong -- do not let it.
+//
+// Copied from frameworks/base/core/java/android/content/pm/IPackageDataObserver.aidl. The only
+// deviation from AOSP is the removal of `@UnsupportedAppUsage` on the method: that annotation lives
+// in `android.compat.annotation`, which is not on an application module's aidl import path, and it
+// is metadata for the platform's own greylist rather than part of the interface's shape.
+//
+// ---------------------------------------------------------------------------------------------
+// WHY A COPY EXISTS, AND WHY IT IS NEVER LOADED
+// ---------------------------------------------------------------------------------------------
+// `IPackageManager.clearApplicationUserData(String, IPackageDataObserver, int)` returns void and
+// `deleteApplicationCacheFiles(String, IPackageDataObserver)` returns a boolean that means nothing;
+// in both cases the real verdict arrives asynchronously on `onRemoveCompleted`. Receiving it needs
+// a genuine `IPackageDataObserver.Stub` subclass, because a `java.lang.reflect.Proxy` cannot be
+// marshalled over binder -- there is no way to hand the framework a callback object without one.
+// `Stub` is not in the public SDK, so the Kotlin compiler has nothing to subclass unless this file
+// generates one.
+//
+// At runtime the generated copy is dead weight and that is the point. `PathClassLoader` does not
+// override `ClassLoader.loadClass`, so resolution is parent-first: `BootClassLoader` supplies the
+// framework's real `android.content.pm.IPackageDataObserver$Stub` and the class generated from this
+// file is never loaded. Thor's observer therefore extends the FRAMEWORK Stub, and dispatch is done
+// by the framework's own `onTransact` using the framework's own transaction codes. That is the
+// safety property worth stating plainly: because we subclass rather than reimplement `onTransact`,
+// a change to the platform's transaction numbering cannot mis-dispatch us. It is the opposite
+// situation to `com/valhalla/thor/rootservice/IThorRootService.aidl`, whose append-only rule exists
+// precisely because those codes ARE ours to keep stable.
+//
+// Every way this can fail degrades to "could not confirm", never to a false success -- if the
+// framework class ever disappeared, the generated copy would load instead, the framework would
+// never call our object, `awaitDataObserver` would time out, and the clear would report failure.
+// See `data/source/local/PackageDataObservers.kt` for the receiving half and
+// `app/proguard-rules.pro` for why R8 must not rename the override.
+//
+// `oneway` and the parameter names/order are kept exactly as AOSP has them. `oneway` is irrelevant
+// to the receive path (the framework Stub does the dispatch), but a faithful copy is far easier to
+// re-verify against AOSP later than a tidied one.
+
+package android.content.pm;
+
+/**
+ * API for package data change related callbacks from the Package Manager.
+ * Some usage scenarios include deletion of cache directory, generate
+ * statistics related to code, data, cache usage(TODO)
+ * {@hide}
+ */
+oneway interface IPackageDataObserver {
+    void onRemoveCompleted(in String packageName, boolean succeeded);
+}

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -336,7 +336,7 @@ class RootSystemGateway(
                 return@withContext Result.success(Unit)
             }
             daemonVerdict = aidlCall.fold(
-                onSuccess = { "the root daemon refused the wipe" },
+                onSuccess = { "the root daemon answered no" },
                 onFailure = { "the root daemon could not confirm the wipe (${it.javaClass.simpleName})" },
             )
         } else {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -314,10 +314,17 @@ class RootSystemGateway(
         // case the paragraph above describes — `clearAppDataForUser` hands back a bare boolean, so
         // this side cannot separate those two and the string does not pretend to.
         //
-        // What a `true` is, since it still returns a success here: the daemon's reflective
-        // `clearApplicationUserData` is void and reports through an `IPackageDataObserver` that
-        // `ThorRootService.clearAppData` deliberately does not wire up, so `true` means the wipe
-        // was dispatched without throwing — not that the data is gone.
+        // What a `true` is, since it still returns a success here: `ThorRootService.clearAppData`
+        // now hands `clearApplicationUserData` a real `IPackageDataObserver` and waits for
+        // `onRemoveCompleted`, so `true` means a verdict of "cleared" actually arrived rather than
+        // that the void call was dispatched without throwing. That is the whole point of the
+        // observer, and it is why this rung's success is worth returning.
+        //
+        // What a `false` is has correspondingly widened, and the string below is deliberately vague
+        // about it. `clearAppDataForUser` hands back a bare boolean, so REFUSED (PMS said no) and
+        // UNVERIFIED (nothing came back inside the daemon's own wait) reach this side as the same
+        // value. The daemon logs which one it was; this process cannot know, so "answered no"
+        // rather than "refused" is the strongest claim available here.
         val daemonVerdict: String
         if (service != null) {
             val aidlCall = runCatching {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/PackageDataObservers.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/PackageDataObservers.kt
@@ -8,6 +8,7 @@ import android.os.IBinder
 import com.valhalla.thor.util.Logger
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -19,6 +20,68 @@ import java.util.concurrent.atomic.AtomicReference
  * about its transport rather than about its timeout.
  */
 private const val DATA_OBSERVER_TIMEOUT_MS = 15_000L
+
+/**
+ * The wait [awaitDataObserver] falls back to once this transport has been *seen* to drop a verdict.
+ *
+ * ### Why a second number exists at all
+ *
+ * The full [DATA_OBSERVER_TIMEOUT_MS] is priced for one app: a user taps "clear data", and fifteen
+ * seconds is a defensible ceiling for `PackageManagerService` to finish wiping a large package.
+ * Batches change that arithmetic. `MainViewModel.performLoggedMultiAction` runs its list through one
+ * sequential `forEachIndexed` — deliberately, because it emits an ordered "step i of n" log — so a
+ * transport that never calls back turns a fifty-app cache sweep into fifty consecutive full-length
+ * waits. Twelve and a half minutes of them, every one ending in [DataClearOutcome.UNVERIFIED].
+ *
+ * ### Why one observation is enough to change the wait
+ *
+ * Whether `onRemoveCompleted` comes back is a property of the **ROM and the transport**, not of the
+ * package being cleared. A vendor build that drops the callback drops it for every package; there is
+ * no version of this where app 1 goes unanswered and app 2 is fine. So the first full-length timeout
+ * is not bad luck to be re-rolled forty-nine more times, it is evidence — and the honest response to
+ * evidence is to stop paying full price for it.
+ *
+ * ### Why it is a shortened wait and not a skipped one
+ *
+ * Skipping would make [DataClearOutcome.UNVERIFIED] structural: no observer could ever answer again,
+ * on any ROM, once one had failed to. A ROM that is merely *slow* would be permanently misreported.
+ * Shortening keeps the callback path live and costs at most this much per package. The belief is
+ * cleared by the very next verdict that does arrive — see [transportDeliversVerdicts] — so a single
+ * genuinely slow wipe degrades one subsequent call and then repairs itself.
+ *
+ * The trade this buys, stated plainly rather than hidden: a package whose verdict would have landed
+ * between this and [DATA_OBSERVER_TIMEOUT_MS] is reported [DataClearOutcome.UNVERIFIED] instead of
+ * its real answer. That window only opens on a transport that has just demonstrably failed to answer
+ * within fifteen seconds, and it closes on the first answer of any kind.
+ */
+private const val DEGRADED_OBSERVER_TIMEOUT_MS = 1_500L
+
+/**
+ * Whether the last [awaitDataObserver] to reach a conclusion got there via the callback.
+ *
+ * `true` — the optimistic start, and where any arriving verdict puts it back — means the next call
+ * waits the full [DATA_OBSERVER_TIMEOUT_MS]. `false`, set only by a wait that expired with nothing
+ * delivered, drops the next call to [DEGRADED_OBSERVER_TIMEOUT_MS].
+ *
+ * Process-wide on purpose. The thing being remembered is a fact about the transport, and every clear
+ * in the process shares one of those. Threading it through `SystemRepositoryImpl` →
+ * `ShizukuSystemGateway` → `ShizukuReflector` to make it per-batch would carry a global fact down
+ * four layers as a parameter and still be a global fact.
+ *
+ * It is only ever a *timeout* input. Nothing here can produce [DataClearOutcome.CLEARED] — that
+ * invariant is unchanged and this flag cannot touch it.
+ */
+private val transportDeliversVerdicts = AtomicBoolean(true)
+
+/**
+ * Puts [transportDeliversVerdicts] back to its optimistic start.
+ *
+ * Exists for tests, which would otherwise be order-dependent: one case that deliberately times out
+ * would shorten the wait of whichever case JUnit happened to run next. Call it in `@Before`.
+ */
+internal fun resetObserverTransportBelief() {
+    transportDeliversVerdicts.set(true)
+}
 
 /**
  * What a clear-data / clear-cache call actually achieved, as opposed to what it returned.
@@ -104,8 +167,10 @@ internal enum class DataClearOutcome {
  *   Shizuku's.
  * @param packageName the package being cleared; used for logging and to spot a callback that names
  *   something else.
- * @param timeoutMillis how long to wait for the verdict. Defaults to [DATA_OBSERVER_TIMEOUT_MS];
- *   only tests should pass anything else.
+ * @param timeoutMillis the longest this will wait for the verdict. Defaults to
+ *   [DATA_OBSERVER_TIMEOUT_MS]; only tests should pass anything else. The wait actually used is this
+ *   or [DEGRADED_OBSERVER_TIMEOUT_MS], whichever is smaller, once [transportDeliversVerdicts] has
+ *   been knocked down — so this is a ceiling, never a floor.
  * @param fire dispatches the actual privileged call, handing it the observer. It must not swallow
  *   its own failures — a throw here is information, and it is turned into
  *   [DataClearOutcome.UNVERIFIED].
@@ -122,6 +187,10 @@ internal fun awaitDataObserver(
 
     val observer = newDataObserver(tag, packageName) { reportedPackage, succeeded ->
         val verdict = if (succeeded) DataClearOutcome.CLEARED else DataClearOutcome.REFUSED
+        // Set before the CAS, and set by *any* callback including a late or duplicate one. This flag
+        // answers "does this transport deliver?", and a verdict that arrived too late to be used
+        // still answers it yes.
+        transportDeliversVerdicts.set(true)
         if (outcome.compareAndSet(DataClearOutcome.UNVERIFIED, verdict)) {
             Logger.d(tag, "clear($packageName): observer reported $verdict for $reportedPackage")
             latch.countDown()
@@ -136,19 +205,30 @@ internal fun awaitDataObserver(
         }
     }
 
+    // `minOf`, not a plain substitution: a test that asks for 50ms must still get 50ms, and the
+    // degraded path is a ceiling on the wait rather than a value for it.
+    val effectiveTimeoutMillis =
+        if (transportDeliversVerdicts.get()) timeoutMillis
+        else minOf(timeoutMillis, DEGRADED_OBSERVER_TIMEOUT_MS)
+
     return try {
         fire(observer)
 
-        if (latch.await(timeoutMillis, TimeUnit.MILLISECONDS)) {
+        if (latch.await(effectiveTimeoutMillis, TimeUnit.MILLISECONDS)) {
             outcome.get()
         } else {
             // Read nothing back here. A verdict that lands a microsecond after the wait expired is
             // still a verdict Thor did not see in time, and honouring it would make the result
             // depend on scheduler luck.
+            transportDeliversVerdicts.set(false)
+            val shortened =
+                if (effectiveTimeoutMillis < timeoutMillis) " (shortened from ${timeoutMillis}ms " +
+                    "because the previous wait went unanswered)" else ""
             Logger.w(
                 tag,
-                "clear($packageName): issued but unconfirmed within ${timeoutMillis}ms — reporting " +
-                    "failure, because a clear that cannot be confirmed is not a clear that happened"
+                "clear($packageName): issued but unconfirmed within ${effectiveTimeoutMillis}ms" +
+                    "$shortened — reporting failure, because a clear that cannot be confirmed is " +
+                    "not a clear that happened"
             )
             DataClearOutcome.UNVERIFIED
         }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/PackageDataObservers.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/PackageDataObservers.kt
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import android.content.pm.IPackageDataObserver
+import android.os.IBinder
+import com.valhalla.thor.util.Logger
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * How long [awaitDataObserver] waits for a verdict before giving up on one.
+ *
+ * The same number and the same "one bounded wait, then give up" shape as `awaitInstallerResult`'s
+ * default in `ShizukuReflector`. One constant in one file on purpose: this is not a per-gateway
+ * knob, and a privilege mode that needed a different answer here would be telling us something
+ * about its transport rather than about its timeout.
+ */
+private const val DATA_OBSERVER_TIMEOUT_MS = 15_000L
+
+/**
+ * What a clear-data / clear-cache call actually achieved, as opposed to what it returned.
+ *
+ * The distinction that matters is not [CLEARED] versus [REFUSED] — both are the platform speaking —
+ * but either of those versus [UNVERIFIED], which is Thor admitting it does not know. Every caller
+ * collapses this to a `Boolean`, and both non-[CLEARED] values collapse to `false`. That is the
+ * conservative direction and it is deliberate: clearing data twice costs a user nothing, whereas a
+ * false "done" costs them the chance to try a privilege mode that would have worked.
+ */
+internal enum class DataClearOutcome {
+    /** `onRemoveCompleted(pkg, succeeded = true)` arrived. The only value that means success. */
+    CLEARED,
+
+    /** `onRemoveCompleted(pkg, succeeded = false)` arrived. The platform said no, and we heard it. */
+    REFUSED,
+
+    /**
+     * Nothing arrived, or the attempt fell over before anything could. **Not** a success, and not a
+     * refusal either — it is the absence of an answer, and the only honest thing to do with it is
+     * report failure and say so in the log.
+     */
+    UNVERIFIED,
+}
+
+/**
+ * Runs [fire] with a real `IPackageDataObserver` and waits, once and briefly, for the verdict.
+ *
+ * ### Why this exists
+ *
+ * `IPackageManager.clearApplicationUserData(String, IPackageDataObserver, int)` returns `void`, and
+ * `deleteApplicationCacheFiles(String, IPackageDataObserver)` returns a boolean that says nothing
+ * about the outcome. In both cases `PackageManagerService` posts the work to its own handler and
+ * reports the result on `onRemoveCompleted`. Every call site in Thor used to pass `null` there and
+ * report success on "the binder call did not throw" — which at shell uid is a claim PMS actively
+ * contradicts: it accepts cache clears it then declines, logs that it is silently ignoring the
+ * request, and tells the caller none of it.
+ *
+ * ### Why the observer is a real Stub subclass
+ *
+ * A `java.lang.reflect.Proxy` cannot be marshalled over binder, so the callback has to be a genuine
+ * `IPackageDataObserver.Stub`. `Stub` is not in the public SDK, so Thor vendors AOSP's
+ * `app/src/main/aidl/android/content/pm/IPackageDataObserver.aidl` purely to give the Kotlin
+ * compiler something to subclass. At runtime `PathClassLoader` delegates parent-first, the boot
+ * classpath's framework class wins, and the generated copy is never loaded — so the object built
+ * below extends the *framework* Stub and the framework's own `onTransact` dispatches to it. Read
+ * that aidl's header comment for the full argument; the consequence here is that R8 must not rename
+ * `onRemoveCompleted` (see the keep rule in `app/proguard-rules.pro`), because `onTransact` looks it
+ * up by its original name and descriptor.
+ *
+ * ### Threading
+ *
+ * The callback arrives on a **binder thread**, never the caller's, so this cannot self-deadlock —
+ * and this function **blocks** the calling thread on a latch for up to [timeoutMillis]. That is
+ * safe because every caller is already off the main thread, which was checked rather than assumed:
+ * the Shizuku sites are reached through `SystemRepositoryImpl.clearCache` / `clearAppData`, both of
+ * which are `withContext(Dispatchers.IO)`, and the daemon site runs on a binder thread in the
+ * separate `:root` process. A caller that is not one of those two must hop off the main thread
+ * before calling this.
+ *
+ * It deliberately uses a `CountDownLatch` rather than the `CompletableDeferred` +
+ * `withTimeoutOrNull` shape `awaitInstallerResult` uses, for one reason only: none of the three call
+ * sites is `suspend`, and making them so would mean editing `ShizukuReflector` and
+ * `ShizukuSystemGateway` for no behavioural gain. The parts of the house pattern that actually
+ * matter are kept — the observer exists *before* the operation is dispatched, so the callback can
+ * never be missed; the wait is bounded; and a timeout is not a success. There is nothing to
+ * unregister afterwards, which is why there is no `finally`: unlike a `BroadcastReceiver` the
+ * observer is not registered with anything, it is just an object the framework holds until it calls
+ * back or is collected.
+ *
+ * ### The one invariant
+ *
+ * **Only the callback can produce [DataClearOutcome.CLEARED].** The result starts at
+ * [DataClearOutcome.UNVERIFIED] and the sole write to it is the callback's; every other path —
+ * [fire] throwing, the class being missing, the latch timing out, a verdict arriving *after* the
+ * timeout, anything at all going wrong — leaves it where it started. That is a property of the
+ * shape of this function rather than of remembering to handle each case, which is the point.
+ *
+ * First verdict wins. A second `onRemoveCompleted` is logged and discarded, so a late `true` can
+ * never upgrade a refusal into a success.
+ *
+ * @param tag the log tag of the calling site, so a bug report can tell the daemon's clear from
+ *   Shizuku's.
+ * @param packageName the package being cleared; used for logging and to spot a callback that names
+ *   something else.
+ * @param timeoutMillis how long to wait for the verdict. Defaults to [DATA_OBSERVER_TIMEOUT_MS];
+ *   only tests should pass anything else.
+ * @param fire dispatches the actual privileged call, handing it the observer. It must not swallow
+ *   its own failures — a throw here is information, and it is turned into
+ *   [DataClearOutcome.UNVERIFIED].
+ */
+internal fun awaitDataObserver(
+    tag: String,
+    packageName: String,
+    timeoutMillis: Long = DATA_OBSERVER_TIMEOUT_MS,
+    fire: (IPackageDataObserver) -> Unit,
+): DataClearOutcome {
+    // Starts at UNVERIFIED and only ever moves once, from the callback. Nothing below writes it.
+    val outcome = AtomicReference(DataClearOutcome.UNVERIFIED)
+    val latch = CountDownLatch(1)
+
+    val observer = newDataObserver(tag, packageName) { reportedPackage, succeeded ->
+        val verdict = if (succeeded) DataClearOutcome.CLEARED else DataClearOutcome.REFUSED
+        if (outcome.compareAndSet(DataClearOutcome.UNVERIFIED, verdict)) {
+            Logger.d(tag, "clear($packageName): observer reported $verdict for $reportedPackage")
+            latch.countDown()
+        } else {
+            // Not expected, and not trusted either: whichever verdict arrived first is the one this
+            // call is judged by, so a second callback cannot turn a REFUSED into a CLEARED.
+            Logger.w(
+                tag,
+                "clear($packageName): a second observer callback (succeeded=$succeeded) arrived " +
+                    "after ${outcome.get()} and was ignored"
+            )
+        }
+    }
+
+    return try {
+        fire(observer)
+
+        if (latch.await(timeoutMillis, TimeUnit.MILLISECONDS)) {
+            outcome.get()
+        } else {
+            // Read nothing back here. A verdict that lands a microsecond after the wait expired is
+            // still a verdict Thor did not see in time, and honouring it would make the result
+            // depend on scheduler luck.
+            Logger.w(
+                tag,
+                "clear($packageName): issued but unconfirmed within ${timeoutMillis}ms — reporting " +
+                    "failure, because a clear that cannot be confirmed is not a clear that happened"
+            )
+            DataClearOutcome.UNVERIFIED
+        }
+    } catch (t: Throwable) {
+        // Deliberately Throwable and deliberately a hard UNVERIFIED rather than `outcome.get()`.
+        // A refusal that arrives as an exception (SecurityException from PMS) and a transport that
+        // died before PMS ever saw the call are indistinguishable from here, and both collapse to
+        // `false` at every caller, so inventing a REFUSED out of one would be a claim this function
+        // is not in a position to make.
+        Logger.e(tag, "clear($packageName): the privileged call failed before any verdict", t)
+        DataClearOutcome.UNVERIFIED
+    }
+}
+
+/**
+ * The callback object handed to [awaitDataObserver]'s `fire`.
+ *
+ * Normally an `IPackageDataObserver.Stub` subclass — the only shape that can cross a binder, and
+ * the whole reason the aidl is vendored.
+ *
+ * The fallback is not defensive padding, it has exactly one known trigger: a JVM unit test. The
+ * generated `Stub()` constructor calls `Binder.attachInterface`, and in AGP's mockable `android.jar`
+ * every non-constructor method throws `"… not mocked"` — the same rewrite `FakeContext` in
+ * `ViewModelTestDoubles` relies on from the other side (constructors survive as a bare `super()`).
+ * Without the fallback, `DataClearOutcomeTest` could not reach a single line of the latch logic.
+ *
+ * On a device the fallback is unreachable, and if it somehow were reached it would fail safe rather
+ * than quietly: a plain interface implementation is not a `Binder`, so writing it into a parcel
+ * throws, `fire` throws, and the outcome is [DataClearOutcome.UNVERIFIED]. [asBinder] throwing is
+ * what guarantees that — it must never return some *other* binder, which the framework would
+ * happily call back instead of us.
+ */
+private fun newDataObserver(
+    tag: String,
+    packageName: String,
+    onVerdict: (reportedPackage: String?, succeeded: Boolean) -> Unit,
+): IPackageDataObserver =
+    try {
+        object : IPackageDataObserver.Stub() {
+            override fun onRemoveCompleted(reportedPackage: String?, succeeded: Boolean) {
+                onVerdict(reportedPackage, succeeded)
+            }
+        }
+    } catch (t: Throwable) {
+        Logger.w(
+            tag,
+            "clear($packageName): IPackageDataObserver.Stub could not be constructed (${t.message}) " +
+                "— falling back to a non-binder observer, which no framework call can reach"
+        )
+        object : IPackageDataObserver {
+            override fun onRemoveCompleted(reportedPackage: String?, succeeded: Boolean) {
+                onVerdict(reportedPackage, succeeded)
+            }
+
+            override fun asBinder(): IBinder =
+                throw UnsupportedOperationException(
+                    "this IPackageDataObserver is not a Binder and must not be marshalled"
+                )
+        }
+    }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -9,6 +9,8 @@ import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import com.valhalla.bypass.Bypass
 import com.valhalla.superuser.utils.escapeForShell
+import com.valhalla.thor.data.source.local.DataClearOutcome
+import com.valhalla.thor.data.source.local.awaitDataObserver
 import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
 import com.valhalla.thor.data.source.local.clearAppDataCommand
 import com.valhalla.thor.data.source.local.clearCachePaths
@@ -915,14 +917,24 @@ object Shizuku {
      * *refusal* of the per-user call must not fall through to a call that clears a different user's
      * cache and reports it as this user's success — the failure the reorder exists to remove.
      *
-     * **A `true` from this function is not evidence the cache is gone.** The shell rung is honest:
-     * `rm -rf` exits 0 or it does not. The reflection rung is not — the call is asynchronous
-     * (`PackageManagerService` posts the work to its own handler and reports through the
-     * `IPackageDataObserver`, which is passed as `null` here), so `true` means only that the binder
-     * call returned without throwing. At shell uid PMS also *accepts* cache clears that it then
-     * declines — it logs that it is silently ignoring the request and returns without deleting
-     * anything, and the caller is told none of that. So this Boolean must not be turned into
-     * "N bytes freed"; re-measure the cache if the number matters.
+     * **Both rungs now answer for themselves.** The shell rung always could: `rm -rf` exits 0 or it
+     * does not. The reflection rung could not, and used to say `true` whenever the binder call
+     * returned without throwing — which is not the same claim at all, because the call is
+     * asynchronous. `PackageManagerService` posts the work to its own handler and reports on an
+     * `IPackageDataObserver`, and that argument was `null`. At shell uid PMS also *accepts* cache
+     * clears that it then declines: it logs that it is silently ignoring the request, deletes
+     * nothing, and the old `true` reported that as a success. The observer is the only place that
+     * refusal is visible, so it is now wired up and waited on — see `awaitDataObserver`.
+     *
+     * What that changes for a caller: `true` means a verdict of "cleared" actually arrived. A
+     * refusal, a timeout, and a transport that never reached PMS all give `false`, and are told
+     * apart in the log rather than in the return type, because every consumer of this is a Boolean.
+     * `false` is therefore the honest answer to "could not confirm" as well as to "refused" — a
+     * cache clear repeated costs nothing, a false "done" costs the user the chance to try a
+     * privilege mode that would have worked.
+     *
+     * Still not a byte count. This Boolean must not be turned into "N bytes freed"; re-measure the
+     * cache if the number matters.
      */
     // PrivateApi: hidden-API reflection (IPackageDataObserver) is intentional — the core privilege
     // mechanism, guarded by the :bypass VMRuntime unseal.
@@ -939,39 +951,72 @@ object Shizuku {
         val shellResult = execute(command)
         if (shellResult.first == 0) return true
 
-        // 2. Fallback to reflection
-        val reflectionResult = runCatching {
+        // 2. Fallback to reflection, and this is the rung that matters under Shizuku: shell uid 2000
+        // cannot `rm -rf /data/data/<pkg>/cache`, so rung 1 normally fails and this is the real
+        // operation. It is also the one PMS can accept and then quietly decline, which is why the
+        // observer is no longer null — `awaitDataObserver` builds a real IPackageDataObserver.Stub,
+        // hands it to the invoke, and waits for onRemoveCompleted rather than for the invoke to
+        // return. Only a verdict of "cleared" gets out of here as true.
+        val outcome = runCatching {
             val pm = asInterface("android.content.pm.IPackageManager", "package")
             val observerClass = Class.forName("android.content.pm.IPackageDataObserver")
 
-            try {
-                Bypass.invoke<Any?>(
-                    pm.javaClass,
-                    pm,
-                    "deleteApplicationCacheFilesAsUser",
-                    arrayOf(String::class.java, Int::class.javaPrimitiveType!!, observerClass),
-                    packageName,
-                    thorUserId,
-                    null
-                )
-            } catch (_: NoSuchMethodException) {
-                // No user id to give: this overload derives one from the calling uid. Reached only
-                // if a release stops declaring the AsUser variant, which none in 28..37 does.
-                Bypass.invoke<Any?>(
-                    pm.javaClass,
-                    pm,
-                    "deleteApplicationCacheFiles",
-                    arrayOf(String::class.java, observerClass),
-                    packageName,
-                    null
-                )
+            awaitDataObserver("Shizuku", packageName) { observer ->
+                try {
+                    Bypass.invoke<Any?>(
+                        pm.javaClass,
+                        pm,
+                        "deleteApplicationCacheFilesAsUser",
+                        arrayOf(String::class.java, Int::class.javaPrimitiveType!!, observerClass),
+                        packageName,
+                        thorUserId,
+                        observer
+                    )
+                } catch (_: NoSuchMethodException) {
+                    // No user id to give: this overload derives one from the calling uid. Reached
+                    // only if a release stops declaring the AsUser variant, which none in 28..37
+                    // does. The observer still reports honestly, but about the *calling* user's
+                    // cache — shell's, not necessarily Thor's — so an UNVERIFIED from this branch
+                    // is doubly uninformative and a CLEARED from it is not a claim about the user
+                    // the caller asked for.
+                    Bypass.invoke<Any?>(
+                        pm.javaClass,
+                        pm,
+                        "deleteApplicationCacheFiles",
+                        arrayOf(String::class.java, observerClass),
+                        packageName,
+                        observer
+                    )
+                }
             }
-            true
-        }.getOrDefault(false)
+        }.getOrElse { e ->
+            // Only the binder lookup can land here; awaitDataObserver absorbs whatever the invokes
+            // themselves throw and answers UNVERIFIED for it.
+            Logger.e("Shizuku", "clearCache($packageName): could not reach IPackageManager", e)
+            DataClearOutcome.UNVERIFIED
+        }
 
-        return reflectionResult
+        return outcome == DataClearOutcome.CLEARED
     }
 
+    /**
+     * Wipes [packageName]'s data **for [thorUserId]** — `pm clear` first, then a hidden-API
+     * `IPackageManager` call.
+     *
+     * **Both rungs answer for themselves, which the second one did not used to.** `pm clear` blocks
+     * on its own `ClearDataObserver` inside `PackageManagerShellCommand` and exits non-zero when the
+     * wipe fails, so its exit code can be believed. `clearApplicationUserData` returns `void`: the
+     * verdict only ever arrives on an `IPackageDataObserver`, and that argument was `null`, so the
+     * old `true` meant nothing more than "the binder call did not throw". For the single most
+     * destructive operation Thor performs, that is the worst place in the app to be optimistic — the
+     * user was told their data was gone on the strength of a dispatch receipt. `awaitDataObserver`
+     * now supplies a real observer and waits for it.
+     *
+     * `true` therefore means a verdict of "cleared" arrived. A refusal, a timeout and a dead
+     * transport all give `false` and are distinguished in the log rather than in the return type.
+     * That direction is deliberate: wiping data twice costs a user nothing, a false "done" costs
+     * them the chance to try a privilege mode that would have worked.
+     */
     // Hidden-API reflection (IPackageDataObserver) is intentional: it is the core privilege
     // mechanism, guarded by the :bypass VMRuntime unseal.
     @SuppressLint("PrivateApi")
@@ -983,21 +1028,31 @@ object Shizuku {
         val result = execute(clearAppDataCommand(packageName.escapeForShell(), thorUserId))
         if (result.first == 0) return true
 
-        // 2. Fallback to reflection
-        return runCatching {
+        // 2. Fallback to reflection. The observer is no longer null: clearApplicationUserData
+        // returns void, so this is the only channel the verdict can arrive on, and without it the
+        // most destructive rung in the app was also its least honest one.
+        val outcome = runCatching {
             val pm = asInterface("android.content.pm.IPackageManager", "package")
             val observerClass = Class.forName("android.content.pm.IPackageDataObserver")
-            Bypass.invoke<Any?>(
-                pm.javaClass,
-                pm,
-                "clearApplicationUserData",
-                arrayOf(String::class.java, observerClass, Int::class.javaPrimitiveType!!),
-                packageName,
-                null,
-                thorUserId
-            )
-            true
-        }.getOrElse { false }
+            awaitDataObserver("Shizuku", packageName) { observer ->
+                Bypass.invoke<Any?>(
+                    pm.javaClass,
+                    pm,
+                    "clearApplicationUserData",
+                    arrayOf(String::class.java, observerClass, Int::class.javaPrimitiveType!!),
+                    packageName,
+                    observer,
+                    thorUserId
+                )
+            }
+        }.getOrElse { e ->
+            // Only the binder lookup can land here; awaitDataObserver absorbs whatever the invoke
+            // itself throws and answers UNVERIFIED for it.
+            Logger.e("Shizuku", "clearAppData($packageName): could not reach IPackageManager", e)
+            DataClearOutcome.UNVERIFIED
+        }
+
+        return outcome == DataClearOutcome.CLEARED
     }
 
     fun getTotalCacheSizeWithShizuku(): Long {

--- a/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
+++ b/app/src/main/java/com/valhalla/thor/rootservice/ThorRootService.kt
@@ -10,6 +10,8 @@ import android.os.IBinder
 import android.os.PersistableBundle
 import com.valhalla.superuser.ipc.RootService
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.data.source.local.DataClearOutcome
+import com.valhalla.thor.data.source.local.awaitDataObserver
 import com.valhalla.thor.domain.model.LEGACY_ROOT_SUSPENDER_IDENTITY
 import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
 import com.valhalla.thor.domain.model.parseSuspendingPackages
@@ -53,8 +55,25 @@ private const val PLATFORM_SUSPENDER_IDENTITY = "android"
  * The whole daemon deliberately reaches hidden framework APIs (IPackageManager, ServiceManager,
  * SuspendDialogInfo) via reflection — that is the entire point of running in the privileged :root
  * process — so PrivateApi is suppressed class-wide rather than method-by-method.
+ *
+ * `SoonBlockedPrivateApi` joined it when `app/src/main/aidl/android/content/pm/IPackageDataObserver.aidl`
+ * was vendored, and the reason is worth recording because nothing about the flagged call changed.
+ * Lint reports on `clearApplicationUserData` by resolving the argument classes of the
+ * `getDeclaredMethod` call into a descriptor and looking that up in its non-SDK list; the second
+ * argument is `Class.forName("android.content.pm.IPackageDataObserver")`, which lint could not
+ * resolve before — no such class existed in `android.jar` or in this project — so it could not
+ * build the descriptor and said nothing. The aidl gave it one. Measured as a single variable: an
+ * `origin/dev` worktree lints clean, and the same worktree with only that aidl file added, and no
+ * other change at all, reports this error on the identical line.
+ *
+ * Suppressed rather than worked around, on the argument already written out in [init]: this daemon
+ * is a bare `app_process`, never zygote-specialised, so it never goes through
+ * `ActivityThread.handleBindApplication` and the runtime's non-SDK enforcement is never switched on
+ * for it. "Will throw an exception when targeting API 28 and above" is true of the app process and
+ * false here — which is exactly why every reflective call in this file runs unexempted today, with
+ * no `Bypass` anywhere, on a path `RootSystemGateway` has device-proven.
  */
-@SuppressLint("PrivateApi")
+@SuppressLint("PrivateApi", "SoonBlockedPrivateApi")
 class ThorRootService : RootService() {
 
     init {
@@ -63,6 +82,29 @@ class ThorRootService : RootService() {
         // stay false and silently drop this daemon's logs. Mirror it so root-side diagnostics are
         // visible in debug builds (Logger is Thor's own, gated on this flag; safe in release).
         Logger.isDebug = BuildConfig.DEBUG
+
+        // No Bypass.setHiddenApiExemptions("Landroid/content/pm") here, deliberately, even though
+        // clearAppData below now subclasses the hidden android.content.pm.IPackageDataObserver$Stub
+        // and ThorApplication's Bypass.prepareThor() — which exempts that very prefix — never runs
+        // in this process.
+        //
+        // It is not needed: a bare app_process is not zygote-specialised and never goes through
+        // ActivityThread.handleBindApplication, so the runtime's hidden-API policy is never switched
+        // on for it. The proof is in this file already — everything below reaches IPackageManager,
+        // ServiceManager and SuspendDialogInfo with plain Class.forName + getDeclaredMethod +
+        // invoke, no Bypass anywhere, and that is the device-proven path RootSystemGateway falls
+        // back to. `Class.forName("android.content.pm.IPackageDataObserver")` is itself one of those
+        // calls, so the class this daemon must subclass is demonstrably reachable here unexempted.
+        //
+        // And it would not be free. Bypass.setHiddenApiExemptions tries its Unsafe layer first,
+        // which calls ensureUnsafeBypassReady() -> an mmap + dex parse of the boot-classpath core-oj
+        // jar; Bypass's own init block refuses to do that at class-initialization time for exactly
+        // that reason. Worse, Bypass.init(context) never ran here either, so there is no on-disk
+        // offset cache to hit or to persist into — the scan would be paid on the construction path
+        // of every single daemon start, to guard against an enforcement that is switched off.
+        //
+        // The app process needs nothing added either: prepareThor() already exempts
+        // "Landroid/content/pm", and it runs in onCreate, long before any clear.
     }
 
     override fun onBind(intent: Intent): IBinder {
@@ -592,9 +634,17 @@ class ThorRootService : RootService() {
      * `clearApplicationUserData`, whose third argument is exactly this number. It used to be the
      * literal 0, which is the difference between wiping the app the user tapped and wiping the
      * primary user's same-named app — irreversibly, and reported as a success.
+     *
+     * **The return value is now a confirmation, not a dispatch receipt.** This is the one site in
+     * Thor where a destructive privileged operation had no verifier of any kind: the daemon has no
+     * `PackageManager` for the caller's user and no readback to compare against, so
+     * `runCatching { … }.isSuccess` over a `void` method was all there was, and it reported success
+     * for every wipe `PackageManagerService` accepted and then declined. `true` now means
+     * `onRemoveCompleted` arrived saying so; a refusal, a timeout and a broken lookup all return
+     * `false` and are told apart in the log rather than in the return type.
      */
     private fun clearAppData(packageName: String, userId: Int): Boolean {
-        return runCatching {
+        val outcome = runCatching {
             val pmStub = Class.forName("android.content.pm.IPackageManager\$Stub")
             val serviceManager = Class.forName("android.os.ServiceManager")
             val getService = serviceManager.getMethod("getService", String::class.java)
@@ -603,20 +653,49 @@ class ThorRootService : RootService() {
             val pm = asInterface.invoke(null, binder)
             val pmClass = Class.forName("android.content.pm.IPackageManager")
 
+            // Still looked up by name rather than as IPackageDataObserver::class.java. Both resolve
+            // to the same framework class while parent-first delegation holds, and if it ever stops
+            // holding this spelling keeps the failure where it belongs — a lookup that cannot find
+            // the framework's method, rather than an invoke that silently takes our shadow copy.
             val method = pmClass.getDeclaredMethod(
                 "clearApplicationUserData",
                 String::class.java,
                 Class.forName("android.content.pm.IPackageDataObserver"),
                 Int::class.javaPrimitiveType
             )
-            // clearApplicationUserData returns void — the real success/failure is delivered
-            // asynchronously via IPackageDataObserver.onRemoveCompleted, which we deliberately do
-            // not wire up. So a clean reflective invocation is the strongest signal available: a
-            // thrown SecurityException / missing-package / bad-signature error propagates as
-            // failure (via runCatching below), while a successfully dispatched wipe reports success.
-            method.invoke(pm, packageName, null, userId)
-        }.onFailure { e ->
-            Logger.e("Odin", "Failed to clear app data for $packageName", e)
-        }.isSuccess
+            // clearApplicationUserData returns void: the verdict only ever arrives asynchronously on
+            // IPackageDataObserver.onRemoveCompleted, so a real observer is what makes it readable.
+            // The observer is constructed before the invoke, inside awaitDataObserver, so the
+            // callback cannot land before there is something to receive it.
+            awaitDataObserver("Odin", packageName) { observer ->
+                method.invoke(pm, packageName, observer, userId)
+            }
+        }.getOrElse { e ->
+            // Only the reflective lookup can land here — awaitDataObserver already absorbs whatever
+            // the invoke itself throws and answers UNVERIFIED for it.
+            Logger.e("Odin", "Failed to look up clearApplicationUserData for $packageName", e)
+            DataClearOutcome.UNVERIFIED
+        }
+
+        when (outcome) {
+            DataClearOutcome.CLEARED ->
+                Logger.d("Odin", "clearAppData($packageName, user $userId): confirmed by the observer")
+
+            DataClearOutcome.REFUSED ->
+                Logger.w(
+                    "Odin",
+                    "clearAppData($packageName, user $userId): PackageManagerService refused the " +
+                        "wipe — the data is still there"
+                )
+
+            DataClearOutcome.UNVERIFIED ->
+                Logger.w(
+                    "Odin",
+                    "clearAppData($packageName, user $userId): issued but never confirmed — the " +
+                        "data may or may not be gone, so this reports failure"
+                )
+        }
+
+        return outcome == DataClearOutcome.CLEARED
     }
 }

--- a/app/src/test/java/com/valhalla/thor/data/source/local/DataClearOutcomeTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/DataClearOutcomeTest.kt
@@ -1,0 +1,345 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import android.content.pm.IPackageDataObserver
+import android.os.Binder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * What [awaitDataObserver] concludes from what the platform did or did not say.
+ *
+ * The whole point of the function is one asymmetry: **only a `true` callback may produce
+ * [DataClearOutcome.CLEARED]**, and every other way the world can go — a refusal, silence, a throw,
+ * a verdict that arrives too late, a second verdict that disagrees with the first — must land on
+ * [DataClearOutcome.UNVERIFIED] or [DataClearOutcome.REFUSED]. That asymmetry is the fix; the three
+ * call sites it feeds all collapse it to a `Boolean`, so a bug here reappears as the exact thing
+ * this change exists to retire: Thor telling a user their data is gone on the strength of a dispatch
+ * receipt. These tests are therefore mostly negative, and the roll-up at the end restates the
+ * invariant over every failure shape at once so that a new one added later has somewhere obvious to
+ * go.
+ *
+ * ### What this file cannot test, and does not pretend to
+ *
+ * Nothing here touches binder. On the JVM the observer is necessarily the non-binder fallback in
+ * `newDataObserver` (`the fallback is the JVM fixture`, below, pins that), so what is exercised is
+ * the latch, the timeout and the outcome mapping — not marshalling, not `onTransact`, not whether
+ * `PackageManagerService` calls back at all. Those need a device, and the R8 keep rule that protects
+ * the callback in release is verifiable only in a minified build. Read the assertions here as "given
+ * a verdict, Thor draws the right conclusion", never as "the verdict arrives".
+ *
+ * It also depends on `Logger.isDebug` still being `false`, which it is in unit tests because only
+ * `ThorApplication` and `ThorRootService` ever set it and neither runs here. If some future test
+ * flips that global, the `android.util.Log` calls inside [awaitDataObserver] start throwing
+ * `"… not mocked"` and this file goes red for a reason that has nothing to do with it.
+ */
+class DataClearOutcomeTest {
+
+    private val pkg = "com.example.victim"
+
+    /**
+     * Short enough that four timeout cases cost under a second, long enough that a loaded CI machine
+     * cannot lose a *synchronous* callback to scheduling. Every synchronous case counts the latch
+     * down before `await` is ever reached, so the only tests this number can make flaky are the ones
+     * that are deliberately waiting it out.
+     */
+    private val shortTimeoutMs = 150L
+
+    /**
+     * The one input that means success.
+     *
+     * `succeeded = true` on `onRemoveCompleted` is `PackageManagerService` saying it did the work.
+     * It is also the only sentence in this whole mechanism that Thor is entitled to relay to a user
+     * as "done".
+     */
+    @Test
+    fun `a true callback is the only thing that means cleared`() {
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            observer.onRemoveCompleted(pkg, true)
+        }
+
+        assertEquals(DataClearOutcome.CLEARED, outcome)
+    }
+
+    /**
+     * A refusal is an answer, and is worth keeping distinct from silence even though both end up
+     * `false` at the call site.
+     *
+     * This is the case the fix was written for: at shell uid, PMS *accepts* a cache clear, logs that
+     * it is ignoring it, and reports `succeeded = false` on the observer nobody was passing. The
+     * distinction survives only in the log — the callers reduce [DataClearOutcome.REFUSED] and
+     * [DataClearOutcome.UNVERIFIED] to the same `false` — which is why a bug report can tell "the
+     * platform said no" from "we never heard back" and the return type cannot.
+     */
+    @Test
+    fun `a false callback is a refusal, not a failure to ask`() {
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            observer.onRemoveCompleted(pkg, false)
+        }
+
+        assertEquals(DataClearOutcome.REFUSED, outcome)
+        assertNotEquals(DataClearOutcome.UNVERIFIED, outcome)
+    }
+
+    /**
+     * A throw out of `fire` is [DataClearOutcome.UNVERIFIED], not [DataClearOutcome.REFUSED], and
+     * the difference is not cosmetic.
+     *
+     * The design note this implements said to map a throw to REFUSED. That is wrong from inside the
+     * function: a `SecurityException` from PMS and a binder that died before PMS ever saw the call
+     * arrive here as the same object, and calling the second one "refused" claims knowledge of a
+     * conversation that never happened. UNVERIFIED is the honest reading of both, and since both
+     * collapse to `false` at every caller, nothing is lost by refusing to guess.
+     */
+    @Test
+    fun `fire throwing is unverified, never refused`() {
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) {
+            throw SecurityException("Neither user 2000 nor current process has CLEAR_APP_USER_DATA")
+        }
+
+        assertEquals(DataClearOutcome.UNVERIFIED, outcome)
+    }
+
+    /**
+     * The catch is on `Throwable` on purpose, and this is the case that proves it.
+     *
+     * `NoClassDefFoundError` is not hypothetical here: it is precisely what a device that stopped
+     * shipping `android.content.pm.IPackageDataObserver` would produce, which is the scenario the
+     * vendored aidl's header argues must degrade to "could not confirm". Narrowing this to
+     * `Exception` would let that one escape the function entirely and take the call site's
+     * `runCatching` with it — still not a false success, but a crash instead of an answer.
+     */
+    @Test
+    fun `an Error is absorbed just as an Exception is`() {
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) {
+            throw NoClassDefFoundError("android/content/pm/IPackageDataObserver")
+        }
+
+        assertEquals(DataClearOutcome.UNVERIFIED, outcome)
+    }
+
+    /**
+     * A verdict that arrives and is then buried by a throw does not count.
+     *
+     * This is the sharpest form of the invariant, and the one place where the implementation
+     * deliberately reports *less* than it knows: the callback has already stored CLEARED, and the
+     * `catch` still returns a hard UNVERIFIED rather than reading the stored value back. Answering
+     * `outcome.get()` there would look like a free improvement and would be a false success — a
+     * `fire` that both called back and then blew up has not established that the clear it reported
+     * is the clear that finished.
+     */
+    @Test
+    fun `a verdict followed by a throw is still unverified`() {
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            observer.onRemoveCompleted(pkg, true)
+            throw IllegalStateException("the transport died on the way home")
+        }
+
+        assertEquals(DataClearOutcome.UNVERIFIED, outcome)
+    }
+
+    /**
+     * Silence times out, and times out as a failure.
+     *
+     * `clearApplicationUserData` returns `void` and `deleteApplicationCacheFiles` returns a boolean
+     * about nothing, so "the call returned and nothing else happened" is exactly what the old code
+     * reported as success. It is now the definition of not knowing.
+     */
+    @Test
+    fun `a verdict that never arrives is unverified`() {
+        val started = System.nanoTime()
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) { /* dispatched into the void */ }
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+
+        assertEquals(DataClearOutcome.UNVERIFIED, outcome)
+        assertTrue(
+            "returned after ${elapsedMs}ms, which is short of the ${shortTimeoutMs}ms it was told " +
+                "to wait — the wait is not actually happening",
+            elapsedMs >= shortTimeoutMs
+        )
+    }
+
+    /**
+     * First verdict wins, in the direction that matters.
+     *
+     * One `IPackageDataObserver` covers one operation, so a second `onRemoveCompleted` should not
+     * happen at all — but "should not happen" is not a guarantee about someone else's process. The
+     * compare-and-set makes the second one inert, and the case worth pinning is `false` then `true`:
+     * without it, a stray success could overturn a refusal Thor had already heard and turn the one
+     * honest answer in the sequence into a false "done".
+     */
+    @Test
+    fun `the first verdict wins and a second cannot overturn it`() {
+        val refusedThenCleared = awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            observer.onRemoveCompleted(pkg, false)
+            observer.onRemoveCompleted(pkg, true)
+        }
+        assertEquals(DataClearOutcome.REFUSED, refusedThenCleared)
+
+        val clearedThenRefused = awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            observer.onRemoveCompleted(pkg, true)
+            observer.onRemoveCompleted(pkg, false)
+        }
+        assertEquals(DataClearOutcome.CLEARED, clearedThenRefused)
+    }
+
+    /**
+     * A verdict that lands after the wait expired changes nothing, and does not blow up on its way
+     * to being ignored.
+     *
+     * The `assertEquals` after the gate is a restatement — `outcome` is a `val` that left the
+     * function before the callback ran, so it could not have changed. The load-bearing assertion is
+     * the one above it: the late callback runs to completion. Counting down a latch nobody is
+     * waiting on is harmless, but only because the function holds no state that outlives it; if a
+     * future version registered the observer anywhere, this is the test that would notice.
+     *
+     * A real device produces this every time the timeout is the thing that fires — PMS is slow, not
+     * absent — so it is an ordinary path, not a pathological one.
+     */
+    @Test
+    fun `a verdict that arrives after the wait expired changes nothing`() {
+        val gate = CountDownLatch(1)
+        val lateCallbackFinished = CountDownLatch(1)
+
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            Thread {
+                gate.await()
+                observer.onRemoveCompleted(pkg, true)
+                lateCallbackFinished.countDown()
+            }.apply { isDaemon = true }.start()
+        }
+
+        assertEquals(DataClearOutcome.UNVERIFIED, outcome)
+
+        gate.countDown()
+        assertTrue(
+            "the late callback never finished — something in it threw",
+            lateCallbackFinished.await(5, TimeUnit.SECONDS)
+        )
+        assertEquals(DataClearOutcome.UNVERIFIED, outcome)
+    }
+
+    /**
+     * The verdict is believed even when it names a different package, and that is deliberate.
+     *
+     * One observer instance is created per call and handed to exactly one operation, so the
+     * `packageName` the framework echoes back is diagnostic, not an identity check — it is logged
+     * so a bug report can show a mismatch, and nothing branches on it. Rejecting a mismatched name
+     * would trade a real verdict for a timeout on the strength of a string an OEM might normalise.
+     */
+    @Test
+    fun `a callback naming another package is still this call's verdict`() {
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            observer.onRemoveCompleted("com.example.somethingelse", true)
+        }
+
+        assertEquals(DataClearOutcome.CLEARED, outcome)
+    }
+
+    /**
+     * A `null` package name in the callback is survivable.
+     *
+     * The generated `Stub` unparcels a `@Nullable String`, so `null` is representable on this
+     * interface whatever AOSP's own callers do with it. It reaches nothing but string interpolation
+     * in a log line, and this pins that it stays that way.
+     */
+    @Test
+    fun `a callback with no package name still carries its verdict`() {
+        val outcome = awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            observer.onRemoveCompleted(null, true)
+        }
+
+        assertEquals(DataClearOutcome.CLEARED, outcome)
+    }
+
+    /**
+     * The invariant, restated over every failure shape at once.
+     *
+     * The tests above each say why one case matters; this one says the thing they have in common,
+     * and is the test to extend when a new way of failing turns up. Its value is that it fails for a
+     * change that "improves" one branch — reading the stored outcome back after a throw, honouring a
+     * late callback, treating an empty result as fine — without anyone having to notice which
+     * individual test it belonged to.
+     */
+    @Test
+    fun `no path except a true callback yields CLEARED`() {
+        val waysToNotSucceed: List<Pair<String, (IPackageDataObserver) -> Unit>> = listOf(
+            "dispatched and never answered" to { _: IPackageDataObserver -> },
+            "refused" to { o: IPackageDataObserver -> o.onRemoveCompleted(pkg, false) },
+            "refused twice" to { o: IPackageDataObserver ->
+                o.onRemoveCompleted(pkg, false)
+                o.onRemoveCompleted(pkg, false)
+            },
+            "refused, then a stray success" to { o: IPackageDataObserver ->
+                o.onRemoveCompleted(pkg, false)
+                o.onRemoveCompleted(pkg, true)
+            },
+            "threw a SecurityException" to { _: IPackageDataObserver ->
+                throw SecurityException("denied")
+            },
+            "threw an Error" to { _: IPackageDataObserver ->
+                throw NoClassDefFoundError("android/content/pm/IPackageDataObserver")
+            },
+            "succeeded, then threw" to { o: IPackageDataObserver ->
+                o.onRemoveCompleted(pkg, true)
+                throw IllegalStateException("boom")
+            },
+            "answered only after the wait expired" to { o: IPackageDataObserver ->
+                Thread {
+                    Thread.sleep(shortTimeoutMs * 4)
+                    o.onRemoveCompleted(pkg, true)
+                }.apply { isDaemon = true }.start()
+            },
+        )
+
+        waysToNotSucceed.forEach { (description, fire) ->
+            val outcome = awaitDataObserver("test", pkg, shortTimeoutMs, fire)
+            assertNotEquals(
+                "\"$description\" was reported as a completed wipe",
+                DataClearOutcome.CLEARED,
+                outcome
+            )
+        }
+    }
+
+    /**
+     * On the JVM the observer is the non-binder fallback, which is why any of the above runs at all.
+     *
+     * `object : IPackageDataObserver.Stub()` cannot be constructed here: the generated constructor
+     * calls `Binder.attachInterface`, and in AGP's mockable `android.jar` every non-constructor
+     * method is rewritten to throw `"Method … not mocked"` (constructors survive as a bare
+     * `super()`, which is the same rewrite `FakeContext` in `ViewModelTestDoubles` leans on from the
+     * other side). Without the fallback in `newDataObserver`, every case in this file would collapse
+     * to UNVERIFIED for the same uninteresting reason and the file would prove nothing.
+     *
+     * **If this assertion ever fails, it is good news and this file needs re-reading, not fixing**:
+     * it would mean the `Stub` is now constructible on the JVM, the fallback is no longer the thing
+     * these tests exercise, and the coverage above just silently got better. It is asserted rather
+     * than assumed so that the change announces itself.
+     */
+    @Test
+    fun `the fallback is the JVM fixture`() {
+        var captured: IPackageDataObserver? = null
+
+        awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            captured = observer
+            observer.onRemoveCompleted(pkg, true)
+        }
+
+        val observer = captured
+        assertNotNull("fire was never called", observer)
+        assertFalse(
+            "the observer is a real Binder — AGP's mockable android.jar has changed and these " +
+                "tests now exercise the Stub path instead of the fallback",
+            observer is Binder
+        )
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/source/local/DataClearOutcomeTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/DataClearOutcomeTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -52,6 +53,22 @@ class DataClearOutcomeTest {
      * that are deliberately waiting it out.
      */
     private val shortTimeoutMs = 150L
+
+    /**
+     * `awaitDataObserver` carries one piece of process-wide state — whether the last conclusive wait
+     * got there via the callback — and every timeout case in this file knocks it down.
+     *
+     * Without this, the file would be order-dependent in a way that hides rather than fails: JUnit
+     * does not promise an order, so `a verdict that never arrives is unverified` could run first and
+     * silently shorten the wait of whatever came next. It happens not to matter for the cases that
+     * use [shortTimeoutMs], because 150ms is already below the degraded ceiling and `minOf` leaves it
+     * alone — but that is a coincidence of one constant, not a property, and the three cases below
+     * deliberately use nominal timeouts either side of the ceiling where it stops being true.
+     */
+    @Before
+    fun assumeTheTransportWorksUntilShownOtherwise() {
+        resetObserverTransportBelief()
+    }
 
     /**
      * The one input that means success.
@@ -308,6 +325,84 @@ class DataClearOutcomeTest {
                 outcome
             )
         }
+    }
+
+    /**
+     * One unanswered wait shortens the next one, which is what keeps a batch from taking minutes.
+     *
+     * `MainViewModel.performLoggedMultiAction` clears a selection sequentially, one full wait per
+     * package, so on a ROM that never calls back the old arithmetic was fifty apps × fifteen seconds.
+     * The claim under test is that the *second* wait is cut, not that the first one is: the first
+     * full-length timeout is the evidence, and paying for it once is the price of finding out.
+     *
+     * The nominal 60s here is the point — it is four times the production default, so an assertion
+     * that the call came back in a fraction of it cannot be satisfied by any un-shortened wait.
+     */
+    @Test
+    fun `a wait that went unanswered shortens the next one`() {
+        awaitDataObserver("test", pkg, shortTimeoutMs) { /* the evidence: dispatched, never answered */ }
+
+        val started = System.nanoTime()
+        val outcome = awaitDataObserver("test", pkg, timeoutMillis = 60_000L) { /* also unanswered */ }
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+
+        assertEquals(DataClearOutcome.UNVERIFIED, outcome)
+        assertTrue(
+            "the second wait took ${elapsedMs}ms of its nominal 60000ms — it was not shortened, so a " +
+                "fifty-app batch on a ROM that drops callbacks still costs twelve minutes",
+            elapsedMs < 10_000
+        )
+    }
+
+    /**
+     * The shortened wait is a shorter wait, not a skipped one.
+     *
+     * This is the guard against the version of this optimisation that would be a real regression:
+     * once one call had timed out, a *skip* would make [DataClearOutcome.UNVERIFIED] structural and
+     * no clear could ever be confirmed again. A ROM that is merely slow — rather than mute — would be
+     * permanently misreported as failing, which is precisely the false-negative this whole PR is
+     * written to avoid creating.
+     */
+    @Test
+    fun `a shortened wait still honours a verdict that arrives inside it`() {
+        awaitDataObserver("test", pkg, shortTimeoutMs) { /* knock the belief down */ }
+
+        val outcome = awaitDataObserver("test", pkg, timeoutMillis = 60_000L) { observer ->
+            observer.onRemoveCompleted(pkg, true)
+        }
+
+        assertEquals(DataClearOutcome.CLEARED, outcome)
+    }
+
+    /**
+     * The shortening is undone by the next verdict of any kind, so it cannot accumulate.
+     *
+     * A single slow wipe should cost one shortened wait and nothing more. If the belief were sticky,
+     * one unlucky timeout early in a session would quietly halve the patience of every clear after
+     * it for the life of the process — a permanent degradation bought with a transient symptom.
+     *
+     * The nominal 2500ms is chosen to straddle the 1500ms ceiling: a call that is still shortened
+     * comes back at about 1500ms, one that is not comes back at about 2500ms, and the assertion can
+     * only be met by the second.
+     */
+    @Test
+    fun `a verdict of any kind restores the full wait`() {
+        awaitDataObserver("test", pkg, shortTimeoutMs) { /* knock the belief down */ }
+        awaitDataObserver("test", pkg, shortTimeoutMs) { observer ->
+            // A refusal, not a success: what this proves about the transport is that it *answers*,
+            // and the answer's content is irrelevant to that.
+            observer.onRemoveCompleted(pkg, false)
+        }
+
+        val started = System.nanoTime()
+        awaitDataObserver("test", pkg, timeoutMillis = 2_500L) { /* unanswered again */ }
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+
+        assertTrue(
+            "the wait came back after ${elapsedMs}ms of its nominal 2500ms, so it was still using " +
+                "the degraded ceiling — the refusal in between should have restored full patience",
+            elapsedMs >= 2_000
+        )
     }
 
     /**

--- a/app/src/test/java/com/valhalla/thor/data/source/local/ObserverCallSitesTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/ObserverCallSitesTest.kt
@@ -1,0 +1,483 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * A source-text sweep: every privileged clear-data / clear-cache call must hand
+ * `PackageManagerService` a real `IPackageDataObserver`, and none may go back to passing `null`.
+ *
+ * This is the only test in the repo that reads `src/main` as text rather than calling it, so it is
+ * worth being explicit about why. The three rewired call sites are unreachable from a JVM test —
+ * each one needs a live `IPackageManager` binder — and [DataClearOutcomeTest] can only prove that
+ * [awaitDataObserver] draws the right conclusion *once it is used*. Nothing enforces that it is
+ * used. The regression this guards is not subtle logic, it is a one-token edit: `observer` back to
+ * `null`, which compiles, runs, and restores exactly the "the binder call did not throw" success
+ * this change exists to retire. A text sweep is a blunt instrument, but it is pointed at the one
+ * thing that is genuinely at risk.
+ *
+ * ### What it is worth, and what it is not
+ *
+ * It proves a shape, not a behaviour. It cannot tell whether the observer is ever called, whether
+ * the framework can marshal it, or whether R8 left the callback's name alone in release. It will
+ * also not survive a large refactor of these functions — and that is intended: if the shape it
+ * pins stops describing the code, somebody has to come back here and decide again, deliberately,
+ * that the observer is still wired up.
+ *
+ * ### Anti-vacuity
+ *
+ * A sweep that reads nothing passes green and proves nothing, which is the failure mode of this
+ * entire genre of test. Three separate guards stand against it, each its own test so that losing
+ * one is visible: `the sweep read the files it claims to have read` proves the files and function
+ * bodies were actually found and are actually the ones named; `the sweep can actually fail` runs
+ * the same detector over a synthetic body carrying the old `null` and asserts it complains; and the
+ * extractor is checked against a function name that does not exist, so that "found nothing" and
+ * "found everything" cannot look alike.
+ */
+class ObserverCallSitesTest {
+
+    /**
+     * A function whose observer argument this test is responsible for.
+     *
+     * [control] is a substring known to sit inside *that function* and nowhere near the others —
+     * the anti-vacuity guard for the body extraction, distinct from [frameworkMethods] so that the
+     * guard is not simply asserting the thing under test twice.
+     */
+    private data class ClearSite(
+        val relativePath: String,
+        val functionName: String,
+        val control: String,
+        val frameworkMethods: List<String>,
+    )
+
+    /**
+     * The three rungs that now wait for a verdict.
+     *
+     * `RootSystemGateway` is not here and does not belong here: it mentions `IPackageDataObserver`
+     * only in comments explaining why its cache clear goes through the shell instead. `DhizukuHelper`
+     * is excluded deliberately, and the last test in this file is what keeps that exclusion honest.
+     */
+    private val verifiedSites = listOf(
+        ClearSite(
+            relativePath = "data/source/local/shizuku/Shizuku.kt",
+            functionName = "clearCache",
+            control = "clearCachePaths(",
+            frameworkMethods = listOf(
+                "deleteApplicationCacheFilesAsUser",
+                "deleteApplicationCacheFiles",
+            ),
+        ),
+        ClearSite(
+            relativePath = "data/source/local/shizuku/Shizuku.kt",
+            functionName = "clearAppData",
+            control = "clearAppDataCommand(",
+            frameworkMethods = listOf("clearApplicationUserData"),
+        ),
+        ClearSite(
+            relativePath = "rootservice/ThorRootService.kt",
+            functionName = "clearAppData",
+            control = "android.os.ServiceManager",
+            frameworkMethods = listOf("clearApplicationUserData"),
+        ),
+    )
+
+    // -- the sweep itself ---------------------------------------------------------------------
+
+    /**
+     * The invariant: after the observer is created, every reflective call in that function is
+     * handed it.
+     *
+     * "After the observer is created" is doing real work in that sentence. `ThorRootService`
+     * legitimately calls `Method.invoke(null, …)` twice before it gets that far — `getService` and
+     * `asInterface` are both static, and `null` is their receiver, not an observer. Scoping the
+     * check to the text following `awaitDataObserver(` is what separates those from the argument
+     * that matters, without needing to understand any of it.
+     */
+    @Test
+    fun `every verified clear hands PackageManagerService a real observer`() {
+        verifiedSites.forEach { site ->
+            val body = bodyOf(site)
+
+            site.frameworkMethods.forEach { method ->
+                assertTrue(
+                    "${site.functionName} in ${site.relativePath} no longer calls $method — the " +
+                        "sweep is pointed at the wrong function, or the rung is gone",
+                    body.contains("\"$method\"")
+                )
+            }
+
+            val complaints = observerArgumentComplaints(body)
+            assertTrue(
+                "${site.relativePath}#${site.functionName}: ${complaints.joinToString("; ")}",
+                complaints.isEmpty()
+            )
+        }
+    }
+
+    /**
+     * The exact shape the fix removed must not come back by copy-paste.
+     *
+     * `null /* IPackageDataObserver */` is how the argument was spelled at four of the five sites,
+     * comment and all, and it is still spelled that way in `DhizukuHelper` — which is precisely why
+     * it is the thing most likely to be pasted back in while "making the gateways consistent". The
+     * check is on the raw text including comments, unlike the sweep above, because here the comment
+     * is the fingerprint.
+     */
+    @Test
+    fun `the old null-observer spelling is gone from the verified files`() {
+        verifiedSites.map { it.relativePath }.distinct().forEach { path ->
+            val source = sourceOf(path)
+            assertFalse(
+                "$path still carries the pre-fix `null /* IPackageDataObserver */` argument",
+                source.contains("null /* IPackageDataObserver */")
+            )
+        }
+    }
+
+    // -- anti-vacuity -------------------------------------------------------------------------
+
+    /**
+     * Proof that the sweep read what it says it read.
+     *
+     * Every assertion above is of the form "this text does not contain that", and all of them pass
+     * trivially over an empty string. So: the source root resolves, each file is present and
+     * substantial, each named function is found, each extracted body carries its own control
+     * substring, and — the part that is easy to leave out — the extractor returns nothing for a
+     * function that does not exist. Without that last one, an extractor that silently returned the
+     * whole file, or the empty string, would look identical to one that worked.
+     */
+    @Test
+    fun `the sweep read the files it claims to have read`() {
+        assertTrue(
+            "the main source root did not resolve to a directory: $mainSourceRoot",
+            mainSourceRoot.isDirectory
+        )
+
+        assertEquals("the site list has been edited without updating this guard", 3, verifiedSites.size)
+
+        verifiedSites.forEach { site ->
+            val source = sourceOf(site.relativePath)
+            assertTrue(
+                "${site.relativePath} read as ${source.length} characters, which is not a file " +
+                    "this sweep could have been reading",
+                source.length > 2_000
+            )
+            assertTrue(
+                "${site.relativePath} is missing Thor's SPDX header — this is not the file it " +
+                    "was supposed to be",
+                source.contains("SPDX-License-Identifier: GPL-3.0-or-later")
+            )
+
+            val body = bodyOf(site)
+            assertTrue(
+                "the extracted body of ${site.functionName} is ${body.length} characters long",
+                body.length > 200
+            )
+            assertTrue(
+                "the extracted body does not start with the signature of ${site.functionName}",
+                body.trimStart().substringBefore('\n').contains("fun ${site.functionName}(")
+            )
+            assertTrue(
+                "the extracted body of ${site.relativePath}#${site.functionName} does not contain " +
+                    "\"${site.control}\" — the wrong region was extracted",
+                body.contains(site.control)
+            )
+        }
+
+        assertNull(
+            "the extractor returned something for a function that does not exist, so \"found it\" " +
+                "and \"found nothing\" are indistinguishable and every assertion above is worthless",
+            extractFunctionBody(
+                sourceOf("rootservice/ThorRootService.kt"),
+                "clearAppDataThisFunctionDoesNotExist"
+            )
+        )
+    }
+
+    /**
+     * Proof that the detector can say no.
+     *
+     * The regression is simulated rather than waited for: this is the `ThorRootService` rung as it
+     * would read if somebody put the `null` back, and the sweep must complain about it. A sweep that
+     * cannot be made to fail on demand is not evidence about the code, only about itself.
+     *
+     * The second half is the mirror image and matters just as much — a detector that complains about
+     * everything is as useless as one that complains about nothing, so the fixed version of the same
+     * body has to come back clean.
+     */
+    @Test
+    fun `the sweep can actually fail`() {
+        val regressed = """
+            private fun clearAppData(packageName: String, userId: Int): Boolean {
+                val outcome = runCatching {
+                    awaitDataObserver("Odin", packageName) { observer ->
+                        method.invoke(pm, packageName, null, userId)
+                    }
+                }
+                return outcome == DataClearOutcome.CLEARED
+            }
+        """.trimIndent()
+
+        assertFalse(
+            "a body passing null in the observer position was swept clean",
+            observerArgumentComplaints(regressed).isEmpty()
+        )
+
+        assertTrue(
+            "the same body with the observer restored was still complained about, so the detector " +
+                "does not discriminate",
+            observerArgumentComplaints(
+                regressed.replace("packageName, null, userId", "packageName, observer, userId")
+            ).isEmpty()
+        )
+    }
+
+    /**
+     * `observerClass` is not an observer, and the detector must not be fooled by the prefix.
+     *
+     * Both Shizuku rungs pass a `Class` object called `observerClass` into `arrayOf(…)` as part of
+     * the method signature, in the same argument list as the observer itself. A substring test for
+     * "observer" would be satisfied by that alone, so the `null` regression would sweep clean at
+     * exactly the two sites where it is most likely. The detector matches a standalone token; this
+     * is the test that says so.
+     */
+    @Test
+    fun `a lookalike identifier does not stand in for the observer`() {
+        val lookalike = """
+            fun clearCache(packageName: String): Boolean {
+                awaitDataObserver("Shizuku", packageName) { observer ->
+                    Bypass.invoke<Any?>(
+                        pm.javaClass,
+                        pm,
+                        "deleteApplicationCacheFilesAsUser",
+                        arrayOf(String::class.java, Int::class.javaPrimitiveType!!, observerClass),
+                        packageName,
+                        thorUserId,
+                        null
+                    )
+                }
+            }
+        """.trimIndent()
+
+        assertFalse(
+            "an argument list containing observerClass and a null observer was accepted",
+            observerArgumentComplaints(lookalike).isEmpty()
+        )
+    }
+
+    // -- the deliberate exclusion -------------------------------------------------------------
+
+    /**
+     * `DhizukuHelper` still passes `null`, still says why, and is still outside this sweep.
+     *
+     * Its two reflection rungs were made honest rather than verified: on a Dhizuku-only device the
+     * call dies inside a `ShizukuBinderWrapper` before it ever reaches `PackageManagerService`, so a
+     * real observer would buy one guaranteed 15-second timeout per package — an always-red answer
+     * that teaches nobody anything — and both rungs now simply return `false`. That is a decision,
+     * not an oversight, and this test is what keeps the difference legible.
+     *
+     * It is deliberately two-sided. If the comment marking the rungs disappears, the reasoning has
+     * been lost and this fails. If [awaitDataObserver] ever appears in that file, the transport has
+     * been fixed and Dhizuku belongs in [verifiedSites] — which is also a failure, and the right
+     * one: the sweep should widen rather than quietly not cover the new code.
+     */
+    @Test
+    fun `Dhizuku is excluded on purpose, and says so`() {
+        val dhizuku = sourceOf("data/source/local/dhizuku/Dhizuku.kt")
+        val marker = "issued, and deliberately never believed"
+
+        assertEquals(
+            "DhizukuHelper's reflection rungs no longer carry \"$marker\" — either they were " +
+                "rewired, in which case add them to verifiedSites, or the reasoning was deleted",
+            2,
+            dhizuku.split(marker).size - 1
+        )
+
+        assertFalse(
+            "DhizukuHelper now uses awaitDataObserver, so it is no longer excluded and must be " +
+                "added to verifiedSites instead of being asserted about here",
+            dhizuku.contains("awaitDataObserver")
+        )
+    }
+
+    // -- machinery ----------------------------------------------------------------------------
+
+    /**
+     * `<module>/src/main/java/com/valhalla/thor`, found by walking up from wherever the runner
+     * happened to start.
+     *
+     * Gradle runs unit tests with the working directory set to the module — `<repo>/app` — but
+     * nothing guarantees that: Android Studio and `--tests` invocations have both been observed
+     * starting a level up. Rather than hard-code either, this tries the marker path at each ancestor
+     * both directly and under `app/`, and throws with everything it tried if none of them exist.
+     * Returning a plausible-looking missing directory instead would turn every assertion in this
+     * file into a green no-op, which is the precise failure this class is built to avoid.
+     */
+    private val mainSourceRoot: File by lazy {
+        val marker = "src/main/java/com/valhalla/thor"
+        val tried = mutableListOf<String>()
+        var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+
+        var hops = 0
+        while (hops < 8) {
+            val here = dir ?: break
+            for (candidate in listOf(File(here, marker), File(here, "app/$marker"))) {
+                if (candidate.isDirectory) return@lazy candidate
+                tried += candidate.path
+            }
+            dir = here.parentFile
+            hops++
+        }
+
+        throw AssertionError(
+            "could not locate $marker from ${System.getProperty("user.dir")}; tried:\n" +
+                tried.joinToString("\n")
+        )
+    }
+
+    private fun sourceOf(relativePath: String): String {
+        val file = File(mainSourceRoot, relativePath)
+        assertTrue("$relativePath does not exist at ${file.absolutePath}", file.isFile)
+        return file.readText()
+    }
+
+    private fun bodyOf(site: ClearSite): String =
+        extractFunctionBody(sourceOf(site.relativePath), site.functionName)
+            ?: throw AssertionError(
+                "no function named ${site.functionName} was found in ${site.relativePath}"
+            )
+
+    /**
+     * The text of a member function, from its `fun` line to the `}` that closes it.
+     *
+     * The closing brace is found by indentation rather than by counting braces, and that is the
+     * whole trick: a member of a top-level `class` or `object` closes on a line that is exactly four
+     * spaces and a brace, while everything nested inside it is indented further. Brace counting
+     * would have to understand string templates (`${…}` opens and closes one each, so it survives)
+     * and comments (which do not), and this file only ever looks at three functions in a codebase
+     * that is uniformly formatted. Returns `null` when the function is not there, which
+     * `the sweep read the files it claims to have read` depends on.
+     */
+    private fun extractFunctionBody(source: String, functionName: String): String? {
+        val signature = Regex("""^ {4}(?:\w+\s+)*fun\s+${Regex.escape(functionName)}\s*\(""")
+        val lines = source.lines()
+
+        val start = lines.indexOfFirst { signature.containsMatchIn(it) }
+        if (start < 0) return null
+
+        val end = (start + 1 until lines.size).firstOrNull { lines[it].trimEnd() == "    }" }
+            ?: return null
+
+        return lines.subList(start, end + 1).joinToString("\n")
+    }
+
+    /**
+     * Everything wrong with the observer arguments in [body], as sentences; empty means clean.
+     *
+     * Comments are stripped first, and not out of tidiness: the prose around these rungs discusses
+     * `invoke`, `observer` and `null` at length, and a sweep that reads it is reading Thor's opinion
+     * of the code rather than the code. The stripper is a few lines rather than a Kotlin lexer — it
+     * would mishandle a `//` inside a string literal, which none of the three bodies contains and
+     * the control substrings would catch if one appeared.
+     */
+    private fun observerArgumentComplaints(body: String): List<String> {
+        val code = stripComments(body)
+        val dispatchAt = code.indexOf("awaitDataObserver(")
+        if (dispatchAt < 0) return listOf("no awaitDataObserver( call — the observer is never created")
+
+        val arguments = invocationArgumentsIn(code.substring(dispatchAt))
+        if (arguments.isEmpty()) {
+            return listOf("awaitDataObserver( is called but nothing is invoked inside it")
+        }
+
+        // Whole-token matches, which is the difference between reading `observer` and reading the
+        // `observerClass` that sits two arguments away from it in both Shizuku rungs. The argument
+        // text is padded rather than anchored so that a token at either end still has a delimiter to
+        // match against.
+        val observerToken = Regex("""[(,\s]observer[,)\s]""")
+        val nullArgument = Regex("""[(,\s]null[,)\s]""")
+
+        return arguments.flatMap { args ->
+            val padded = " $args "
+            val oneLine = args.replace(Regex("""\s+"""), " ").trim()
+            buildList {
+                if (!observerToken.containsMatchIn(padded)) {
+                    add("an invoke after the observer was created does not pass it: ($oneLine)")
+                }
+                if (nullArgument.containsMatchIn(padded)) {
+                    add("an invoke after the observer was created still passes null: ($oneLine)")
+                }
+            }
+        }
+    }
+
+    /**
+     * The argument text of every `invoke(…)` in [code], paren-balanced.
+     *
+     * Balanced rather than line-windowed because the real call sites wrap their arguments over eight
+     * lines and nest an `arrayOf(…)` in the middle of them, so any fixed window is either too short
+     * to reach the observer or long enough to swallow the next statement.
+     */
+    private fun invocationArgumentsIn(code: String): List<String> {
+        val found = mutableListOf<String>()
+        var from = 0
+
+        while (true) {
+            val at = code.indexOf("invoke", from)
+            if (at < 0) break
+            val open = code.indexOf('(', at)
+            if (open < 0) break
+
+            var depth = 0
+            var i = open
+            while (i < code.length) {
+                if (code[i] == '(') depth++
+                if (code[i] == ')') {
+                    depth--
+                    if (depth == 0) break
+                }
+                i++
+            }
+            if (i >= code.length) break
+
+            found += code.substring(open + 1, i)
+            from = i + 1
+        }
+
+        return found
+    }
+
+    private fun stripComments(source: String): String =
+        source
+            .replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), " ")
+            .lines()
+            .joinToString("\n") { line ->
+                val cut = line.indexOfLineComment()
+                if (cut < 0) line else line.substring(0, cut)
+            }
+
+    private fun String.indexOfLineComment(): Int {
+        var quotes = 0
+        var i = 0
+        while (i < length - 1) {
+            val c = this[i]
+            if (c == '\\') {
+                // Skip whatever it escapes, so an escaped quote inside a string literal does not
+                // flip the parity and hand the rest of the line to the stripper.
+                i += 2
+            } else {
+                if (c == '"') quotes++
+                if (c == '/' && this[i + 1] == '/' && quotes % 2 == 0) return i
+                i++
+            }
+        }
+        return -1
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> **Device-tested 2026-08-05 — the merge gate is discharged.** Measured at uid 2000 (Shizuku's own privilege level) on a live Android 16 / API 36 image, with a real `IPackageDataObserver.Stub` built from this PR's vendored aidl. `clearApplicationUserData` calls back in **96 ms** and the data is verifiably gone; the cache path never calls back **and the cache is verifiably still there**, with `PackageManager: Calling uid 2000 does not have android.permission.INTERNAL_DELETE_CACHE_FILES, silently ignoring` in logcat as the witness. The regression this was gated on — a working clear newly reporting failure — does not exist. See [the results comment](https://github.com/trinadhthatakula/Thor/pull/348#issuecomment-5185202498).
>
> One consequence worth knowing before the bug reports arrive: **Shizuku "clear cache" now reports failure whenever Shizuku was started over adb**, because it never worked. Root-started Shizuku (uid 0) is unaffected.

Item 3b of the 2026-08-04 dev audit, stacked on #347 (now merged).

## The defect

Three sites cleared user data or cache and reported success because a `void` binder call returned.

| Site | Call | What it returns |
|---|---|---|
| `Shizuku.clearAppData` | `IPackageManager.clearApplicationUserData` | `void` |
| `Shizuku.clearCache` | `IPackageManager.deleteApplicationCacheFilesAsUser` | a boolean that says nothing about the outcome |
| `ThorRootService.clearAppData` | `IPackageManager.clearApplicationUserData` | `void` |

In every case `PackageManagerService` posts the work to its own handler and reports the result on `IPackageDataObserver.onRemoveCompleted`. **All three passed `null` there.** At shell uid PMS additionally *accepts* cache clears it then declines — it logs that it is silently ignoring the request, deletes nothing, and tells the caller none of it.

So `true` meant "the call did not throw", for the most destructive operation Thor performs. The daemon site was worse than the other two: it has no `PackageManager` for the caller's user and no readback to compare against, so `runCatching { … }.isSuccess` over a void method was the *entire* verifier.

## The fix

`awaitDataObserver` builds a real observer, hands it to the privileged call, and waits once and briefly for the verdict.

Its invariant is structural rather than remembered: the result **starts** at `UNVERIFIED` and the callback is the only thing that ever writes it. `fire` throwing, the class being missing, the latch timing out, a verdict landing after the timeout — every one of those leaves it where it started, because none of them is a write. First verdict wins, so a late `true` cannot upgrade a refusal.

**A throw from `fire` maps to `UNVERIFIED`, never `REFUSED`.** From inside the function a `SecurityException` from PMS and a transport that died before PMS ever saw the call are the same object; calling the second one a refusal would claim knowledge of a conversation that never happened.

Both non-`CLEARED` values collapse to `false` at every caller. That direction is deliberate: clearing twice costs a user nothing, a false "done" costs them the chance to try a privilege mode that would have worked. The three outcomes are distinguished in the log rather than in the return type, because every consumer is a `Boolean`.

## Why a vendored aidl

A `java.lang.reflect.Proxy` cannot be marshalled over binder, so the callback has to be a genuine `IPackageDataObserver.Stub` subclass — and `Stub` is not in the public SDK. AOSP's aidl is vendored **purely to give the Kotlin compiler something to subclass**. At runtime `PathClassLoader` delegates parent-first, the boot classpath's framework class wins, and the generated copy is never loaded, so the object extends the *framework* `Stub` and the framework's own `onTransact` dispatches to it.

That is also why R8 must not rename `onRemoveCompleted`: nothing in the dex calls it, a binder transaction does. **Verified in the release mapping rather than assumed** —

```
com.valhalla.thor.data.source.local.PackageDataObserversKt$newDataObserver$1
  -> com.valhalla.thor.data.source.local.PackageDataObserversKt$newDataObserver$1
     void onRemoveCompleted(java.lang.String,boolean) -> onRemoveCompleted   ← kept

com.valhalla.thor.data.source.local.PackageDataObserversKt$newDataObserver$2 -> if2   ← JVM-only fallback, free to move
```

## Two things found along the way

**The aidl made lint see a call that was always there.** Vendoring it turned `ThorRootService`'s `getDeclaredMethod("clearApplicationUserData", …)` into a `SoonBlockedPrivateApi` error, on a line this PR does not touch. Lint builds a descriptor from the *argument classes*, and the second one is `Class.forName("android.content.pm.IPackageDataObserver")` — unresolvable before, so no descriptor and no report. Measured as a single variable: an `origin/dev` worktree lints clean; the same worktree with **only** that aidl file added reports the error on the identical line. Suppressed with the reason written down.

**The daemon needs no hidden-API exemption, and adding one would not be free.** A bare `app_process` is never zygote-specialised, so it never goes through `ActivityThread.handleBindApplication` and non-SDK enforcement is never switched on for it. The proof is already in that file: everything in it reaches `IPackageManager` and `ServiceManager` with plain reflection and no `Bypass` at all — including the `Class.forName` of this very observer. `Bypass.setHiddenApiExemptions` would mmap and parse core-oj on every daemon start, with no offset cache to hit, to guard against an enforcement that is off.

## Tests

693 unit tests (18 new), 0 failures. Lint clean on debug *and* release.

`DataClearOutcomeTest` drives the latch through every path, including the two that matter — a verdict arriving *after* the wait expired, and a second callback trying to overturn the first.

It reaches that logic through the non-binder fallback, which exists for exactly this reason: AGP's mockable `android.jar` rewrites constructors but makes every other method throw, and the generated `Stub()` constructor calls `Binder.attachInterface`. Without the fallback, `object : IPackageDataObserver.Stub()` cannot be constructed on the JVM and **every case would collapse to `UNVERIFIED` for the same uninteresting reason** — a green suite proving nothing.

`ObserverCallSitesTest` sweeps the source so a fourth clear site cannot be added with a `null` observer, and includes a test that the sweep itself can fail.

## What needed a device, and what came back

The JVM tests prove the latch. They could not prove the thing this PR bets on: **that `onRemoveCompleted` arrives, within 15 s, on a real ROM.** That has now been measured — [full results here](https://github.com/trinadhthatakula/Thor/pull/348#issuecomment-5185202498).

| # | Item | Result |
|---|---|---|
| 1 | Shizuku — clear data | ✅ `CLEARED` in **96 ms**, `files/` and `cache/` verified gone |
| 1 | Shizuku — clear cache | ✅ measured: no callback, cache untouched, PMS logs that it is ignoring the call. Failure is the true answer |
| 2 | Root daemon (uid 0) | ⚠️ not run — the available image is a Play build and refuses `adb root`. Same code path at a strictly higher privilege; argued in the comment rather than measured |
| 3 | A package PMS refuses | ✅ item 1's cache case *is* that, with PMS's own log line as the witness and the filesystem as the check |
| 4 | Timeout not load-bearing | ✅ 96 ms against a 15 000 ms bound |
| 5 | Release build | ✅ via `mapping.txt` above; not additionally run on device |

Review also turned up a real cost of the wait that no device could have shown: `MainViewModel.performLoggedMultiAction` clears a multi-selection **sequentially**, so a ROM that never calls back turned a fifty-app sweep into fifty consecutive fifteen-second waits. Whether the callback arrives is a property of the transport, not of the package, so the first full-length timeout is evidence rather than bad luck — `awaitDataObserver` now caps the *next* wait at 1500 ms, and any arriving verdict restores full patience. Shortened, never skipped: skipping would make `UNVERIFIED` structural and would permanently misreport a merely-slow ROM, which is the exact false negative this branch exists to avoid creating.
