### PR TITLE
docs(billing): name the real reconnection backstop, not the one the library does not provide

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/settings/BillingPolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/BillingPolicy.kt
@@ -110,7 +110,20 @@ private const val BILLING_RETRY_MAX_DELAY_MS = 30_000L
  *
  * Doubling from a second and capped, because both callers are bounded and both have a backstop: a
  * failed acknowledgement is retried by the `queryPurchasesAsync` sweep on the next launch, and a
- * failed reconnection by the next one the billing library itself schedules.
+ * failed reconnection by `refreshPurchases()` on the next resume, which re-arms the ladder through
+ * `BillingReconnectLadder.onResume()`.
+ *
+ * That second half used to read "by the next one the billing library itself schedules", which is
+ * wrong in a way worth naming rather than quietly correcting: **the library schedules nothing.**
+ * `enableAutoServiceReconnection` is lazy — in billing 9.1.0 the only reachable call to
+ * `BillingClientImpl.zzaI(int)` sits behind `zzbw(long)`/`zzbx(long)`, which run at the head of each
+ * API callable, so the binding is rebuilt on the *next API call* and never on a timer. There is also
+ * no listener notification: the library's own reconnect passes an internal `zzbv` to
+ * `zzbu(listener, i)` with `i != 0`, which does not overwrite the app's stored `zzK`, so
+ * `onBillingSetupFinished` never fires again. `BillingProcessorImpl` says all of this at its
+ * `enableAutoServiceReconnection` call and at `scheduleReconnect`; this KDoc was the one place that
+ * said the opposite, and a reader who believed it could have cut the resume re-arm as redundant —
+ * removing the only backstop there is.
  */
 fun billingRetryDelayMillis(attempt: Int): Long {
     if (attempt <= 0) return BILLING_RETRY_BASE_DELAY_MS


### PR DESCRIPTION
One-sentence doc fix, found by an adversarial pass over the merged #342. It survived three independent refutation attempts (0/3 refuted), so it is reported rather than dropped.

## The contradiction

`billingRetryDelayMillis`' KDoc justified its cap like this:

> …both callers are bounded and both have a backstop: a failed acknowledgement is retried by the `queryPurchasesAsync` sweep on the next launch, **and a failed reconnection by the next one the billing library itself schedules.**

The billing library schedules no reconnection at all, and #342 is the commit that established that — in two other places in the same change:

- at the `enableAutoServiceReconnection()` call: *"it is lazy, not proactive… the only reachable call to `BillingClientImpl.zzaI(int)` sits behind `zzbw(long)`/`zzbx(long)`, which run at the head of each API callable — so it rebuilds the binding on the next API call"*
- at `scheduleReconnect`: *"the library's own reconnect passes an internal `zzbv` to `zzbu(listener, i)` with `i != 0`, which does not overwrite the app's stored `zzK` — so `onBillingSetupFinished` never fires again… `scheduleReconnect` is what actually rebuilds a binding lost to a background Play Store self-update, and it is the only thing that can."*

Two KDocs written in the same commit, and this was the wrong half.

## Why it is worth a PR rather than a shrug

It sits on the constant a reader tunes, and it points at a mechanism that does not exist. Someone lowering `BILLING_MAX_RECONNECT_ATTEMPTS` or trimming the resume re-arm would read this line, conclude the library re-drives a failed reconnection on its own, and cut `refreshPurchases()`' `reconnect.onResume()` as redundant — **removing the only backstop there is**, which is precisely the defect #342 was written to fix.

The corrected sentence names `refreshPurchases()` on the next resume, and keeps *why* the old one was wrong alongside it rather than silently swapping the text — the mistake is easy to make again from the flag's name alone.

Docs only. 693 tests pass, lint clean.