### PR TITLE
feat(support): offer Ko-fi and Buy Me a Coffee in the app, like the site already does

### DIFF
--- a/app/src/foss/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
+++ b/app/src/foss/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
@@ -23,15 +23,20 @@ fun SupportDeveloperHelper(
     val sponsorsDesc = stringResource(R.string.sponsor_github_desc)
     val patreonTitle = stringResource(R.string.become_patreon_title)
     val patreonDesc = stringResource(R.string.become_patreon_desc)
+    val kofiTitle = stringResource(R.string.support_kofi_title)
+    val kofiDesc = stringResource(R.string.support_kofi_desc)
+    val coffeeTitle = stringResource(R.string.buy_me_a_coffee_title)
+    val coffeeDesc = stringResource(R.string.buy_me_a_coffee_desc)
     val paypalTitle = stringResource(R.string.donate_paypal_title)
     val paypalDesc = stringResource(R.string.donate_paypal_desc)
 
     val actions = remember(
-        sponsorsTitle, sponsorsDesc, patreonTitle, patreonDesc, paypalTitle, paypalDesc
+        sponsorsTitle, sponsorsDesc, patreonTitle, patreonDesc,
+        kofiTitle, kofiDesc, coffeeTitle, coffeeDesc, paypalTitle, paypalDesc
     ) {
         listOf(
-            // First deliberately: lowest fees of the three, and it sits beside the source, which is
-            // where a FOSS user already is.
+            // First deliberately: lowest fees of the five, and it sits beside the source, which is
+            // where a FOSS user already is. After it, recurring-capable before one-off.
             SupportAction(
                 iconRes = R.drawable.brand_github,
                 title = sponsorsTitle,
@@ -51,6 +56,26 @@ fun SupportDeveloperHelper(
                 description = patreonDesc,
                 onClick = {
                     val intent = Intent(Intent.ACTION_VIEW, "https://www.patreon.com/trinadh".toUri())
+                    runCatching { context.startActivity(intent) }
+                    onDismiss()
+                }
+            ),
+            SupportAction(
+                iconRes = R.drawable.brand_kofi,
+                title = kofiTitle,
+                description = kofiDesc,
+                onClick = {
+                    val intent = Intent(Intent.ACTION_VIEW, "https://ko-fi.com/trinadh".toUri())
+                    runCatching { context.startActivity(intent) }
+                    onDismiss()
+                }
+            ),
+            SupportAction(
+                iconRes = R.drawable.brand_buymeacoffee,
+                title = coffeeTitle,
+                description = coffeeDesc,
+                onClick = {
+                    val intent = Intent(Intent.ACTION_VIEW, "https://www.buymeacoffee.com/trinadh".toUri())
                     runCatching { context.startActivity(intent) }
                     onDismiss()
                 }

--- a/app/src/main/res/drawable/brand_buymeacoffee.xml
+++ b/app/src/main/res/drawable/brand_buymeacoffee.xml
@@ -1,0 +1,39 @@
+<!-- SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor> -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!--
+  A lidded takeaway cup with steam. Not Buy Me a Coffee's trademark — see brand_kofi for why a brand
+  mark is not an option here. The silhouette is deliberately NOT a mug: brand_kofi sits directly
+  above this one in the support sheet, and two coffee cups that differ only in their detail are two
+  identical smudges at 24dp. Lid + taper + steam against mug + handle + saucer reads apart at a
+  glance.
+
+  The steam is stroked rather than filled. Icon(tint = ...) applies a ColorFilter over the whole
+  drawable, so strokeColor is tinted along with fillColor — no fillColor is needed on those paths.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round"
+        android:pathData="M8.4,2.2 c1,1 -1,1.9 0,2.9" />
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round"
+        android:pathData="M12,1.7 c1,1 -1,1.9 0,2.9" />
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round"
+        android:pathData="M15.6,2.2 c1,1 -1,1.9 0,2.9" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M4.9,6.9 h14.2 a1.3,1.3 0 0 1 1.29,1.44 l-0.13,1.2 a1.3,1.3 0 0 1 -1.29,1.16 H4.99 a1.3,1.3 0 0 1 -1.29,-1.16 l-0.13,-1.2 A1.3,1.3 0 0 1 4.9,6.9 z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M5.15,10.4 h13.7 l-1.2,9.4 a2.1,2.1 0 0 1 -2.08,1.8 H8.43 a2.1,2.1 0 0 1 -2.08,-1.8 z" />
+</vector>

--- a/app/src/main/res/drawable/brand_kofi.xml
+++ b/app/src/main/res/drawable/brand_kofi.xml
@@ -1,0 +1,28 @@
+<!-- SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor> -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!--
+  A mug with a heart, on a saucer. Not Ko-fi's trademark: SupportDeveloperBottomSheet draws every
+  action icon with Icon(tint = colorScheme.primary), so a brand mark could never keep its brand
+  colour anyway — the same reason PayPal already uses the generic shield_with_heart. It only has to
+  read as "Ko-fi" beside its own label, and to be distinguishable from brand_buymeacoffee one row
+  below, which is a lidded takeaway cup with steam.
+
+  fillType="evenOdd" is load-bearing: it is what makes the heart a HOLE in the cup. Everything here
+  is drawn in one tint, so a heart drawn as a second filled subpath would be invisible.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:fillType="evenOdd"
+        android:pathData="M4,4 h12 a1,1 0 0 1 1,1 v7 a5,5 0 0 1 -5,5 H8 a5,5 0 0 1 -5,-5 V5 a1,1 0 0 1 1,-1 z M10,14.1 C10,14.1 5.9,11.4 5.9,8.85 C5.9,7.55 6.95,6.5 8.2,6.5 C8.95,6.5 9.65,6.9 10,7.45 C10.35,6.9 11.05,6.5 11.8,6.5 C13.05,6.5 14.1,7.55 14.1,8.85 C14.1,11.4 10,14.1 10,14.1 Z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M17,6.2 h1.6 a3.4,3.4 0 0 1 0,6.8 H17 v-2 h1.6 a1.4,1.4 0 0 0 0,-2.8 H17 z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M3.2,18.6 h13.6 a1.2,1.2 0 0 1 0,2.4 H3.2 a1.2,1.2 0 0 1 0,-2.4 z" />
+</vector>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -433,6 +433,10 @@
     <string name="sponsor_github_desc">تبرع لمرة واحدة أو شهريًا، بجانب الشيفرة المصدرية مباشرة</string>
     <string name="become_patreon_title">كن داعمًا على Patreon</string>
     <string name="become_patreon_desc">دعم التطوير المستمر باشتراك شهري</string>
+    <string name="support_kofi_title">الدعم عبر Ko-fi</string>
+    <string name="support_kofi_desc">اشترِ قهوة مرة واحدة أو كل شهر</string>
+    <string name="buy_me_a_coffee_title">الدعم عبر Buy Me a Coffee</string>
+    <string name="buy_me_a_coffee_desc">قهوة لمرة واحدة أو عضوية شهرية</string>
     <string name="donate_paypal_title">التبرع عبر PayPal</string>
     <string name="donate_paypal_desc">أرسل تبرعًا لمرة واحدة مباشرة</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -399,6 +399,10 @@
     <string name="sponsor_github_desc">Puntual o mensual, justo al lado del código</string>
     <string name="become_patreon_title">Hacerse Patreon</string>
     <string name="become_patreon_desc">Apoya el desarrollo continuo con una suscripción mensual</string>
+    <string name="support_kofi_title">Apoyar en Ko-fi</string>
+    <string name="support_kofi_desc">Invita a un café, una vez o cada mes</string>
+    <string name="buy_me_a_coffee_title">Apoyar en Buy Me a Coffee</string>
+    <string name="buy_me_a_coffee_desc">Un café puntual o una membresía mensual</string>
     <string name="donate_paypal_title">Donar a través de PayPal</string>
     <string name="donate_paypal_desc">Envía una donación única directamente</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -399,6 +399,10 @@
     <string name="sponsor_github_desc">Ponctuel ou mensuel, au plus près du code</string>
     <string name="become_patreon_title">Devenir Patreon</string>
     <string name="become_patreon_desc">Soutenir le développement continu avec un abonnement mensuel</string>
+    <string name="support_kofi_title">Soutenir sur Ko-fi</string>
+    <string name="support_kofi_desc">Offrir un café, une fois ou chaque mois</string>
+    <string name="buy_me_a_coffee_title">Soutenir sur Buy Me a Coffee</string>
+    <string name="buy_me_a_coffee_desc">Un café ponctuel ou un abonnement mensuel</string>
     <string name="donate_paypal_title">Faire un don via PayPal</string>
     <string name="donate_paypal_desc">Envoyer un don unique directement</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -391,6 +391,10 @@
     <string name="sponsor_github_desc">一次性或按月赞助，就在代码旁边</string>
     <string name="become_patreon_title">成为 Patreon 赞助者</string>
     <string name="become_patreon_desc">通过按月订阅支持持续开发</string>
+    <string name="support_kofi_title">在 Ko-fi 上支持</string>
+    <string name="support_kofi_desc">请喝一杯咖啡，一次或每月</string>
+    <string name="buy_me_a_coffee_title">在 Buy Me a Coffee 上支持</string>
+    <string name="buy_me_a_coffee_desc">一次性咖啡或按月会员</string>
     <string name="donate_paypal_title">通过 PayPal 捐赠</string>
     <string name="donate_paypal_desc">直接发送一次性捐赠</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -392,9 +392,9 @@
     <string name="become_patreon_title">成为 Patreon 赞助者</string>
     <string name="become_patreon_desc">通过按月订阅支持持续开发</string>
     <string name="support_kofi_title">在 Ko-fi 上支持</string>
-    <string name="support_kofi_desc">请喝一杯咖啡，一次或每月</string>
+    <string name="support_kofi_desc">请我喝杯咖啡，一次或每月</string>
     <string name="buy_me_a_coffee_title">在 Buy Me a Coffee 上支持</string>
-    <string name="buy_me_a_coffee_desc">一次性咖啡或按月会员</string>
+    <string name="buy_me_a_coffee_desc">单次请我喝杯咖啡，或按月成为会员</string>
     <string name="donate_paypal_title">通过 PayPal 捐赠</string>
     <string name="donate_paypal_desc">直接发送一次性捐赠</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -540,6 +540,10 @@
     <string name="sponsor_github_desc">One-off or monthly, right next to the code</string>
     <string name="become_patreon_title">Become a Patreon</string>
     <string name="become_patreon_desc">Support ongoing development with a monthly subscription</string>
+    <string name="support_kofi_title">Support on Ko-fi</string>
+    <string name="support_kofi_desc">Buy a coffee once, or every month</string>
+    <string name="buy_me_a_coffee_title">Buy Me a Coffee</string>
+    <string name="buy_me_a_coffee_desc">A one-off coffee, or a monthly membership</string>
     <string name="donate_paypal_title">Donate via PayPal</string>
     <string name="donate_paypal_desc">Send a one-time donation directly</string>
 

--- a/app/src/store/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
+++ b/app/src/store/java/com/valhalla/thor/presentation/settings/SupportDeveloperHelper.kt
@@ -43,20 +43,27 @@ fun SupportDeveloperHelper(
 
     var pendingChangeProductId by remember { mutableStateOf<String?>(null) }
 
-    // "Direct" tab — GitHub Sponsors + Patreon + PayPal. Always available, including in the store
+    // "Direct" tab — GitHub Sponsors + Patreon + Ko-fi + Buy Me a Coffee + PayPal, the same five
+    // routes the website and .github/FUNDING.yml advertise. Always available, including in the store
     // build. Resolve strings via stringResource (configuration-aware) in composable scope, then pass
     // them into remember as keys so the list recomputes on locale/config change.
     val sponsorsTitle = stringResource(R.string.sponsor_github_title)
     val sponsorsDesc = stringResource(R.string.sponsor_github_desc)
     val patreonTitle = stringResource(R.string.become_patreon_title)
     val patreonDesc = stringResource(R.string.become_patreon_desc)
+    val kofiTitle = stringResource(R.string.support_kofi_title)
+    val kofiDesc = stringResource(R.string.support_kofi_desc)
+    val coffeeTitle = stringResource(R.string.buy_me_a_coffee_title)
+    val coffeeDesc = stringResource(R.string.buy_me_a_coffee_desc)
     val paypalTitle = stringResource(R.string.donate_paypal_title)
     val paypalDesc = stringResource(R.string.donate_paypal_desc)
     val directActions = remember(
-        sponsorsTitle, sponsorsDesc, patreonTitle, patreonDesc, paypalTitle, paypalDesc
+        sponsorsTitle, sponsorsDesc, patreonTitle, patreonDesc,
+        kofiTitle, kofiDesc, coffeeTitle, coffeeDesc, paypalTitle, paypalDesc
     ) {
         listOf(
-            // First deliberately: lowest fees of the three, and it sits beside the source.
+            // First deliberately: lowest fees of the five, and it sits beside the source. After it,
+            // recurring-capable before one-off.
             SupportAction(
                 iconRes = R.drawable.brand_github,
                 title = sponsorsTitle,
@@ -76,6 +83,26 @@ fun SupportDeveloperHelper(
                 description = patreonDesc,
                 onClick = {
                     val intent = Intent(Intent.ACTION_VIEW, "https://www.patreon.com/trinadh".toUri())
+                    runCatching { context.startActivity(intent) }
+                    onDismiss()
+                }
+            ),
+            SupportAction(
+                iconRes = R.drawable.brand_kofi,
+                title = kofiTitle,
+                description = kofiDesc,
+                onClick = {
+                    val intent = Intent(Intent.ACTION_VIEW, "https://ko-fi.com/trinadh".toUri())
+                    runCatching { context.startActivity(intent) }
+                    onDismiss()
+                }
+            ),
+            SupportAction(
+                iconRes = R.drawable.brand_buymeacoffee,
+                title = coffeeTitle,
+                description = coffeeDesc,
+                onClick = {
+                    val intent = Intent(Intent.ACTION_VIEW, "https://www.buymeacoffee.com/trinadh".toUri())
                     runCatching { context.startActivity(intent) }
                     onDismiss()
                 }

--- a/release-notes/v1.94.0/github.md
+++ b/release-notes/v1.94.0/github.md
@@ -1,7 +1,7 @@
 # Thor v1.94.0 Release Notes
 
 The first stable since **v1.93.0**, consolidating everything that shipped through the
-`v1.93.1`, `v1.93.2` and `v1.93.3` pre-release builds — **65 pull requests**.
+`v1.93.1`, `v1.93.2` and `v1.93.3` pre-release builds — **66 pull requests**.
 
 Two threads run through it. The first is **new ground**: freeze profiles, bulk backup and
 `.xapk` export, permission filtering, and a support catalogue that comes from Play instead of
@@ -136,6 +136,9 @@ suspension another privilege mode applied.
 ### 💖 Support (#311, #342, #351)
 
 * **GitHub Sponsors** alongside Patreon and PayPal (#311).
+* **Ko-fi and Buy Me a Coffee are now in the app** (#356). The website and `FUNDING.yml` have
+  advertised five funding routes for a while; the in-app sheet only ever offered three. All five
+  now agree.
 * **Support tiers are probed rather than hardcoded** (#351). Play exposes no catalogue-
   enumeration API, so Thor queries a candidate ID set and renders whatever Play answers with —
   a tier added in Play Console shows up without an app release. Prices and their ordering come
@@ -179,6 +182,7 @@ suspension another privilege mode applied.
 
 ## 🛠 Commits Log (`v1.93.0...v1.94.0`)
 
+* `fbf2d54e` — #356 Ko-fi and Buy Me a Coffee in the app
 * `0ea6f93b` — #354 lint warning sweep, guards preserved
 * `1f31a36f` — #352 release 1.93.3
 * `172583f7` — #351 probe support tiers instead of hardcoding them

--- a/release-notes/v1.94.0/github.md
+++ b/release-notes/v1.94.0/github.md
@@ -133,7 +133,7 @@ suspension another privilege mode applied.
 * The in-app **language picker works below API 33** (#345), and a language change reaches the
   caches that hold copies.
 
-### 💖 Support (#311, #342, #351)
+### 💖 Support (#311, #342, #351, #356)
 
 * **GitHub Sponsors** alongside Patreon and PayPal (#311).
 * **Ko-fi and Buy Me a Coffee are now in the app** (#356). The website and `FUNDING.yml` have


### PR DESCRIPTION
The website and `.github/FUNDING.yml` both advertise **five** funding routes. The in-app
support sheet offered **three**. This closes that gap in both flavours.

| Route | Site (`web/src/lib/site.ts`) | `FUNDING.yml` | App — before | App — after |
|---|:---:|:---:|:---:|:---:|
| GitHub Sponsors | ✅ | ✅ | ✅ | ✅ |
| Patreon | ✅ | ✅ | ✅ | ✅ |
| **Ko-fi** | ✅ | ✅ | ❌ | ✅ |
| **Buy Me a Coffee** | ✅ | ✅ | ❌ | ✅ |
| PayPal | ✅ | ✅ | ✅ | ✅ |

URLs are the ones the owner confirmed, byte-for-byte the same as the site's:
`ko-fi.com/trinadh` and `www.buymeacoffee.com/trinadh`.

### Order

Sponsors, Patreon, Ko-fi, Buy Me a Coffee, PayPal. Sponsors stays first for the reason already
in the comment (lowest fees, and it sits beside the source); the rest is recurring-capable
before one-off. The three existing entries keep their relative order — nothing was reshuffled.
The comment saying "lowest fees of the three" is updated, since it would otherwise be false the
moment this lands.

### Icons

Drawn, not borrowed. `SupportDeveloperBottomSheet` renders every icon with
`Icon(tint = colorScheme.primary)`, so a genuine brand mark could never keep its brand colour —
which is exactly why PayPal already uses the generic `shield_with_heart`. `brand_kofi` is a mug
with a heart; `brand_buymeacoffee` is a lidded takeaway cup with steam. The silhouettes are
deliberately unalike: the two rows are adjacent, and two coffee cups that differ only in detail
are two identical smudges at 24dp. Both were rendered and eyeballed at 24 px and 48 px before
landing.

Two things a reviewer would otherwise have to work out:

- `brand_kofi` needs `fillType="evenOdd"` — everything is one tint, so the heart must be a
  **hole** in the cup. As a second filled subpath it would be invisible.
- `brand_buymeacoffee` **strokes** its steam. `Icon()`'s tint is a `ColorFilter` over the whole
  drawable, so `strokeColor` is tinted along with `fillColor`; those paths need no `fillColor`.

### Layout

Three rows → five needed no change. Both `SupportDeveloperBottomSheet` and
`SupportDeveloperTabbedBottomSheet` already wrap their content in `verticalScroll`, so the sheet
scrolls rather than clips.

### Checks

- `assembleFossDebug` + `assembleStoreDebug` — pass.
- `lintFossDebug` + `lintStoreDebug` — pass. **Zero `MissingTranslation`**: strings are in all
  five locales (en, ar, es, fr, zh-rCN). **Zero new `VectorPath`** — the five hints in the report
  are the pre-existing `thor_mono`, `thor_drawn_foreground` and `dhizuku` icons.
- Not device-tested. The icons were verified by rendering the identical path data, not on a
  handset.

### One thing to decide

The store flavour gets these too, matching how it already carries Patreon and PayPal on its
"Direct" tab. That keeps the two flavours consistent and doesn't change the risk category — but
if you'd rather keep external funding links out of the Play build entirely, say so and I'll
scope them to `foss` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ko-fi and Buy Me a Coffee options to the developer support section.
  * Each option opens its corresponding support page and includes an icon, title, and description.
  * Added localized support text in Arabic, Spanish, French, Simplified Chinese, and English.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->