### PR TITLE
chore(release): 1.93.3

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/1933.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1933.txt
@@ -1,0 +1,13 @@
+• ✅ Freeze, restrict and clear-data now report what really happened.
+
+• 🔒 App lock now covers app start, and hides your app list in Recents.
+
+• 🌍 Language picker works on Android 12 and below.
+
+• ⚡ Bulk actions no longer stall 15 seconds per app on some ROMs.
+
+• 📦 The installer verifies the exact bytes it installs.
+
+• 🛠️ Fixed a crash loop from an unreadable settings file.
+
+• 💖 Support tiers load from Play — new ones appear without an update.

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ org.gradle.welcome=never
 initialVersionCode=1921
 # REQUIRED: The active source of truth for our release manager
 # Logic: 1822 -> 1.82.2 (based on math: code/1000 . code%1000/10 . code%10)
-versionCode=1932
+versionCode=1933
 # versionName intentionally omitted — auto-calculated from versionCode by the
 # resolveVersionName()/calculateVersionName() helpers in app/build.gradle.kts
 # (1908 -> 1.90.8). Per CLAUDE.md, never set versionName directly; bump versionCode only.

--- a/release-notes/v1.93.3/github.md
+++ b/release-notes/v1.93.3/github.md
@@ -1,0 +1,57 @@
+## Thor v1.93.3
+
+28 commits since v1.93.2. The theme is honesty about results: several privileged
+actions used to report success from an exit code that never meant success.
+
+### Fixed — privileged actions
+
+- **Judge privileged actions by a readback, not an exit code** (`3cbb43e4`). `pm`
+  and `am` return 0 for work they did not do; Thor now re-reads the state it
+  asked for.
+- **Clear-data waits for the observer** instead of reporting a wipe that was only
+  dispatched (`82152a24`).
+- **The app-ops fallback stops reporting a restriction it never applied**
+  (`e95aa903`).
+- **Every privileged command names the user**, per that command's own AOSP
+  default (`ffc45da7`) — work profiles and secondary users were being targeted by
+  accident.
+- **One mute ROM no longer costs a batch fifteen seconds per app** (`25506ba1`).
+- **Dhizuku tries the per-user cache overload first**, as Shizuku already did
+  (`d1272b77`).
+- **Root schedules the stale unbind** the H2 timeout used to throw away
+  (`7f977814`).
+
+### Fixed — security and stability
+
+- **App lock covers cold start**, and the app list no longer leaks to Recents
+  (`5c487ee2`).
+- **An unreadable settings file no longer crash-loops the app** (`3a316da8`).
+- **The installer makes the confirmed identity and the installed bytes one set**
+  (`7eee6dbd`), and **cancels a superseded parse** so it reclaims its own staged
+  copy (`318316a8`).
+
+### Fixed — localisation
+
+- **The in-app language picker works below API 33** (`eddbd9b4`).
+- **A language change reaches the caches that hold copies** (`5746afde`).
+
+### Billing
+
+- **Support tiers are probed, not hardcoded** (`d61a89c8`). Play exposes no
+  catalogue-enumeration API, so Thor queries a candidate ID set and renders
+  whatever Play answers with — a tier added in Play Console appears without an
+  app release. Prices and their order come from Play's own localized figures.
+- **The details a purchase is charged from stay on the same snapshot as the list
+  shown** (`8f6ce8dc`).
+- **A resume rebuilds a connection the retry ladder gave up on** (`d9db1ac0`),
+  and **`isReady` is no longer consulted** where the reconnect flag made it a
+  constant true (`472dc88a`).
+
+### Internal
+
+- R8 now runs on every PR, so the first minified build is not the one that ships
+  (`0ac629d0`).
+- Named dispatchers are injected rather than hardcoded (`ccbc08a3`).
+- Follow-up index reswept and dated in UTC (`9f772b91`, `1e5ab647`).
+
+**Full changelog**: https://github.com/trinadhthatakula/Thor/compare/v1.93.2-dev-106...v1.93.3

--- a/release-notes/v1.93.3/playstore.txt
+++ b/release-notes/v1.93.3/playstore.txt
@@ -1,0 +1,13 @@
+• ✅ Freeze, restrict and clear-data now report what really happened.
+
+• 🔒 App lock now covers app start, and hides your app list in Recents.
+
+• 🌍 Language picker works on Android 12 and below.
+
+• ⚡ Bulk actions no longer stall 15 seconds per app on some ROMs.
+
+• 📦 The installer verifies the exact bytes it installs.
+
+• 🛠️ Fixed a crash loop from an unreadable settings file.
+
+• 💖 Support tiers load from Play — new ones appear without an update.

--- a/release-notes/v1.93.3/telegram.md
+++ b/release-notes/v1.93.3/telegram.md
@@ -1,0 +1,21 @@
+🚀 **Thor v1.93.3 — actions that tell you the truth.**
+
+**Fixed:**
+
+• ✅ **Freeze, restrict and clear-data now check the result** instead of trusting an exit code — what Thor can't do, it now says.
+
+• 🔒 **App lock covers the moment Thor opens**, and your app list no longer shows in Recents.
+
+• 🌍 **Language picker works on Android 12 and below**, and a switch reaches every screen.
+
+• ⚡ **Bulk actions stop stalling ~15s per app** on ROMs that never answer.
+
+• 📦 **The installer verifies the exact bytes it installs.**
+
+• 🛠️ **An unreadable settings file no longer crash-loops Thor.**
+
+• 👥 **Privileged commands name the user** — work profiles hit the right one.
+
+**New:**
+
+• 💖 **Support tiers load from Play**, so new ones appear without an app update.

--- a/shizu_store.json
+++ b/shizu_store.json
@@ -23,7 +23,7 @@
   ],
   "repo_url": "https://github.com/trinadhthatakula/Thor",
   "download_url": "https://github.com/trinadhthatakula/Thor/releases/latest/download/foss-release.apk",
-  "changelog": "• 🧊 Freezing a preinstalled app no longer wipes its data — Thor disables it, and keeps the data if it must remove it.\n\n• ❄️ Removing an app from the Freezer unfreezes it first, on every screen — and says so if it can't.\n\n• 📱 Fixed the app list collapsing to one entry on Chinese-market ROMs.\n\n• ⏸️ Thor no longer claims success when it couldn't unsuspend an app.\n\n• 🔄 Privilege Check's Refresh re-checks Root, Shizuku and Dhizuku.\n\n• 💖 New: more ways to support Thor's development.",
+  "changelog": "• ✅ Freeze, restrict and clear-data now report what really happened.\n\n• 🔒 App lock now covers app start, and hides your app list in Recents.\n\n• 🌍 Language picker works on Android 12 and below.\n\n• ⚡ Bulk actions no longer stall 15 seconds per app on some ROMs.\n\n• 📦 The installer verifies the exact bytes it installs.\n\n• 🛠️ Fixed a crash loop from an unreadable settings file.\n\n• 💖 Support tiers load from Play — new ones appear without an update.",
   "store_issue_number": 279,
   "category": "Tools",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Release prep for **v1.93.3** (`versionCode` 1932 → 1933). Merging this into `dev` publishes nothing — the `dev` → `master` PR that follows is the publish.

## What's in the release

28 commits since v1.93.2. Mostly one theme: several privileged actions reported success from an exit code that never meant success, and now re-read the state they asked for.

## Channels

Written once in `playstore.txt`, propagated to the two consumers that read their own copy:

| Copy | Consumer | Audited by |
|---|---|---|
| `release-notes/v1.93.3/playstore.txt` | Play "What's new" | — |
| `fastlane/…/changelogs/1933.txt` | F-Droid | **nothing** — the `diff` below is its only gate |
| `shizu_store.json` `.changelog` | Shizu CoreFetch | `check-shizu-manifest.sh`, on every PR |
| `release-notes/v1.93.3/telegram.md` | Telegram caption | — |
| `release-notes/v1.93.3/github.md` | GitHub Release body | — |

## Verification

- `diff playstore.txt fastlane/…/1933.txt` → identical
- `check-shizu-manifest.sh` → all five sections pass, changelog matches, `versionCode 1933 -> v1.93.3`
- Length gates measured on the **assembled caption**, not the file — the file is the smaller number and the one that has misled before:
  - `playstore.txt` **447** / 500
  - Telegram via `dev-check.yml` **908** / 1024
  - Telegram via `telegram-release.yml` **904** / 1024
- Built `assembleFossRelease`: the APK reports `versionCode='1933' versionName='1.93.3-foss'`, so the derived name is confirmed rather than assumed.