### PR TITLE
docs(release-notes): record #357 in the v1.94.0 notes

### DIFF
--- a/release-notes/v1.94.0/github.md
+++ b/release-notes/v1.94.0/github.md
@@ -1,7 +1,7 @@
 # Thor v1.94.0 Release Notes
 
 The first stable since **v1.93.0**, consolidating everything that shipped through the
-`v1.93.1`, `v1.93.2` and `v1.93.3` pre-release builds — **66 pull requests**.
+`v1.93.1`, `v1.93.2` and `v1.93.3` pre-release builds — **67 pull requests**.
 
 Two threads run through it. The first is **new ground**: freeze profiles, bulk backup and
 `.xapk` export, permission filtering, and a support catalogue that comes from Play instead of
@@ -28,6 +28,8 @@ uninstalling it, and taking its data with it.**
   code that never meant success.
 * 🔒 **App lock covers cold start**, and the app list no longer leaks into the Recents preview.
 * 📱 **One app-info sheet**, with the full details built in — the detailed-view switch is gone.
+* 🏠 **The home shortcuts pack themselves to the space they have**, and the Installer and
+  Extensions tiles can be switched off in Settings.
 * 💖 **Support tiers are read from Play**, so a new tier appears without an app update.
 
 ---
@@ -59,6 +61,19 @@ Filter by what apps can actually reach: Camera, Microphone, Location and the res
 
 App info and app details are one sheet. The "detailed view" toggle it replaces is retired
 rather than hidden.
+
+### 🏠 An adaptive home grid, with tiles you can hide (#357 — for GH#344)
+
+The home shortcuts pack to the room they have instead of to a fixed 2×2. An odd number of tiles
+leads with a full-width one rather than leaving a hole, and in the navigation rail — where a
+tile has no width for its label — each takes its own row and explains itself on a long press.
+
+**Installer** and **Extensions** each got a switch in **Settings → General**. Hiding a tile
+takes away the shortcut, never the feature: the installer still handles APK intents, and
+Extensions keeps its own Settings entry. The two preferences stack with the existing eligibility
+rules rather than overriding them, so asking for the Extensions tile without a privilege mode
+still shows nothing — and hiding both with no privilege legitimately empties the grid, which
+disappears rather than leaving a gap where it used to be.
 
 ### 🧊 System-app freeze: disable first, remove second (#314, #332 — for GH#316)
 
@@ -182,6 +197,7 @@ suspension another privilege mode applied.
 
 ## 🛠 Commits Log (`v1.93.0...v1.94.0`)
 
+* `59236b5e` — #357 adaptive home grid, and hiding the Installer and Extensions tiles
 * `fbf2d54e` — #356 Ko-fi and Buy Me a Coffee in the app
 * `0ea6f93b` — #354 lint warning sweep, guards preserved
 * `1f31a36f` — #352 release 1.93.3

--- a/release-notes/v1.94.0/telegram.md
+++ b/release-notes/v1.94.0/telegram.md
@@ -8,15 +8,17 @@
 
 • 🔎 **Filter apps by permission** — Camera, Mic, Location and more.
 
+• 🏠 **Hide the Installer or Extensions tile** from the home screen.
+
 • 💖 **Support tiers load from Play**, so new ones appear without an app update.
 
 **Fixed:**
 
 • 🧊 **Freezing a preinstalled app no longer wipes its data** — Thor disables it instead.
 
-• ✅ **Freeze, restrict and clear-data check the result** instead of trusting an exit code.
+• ✅ **Freeze, restrict and clear-data check the result**, not the exit code.
 
-• 🔒 **App lock covers the moment Thor opens**, and your app list no longer shows in Recents.
+• 🔒 **App lock covers the moment Thor opens**, and Recents hides your app list.
 
 • 📱 **App list survives a ROM revoking package visibility.**
 


### PR DESCRIPTION
PR #357 merged after the v1.94.0 notes were written and is absent from all three of them. 1940 has not published yet — the `dev` → `master` merge that fires `dev-check.yml` is still to come — so #357 belongs to this release, not the next.

## github.md
Four edits, matching what #356 did to the same file:
- a Highlights bullet
- a `### 🏠 An adaptive home grid, with tiles you can hide` section under *What's Changed*, covering both halves — the adaptive packing and the two **Settings → General** switches (for GH#344)
- the commit-log line (`59236b5e`)
- the intro PR count, **66 → 67**, which is the one number in the file the commit log can be counted against

## telegram.md
One new line, which needed making room for.

The channel receives the file plus a **141-unit wrapper** built in `dev-check.yml:242`, so the real budget is 1024 minus that — and the file was already at 803. Two lines were tightened losslessly to buy the space:

- `check the result, **not the exit code**` (was “instead of trusting an exit code”)
- `**Recents hides your app list**` (was “your app list no longer shows in Recents”)

Measured on the **assembled** caption, not the file: **998 of 1024, margin 26**. Worth recording that a hand count of the new line said 55 units — it is 68. Three earlier drafts all overflowed.

## playstore.txt — deliberately untouched
Same call #356 made. It sits at **483 of Play's 500**, and the only way to fit a home-tile line is to shave nuance off bullets that matter more to a Play reader than this one does: a freeze that stopped wiping data, and privileged actions that now report what really happened. Leaving it alone also keeps `fastlane/.../changelogs/1940.txt` and `shizu_store.json` byte-identical to it, so no propagation step was needed.

## Verification
| check | result |
|---|---|
| `wc -m playstore.txt` | 483 / 500 |
| assembled Telegram caption | 998 / 1024 (margin 26) |
| `diff` playstore.txt ↔ fastlane 1940.txt | identical |
| `check-shizu-manifest.sh` | all checks passed, changelog matches 1940 |
| closing-keyword grep over the notes | clean |

No code touched — docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hiding the Installer or Extensions tile from the home screen.
  * Documented adaptive home-grid behavior and tile-visibility settings.

* **Documentation**
  * Clarified that freeze, restrict, and clear-data actions verify their results.
  * Clarified that App Lock protects the app’s opening moment and Recents can hide the app list.
  * Updated the GitHub release notes with the latest pull request count and commit details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->