### PR TITLE
feat(home): let users hide the Installer and Extensions tiles, and pack the bento adaptively

### DIFF
--- a/app/src/androidTest/java/com/valhalla/thor/presentation/home/BentoTileTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/presentation/home/BentoTileTest.kt
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.home
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.valhalla.thor.R
+import com.valhalla.thor.presentation.home.components.BentoTile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Guards the two behaviours the compact bento tile depends on. Both are regressions waiting to
+ * happen: the first because dropping a Text also drops its string from the merged semantics node,
+ * the second because a nested clickable silently swallows the parent's long press.
+ */
+@RunWith(AndroidJUnit4::class)
+class BentoTileTest {
+
+    @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+    private val title = "Reinstall All"
+    private val subtitle = "7 user apps not from Play Store. Fix them?"
+    private val dismissLabel: String
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+            .getString(R.string.dismiss)
+
+    private fun setTile(
+        showSubtitle: Boolean = false,
+        onLongClick: (() -> Unit)? = {},
+        onLongClickLabel: String? = null,
+        onClose: (() -> Unit)? = null,
+        onClick: () -> Unit = {},
+    ) = rule.setContent {
+        BentoTile(
+            title = title,
+            subtitle = subtitle,
+            icon = R.drawable.apk_install,
+            showSubtitle = showSubtitle,
+            onLongClick = onLongClick,
+            onLongClickLabel = onLongClickLabel,
+            onClose = onClose,
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+
+    @Test fun compactTile_keepsTheSubtitleInTheAccessibilityTree() {
+        setTile(showSubtitle = false)
+
+        // Not rendered as text...
+        rule.onNodeWithText(subtitle).assertDoesNotExist()
+        // ...but still announced. The tile root merges its descendants, so the string has to
+        // survive somewhere beneath it or TalkBack loses the scope of the action entirely.
+        rule.onNodeWithContentDescription(subtitle).assertExists()
+        rule.onNodeWithText(title).assertExists()
+    }
+
+    @Test fun wideTile_rendersTheSubtitleAsText() {
+        setTile(showSubtitle = true)
+
+        rule.onNodeWithText(subtitle).assertExists()
+        rule.onNodeWithText(title).assertExists()
+    }
+
+    @Test fun compactTile_exposesLongPressAsAnAccessibilityAction() {
+        setTile(showSubtitle = false, onLongClickLabel = "Show details")
+
+        val config = rule.onNodeWithText(title).fetchSemanticsNode().config
+        assertEquals("Show details", config[SemanticsActions.OnLongClick].label)
+        assertTrue("the tile must announce itself as a button", SemanticsProperties.Role in config)
+    }
+
+    /**
+     * The dismiss X sits inside the tile. Given its own plain clickable it would consume the
+     * pointer down, so the tile's long-press timer would never start and holding the corner would
+     * dismiss the card instead of explaining it. Both gestures are wired on the X for that reason.
+     */
+    @Test fun longPressOnTheDismissTarget_explainsRatherThanDismisses() {
+        var dismissed = 0
+        var explained = 0
+        var clicked = 0
+        setTile(onLongClick = { explained++ }, onClose = { dismissed++ }, onClick = { clicked++ })
+
+        rule.onNodeWithContentDescription(dismissLabel, useUnmergedTree = true)
+            .performTouchInput { longClick() }
+        rule.waitForIdle()
+
+        assertEquals("holding the X must not dismiss the card", 0, dismissed)
+        assertEquals("holding the X must not run the tile action", 0, clicked)
+        assertEquals("holding the X must open the explanation", 1, explained)
+    }
+
+    @Test fun tapOnTheDismissTarget_stillDismisses() {
+        var dismissed = 0
+        var explained = 0
+        var clicked = 0
+        setTile(onLongClick = { explained++ }, onClose = { dismissed++ }, onClick = { clicked++ })
+
+        rule.onNodeWithContentDescription(dismissLabel, useUnmergedTree = true).performClick()
+        rule.waitForIdle()
+
+        assertEquals(1, dismissed)
+        assertEquals("dismissing must not also run the tile action", 0, clicked)
+        assertEquals(0, explained)
+    }
+
+    @Test fun longPressOnTheTileBody_explainsInsteadOfActing() {
+        var explained = 0
+        var clicked = 0
+        setTile(onLongClick = { explained++ }, onClose = {}, onClick = { clicked++ })
+
+        rule.onNodeWithText(title).performTouchInput { longClick() }
+        rule.waitForIdle()
+
+        assertEquals("a long press must suppress the click", 0, clicked)
+        assertEquals(1, explained)
+    }
+}

--- a/app/src/androidTest/java/com/valhalla/thor/presentation/home/HomeActionsBentoTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/presentation/home/HomeActionsBentoTest.kt
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.home
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.hasAnySibling
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.valhalla.thor.R
+import com.valhalla.thor.presentation.home.components.HomeActionsBento
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end cover for the long-press explanation: a paired tile drops its description, so the
+ * sheet is the only place that text still exists for a sighted user. A wide tile shows it inline
+ * and must not open anything.
+ */
+@RunWith(AndroidJUnit4::class)
+class HomeActionsBentoTest {
+
+    @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun str(id: Int) =
+        InstrumentationRegistry.getInstrumentation().targetContext.getString(id)
+
+    private var clearCacheRuns = 0
+    private var installRuns = 0
+
+    /** Root privilege + reinstall card = the full 2x2, so every tile is paired and compact. */
+    private fun setFullGrid() = rule.setContent {
+        HomeActionsBento(
+            reinstallVisible = true,
+            isRoot = true,
+            hasPrivilege = true,
+            unknownInstallerCount = 7,
+            selectedTypeName = "user",
+            onReinstall = {},
+            onDismissReinstall = {},
+            onInstall = { installRuns++ },
+            onClearCache = { clearCacheRuns++ },
+            onNavigateToExtensionManager = {},
+        )
+    }
+
+    private fun awaitText(text: String) =
+        rule.waitUntil(5_000) { rule.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty() }
+
+    @Test fun pairedTile_dropsItsDescriptionUntilLongPressed() {
+        val title = str(R.string.clear_all_cache)
+        val body = str(R.string.clear_all_cache_subtitle)
+        setFullGrid()
+
+        rule.onNodeWithText(body).assertDoesNotExist()
+
+        rule.onNodeWithText(title).performTouchInput { longClick() }
+        awaitText(body)
+        rule.onNodeWithText(body).assertExists()
+    }
+
+    @Test fun confirmingInTheSheet_runsTheActionTheLongPressSuppressed() {
+        val title = str(R.string.clear_all_cache)
+        val body = str(R.string.clear_all_cache_subtitle)
+        setFullGrid()
+
+        rule.onNodeWithText(title).performTouchInput { longClick() }
+        awaitText(body)
+        assertEquals("a long press must not run the action on its own", 0, clearCacheRuns)
+
+        // The confirm button is the clickable node sitting next to Cancel. The tile carries the
+        // same label but no Cancel sibling; the sheet's heading has the sibling but no action.
+        rule.onNode(
+            hasText(title) and hasClickAction() and hasAnySibling(hasText(str(R.string.cancel)))
+        ).performClick()
+        rule.waitForIdle()
+
+        assertEquals(1, clearCacheRuns)
+    }
+
+    @Test fun cancellingTheSheet_runsNothing() {
+        val title = str(R.string.clear_all_cache)
+        val body = str(R.string.clear_all_cache_subtitle)
+        setFullGrid()
+
+        rule.onNodeWithText(title).performTouchInput { longClick() }
+        awaitText(body)
+        rule.onNodeWithText(str(R.string.cancel)).performClick()
+        rule.waitForIdle()
+
+        assertEquals(0, clearCacheRuns)
+        assertEquals(0, installRuns)
+    }
+
+    @Test fun wideTile_showsItsDescriptionInlineAndDoesNotOpenTheSheet() {
+        // No reinstall card and no root: Install + Extensions is an even pair... add the card back
+        // and Install becomes the odd leader, full-width, with its description intact.
+        rule.setContent {
+            HomeActionsBento(
+                reinstallVisible = true,
+                isRoot = false,
+                hasPrivilege = true,
+                unknownInstallerCount = 7,
+                selectedTypeName = "user",
+                onReinstall = {},
+                onDismissReinstall = {},
+                onInstall = { installRuns++ },
+                onClearCache = {},
+                onNavigateToExtensionManager = {},
+            )
+        }
+        val title = str(R.string.install_from_file)
+        val body = str(R.string.install_from_file_subtitle)
+
+        rule.onNodeWithText(body).assertExists()
+
+        rule.onNodeWithText(title).performTouchInput { longClick() }
+        rule.waitForIdle()
+
+        // Nothing to explain, so nothing opened: the description is still the only copy on screen.
+        assertEquals(1, rule.onAllNodesWithText(body).fetchSemanticsNodes().size)
+        rule.onNodeWithText(str(R.string.cancel)).assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -118,6 +118,10 @@ class PreferenceRepositoryImpl(
         val SELECTED_FILTER = stringPreferencesKey("selected_filter")
         val SHOW_REINSTALL_ALL = booleanPreferencesKey("show_reinstall_all")
 
+        // Home tiles
+        val SHOW_INSTALLER_TILE = booleanPreferencesKey("show_installer_tile")
+        val SHOW_EXTENSIONS_TILE = booleanPreferencesKey("show_extensions_tile")
+
         // Theme
         val THEME_MODE = stringPreferencesKey("theme_mode")
         val USE_DYNAMIC_COLOR = booleanPreferencesKey("use_dynamic_color")
@@ -201,6 +205,14 @@ class PreferenceRepositoryImpl(
 
     override suspend fun setReinstallAllCardVisibility(isVisible: Boolean) {
         context.dataStore.edit { it[Keys.SHOW_REINSTALL_ALL] = isVisible }
+    }
+
+    override suspend fun setInstallerTileVisibility(isVisible: Boolean) {
+        context.dataStore.edit { it[Keys.SHOW_INSTALLER_TILE] = isVisible }
+    }
+
+    override suspend fun setExtensionsTileVisibility(isVisible: Boolean) {
+        context.dataStore.edit { it[Keys.SHOW_EXTENSIONS_TILE] = isVisible }
     }
 
     // --- Theme ---
@@ -465,6 +477,8 @@ internal fun Preferences.toUserPreferences(
         appFilterType = filterType,
         appSelectedFilter = prefs[Keys.SELECTED_FILTER] ?: "All",
         showReinstallAllCard = prefs[Keys.SHOW_REINSTALL_ALL] ?: true,
+        showInstallerTile = prefs[Keys.SHOW_INSTALLER_TILE] ?: true,
+        showExtensionsTile = prefs[Keys.SHOW_EXTENSIONS_TILE] ?: true,
         themeMode = themeMode,
         useDynamicColor = prefs[Keys.USE_DYNAMIC_COLOR] ?: false,
         useAmoled = prefs[Keys.USE_AMOLED] ?: false,

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -13,6 +13,12 @@ data class UserPreferences(
     // Home Screen Config
     val showReinstallAllCard: Boolean = true,
 
+    // Which of the two always-available Home tiles the user wants there. Both default to shown —
+    // hiding a tile only removes the shortcut, never the feature: Installer still handles APK
+    // intents and Extensions keeps its Settings entry.
+    val showInstallerTile: Boolean = true,
+    val showExtensionsTile: Boolean = true,
+
     // Theme
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val useDynamicColor: Boolean = false,

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -35,6 +35,10 @@ interface PreferenceRepository {
     suspend fun updateAppFilter(filterType: FilterType, selectedFilter: String)
     suspend fun setReinstallAllCardVisibility(isVisible: Boolean)
 
+    // --- Home tiles ---
+    suspend fun setInstallerTileVisibility(isVisible: Boolean)
+    suspend fun setExtensionsTileVisibility(isVisible: Boolean)
+
     // --- Theme ---
     suspend fun setThemeMode(themeMode: ThemeMode)
     suspend fun setDynamicColor(enabled: Boolean)

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -157,6 +157,7 @@ fun HomeScreen(
                         onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
                         onClearCache = { showCacheDialog = true },
                         onNavigateToExtensionManager = onNavigateToExtensionManager,
+                        narrowContainer = true,
                     )
                 }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -48,6 +48,7 @@ import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.presentation.home.components.AppDistributionChart
 import com.valhalla.thor.presentation.home.components.DashboardHeader
 import com.valhalla.thor.presentation.home.components.HomeActionsBento
+import com.valhalla.thor.presentation.home.components.homeActionRows
 import com.valhalla.thor.presentation.home.components.SupportCommunitySection
 import com.valhalla.thor.presentation.home.components.SummaryStatRow
 import com.valhalla.thor.presentation.settings.SupportDeveloperHelper
@@ -90,6 +91,15 @@ fun HomeScreen(
     val isRoot = state.activePrivilegeMode == PrivilegeMode.ROOT
     val reinstallVisible = state.activePrivilegeMode != null &&
         state.unknownInstallerCount > 0 && state.showReinstallCard
+    // Both optional tiles hidden with no privilege leaves the bento with nothing to draw, so the
+    // spacer that separates it from the summary row goes with it rather than leaving a bare gap.
+    val hasHomeActions = homeActionRows(
+        reinstallVisible = reinstallVisible,
+        isRoot = isRoot,
+        hasPrivilege = hasPrivilege,
+        showInstaller = state.showInstallerTile,
+        showExtensions = state.showExtensionsTile,
+    ).isNotEmpty()
 
     // The bottom inset (nav-bar height + system navigation-bar insets) is already applied by
     // MainScreen, which hosts this screen inside Scaffold's Box(Modifier.padding(innerPadding)).
@@ -144,21 +154,25 @@ fun HomeScreen(
                         modifier = Modifier.padding(horizontal = 0.dp)
                     )
 
-                    Spacer(Modifier.height(16.dp))
+                    if (hasHomeActions) {
+                        Spacer(Modifier.height(16.dp))
 
-                    HomeActionsBento(
-                        reinstallVisible = reinstallVisible,
-                        isRoot = isRoot,
-                        hasPrivilege = hasPrivilege,
-                        unknownInstallerCount = state.unknownInstallerCount,
-                        selectedTypeName = state.selectedType.name.lowercase(),
-                        onReinstall = onReinstallAll,
-                        onDismissReinstall = { viewModel.dismissReinstallCard() },
-                        onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
-                        onClearCache = { showCacheDialog = true },
-                        onNavigateToExtensionManager = onNavigateToExtensionManager,
-                        narrowContainer = true,
-                    )
+                        HomeActionsBento(
+                            reinstallVisible = reinstallVisible,
+                            isRoot = isRoot,
+                            hasPrivilege = hasPrivilege,
+                            unknownInstallerCount = state.unknownInstallerCount,
+                            selectedTypeName = state.selectedType.name.lowercase(),
+                            onReinstall = onReinstallAll,
+                            onDismissReinstall = { viewModel.dismissReinstallCard() },
+                            onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
+                            onClearCache = { showCacheDialog = true },
+                            onNavigateToExtensionManager = onNavigateToExtensionManager,
+                            showInstaller = state.showInstallerTile,
+                            showExtensions = state.showExtensionsTile,
+                            narrowContainer = true,
+                        )
+                    }
                 }
 
                 // Right Column: Distribution & Support
@@ -217,22 +231,26 @@ fun HomeScreen(
                 modifier = Modifier.padding(horizontal = 24.dp)
             )
 
-            Spacer(Modifier.height(12.dp))
-
             // --- ACTIONS ---
-            HomeActionsBento(
-                reinstallVisible = reinstallVisible,
-                isRoot = isRoot,
-                hasPrivilege = hasPrivilege,
-                unknownInstallerCount = state.unknownInstallerCount,
-                selectedTypeName = state.selectedType.name.lowercase(),
-                onReinstall = onReinstallAll,
-                onDismissReinstall = { viewModel.dismissReinstallCard() },
-                onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
-                onClearCache = { showCacheDialog = true },
-                onNavigateToExtensionManager = onNavigateToExtensionManager,
-                modifier = Modifier.padding(horizontal = 24.dp),
-            )
+            if (hasHomeActions) {
+                Spacer(Modifier.height(12.dp))
+
+                HomeActionsBento(
+                    reinstallVisible = reinstallVisible,
+                    isRoot = isRoot,
+                    hasPrivilege = hasPrivilege,
+                    unknownInstallerCount = state.unknownInstallerCount,
+                    selectedTypeName = state.selectedType.name.lowercase(),
+                    onReinstall = onReinstallAll,
+                    onDismissReinstall = { viewModel.dismissReinstallCard() },
+                    onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
+                    onClearCache = { showCacheDialog = true },
+                    onNavigateToExtensionManager = onNavigateToExtensionManager,
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                    showInstaller = state.showInstallerTile,
+                    showExtensions = state.showExtensionsTile,
+                )
+            }
 
             Spacer(Modifier.height(24.dp))
 

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -45,6 +45,10 @@ data class HomeUiState(
 
     // Preferences
     val showReinstallCard: Boolean = true, // <--- Controlled by DataStore
+    // GH#344: which of the two optional Home tiles the user kept. Not a capability check —
+    // [activePrivilegeMode] still decides whether Extensions is eligible at all.
+    val showInstallerTile: Boolean = true,
+    val showExtensionsTile: Boolean = true,
     val extensionsUnlocked: Boolean = false
 )
 
@@ -86,6 +90,8 @@ class HomeViewModel(
             unknownInstallerCount = stats.unknownCount,
             distributionData = stats.distribution,
             showReinstallCard = prefs.showReinstallAllCard,
+            showInstallerTile = prefs.showInstallerTile,
+            showExtensionsTile = prefs.showExtensionsTile,
             isRootAvailable = priv.root,
             isShizukuAvailable = priv.shizuku,
             isDhizukuAvailable = priv.dhizuku,

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/BentoTile.kt
@@ -4,16 +4,17 @@
 package com.valhalla.thor.presentation.home.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,6 +23,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -32,6 +36,11 @@ import com.valhalla.thor.R
  * Modifier.weight(1f) (half-width, paired) and fillMaxWidth() (full-width, solo). Icon chip on
  * top, then title + subtitle. Uniform min height so paired tiles align. Mirrors the color logic
  * of the former ActionCard (isPrimary/isWarning/neutral).
+ *
+ * When [showSubtitle] is false the tile is *compact*: the subtitle is dropped from the layout and
+ * the title is allowed to wrap to two lines instead. A half-width tile has no room for both, and
+ * clipping the title is worse than hiding a description the long-press sheet can show in full.
+ * The subtitle stays in the accessibility tree either way — see the Spacer below.
  */
 @Composable
 fun BentoTile(
@@ -41,6 +50,9 @@ fun BentoTile(
     modifier: Modifier = Modifier,
     isPrimary: Boolean = false,
     isWarning: Boolean = false,
+    showSubtitle: Boolean = true,
+    onLongClick: (() -> Unit)? = null,
+    onLongClickLabel: String? = null,
     onClose: (() -> Unit)? = null,
     onClick: () -> Unit,
 ) {
@@ -58,14 +70,32 @@ fun BentoTile(
         modifier = modifier
             .clip(RoundedCornerShape(28.dp))
             .background(containerColor)
-            .clickable(onClick = onClick)
+            .combinedClickable(
+                role = Role.Button,
+                onLongClickLabel = onLongClickLabel,
+                onLongClick = onLongClick,
+                onClick = onClick,
+            )
             .defaultMinSize(minHeight = 112.dp)
             .padding(18.dp)
     ) {
         if (onClose != null) {
-            IconButton(
-                onClick = onClose,
-                modifier = Modifier.align(Alignment.TopEnd)
+            // Not an IconButton: its own clickable would consume the down event before the tile's
+            // long-press timer could start, leaving a 48 dp corner where holding dismisses the
+            // card instead of opening the sheet. Carrying the same onLongClick here keeps the
+            // gesture uniform across the whole tile.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .clip(CircleShape)
+                    .combinedClickable(
+                        role = Role.Button,
+                        onLongClickLabel = onLongClickLabel,
+                        onLongClick = onLongClick,
+                        onClick = onClose,
+                    )
+                    .size(48.dp),
+                contentAlignment = Alignment.Center
             ) {
                 Icon(
                     painter = painterResource(R.drawable.round_close),
@@ -98,17 +128,24 @@ fun BentoTile(
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.ExtraBold,
                     color = contentColor,
-                    maxLines = 1,
+                    maxLines = if (showSubtitle) 1 else 2,
                     overflow = TextOverflow.Ellipsis
                 )
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (isPrimary) contentColor.copy(alpha = 0.8f)
-                    else MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
-                )
+                if (showSubtitle) {
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (isPrimary) contentColor.copy(alpha = 0.8f)
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                } else {
+                    // The tile root merges its descendants, so deleting the subtitle Text would
+                    // also delete the string from what TalkBack reads out. A zero-size node right
+                    // after the title keeps both the content and its reading order.
+                    Spacer(Modifier.semantics { contentDescription = subtitle })
+                }
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
@@ -7,23 +7,36 @@ package com.valhalla.thor.presentation.home.components
 enum class HomeAction { REINSTALL, INSTALL, CLEAR_CACHE, EXTENSIONS }
 
 /**
- * Computes the Home bento rows from the current privilege/state flags.
- * Row 1 = [Reinstall?] + Install (Install is always present).
- * Row 2 = [Clear cache (root)?] + [Extensions (privilege)?].
- * A row that ends up with a single tile renders full-width; empty rows are dropped.
+ * Packs the visible Home actions into bento rows: pairs throughout, with a single full-width
+ * leader when the count is odd. 4 tiles -> 2x2; 3 -> one wide then a pair; 2 -> one pair; 1 -> one
+ * wide tile.
+ *
+ * The leader goes first rather than last so the wide tile lands at the top of the grid, next to
+ * the summary row, instead of leaving a ragged edge at the bottom.
+ *
+ * Order is Install, Clear cache, Extensions, Reinstall. Reinstall is last because it is the only
+ * dismissible tile: putting it at the end means dismissing it re-packs the rows below it rather
+ * than shifting every other tile up one slot.
+ *
+ * [narrowContainer] is for a pane too narrow to pair tiles at all (the wide-screen rail) — every
+ * action then gets its own full-width row.
  */
 fun homeActionRows(
     reinstallVisible: Boolean,
     isRoot: Boolean,
     hasPrivilege: Boolean,
+    narrowContainer: Boolean = false,
 ): List<List<HomeAction>> {
-    val row1 = listOfNotNull(
-        HomeAction.REINSTALL.takeIf { reinstallVisible },
+    val actions = listOfNotNull(
         HomeAction.INSTALL,
-    )
-    val row2 = listOfNotNull(
         HomeAction.CLEAR_CACHE.takeIf { isRoot },
         HomeAction.EXTENSIONS.takeIf { hasPrivilege },
+        HomeAction.REINSTALL.takeIf { reinstallVisible },
     )
-    return listOf(row1, row2).filter { it.isNotEmpty() }
+    if (narrowContainer) return actions.map { listOf(it) }
+    return if (actions.size % 2 == 1) {
+        listOf(listOf(actions.first())) + actions.drop(1).chunked(2)
+    } else {
+        actions.chunked(2)
+    }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
@@ -18,6 +18,13 @@ enum class HomeAction { REINSTALL, INSTALL, CLEAR_CACHE, EXTENSIONS }
  * dismissible tile: putting it at the end means dismissing it re-packs the rows below it rather
  * than shifting every other tile up one slot.
  *
+ * [showInstaller] and [showExtensions] are the user's own answer (GH#344): both tiles are shortcuts
+ * to something reachable elsewhere — Installer still handles APK intents, Extensions keeps its
+ * Settings entry — so hiding either is a layout choice, not a feature switch. They stack with the
+ * eligibility rules rather than replacing them: Extensions needs a privilege *and* the preference.
+ * Every tile can end up hidden, and an empty list is a legitimate answer; callers must not assume
+ * at least one row.
+ *
  * [narrowContainer] is for a pane too narrow to pair tiles at all (the wide-screen rail) — every
  * action then gets its own full-width row.
  */
@@ -25,12 +32,14 @@ fun homeActionRows(
     reinstallVisible: Boolean,
     isRoot: Boolean,
     hasPrivilege: Boolean,
+    showInstaller: Boolean = true,
+    showExtensions: Boolean = true,
     narrowContainer: Boolean = false,
 ): List<List<HomeAction>> {
     val actions = listOfNotNull(
-        HomeAction.INSTALL,
+        HomeAction.INSTALL.takeIf { showInstaller },
         HomeAction.CLEAR_CACHE.takeIf { isRoot },
-        HomeAction.EXTENSIONS.takeIf { hasPrivilege },
+        HomeAction.EXTENSIONS.takeIf { hasPrivilege && showExtensions },
         HomeAction.REINSTALL.takeIf { reinstallVisible },
     )
     if (narrowContainer) return actions.map { listOf(it) }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
@@ -34,6 +34,10 @@ private data class HomeActionCopy(val title: String, val subtitle: String, val i
  * Paired tiles are too narrow for a description, so they drop it and long-press opens
  * [InfoBottomSheet] instead. Full-width tiles keep theirs and long-press is a no-op there.
  *
+ * [showInstaller] and [showExtensions] are the persisted GH#344 preferences — see [homeActionRows].
+ * With both off and no privilege there is nothing left to show, and this composable then emits
+ * nothing at all.
+ *
  * [narrowContainer] is for a pane too narrow to pair tiles at all — the wide-screen rail, where
  * the grid gets roughly a third of a 600 dp window. Every tile then goes full-width *and* compact:
  * measured across five locales and three font scales, that is the only combination in that pane
@@ -52,10 +56,18 @@ fun HomeActionsBento(
     onClearCache: () -> Unit,
     onNavigateToExtensionManager: () -> Unit,
     modifier: Modifier = Modifier,
+    showInstaller: Boolean = true,
+    showExtensions: Boolean = true,
     narrowContainer: Boolean = false,
 ) {
-    val rows = homeActionRows(reinstallVisible, isRoot, hasPrivilege, narrowContainer)
+    val rows = homeActionRows(
+        reinstallVisible, isRoot, hasPrivilege, showInstaller, showExtensions, narrowContainer
+    )
     var explaining by rememberSaveable { mutableStateOf<HomeAction?>(null) }
+    // Hiding both optional tiles with no privilege leaves nothing to draw. Emit no Column at all
+    // rather than an empty one — the Column carries no padding of its own, but its callers stack
+    // spacers around it, and a bare 36 dp gap reads as a rendering bug.
+    if (rows.isEmpty()) return
 
     @Composable
     fun copyFor(action: HomeAction) = when (action) {

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
@@ -12,16 +12,32 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.valhalla.thor.R
+import com.valhalla.thor.presentation.widgets.InfoBottomSheet
+
+/** Title, description and icon for one bento tile. */
+private data class HomeActionCopy(val title: String, val subtitle: String, val icon: Int)
 
 /**
  * The Home actions bento grid. Renders the rows from [homeActionRows]: a two-tile row is a
  * weighted pair (equal height via IntrinsicSize.Min); a one-tile row spans full width.
  * Shared by both HomeScreen layout branches. animateContentSize smooths reflow when a tile
  * appears/disappears (privilege resolves, reinstall dismissed).
+ *
+ * Paired tiles are too narrow for a description, so they drop it and long-press opens
+ * [InfoBottomSheet] instead. Full-width tiles keep theirs and long-press is a no-op there.
+ *
+ * [narrowContainer] is for a pane too narrow to pair tiles at all — the wide-screen rail, where
+ * the grid gets roughly a third of a 600 dp window. Every tile then goes full-width *and* compact:
+ * measured across five locales and three font scales, that is the only combination in that pane
+ * where nothing clips.
  */
 @Composable
 fun HomeActionsBento(
@@ -36,44 +52,64 @@ fun HomeActionsBento(
     onClearCache: () -> Unit,
     onNavigateToExtensionManager: () -> Unit,
     modifier: Modifier = Modifier,
+    narrowContainer: Boolean = false,
 ) {
-    val rows = homeActionRows(reinstallVisible, isRoot, hasPrivilege)
+    val rows = homeActionRows(reinstallVisible, isRoot, hasPrivilege, narrowContainer)
+    var explaining by rememberSaveable { mutableStateOf<HomeAction?>(null) }
+
+    @Composable
+    fun copyFor(action: HomeAction) = when (action) {
+        HomeAction.REINSTALL -> HomeActionCopy(
+            title = stringResource(R.string.reinstall_all),
+            subtitle = stringResource(
+                R.string.reinstall_all_subtitle, unknownInstallerCount, selectedTypeName
+            ),
+            icon = R.drawable.apk_install,
+        )
+        HomeAction.INSTALL -> HomeActionCopy(
+            title = stringResource(R.string.install_from_file),
+            subtitle = stringResource(R.string.install_from_file_subtitle),
+            icon = R.drawable.apk_install,
+        )
+        HomeAction.CLEAR_CACHE -> HomeActionCopy(
+            title = stringResource(R.string.clear_all_cache),
+            subtitle = stringResource(R.string.clear_all_cache_subtitle),
+            icon = R.drawable.clear_all,
+        )
+        HomeAction.EXTENSIONS -> HomeActionCopy(
+            title = stringResource(R.string.home_extensions_title),
+            // Not home_extensions_subtitle: "Manage & open" is a label, not an explanation.
+            subtitle = stringResource(R.string.manage_extensions_desc),
+            icon = R.drawable.round_extension,
+        )
+    }
+
+    fun onClick(action: HomeAction) = when (action) {
+        HomeAction.REINSTALL -> onReinstall
+        HomeAction.INSTALL -> onInstall
+        HomeAction.CLEAR_CACHE -> onClearCache
+        HomeAction.EXTENSIONS -> onNavigateToExtensionManager
+    }
 
     @Composable
     fun Tile(action: HomeAction, tileModifier: Modifier) {
-        when (action) {
-            HomeAction.REINSTALL -> BentoTile(
-                title = stringResource(R.string.reinstall_all),
-                subtitle = stringResource(R.string.reinstall_all_subtitle, unknownInstallerCount, selectedTypeName),
-                icon = R.drawable.apk_install,
-                isWarning = true,
-                onClose = onDismissReinstall,
-                onClick = onReinstall,
-                modifier = tileModifier,
-            )
-            HomeAction.INSTALL -> BentoTile(
-                title = stringResource(R.string.install_from_file),
-                subtitle = stringResource(R.string.install_from_file_subtitle),
-                icon = R.drawable.apk_install,
-                isPrimary = true,
-                onClick = onInstall,
-                modifier = tileModifier,
-            )
-            HomeAction.CLEAR_CACHE -> BentoTile(
-                title = stringResource(R.string.clear_all_cache),
-                subtitle = stringResource(R.string.clear_all_cache_subtitle),
-                icon = R.drawable.clear_all,
-                onClick = onClearCache,
-                modifier = tileModifier,
-            )
-            HomeAction.EXTENSIONS -> BentoTile(
-                title = stringResource(R.string.home_extensions_title),
-                subtitle = stringResource(R.string.home_extensions_subtitle),
-                icon = R.drawable.round_extension,
-                onClick = onNavigateToExtensionManager,
-                modifier = tileModifier,
-            )
-        }
+        // A full-width tile shows its description already, so there is nothing for the sheet to
+        // add — except in the rail, where full-width tiles are compact too.
+        val showSubtitle = !narrowContainer && rows.first { action in it }.size == 1
+        val copy = copyFor(action)
+        BentoTile(
+            title = copy.title,
+            subtitle = copy.subtitle,
+            icon = copy.icon,
+            isPrimary = action == HomeAction.INSTALL,
+            isWarning = action == HomeAction.REINSTALL,
+            showSubtitle = showSubtitle,
+            onLongClick = if (showSubtitle) null else ({ explaining = action }),
+            onLongClickLabel = if (showSubtitle) null else stringResource(R.string.show_details),
+            onClose = if (action == HomeAction.REINSTALL) onDismissReinstall else null,
+            onClick = onClick(action),
+            modifier = tileModifier,
+        )
     }
 
     Column(
@@ -92,5 +128,20 @@ fun HomeActionsBento(
                 }
             }
         }
+    }
+
+    explaining?.let { action ->
+        val copy = copyFor(action)
+        InfoBottomSheet(
+            title = copy.title,
+            body = copy.subtitle,
+            icon = copy.icon,
+            confirmLabel = copy.title,
+            onConfirm = {
+                explaining = null
+                onClick(action)()
+            },
+            onDismiss = { explaining = null },
+        )
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -204,6 +204,24 @@ fun SettingsScreen(
             )
 
             SettingsSwitchRow(
+                icon = R.drawable.apk_install,
+                title = stringResource(R.string.show_installer_tile),
+                subtitle = stringResource(R.string.show_installer_tile_desc),
+                checked = prefs.showInstallerTile,
+                enableMarqueeOnClick = true,
+                onCheckedChange = { viewModel.setInstallerTileVisibility(it) }
+            )
+
+            SettingsSwitchRow(
+                icon = R.drawable.round_extension,
+                title = stringResource(R.string.show_extensions_tile),
+                subtitle = stringResource(R.string.show_extensions_tile_desc),
+                checked = prefs.showExtensionsTile,
+                enableMarqueeOnClick = true,
+                onCheckedChange = { viewModel.setExtensionsTileVisibility(it) }
+            )
+
+            SettingsSwitchRow(
                 icon = R.drawable.settings_backup_restore,
                 title = stringResource(R.string.auto_reinstall),
                 subtitle = stringResource(R.string.auto_reinstall_desc),

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -167,6 +167,14 @@ class SettingsViewModel(
         viewModelScope.launch { preferenceRepository.setReinstallAllCardVisibility(visible) }
     }
 
+    fun setInstallerTileVisibility(visible: Boolean) {
+        viewModelScope.launch { preferenceRepository.setInstallerTileVisibility(visible) }
+    }
+
+    fun setExtensionsTileVisibility(visible: Boolean) {
+        viewModelScope.launch { preferenceRepository.setExtensionsTileVisibility(visible) }
+    }
+
     fun setAutoReinstallEnabled(enabled: Boolean) {
         viewModelScope.launch { preferenceRepository.setAutoReinstallEnabled(enabled) }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/InfoBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/InfoBottomSheet.kt
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.widgets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.valhalla.thor.R
+
+/**
+ * Explains one action in full, opened by long-pressing its tile. Half-width bento tiles have to
+ * drop their description to keep the title from clipping; this is where that description goes.
+ *
+ * Unlike the app's other bottom sheets this one carries buttons. A long press fires onLongClick
+ * *instead of* onClick, so holding a tile no longer performs its action — [confirmLabel] hands
+ * that back, letting the user read the explanation and then go ahead without a second gesture.
+ */
+@Composable
+fun InfoBottomSheet(
+    title: String,
+    body: String,
+    icon: Int,
+    confirmLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        // Short, fixed-height content: a partial detent would only ever hide part of a paragraph
+        // the user explicitly asked to read.
+        sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Expanded, SheetValue.Hidden)
+        ),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f),
+                        shape = RoundedCornerShape(20.dp)
+                    )
+                    .padding(14.dp)
+            ) {
+                Icon(
+                    painter = painterResource(icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.onSurface
+                )
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.cancel))
+                }
+                Button(onClick = onConfirm) {
+                    Text(confirmLabel)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -13,6 +13,10 @@
     <string name="general">عام</string>
     <string name="show_reinstall_card">إظهار بطاقة إعادة التثبيت</string>
     <string name="show_reinstall_card_desc">إظهار تذكير إصلاح المتجر على الشاشة الرئيسية</string>
+    <string name="show_installer_tile">إظهار مربع المثبِّت</string>
+    <string name="show_installer_tile_desc">إظهار "تثبيت من ملف" على الشاشة الرئيسية</string>
+    <string name="show_extensions_tile">إظهار مربع الإضافات</string>
+    <string name="show_extensions_tile_desc">إظهار الإضافات على الشاشة الرئيسية</string>
     <string name="appearance">المظهر</string>
     <string name="theme">المظهر</string>
     <string name="theme_desc">نمط الواجهة المرئية</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -57,6 +57,7 @@
     <string name="error_title">خطأ</string>
     <string name="refresh">تحديث</string>
     <string name="dismiss">تجاهل</string>
+    <string name="show_details">عرض التفاصيل</string>
     <string name="search_apps">بحث عن تطبيقات&#8230;</string>
     <string name="unknown">غير معروف</string>
 
@@ -66,7 +67,6 @@
     <string name="install_from_file">تثبيت من ملف</string>
     <string name="install_from_file_subtitle">تثبيت APK أو XAPK أو APKS أو حزم مقسمة</string>
     <string name="home_extensions_title">الإضافات</string>
-    <string name="home_extensions_subtitle">إدارة وفتح</string>
     <string name="app_distribution">توزيع التطبيقات</string>
     <string name="total_apps">الإجمالي: %1$d</string>
     <string name="others">أخرى</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -57,6 +57,7 @@
     <string name="error_title">Error</string>
     <string name="refresh">Actualizar</string>
     <string name="dismiss">Descartar</string>
+    <string name="show_details">Ver detalles</string>
     <string name="search_apps">Buscar aplicaciones&#8230;</string>
     <string name="unknown">Desconocido</string>
 
@@ -66,7 +67,6 @@
     <string name="install_from_file">Instalar desde archivo</string>
     <string name="install_from_file_subtitle">Instalar APK, XAPK, APKS o paquetes divididos</string>
     <string name="home_extensions_title">Extensiones</string>
-    <string name="home_extensions_subtitle">Administrar y abrir</string>
     <string name="app_distribution">Distribución de aplicaciones</string>
     <string name="total_apps">TOTAL: %1$d</string>
     <string name="others">Otros</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -13,6 +13,10 @@
     <string name="general">GENERAL</string>
     <string name="show_reinstall_card">Mostrar tarjeta de reinstalación</string>
     <string name="show_reinstall_card_desc">Mostrar recordatorio de Fix Store en la pantalla de inicio</string>
+    <string name="show_installer_tile">Mostrar mosaico del instalador</string>
+    <string name="show_installer_tile_desc">Mostrar «Instalar desde archivo» en la pantalla de inicio</string>
+    <string name="show_extensions_tile">Mostrar mosaico de extensiones</string>
+    <string name="show_extensions_tile_desc">Mostrar Extensiones en la pantalla de inicio</string>
     <string name="appearance">APARIENCIA</string>
     <string name="theme">Tema</string>
     <string name="theme_desc">Estilo de interfaz visual</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -57,6 +57,7 @@
     <string name="error_title">Erreur</string>
     <string name="refresh">Actualiser</string>
     <string name="dismiss">Ignorer</string>
+    <string name="show_details">Afficher les détails</string>
     <string name="search_apps">Rechercher des applis&#8230;</string>
     <string name="unknown">Inconnu</string>
 
@@ -66,7 +67,6 @@
     <string name="install_from_file">Installer depuis un fichier</string>
     <string name="install_from_file_subtitle">Installer APK, XAPK, APKS ou lots de fichiers</string>
     <string name="home_extensions_title">Extensions</string>
-    <string name="home_extensions_subtitle">Gérer et ouvrir</string>
     <string name="app_distribution">Distribution des applis</string>
     <string name="total_apps">TOTAL : %1$d</string>
     <string name="others">Autres</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,6 +13,10 @@
     <string name="general">GÉNÉRAL</string>
     <string name="show_reinstall_card">Afficher la carte de réinstallation</string>
     <string name="show_reinstall_card_desc">Afficher le rappel Fix Store sur l\'écran d\'accueil</string>
+    <string name="show_installer_tile">Afficher la tuile d\'installation</string>
+    <string name="show_installer_tile_desc">Afficher « Installer depuis un fichier » sur l\'écran d\'accueil</string>
+    <string name="show_extensions_tile">Afficher la tuile des extensions</string>
+    <string name="show_extensions_tile_desc">Afficher les extensions sur l\'écran d\'accueil</string>
     <string name="appearance">APPARENCE</string>
     <string name="theme">Thème</string>
     <string name="theme_desc">Style d\'interface visuelle</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -12,6 +12,10 @@
     <string name="general">通用</string>
     <string name="show_reinstall_card">显示重新安装卡片</string>
     <string name="show_reinstall_card_desc">在主屏幕上显示修复商店提醒</string>
+    <string name="show_installer_tile">显示安装器磁贴</string>
+    <string name="show_installer_tile_desc">在主屏幕上显示“从文件安装”</string>
+    <string name="show_extensions_tile">显示扩展磁贴</string>
+    <string name="show_extensions_tile_desc">在主屏幕上显示扩展</string>
     <string name="appearance">外观</string>
     <string name="theme">主题</string>
     <string name="theme_desc">视觉界面风格</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -56,6 +56,7 @@
     <string name="error_title">错误</string>
     <string name="refresh">刷新</string>
     <string name="dismiss">关闭</string>
+    <string name="show_details">查看详情</string>
     <string name="search_apps">搜索应用&#8230;</string>
     <string name="unknown">未知</string>
 
@@ -65,7 +66,6 @@
     <string name="install_from_file">从文件安装</string>
     <string name="install_from_file_subtitle">安装 APK、XAPK、APKS 或分割包</string>
     <string name="home_extensions_title">扩展</string>
-    <string name="home_extensions_subtitle">管理和打开</string>
     <string name="app_distribution">应用分布</string>
     <string name="total_apps">总计: %1$d</string>
     <string name="others">其他</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,10 @@
     <string name="general">GENERAL</string>
     <string name="show_reinstall_card">Show Reinstall Card</string>
     <string name="show_reinstall_card_desc">Show Fix Store reminder on home screen</string>
+    <string name="show_installer_tile">Show Installer Tile</string>
+    <string name="show_installer_tile_desc">Show Install from File on the home screen</string>
+    <string name="show_extensions_tile">Show Extensions Tile</string>
+    <string name="show_extensions_tile_desc">Show Extensions on the home screen</string>
     <string name="auto_reinstall">Auto Reinstall Apps</string>
     <string name="auto_reinstall_desc">Automatically preserve Google Play Store as the installer of record to enable background updates</string>
     <string name="appearance">APPEARANCE</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,6 +59,9 @@
     <string name="error_title">Error</string>
     <string name="refresh">Refresh</string>
     <string name="dismiss">Dismiss</string>
+    <!-- Accessibility label for the long-press action on a compact Home tile. TalkBack reads it
+         as "double-tap and hold to show details", so keep it a verb phrase. -->
+    <string name="show_details">Show details</string>
     <string name="search_apps">Search apps&#8230;</string>
     <string name="unknown">Unknown</string>
 
@@ -68,7 +71,6 @@
     <string name="install_from_file">Install from File</string>
     <string name="install_from_file_subtitle">Install APK, XAPK, APKS or Split bundles</string>
     <string name="home_extensions_title">Extensions</string>
-    <string name="home_extensions_subtitle">Manage &amp; open</string>
     <string name="app_distribution">App Distribution</string>
     <string name="total_apps">TOTAL: %1$d</string>
     <string name="others">Others</string>

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -331,6 +331,14 @@ class FakePreferenceRepository(
         prefs.update { it.copy(showReinstallAllCard = isVisible) }
     }
 
+    override suspend fun setInstallerTileVisibility(isVisible: Boolean) {
+        prefs.update { it.copy(showInstallerTile = isVisible) }
+    }
+
+    override suspend fun setExtensionsTileVisibility(isVisible: Boolean) {
+        prefs.update { it.copy(showExtensionsTile = isVisible) }
+    }
+
     override suspend fun setThemeMode(themeMode: ThemeMode) {
         prefs.update { it.copy(themeMode = themeMode) }
     }

--- a/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
@@ -14,21 +14,47 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * All three flags derive from one nullable field on the Home state, so only five of the eight
- * combinations are reachable: root implies privilege, and so does a visible reinstall card.
- * Each reachable state is asserted below; the last test pins the packing invariant across all of
- * them.
+ * The three privilege flags all derive from one nullable field on the Home state, so only five of
+ * their eight combinations are reachable: root implies privilege, and so does a visible reinstall
+ * card. The two GH#344 preferences are independent of all of that and of each other, so the
+ * reachable set is those five crossed with all four preference pairs.
+ *
+ * Each privilege state is asserted on its own below, then the preference rules, then the packing
+ * and visibility invariants across every combination.
  */
 class HomeActionsTest {
 
-    /** (reinstall, root, privilege) for every state the Home screen can actually be in. */
-    private val reachableStates = listOf(
-        Triple(false, false, false),
-        Triple(false, false, true),
-        Triple(true, false, true),
-        Triple(false, true, true),
-        Triple(true, true, true),
-    )
+    /** One state the Home screen can be in: the three derived flags plus the two preferences. */
+    private data class State(
+        val reinstall: Boolean,
+        val root: Boolean,
+        val privilege: Boolean,
+        val showInstaller: Boolean,
+        val showExtensions: Boolean,
+    ) {
+        fun rows() = homeActionRows(reinstall, root, privilege, showInstaller, showExtensions)
+
+        override fun toString() = "reinstall=$reinstall root=$root privilege=$privilege " +
+            "installer=$showInstaller extensions=$showExtensions"
+    }
+
+    /** The five reachable privilege states, crossed with every preference pair. */
+    private val reachableStates: List<State> =
+        listOf(
+            Triple(false, false, false),
+            Triple(false, false, true),
+            Triple(true, false, true),
+            Triple(false, true, true),
+            Triple(true, true, true),
+        ).flatMap { (reinstall, root, privilege) ->
+            listOf(true, false).flatMap { installer ->
+                listOf(true, false).map { extensions ->
+                    State(reinstall, root, privilege, installer, extensions)
+                }
+            }
+        }
+
+    // --- Privilege states, both tiles kept ------------------------------------------------------
 
     @Test fun noPrivilege_onlyInstallFullWidth() {
         assertEquals(
@@ -82,29 +108,112 @@ class HomeActionsTest {
         )
     }
 
-    @Test fun everyReachableState_packsIntoPairsWithAtMostOneWideLeader() {
-        for ((reinstall, root, privilege) in reachableStates) {
-            val rows = homeActionRows(reinstall, root, privilege)
-            val label = "reinstall=$reinstall root=$root privilege=$privilege"
+    // --- GH#344 visibility preferences ----------------------------------------------------------
 
-            assertTrue("$label: a row holds more than two tiles", rows.all { it.size in 1..2 })
-            assertTrue("$label: an empty row was emitted", rows.none { it.isEmpty() })
+    /** The 2x2 loses its leader and the survivors re-pack, rather than leaving a hole. */
+    @Test fun hidingTheInstaller_dropsOnlyThatTile() {
+        val rows = homeActionRows(
+            reinstallVisible = true, isRoot = true, hasPrivilege = true, showInstaller = false
+        )
+        assertTrue("Install must be gone", INSTALL !in rows.flatten())
+        assertEquals(listOf(listOf(CLEAR_CACHE), listOf(EXTENSIONS, REINSTALL)), rows)
+    }
+
+    @Test fun hidingExtensions_dropsOnlyThatTile() {
+        val rows = homeActionRows(
+            reinstallVisible = true, isRoot = true, hasPrivilege = true, showExtensions = false
+        )
+        assertTrue("Extensions must be gone", EXTENSIONS !in rows.flatten())
+        assertEquals(listOf(listOf(INSTALL), listOf(CLEAR_CACHE, REINSTALL)), rows)
+    }
+
+    @Test fun hidingBoth_keepsThePrivilegedTiles() {
+        val rows = homeActionRows(
+            reinstallVisible = true,
+            isRoot = true,
+            hasPrivilege = true,
+            showInstaller = false,
+            showExtensions = false,
+        )
+        assertEquals(listOf(listOf(CLEAR_CACHE, REINSTALL)), rows)
+    }
+
+    /**
+     * The whole grid can legitimately disappear — hiding both optional tiles with no privilege
+     * leaves nothing eligible. HomeScreen drops its spacer on this, so it has to stay an empty
+     * list rather than a row of nothing.
+     */
+    @Test fun hidingBothWithNoPrivilege_leavesNothingToDraw() {
+        assertEquals(
+            emptyList<List<HomeAction>>(),
+            homeActionRows(
+                reinstallVisible = false,
+                isRoot = false,
+                hasPrivilege = false,
+                showInstaller = false,
+                showExtensions = false,
+            )
+        )
+    }
+
+    /** The preference relaxes nothing: without a privilege there is no Extensions tile to keep. */
+    @Test fun wantingExtensionsWithoutPrivilege_staysHidden() {
+        val rows = homeActionRows(
+            reinstallVisible = false, isRoot = false, hasPrivilege = false, showExtensions = true
+        )
+        assertEquals(listOf(listOf(INSTALL)), rows)
+    }
+
+    /** Hiding a tile is layout-only, so the rail packs the survivors the same way. */
+    @Test fun narrowContainer_respectsTheVisibilityPreferences() {
+        assertEquals(
+            listOf(listOf(CLEAR_CACHE), listOf(REINSTALL)),
+            homeActionRows(
+                reinstallVisible = true,
+                isRoot = true,
+                hasPrivilege = true,
+                showInstaller = false,
+                showExtensions = false,
+                narrowContainer = true,
+            )
+        )
+    }
+
+    // --- Invariants across every reachable state ------------------------------------------------
+
+    @Test fun everyReachableState_packsIntoPairsWithAtMostOneWideLeader() {
+        for (state in reachableStates) {
+            val rows = state.rows()
+
+            assertTrue("$state: a row holds more than two tiles", rows.all { it.size in 1..2 })
+            assertTrue("$state: an empty row was emitted", rows.none { it.isEmpty() })
             assertTrue(
-                "$label: a single-tile row appears somewhere other than first",
+                "$state: a single-tile row appears somewhere other than first",
                 rows.drop(1).all { it.size == 2 }
             )
 
             val flat = rows.flatten()
-            assertEquals("$label: a tile was duplicated", flat.size, flat.toSet().size)
-            assertTrue("$label: Install is missing", INSTALL in flat)
-            assertEquals("$label: Clear cache visibility", root, CLEAR_CACHE in flat)
-            assertEquals("$label: Extensions visibility", privilege, EXTENSIONS in flat)
-            assertEquals("$label: Reinstall visibility", reinstall, REINSTALL in flat)
+            assertEquals("$state: a tile was duplicated", flat.size, flat.toSet().size)
+        }
+    }
+
+    /** Every tile's visibility is exactly its own rule — no tile rides along on another's. */
+    @Test fun everyReachableState_showsExactlyTheEligibleTiles() {
+        for (state in reachableStates) {
+            val flat = state.rows().flatten()
+            assertEquals("$state: Install visibility", state.showInstaller, INSTALL in flat)
+            assertEquals("$state: Clear cache visibility", state.root, CLEAR_CACHE in flat)
+            assertEquals(
+                "$state: Extensions visibility",
+                state.privilege && state.showExtensions,
+                EXTENSIONS in flat
+            )
+            assertEquals("$state: Reinstall visibility", state.reinstall, REINSTALL in flat)
         }
     }
 
     @Test fun everyActionIsReachableFromSomeState() {
-        val seen = reachableStates.flatMap { (r, root, p) -> homeActionRows(r, root, p).flatten() }
+        val seen = reachableStates.flatMap { it.rows().flatten() }
         assertEquals(HomeAction.entries.toSet(), seen.toSet())
     }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
@@ -3,44 +3,108 @@
 
 package com.valhalla.thor.presentation.home
 
+import com.valhalla.thor.presentation.home.components.HomeAction
 import com.valhalla.thor.presentation.home.components.HomeAction.CLEAR_CACHE
 import com.valhalla.thor.presentation.home.components.HomeAction.EXTENSIONS
 import com.valhalla.thor.presentation.home.components.HomeAction.INSTALL
 import com.valhalla.thor.presentation.home.components.HomeAction.REINSTALL
 import com.valhalla.thor.presentation.home.components.homeActionRows
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * All three flags derive from one nullable field on the Home state, so only five of the eight
+ * combinations are reachable: root implies privilege, and so does a visible reinstall card.
+ * Each reachable state is asserted below; the last test pins the packing invariant across all of
+ * them.
+ */
 class HomeActionsTest {
-    @Test fun noPrivilege_onlyInstallFullWidth() {
-        assertEquals(listOf(listOf(INSTALL)), homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = false))
-    }
 
-    @Test fun shizukuOrDhizuku_withReinstall_extensionsFullWidth() {
+    /** (reinstall, root, privilege) for every state the Home screen can actually be in. */
+    private val reachableStates = listOf(
+        Triple(false, false, false),
+        Triple(false, false, true),
+        Triple(true, false, true),
+        Triple(false, true, true),
+        Triple(true, true, true),
+    )
+
+    @Test fun noPrivilege_onlyInstallFullWidth() {
         assertEquals(
-            listOf(listOf(REINSTALL, INSTALL), listOf(EXTENSIONS)),
-            homeActionRows(reinstallVisible = true, isRoot = false, hasPrivilege = true)
+            listOf(listOf(INSTALL)),
+            homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = false)
         )
     }
 
-    @Test fun shizukuOrDhizuku_noReinstall() {
+    @Test fun shizukuOrDhizuku_noReinstall_isOnePair() {
         assertEquals(
-            listOf(listOf(INSTALL), listOf(EXTENSIONS)),
+            listOf(listOf(INSTALL, EXTENSIONS)),
             homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = true)
         )
     }
 
-    @Test fun root_withReinstall_fullGrid() {
+    @Test fun shizukuOrDhizuku_withReinstall_leadsWide() {
         assertEquals(
-            listOf(listOf(REINSTALL, INSTALL), listOf(CLEAR_CACHE, EXTENSIONS)),
-            homeActionRows(reinstallVisible = true, isRoot = true, hasPrivilege = true)
+            listOf(listOf(INSTALL), listOf(EXTENSIONS, REINSTALL)),
+            homeActionRows(reinstallVisible = true, isRoot = false, hasPrivilege = true)
         )
     }
 
-    @Test fun root_noReinstall() {
+    @Test fun root_noReinstall_leadsWide() {
         assertEquals(
             listOf(listOf(INSTALL), listOf(CLEAR_CACHE, EXTENSIONS)),
             homeActionRows(reinstallVisible = false, isRoot = true, hasPrivilege = true)
         )
+    }
+
+    @Test fun root_withReinstall_isTwoByTwo() {
+        assertEquals(
+            listOf(listOf(INSTALL, CLEAR_CACHE), listOf(EXTENSIONS, REINSTALL)),
+            homeActionRows(reinstallVisible = true, isRoot = true, hasPrivilege = true)
+        )
+    }
+
+    /** Reinstall is last in the flow, so dismissing it re-packs only the tiles after it. */
+    @Test fun dismissingReinstall_leavesTheOtherTilesInPlace() {
+        val withCard = homeActionRows(reinstallVisible = true, isRoot = true, hasPrivilege = true)
+        val without = homeActionRows(reinstallVisible = false, isRoot = true, hasPrivilege = true)
+        assertEquals(listOf(INSTALL, CLEAR_CACHE, EXTENSIONS), without.flatten())
+        assertEquals(listOf(INSTALL, CLEAR_CACHE, EXTENSIONS, REINSTALL), withCard.flatten())
+    }
+
+    @Test fun narrowContainer_givesEveryTileItsOwnRow() {
+        assertEquals(
+            listOf(listOf(INSTALL), listOf(CLEAR_CACHE), listOf(EXTENSIONS), listOf(REINSTALL)),
+            homeActionRows(
+                reinstallVisible = true, isRoot = true, hasPrivilege = true, narrowContainer = true
+            )
+        )
+    }
+
+    @Test fun everyReachableState_packsIntoPairsWithAtMostOneWideLeader() {
+        for ((reinstall, root, privilege) in reachableStates) {
+            val rows = homeActionRows(reinstall, root, privilege)
+            val label = "reinstall=$reinstall root=$root privilege=$privilege"
+
+            assertTrue("$label: a row holds more than two tiles", rows.all { it.size in 1..2 })
+            assertTrue("$label: an empty row was emitted", rows.none { it.isEmpty() })
+            assertTrue(
+                "$label: a single-tile row appears somewhere other than first",
+                rows.drop(1).all { it.size == 2 }
+            )
+
+            val flat = rows.flatten()
+            assertEquals("$label: a tile was duplicated", flat.size, flat.toSet().size)
+            assertTrue("$label: Install is missing", INSTALL in flat)
+            assertEquals("$label: Clear cache visibility", root, CLEAR_CACHE in flat)
+            assertEquals("$label: Extensions visibility", privilege, EXTENSIONS in flat)
+            assertEquals("$label: Reinstall visibility", reinstall, REINSTALL in flat)
+        }
+    }
+
+    @Test fun everyActionIsReachableFromSomeState() {
+        val seen = reachableStates.flatMap { (r, root, p) -> homeActionRows(r, root, p).flatten() }
+        assertEquals(HomeAction.entries.toSet(), seen.toSet())
     }
 }


### PR DESCRIPTION
Closes #344.

## The setting #344 asked for

Installer and Extensions can now each be hidden from Home, independently, from **Settings ▸ GENERAL**. Both tiles are shortcuts to something still reachable elsewhere — hiding Installer leaves APK intent handling untouched, hiding Extensions leaves its Settings entry — so this is a layout choice, not a feature switch.

The two preferences stack with the existing eligibility rules rather than replacing them: `INSTALL.takeIf { showInstaller }`, `EXTENSIONS.takeIf { hasPrivilege && showExtensions }`. A preference cannot conjure a tile the privilege check refuses.

Hiding both with no privilege leaves nothing eligible, and that is a legitimate answer rather than a bug to guard against: `homeActionRows` returns an empty list, `HomeActionsBento` emits no `Column`, and both `HomeScreen` branches drop the spacer that separates the grid from the summary row — otherwise a bare 36 dp gap is left where the grid used to be.

Plumbed on the existing `showReinstallAllCard` path end to end: two DataStore keys (`show_installer_tile`, `show_extensions_tile`, both defaulting to `true`) → `UserPreferences` → `PreferenceRepository(+Impl)` → `HomeUiState` → both `HomeActionsBento` call sites.

## What changed

`homeActionRows` flowed the visible actions into pairs with a single wide leader when the count is odd, replacing the fixed positional buckets:

| visible | before | after |
|---|---|---|
| 4 | `[Reinstall, Install]` `[Clear cache, Extensions]` | 2×2 |
| 3 | `[Reinstall, Install]` `[Extensions]` | wide leader, then a pair |
| 2 | `[Install]` `[Extensions]` | one pair |
| 1 | `[Install]` | one wide tile |
| 0 | — | nothing at all |

Install was unconditional in row 1, so Reinstall and Clear cache could never go full-width no matter how few tiles were showing. Reinstall now sits at the end of the flow: it is the only dismissible tile, so dismissing it re-packs the rows after it rather than shifting every other tile up a slot.

## Why the description moves to a sheet

Half-width tiles have never had room for a title and a description both. Measured at 393 dp across five locales × three font scales: **156 titles and 224 descriptions clipped**. At the default font size, en/es/fr already lost **4/9/9 of 13** descriptions.

Paired tiles now drop the description and give the title its second line; a long press opens a bottom sheet with the full text (218–266 dp, no scrolling in any locale). Wide tiles keep their description inline and have **no** long press — there would be nothing to add. **Nothing clips at the default font size in any locale.**

The wide-screen rail gets `narrowContainer = true`. At roughly a third of a 600 dp window even a full-width tile cannot hold a one-line title plus a description, so every tile there goes full-width *and* compact — the only combination measured to clip nothing in that pane (2 columns there still clips a title in 11 of 15 locale×font combinations).

## Two details the design turns on

Both are covered by instrumented tests because both are silent failures:

- **The dismiss X is a plain `Box` with `combinedClickable`, not an `IconButton`.** `IconButton` inflates an 18 dp icon to a 48 dp target and its `clickable` consumes the pointer down, so the tile's long-press timer never started — holding that corner *dismissed the card* instead of explaining it. Measured before the fix: `parentLong=0 parentClick=0 dismiss=1`.
- **Dropping the subtitle `Text` also drops its string from the tile's merged semantics node**, taking the scope of the action away from TalkBack. A zero-size semantics node after the title keeps both the content and its reading order.

A long press fires `onLongClick` *instead of* `onClick`, so holding a tile no longer performs its action. The sheet's confirm button hands that back and reuses the tile's own title, costing no new translation.

## Strings

`show_details` lands in all five locales and `home_extensions_subtitle` ("Manage & open") leaves them — the sheet needs an explanation, not a label, so Extensions reuses the existing `manage_extensions_desc`. The two new Settings switches add four strings (`show_installer_tile{,_desc}`, `show_extensions_tile{,_desc}`) in the same commit as their usage. Parity holds across en/ar/es/fr/zh-rCN.

## Verification

- 16 unit tests (`HomeActionsTest`) — the five reachable privilege states crossed with all four preference pairs, each tile's visibility asserted against its own rule, plus the packing invariant. 726 unit tests green overall.
- 10 instrumented tests on API 36 (`BentoTileTest`, `HomeActionsBentoTest`) — semantics, the dead zone, and the sheet end to end
- `lintStoreRelease` clean (it caught the newly-dead string; removed)
- All five states and the sheet captured on-device and eyeballed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added long-press interactions to Home action tiles with accessible detail labels.
  * Added informational bottom sheets with confirmation and cancellation actions.
  * Added settings to independently show or hide Installer and Extensions tiles.
  * Improved tile layouts across compact and wide screen sizes.
  * Added localized accessibility text in Arabic, Spanish, French, and Chinese.

* **Bug Fixes**
  * Improved action tile arrangement and visibility across different device states.
  * Updated extensions descriptions for clearer presentation.

* **Tests**
  * Expanded coverage for tile interactions, accessibility, layouts, visibility, and confirmation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
