### PR TITLE
refactor(di): inject named dispatchers instead of hardcoding Dispatchers.*

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -17,8 +17,9 @@ import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import com.valhalla.thor.util.Logger
 import com.valhalla.superuser.utils.escapeForShell
@@ -34,7 +35,8 @@ class DhizukuSystemGateway(
     // availability probe binds the Dhizuku client through it — see DhizukuHelper.isDhizukuAvailable.
     private val context: Context,
     private val reflector: DhizukuReflector,
-    private val preferenceRepository: PreferenceRepository
+    private val preferenceRepository: PreferenceRepository,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : SystemGateway {
 
     override suspend fun isRootAvailable() = false
@@ -44,7 +46,7 @@ class DhizukuSystemGateway(
     // DhizukuHelper.isDhizukuAvailable() performs blocking binder IPC (DhizukuAPI) and may re-bind
     // the client; confine it to IO at the gateway boundary so this probe is main-safe regardless of
     // the caller's dispatcher.
-    override suspend fun isDhizukuAvailable(): Boolean = withContext(Dispatchers.IO) {
+    override suspend fun isDhizukuAvailable(): Boolean = withContext(ioDispatcher) {
         DhizukuHelper.isDhizukuAvailable(context)
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -114,21 +114,47 @@ class RootSystemGateway(
      * Bounded for the same reason the bind below is (H2): this runs inside `connectionMutex`, so a
      * main looper that never gets round to us must not pin that mutex and deadlock every later
      * privileged op. `withTimeoutOrNull` returns rather than throws, so on timeout the caller
-     * carries on to the bind — no worse off than before, when this never ran at all.
+     * carries on to the bind.
+     *
+     * That timeout cannot simply give up, though, which is why there is a fallback below. It
+     * cancels the main-dispatched block, so `conn` is never handed back to `RootServiceManager`,
+     * and the caller then nulls `activeConnection` and drops the last reference to it. What that
+     * strands is not a bare object leak: `RootServiceManager.connections` is refcounted per
+     * `ServiceConnection`, and `services` is keyed by intent rather than by connection, so a
+     * record that is never removed holds the service's `refCount` above zero for the life of the
+     * process — after which no unbind of any *later* connection can reach the `refCount == 0`
+     * branch that actually releases the service inside the root process.
      */
     private suspend fun unbindStaleConnection(conn: ServiceConnection) {
-        withTimeoutOrNull(ROOT_SERVICE_BIND_TIMEOUT_MS) {
-            withContext(Dispatchers.Main) {
-                runCatching { RootService.unbind(conn) }
-                    .onFailure {
-                        Logger.w(
-                            "RootSystemGateway",
-                            "unbind of stale root connection failed: ${it.message.orEmpty()}"
-                        )
-                    }
-            }
+        val unbound = withTimeoutOrNull(ROOT_SERVICE_BIND_TIMEOUT_MS) {
+            withContext(Dispatchers.Main) { unbindOnMain(conn) }
         }
+        if (unbound == true) return
+
+        // Not observed to have happened, so hand it to the looper to do whenever it catches up.
+        // This keeps the ordering claim above intact rather than reintroducing the race it warns
+        // about: the post is enqueued here, *before* the bind that follows queues its own main
+        // dispatch, so a looper that recovers still runs this unbind first.
+        //
+        // Deliberately does not touch `activeConnection` — by the time this runs, that field may
+        // legitimately hold a newer connection, and clearing it would strand that one instead.
+        //
+        // Also covers the (near-unreachable) throwing path rather than only the timeout, so this
+        // does not rest on the order of statements inside Odin's `unbind`; a redundant retry there
+        // is a no-op, since removing an absent connection does nothing.
+        android.os.Handler(android.os.Looper.getMainLooper()).post { unbindOnMain(conn) }
     }
+
+    /** The unbind itself, factored out only so the timeout fallback above can reuse it. */
+    private fun unbindOnMain(conn: ServiceConnection): Boolean =
+        runCatching { RootService.unbind(conn) }
+            .onFailure {
+                Logger.w(
+                    "RootSystemGateway",
+                    "unbind of stale root connection failed: ${it.message.orEmpty()}"
+                )
+            }
+            .isSuccess
 
     private suspend fun getRootService(): IThorRootService? = connectionMutex.withLock {
         if (!isDaemonReset) {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -30,6 +30,7 @@ import com.valhalla.thor.domain.model.parseSuspendingPackages
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -37,6 +38,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import java.io.File
 import kotlin.coroutines.resume
@@ -80,13 +82,53 @@ private val SUSPEND_USER_ID: Int get() = thorUserId
 class RootSystemGateway(
     private val context: Context,
     private val shellRepository: ShellRepository,
-    private val preferenceRepository: PreferenceRepository
+    private val preferenceRepository: PreferenceRepository,
+    // Covers three sites, not every shell call: clearAppData, setAppSuspended and
+    // reinstallAppWithGoogle hop onto this, while the other overrides reach the shell through
+    // runCommand, which adds no withContext and so runs on — and stays on — the caller's context.
+    // There is deliberately no matching "main" parameter; see the bind site in getRootService.
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : SystemGateway {
 
     private var rootService: IThorRootService? = null
     private val connectionMutex = Mutex()
     private var isDaemonReset = false
     private var activeConnection: ServiceConnection? = null
+
+    /**
+     * Drop a stale [ServiceConnection], on the main thread because Odin requires it.
+     *
+     * `RootService.unbind` is `@MainThread` and enforces that at runtime — `RootServiceManager`
+     * opens it with `enforceMainThread()`, which throws `IllegalStateException` unless
+     * `Looper.myLooper()` is the main looper. [getRootService]'s callers arrive under
+     * `withContext(ioDispatcher)`, so both cleanup sites below were throwing that exception into a
+     * `runCatching` that discarded it, then nulling `activeConnection` regardless: the binding was
+     * never actually released and the reference to it was thrown away, which is a leak that
+     * survives until the process dies. `invokeOnCancellation` already got this right by posting to
+     * the main looper; the two cleanup paths never had the same treatment applied.
+     *
+     * Suspending rather than posting, so the unbind is ordered strictly before the rebind that
+     * follows it instead of racing that rebind from a queued Runnable. A failure is now logged
+     * rather than silently swallowed — if this ever throws again it should be visible.
+     *
+     * Bounded for the same reason the bind below is (H2): this runs inside `connectionMutex`, so a
+     * main looper that never gets round to us must not pin that mutex and deadlock every later
+     * privileged op. `withTimeoutOrNull` returns rather than throws, so on timeout the caller
+     * carries on to the bind — no worse off than before, when this never ran at all.
+     */
+    private suspend fun unbindStaleConnection(conn: ServiceConnection) {
+        withTimeoutOrNull(ROOT_SERVICE_BIND_TIMEOUT_MS) {
+            withContext(Dispatchers.Main) {
+                runCatching { RootService.unbind(conn) }
+                    .onFailure {
+                        Logger.w(
+                            "RootSystemGateway",
+                            "unbind of stale root connection failed: ${it.message.orEmpty()}"
+                        )
+                    }
+            }
+        }
+    }
 
     private suspend fun getRootService(): IThorRootService? = connectionMutex.withLock {
         if (!isDaemonReset) {
@@ -103,7 +145,7 @@ class RootSystemGateway(
             } else {
                 rootService = null
                 activeConnection?.let { oldConn ->
-                    runCatching { RootService.unbind(oldConn) }
+                    unbindStaleConnection(oldConn)
                     activeConnection = null
                 }
             }
@@ -111,9 +153,7 @@ class RootSystemGateway(
 
         // Clean up any stale connection before creating a new one
         activeConnection?.let { oldConn ->
-            runCatching {
-                RootService.unbind(oldConn)
-            }
+            unbindStaleConnection(oldConn)
             activeConnection = null
         }
 
@@ -123,6 +163,11 @@ class RootSystemGateway(
         // mutex is released. On timeout the child coroutine is cancelled, which fires
         // invokeOnCancellation below to unbind the stale connection; the caller then falls back.
         withTimeoutOrNull(ROOT_SERVICE_BIND_TIMEOUT_MS) {
+            // Hardcoded, and the one place in this class that must stay so. Odin's RootService.bind
+            // is @MainThread and enforces it at runtime — RootServiceManager.bindInternal opens with
+            // enforceMainThread(), which throws IllegalStateException unless Looper.myLooper() is
+            // the main looper. An injectable "main" here would look like a test seam while being
+            // the opposite: any dispatcher a test substituted would throw rather than bind.
             withContext(Dispatchers.Main) {
                 suspendCancellableCoroutine { continuation ->
                     val intent = Intent(context, com.valhalla.thor.rootservice.ThorRootService::class.java)
@@ -292,7 +337,7 @@ class RootSystemGateway(
         return runCommand(command)
     }
 
-    override suspend fun clearAppData(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun clearAppData(packageName: String): Result<Unit> = withContext(ioDispatcher) {
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
             return@withContext Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
@@ -729,7 +774,7 @@ class RootSystemGateway(
      * or a `FLAG_SUSPENDED` that positively reads false; "could not tell" is a failure, and the
      * failure names the owner so the user learns *which* privilege holds the app.
      */
-    override suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit> = withContext(ioDispatcher) {
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
             return@withContext Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
@@ -1137,7 +1182,7 @@ class RootSystemGateway(
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
 
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             try {
                 // 1. Get the APK path(s)
                 val paths = getAppPaths(packageName)

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -20,8 +20,9 @@ import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import rikka.shizuku.Shizuku
 import com.valhalla.thor.data.source.local.shizuku.Shizuku as ShizukuHelper
@@ -38,14 +39,15 @@ class ShizukuSystemGateway(
     // has to come out of resources. RootSystemGateway takes its Context the same way.
     private val context: Context,
     private val reflector: ShizukuReflector,
-    private val preferenceRepository: PreferenceRepository
+    private val preferenceRepository: PreferenceRepository,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : SystemGateway {
 
     override suspend fun isRootAvailable() = false
 
     // Shizuku.checkSelfPermission()/pingBinder() are blocking binder IPC; confine them to IO
     // at the gateway boundary so this probe is main-safe regardless of the caller's dispatcher.
-    override suspend fun isShizukuAvailable(): Boolean = withContext(Dispatchers.IO) {
+    override suspend fun isShizukuAvailable(): Boolean = withContext(ioDispatcher) {
         try {
             Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED && Shizuku.pingBinder()
         } catch (_: Exception) {

--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -31,11 +31,12 @@ import com.valhalla.thor.domain.repository.AppShortcutController
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 
 /** Owns all launcher-shortcut plumbing for the Freezer feature. */
@@ -45,9 +46,10 @@ class FreezerShortcutManager(
     private val freezerRepository: FreezerRepository,
     private val bulkFreezeRunner: BulkFreezeRunner,
     private val stateReader: AppFreezeStateReader,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : AppShortcutController {
     // App-scoped: bulk work must survive the (finishing) trampoline activity.
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
     // Solid launcher-tile backgrounds for the bulk action shortcuts (shared with the in-app preview).
     private val freezeShortcutBg = FreezerShortcutContract.FREEZE_TILE_COLOR

--- a/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/PrivilegeManager.kt
@@ -14,8 +14,8 @@ import com.valhalla.thor.util.PrivilegeProbeTier
 import com.valhalla.thor.util.PrivilegeProbeTrace
 import com.valhalla.thor.util.timeProbe
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import rikka.shizuku.Shizuku
 
@@ -43,9 +44,17 @@ import rikka.shizuku.Shizuku
 @Single(binds = [PrivilegeStateProvider::class])
 class PrivilegeManager(
     private val systemRepository: SystemRepository,
-    private val preferenceRepository: PreferenceRepository
+    private val preferenceRepository: PreferenceRepository,
+    // `scope` below is process-lifetime and carries the whole combine/collect pipeline, so this
+    // is the dispatcher the probe actually runs on. Note that injecting it does not make this
+    // class unit-testable, which was measured rather than assumed: the `init` block touches
+    // `rikka.shizuku.Shizuku`, whose static initializer builds a Binder, and the stub
+    // android.jar answers `Binder.attachInterface` with "not mocked" — construction throws
+    // ExceptionInInitializerError before any dispatcher matters.
+    @Named("default") private val defaultDispatcher: CoroutineDispatcher,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : PrivilegeStateProvider {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = CoroutineScope(SupervisorJob() + defaultDispatcher)
 
     private val _state = MutableStateFlow(PrivilegeState())
     override val state: StateFlow<PrivilegeState> = _state.asStateFlow()
@@ -132,7 +141,7 @@ class PrivilegeManager(
                         .also { trace?.logRun(it.root, it.shizuku, it.dhizuku) }
                 }
             }
-            .flowOn(Dispatchers.IO)
+            .flowOn(ioDispatcher)
 
     private suspend fun safeProbe(block: suspend () -> Boolean): Boolean = try {
         block()

--- a/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
@@ -10,8 +10,9 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Process
 import com.valhalla.thor.domain.repository.StorageStatsProvider
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 
 /**
@@ -20,14 +21,17 @@ import org.koin.core.annotation.Single
  * (see UsageAccessManager) — a per-package failure is skipped, never thrown.
  */
 @Single(binds = [StorageStatsProvider::class])
-class StorageStatsHelper(private val context: Context) : StorageStatsProvider {
+class StorageStatsHelper(
+    private val context: Context,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
+) : StorageStatsProvider {
 
     private val statsManager = context.getSystemService(StorageStatsManager::class.java)
     private val pm = context.packageManager
     private val user = Process.myUserHandle()
 
     override suspend fun installSizes(packages: List<String>): Map<String, Long> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             val manager = statsManager ?: return@withContext emptyMap()
             // One Binder call for all ApplicationInfo instead of one per package.
             // (queryStatsForPackage below still costs one IPC each — there is no batch

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -19,9 +19,10 @@ import com.valhalla.thor.domain.model.AppMetadata
 import com.valhalla.thor.domain.model.StagedPackage
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.util.getDisplayName
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import java.io.File
 import java.io.FileOutputStream
@@ -32,9 +33,12 @@ import java.util.UUID
 private const val STAGING_DIR_NAME = "staged_installs"
 
 @Single(binds = [AppAnalyzer::class])
-class AppAnalyzerImpl(private val context: Context) : AppAnalyzer {
+class AppAnalyzerImpl(
+    private val context: Context,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
+) : AppAnalyzer {
 
-    override suspend fun analyze(uri: Uri): Result<AnalyzedPackage> = withContext(Dispatchers.IO) {
+    override suspend fun analyze(uri: Uri): Result<AnalyzedPackage> = withContext(ioDispatcher) {
         val displayName = uri.getDisplayName(context)
         // Random, unpredictable temp names (CWE-377): avoids collisions between
         // concurrent analyses and predictable cache paths.

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -25,7 +25,7 @@ import com.valhalla.thor.domain.repository.InstalledAppsPermissionGate
 import com.valhalla.thor.util.LocaleRevision
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.ensureActive
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import java.io.File
 
@@ -42,7 +43,8 @@ class AppRepositoryImpl(
     private val context: Context,
     private val appDao: AppDao,
     private val uadHelper: UadHelper,
-    private val installedAppsPermission: InstalledAppsPermissionGate
+    private val installedAppsPermission: InstalledAppsPermissionGate,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : AppRepository {
 
     private val pm = context.packageManager
@@ -103,7 +105,7 @@ class AppRepositoryImpl(
         val triggerChannel = Channel<Unit>(Channel.CONFLATED)
 
         // The Worker: Consumes triggers, waits for quiet, then fetches ONCE.
-        val worker = launch(Dispatchers.IO) {
+        val worker = launch(ioDispatcher) {
             // Initial load from cache and baseline for comparison
             val cachedMap = try {
                 val entities = appDao.getAllApps()
@@ -357,10 +359,10 @@ class AppRepositoryImpl(
             localeWatcher.cancel()
             worker.cancel()
         }
-    }.flowOn(Dispatchers.IO)
+    }.flowOn(ioDispatcher)
 
     override suspend fun getAppDetails(packageName: String): AppInfo? =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             try {
                 val flags = (PackageManager.MATCH_UNINSTALLED_PACKAGES).toLong()
                 val packInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -386,7 +388,7 @@ class AppRepositoryImpl(
 
     @Suppress("DEPRECATION")
     override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             try {
                 val appInfo = (getAppDetails(packageName) ?: return@withContext null)
                     // Carry the persisted total install size (computed lazily on Size
@@ -502,7 +504,7 @@ class AppRepositoryImpl(
             }
         }
 
-    override suspend fun getApkDetails(apkPath: String): AppInfo? = withContext(Dispatchers.IO) {
+    override suspend fun getApkDetails(apkPath: String): AppInfo? = withContext(ioDispatcher) {
         val flags = PackageManager.GET_PERMISSIONS
         val packInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             pm.getPackageArchiveInfo(apkPath, PackageManager.PackageInfoFlags.of(flags.toLong()))

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -30,11 +30,12 @@ import com.valhalla.thor.R
 import com.valhalla.thor.util.Logger
 import com.valhalla.superuser.utils.escapeForShell
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import kotlinx.coroutines.flow.first
 import com.valhalla.thor.domain.repository.PreferenceRepository
@@ -52,7 +53,12 @@ class InstallerRepositoryImpl(
     private val eventBus: InstallerEventBus,
     private val rootGateway: RootSystemGateway,
     private val shizukuReflector: ShizukuReflector,
-    private val preferenceRepository: PreferenceRepository
+    private val preferenceRepository: PreferenceRepository,
+    // Carries the session writes, the APK extraction and the hashing.
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
+    // Only installWithExternal() uses this: handing the URI to the system's installer chooser is a
+    // UI hand-off, so it stays on main. Note this is plain Main, not Main.immediate.
+    @Named("main") private val mainDispatcher: CoroutineDispatcher
 ) : InstallerRepository {
 
     private val defaultInstaller = context.packageManager.packageInstaller
@@ -101,7 +107,7 @@ class InstallerRepositoryImpl(
         mode: InstallMode,
         canDowngrade: Boolean,
     ) =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             try {
                 when (mode) {
                     InstallMode.ROOT -> {
@@ -299,7 +305,7 @@ class InstallerRepositoryImpl(
     }
 
     private suspend fun installWithExternal(uri: Uri) {
-        withContext(Dispatchers.Main) {
+        withContext(mainDispatcher) {
             try {
                 val intent = Intent(Intent.ACTION_VIEW).apply {
                     setDataAndType(uri, "application/vnd.android.package-archive")

--- a/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PermissionRepositoryImpl.kt
@@ -15,10 +15,11 @@ import com.valhalla.thor.domain.model.runtimeGroupFor
 import com.valhalla.thor.domain.repository.PermissionRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 
 /**
@@ -44,14 +45,15 @@ internal const val PERMISSION_QUERY_FLAGS =
 @Single(binds = [PermissionRepository::class])
 class PermissionRepositoryImpl(
     context: Context,
-    private val systemRepository: SystemRepository
+    private val systemRepository: SystemRepository,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : PermissionRepository {
 
     private val pm = context.packageManager
 
     @Suppress("DEPRECATION")
     override suspend fun getAppPermissions(packageName: String): Result<List<AppPermission>> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             try {
                 val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     pm.getPackageInfo(
@@ -123,7 +125,7 @@ class PermissionRepositoryImpl(
      */
     @Suppress("DEPRECATION")
     override suspend fun buildPermissionIndex(): Result<PermissionIndex> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             try {
                 val packages = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     pm.getInstalledPackages(

--- a/app/src/main/java/com/valhalla/thor/data/repository/StoreRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/StoreRepositoryImpl.kt
@@ -12,11 +12,12 @@ import com.valhalla.thor.domain.model.ExtensionCatalog
 import com.valhalla.thor.domain.repository.StoreRepository
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import java.io.File
 import java.net.HttpURLConnection
@@ -32,11 +33,12 @@ import java.security.MessageDigest
 class StoreRepositoryImpl(
     private val context: Context,
     private val extensionManager: ExtensionManager,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : StoreRepository {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    override suspend fun fetchCatalog(): Result<List<CatalogEntry>> = withContext(Dispatchers.IO) {
+    override suspend fun fetchCatalog(): Result<List<CatalogEntry>> = withContext(ioDispatcher) {
         runCatching {
             val body = httpGet(CATALOG_URL)
             val catalog = json.decodeFromString<ExtensionCatalog>(body)
@@ -51,7 +53,7 @@ class StoreRepositoryImpl(
     }
 
     override suspend fun downloadAndVerify(entry: CatalogEntry): Result<Uri> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             if (entry.apkUrl.isBlank()) {
                 return@withContext Result.failure(
                     IllegalArgumentException("Entry '${entry.id}' has no APK to download")
@@ -142,7 +144,7 @@ class StoreRepositoryImpl(
      * formatting used by the signer-cert hashing) for a case-insensitive compare with the catalog.
      */
     private suspend fun downloadHashing(urlString: String, dest: File): String {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             var url = URL(urlString)
             var redirects = 0
             // Follow redirects MANUALLY so every hop — including the redirect target — is re-validated as

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -12,9 +12,10 @@ import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.first
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 
 @Single(binds = [SystemRepository::class])
@@ -22,10 +23,11 @@ class SystemRepositoryImpl(
     private val rootGateway: RootSystemGateway,
     private val shizukuGateway: ShizukuSystemGateway,
     private val dhizukuGateway: DhizukuSystemGateway,
-    private val preferenceRepository: PreferenceRepository
+    private val preferenceRepository: PreferenceRepository,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : SystemRepository {
 
-    override suspend fun isRootAvailable(): Boolean = withContext(Dispatchers.IO) {
+    override suspend fun isRootAvailable(): Boolean = withContext(ioDispatcher) {
         rootGateway.isRootAvailable()
     }
 
@@ -117,40 +119,40 @@ class SystemRepositoryImpl(
         )
     }
 
-    override suspend fun forceStopApp(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun forceStopApp(packageName: String): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.forceStopApp(packageName) }
     }
 
-    override suspend fun clearCache(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun clearCache(packageName: String): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.clearCache(packageName) }
     }
 
-    override suspend fun clearAppData(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun clearAppData(packageName: String): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.clearAppData(packageName) }
     }
 
     override suspend fun setAppDisabled(packageName: String, isDisabled: Boolean): Result<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             runGatewayAction { it.setAppDisabled(packageName, isDisabled) }
         }
 
     override suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             runGatewayAction { it.setAppSuspended(packageName, isSuspended) }
         }
 
     override suspend fun setAppRestricted(
         packageName: String,
         isRestricted: Boolean
-    ): Result<Unit> = withContext(Dispatchers.IO) {
+    ): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.setAppRestricted(packageName, isRestricted) }
     }
 
-    override suspend fun uninstallApp(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun uninstallApp(packageName: String): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.uninstallApp(packageName) }
     }
 
-    override suspend fun rebootDevice(reason: String): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun rebootDevice(reason: String): Result<Unit> = withContext(ioDispatcher) {
         if (rootGateway.isRootAvailable()) {
             rootGateway.rebootDevice(reason)
         } else {
@@ -167,14 +169,14 @@ class SystemRepositoryImpl(
     // remain available individually as `forceStopApp` and `clearCache`, each returning its own
     // real `Result`.
 
-    override suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
+    override suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.reinstallAppWithGoogle(packageName) }
     }
 
     override suspend fun copyFileWithRoot(
         sourcePath: String,
         destinationPath: String
-    ): Result<Unit> = withContext(Dispatchers.IO) {
+    ): Result<Unit> = withContext(ioDispatcher) {
         if (rootGateway.isRootAvailable()) {
             try {
                 rootGateway.copyFile(sourcePath, destinationPath)
@@ -187,7 +189,7 @@ class SystemRepositoryImpl(
         }
     }
 
-    override suspend fun getAppPaths(packageName: String): Result<List<String>> = withContext(Dispatchers.IO) {
+    override suspend fun getAppPaths(packageName: String): Result<List<String>> = withContext(ioDispatcher) {
         try {
             if (rootGateway.isRootAvailable()) {
                 val paths = rootGateway.getAppPaths(packageName)
@@ -204,19 +206,19 @@ class SystemRepositoryImpl(
     override suspend fun grantPermission(
         packageName: String,
         permissionName: String
-    ): Result<Unit> = withContext(Dispatchers.IO) {
+    ): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.grantPermission(packageName, permissionName) }
     }
 
     override suspend fun revokePermission(
         packageName: String,
         permissionName: String
-    ): Result<Unit> = withContext(Dispatchers.IO) {
+    ): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.revokePermission(packageName, permissionName) }
     }
 
     override suspend fun executeShellCommand(command: String): Result<Pair<Int, String?>> =
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             runGatewayAction { it.executeShellCommand(command) }
         }
 

--- a/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/service/AutoFreezeManager.kt
@@ -20,14 +20,15 @@ import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.util.Logger
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 
 @Single
@@ -38,10 +39,15 @@ class AutoFreezeManager(
     private val manageAppUseCase: ManageAppUseCase,
     private val systemRepository: SystemRepository,
     private val appRepository: AppRepository,
-    private val freezerShortcutManager: com.valhalla.thor.data.launcher.FreezerShortcutManager
+    private val freezerShortcutManager: com.valhalla.thor.data.launcher.FreezerShortcutManager,
+    // Both back a process-lifetime scope below rather than a single call, so these two choose
+    // where every auto-freeze batch and every preference observation lives for the life of the
+    // process — not where one function happens to hop.
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
+    @Named("main") private val mainDispatcher: CoroutineDispatcher
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val mainScope = CoroutineScope(SupervisorJob() + mainDispatcher)
     private var observationJob: Job? = null
     private var isObserving = false
     private var isReceiverRegistered = false

--- a/app/src/main/java/com/valhalla/thor/di/Modules.kt
+++ b/app/src/main/java/com/valhalla/thor/di/Modules.kt
@@ -26,8 +26,18 @@ import org.koin.core.annotation.Single
 @Configuration
 class AppModule {
 
-    // Named CoroutineDispatcher bindings so IO/CPU-bound work can inject a dispatcher
-    // instead of hardcoding Dispatchers.*, keeping call sites testable and swappable.
+    // Named CoroutineDispatcher bindings so IO/CPU-bound work injects a dispatcher instead of
+    // hardcoding Dispatchers.*, which makes the choice visible at the constructor and swappable
+    // in one place.
+    //
+    // Worth being honest about the limit, because the injection sites used to claim more than
+    // this: on its own it does not make a class unit-testable. Almost everything that takes one
+    // of these also takes a Context, `:app` has no mocking library and no Robolectric, so those
+    // classes still cannot be constructed on the JVM. PrivilegeManager is the only injector that
+    // takes no Context, and it is not constructible either — its `init` touches
+    // `rikka.shizuku.Shizuku`, whose static initializer builds a Binder against the stub
+    // android.jar and throws "not mocked". Injecting the dispatcher removes one blocker; for
+    // every class here it is not the last one.
     @Single
     @Named("io")
     fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO

--- a/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionBrowseViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/extension/ExtensionBrowseViewModel.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.data.manager.ExtensionManager
 import com.valhalla.thor.domain.model.CatalogEntry
 import com.valhalla.thor.domain.repository.StoreRepository
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
+import org.koin.core.annotation.Named
 
 /** Per-entry install lifecycle in the store list. */
 sealed interface InstallStatus {
@@ -47,6 +48,7 @@ data class BrowseUiState(
 class ExtensionBrowseViewModel(
     private val storeRepository: StoreRepository,
     private val extensionManager: ExtensionManager,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(BrowseUiState())
@@ -59,7 +61,7 @@ class ExtensionBrowseViewModel(
     fun refresh() {
         _uiState.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
-            val installed = withContext(Dispatchers.IO) {
+            val installed = withContext(ioDispatcher) {
                 runCatching { extensionManager.getInstalledExtensionVersionCodes() }
                     .getOrDefault(emptyMap())
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -18,7 +18,7 @@ import com.valhalla.thor.domain.repository.InstallerRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.R
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
+import org.koin.core.annotation.Named
 
 @KoinViewModel
 class InstallerViewModel(
@@ -34,6 +35,7 @@ class InstallerViewModel(
     private val eventBus: InstallerEventBus,
     private val packageManager: PackageManager,
     private val systemRepository: SystemRepository,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     val installState = eventBus.events
@@ -126,7 +128,7 @@ class InstallerViewModel(
                     // getPackageInfo() and the privilege checks in checkPrivilegeAndModes()
                     // (isShizukuAvailable()/isDhizukuAvailable() are synchronous binder IPC)
                     // must not run on the main thread.
-                    val existing = withContext(Dispatchers.IO) {
+                    val existing = withContext(ioDispatcher) {
                         // Privilege detection is best-effort: an unexpected repository/
                         // binder IPC exception must not crash package parsing. On failure
                         // the available modes simply stay at their defaults (NORMAL) and

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/BillingPolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/BillingPolicy.kt
@@ -208,7 +208,7 @@ sealed interface BillingReconnectStep {
  *
  * `@Synchronized` rather than the `@Volatile` fields this replaced: every one of these is a
  * read-modify-write of two or three fields at once, and they arrive on at least two threads — the
- * billing library's main-thread callbacks and the processor's `Dispatchers.Default` scope — so
+ * billing library's main-thread callbacks and the processor's injected default-dispatcher scope — so
  * `@Volatile` was buying visibility for an operation that was never atomic to begin with. The
  * critical sections are a handful of integer comparisons; nothing blocks inside one.
  *

--- a/app/src/store/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
+++ b/app/src/store/java/com/valhalla/thor/presentation/settings/BillingProcessorImpl.kt
@@ -23,8 +23,8 @@ import com.android.billingclient.api.queryProductDetails
 import com.valhalla.thor.R
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -32,15 +32,24 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import java.util.concurrent.ConcurrentHashMap
 
 @Single
 class BillingProcessorImpl(
-    private val context: Context
+    private val context: Context,
+    // [scope] below is where every retry `delay` in this class is spent — a ~31 s reconnect
+    // ladder. Nothing can reach it from a test: `com.android.billingclient` is a
+    // storeImplementation dependency and the only unit-test task run anywhere is
+    // testFossDebugUnitTest, so this class is not on any test's classpath (see BillingPolicy).
+    @Named("default") private val defaultDispatcher: CoroutineDispatcher,
+    // Toast has a hard main-thread requirement, so this one stays a real dispatcher choice rather
+    // than an implementation detail of `scope`.
+    @Named("main") private val mainDispatcher: CoroutineDispatcher,
 ) : BillingProcessor {
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = CoroutineScope(SupervisorJob() + defaultDispatcher)
 
     private val _isBillingAvailable = MutableStateFlow(true)
     override val isBillingAvailable: StateFlow<Boolean> = _isBillingAvailable.asStateFlow()
@@ -243,7 +252,7 @@ class BillingProcessorImpl(
     }
 
     private fun showToast(message: String) {
-        scope.launch(Dispatchers.Main) {
+        scope.launch(mainDispatcher) {
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
     }


### PR DESCRIPTION
Last branch of the 2026-08-04 dev-audit remediation order (item 8). Sweeps the project rule *"never hardcode `Dispatchers.*` in a class you want to test"* across the 17 classes that still did.

## The honest headline: this is a convention sweep, not a testability win

The first draft of this branch put a justification comment at every injection site claiming a test could now drive the work. **Those comments were wrong, and I only found out by trying to write the test.**

- Almost every injector also takes a `Context`. `:app` has no mocking library and no Robolectric, so those classes still cannot be constructed on the JVM. The repo already said so in `RuntimeGroupForTest`'s KDoc — *"`PermissionRepositoryImpl` cannot be built on a JVM"* — and the comments contradicted it.
- `PrivilegeManager` is the only injector taking **no** `Context`, so I wrote `PrivilegeManagerDispatcherSeamTest` against it. It fails at construction:

  ```
  java.lang.ExceptionInInitializerError at PrivilegeManager.<init>(PrivilegeManager.kt:67)
  Caused by: java.lang.RuntimeException: Method attachInterface in android.os.Binder not mocked.
      at rikka.shizuku.Shizuku$1.<init>(Shizuku.java:50)
      at rikka.shizuku.Shizuku.<clinit>(Shizuku.java:50)
  ```

  `init` registers Shizuku listeners, and Shizuku's static initializer builds a `Binder`. The test was deleted rather than shipped green-by-weakening.

So: **no class in this sweep is JVM-constructible today.** The value here is that the dispatcher choice is visible at the constructor and swappable in one place — not that anything became testable. The rationale now lives **once** in `AppModule`, including that limit, instead of being restated and overstated at 17 constructors. Production bindings are unchanged (`io`→`Dispatchers.IO`, `default`→`Dispatchers.Default`, `main`→`Dispatchers.Main`).

## ⚠️ Contains one real behaviour change on the root path

Not a dispatcher swap — a **pre-existing leak** the sweep surfaced. `getRootService`'s two stale-connection cleanups called `RootService.unbind` from inside `withContext(ioDispatcher)`. Odin's `unbind` is `@MainThread` and *enforces* it (`RootServiceManager.unbind` → `enforceMainThread()` → `IllegalStateException`), so both calls **always threw**, into a `runCatching` that discarded the exception, and then nulled `activeConnection` anyway. The binding was never released and the only handle to it was thrown away.

`unbindStaleConnection` now hops to the main thread, logs the failure instead of swallowing it, and is bounded by the same timeout the bind uses so a wedged main looper cannot pin `connectionMutex` (the H2 invariant). The file already had the correct idiom 50 lines below, in `invokeOnCancellation` — it was simply never applied to these two paths.

**Untested on a rooted device** — I have no rooted hardware here. Callback ordering was traced instead: Odin's `disconnect` posts via `UiThreadHandler.executor` and `withContext(Dispatchers.Main)` always posts, so the old connection's `onServiceDisconnected` (which nulls `rootService` unconditionally) is guaranteed to run before the bind block publishes a new binder. It is its own concern in the diff and can be reverted independently of the sweep.

## `RootSystemGateway` keeps `Dispatchers.Main` hardcoded, deliberately

An earlier revision of this branch injected `@Named("main")` there. That was a **trap**, caught in review: `RootService.bind` is `@MainThread` and enforced at runtime, so an injectable `main` looks like a test seam while being the opposite — any dispatcher a test substituted would throw rather than bind. It also converts a compile-visible guarantee into a DI string a future module override could silently change. Reverted, with the reason named in a comment.

`InstallerRepositoryImpl`'s `@Named("main")` **stays**: it wraps `startActivity` for the installer chooser, a plain UI hand-off with no enforced contract.

## Five framework components deliberately not swept

`ThorApplication`, `InstallReceiver`, `AutoReinstallReceiver`, `FreezerLaunchActivity`, `FreezerTileService`.

The reason is **not** that Koin is out of reach — all five are already `KoinComponent`s using `by inject()` and could take `by inject(named("io"))` today. It is that the JVM test setup cannot construct Android components at all, so there is nothing to gain. (`ThorApplication` has a second blocker: `appScope` is a field initializer, running before `startKoin` in `onCreate`.) Both receivers were checked for the `goAsync()` process-death shape and already handle it — `goAsync()` before launch, `finish()` in a `finally`.

## Verification

| Gate | Result |
|---|---|
| `compileFossDebugKotlin` + `compileStoreDebugKotlin` | BUILD SUCCESSFUL, no new warnings |
| `testFossDebugUnitTest --rerun-tasks` | **696 tests, 0 failures, 0 errors, 0 skipped** (61 suites) |
| `lintFossDebug` | BUILD SUCCESSFUL |
| Koin graph | proven by the build — `koinCompiler` runs with `compileSafety`/`strictSafety`/`unsafeDslChecks`, so a missing or ambiguous binding fails compilation |
| Sweep completeness | `grep Dispatchers.` over all non-test sources leaves only the 5 skipped components and the 2 intentional `Dispatchers.Main` sites above |

Rebased onto `dev` after #348 and #349; `clearAppData`'s observer work from #348 verified intact under the merged change.

## Notes for a follow-up, not fixed here

- **A test injecting one `TestDispatcher` for both `default` and `io` makes `PrivilegeManager`'s `.flowOn(ioDispatcher)` a no-op** — `flowOn` skips the channel when upstream and downstream contexts match. Two distinct instances over one scheduler.
- `RootSystemGateway`'s `rootService` / `isDaemonReset` / `activeConnection` are plain `var`s written from main callbacks and read from IO under the mutex; `@Volatile` would close it. `SystemRepositoryImpl` already does this.
- `FreezerShortcutManager.pinBulkShortcut` composes a 216×216 bitmap and fires the pin IPC on the caller's thread, while both its neighbours hop to `scope` for exactly that reason.
- `InstallerRepositoryImpl.installWithExternal` reports `Success` when the chooser appears, so the EXTERNAL mode's success signal is structurally unfalsifiable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved background task scheduling across app scanning, installation, storage analysis, permissions, billing, and system operations.
  * Improved separation of background processing and interface updates for smoother interactions.

* **Bug Fixes**
  * Improved cancellation handling during permission processing.
  * Enhanced cleanup of stale system-service connections and resilience when service operations fail.

* **Documentation**
  * Clarified background processing configuration and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->