### PR TITLE
revert(i18n): drop the hi-IN changelog translations

### DIFF
--- a/fastlane/metadata/android/hi-IN/changelogs/1931.txt
+++ b/fastlane/metadata/android/hi-IN/changelogs/1931.txt
@@ -1,13 +1,13 @@
-• 🧊 नया: फ्रीज प्रोफाइल — ऐप्स के नामित समूह सहेजें, एक टैप में फ्रीज या अनफ्रीज करें।
+• 🧊 New: Freeze Profiles — save named groups of apps, freeze or unfreeze in one tap.
 
-• 💾 नया: एक साथ कई ऐप्स एक्सपोर्ट करें, अपनी चुनी हुई फ़ोल्डर में।
+• 💾 New: export several apps at once, to a folder you pick.
 
-• 📦 नया: .apk और .apks के साथ .xapk में भी एक्सपोर्ट।
+• 📦 New: export as .xapk, alongside .apk and .apks.
 
-• 🔎 नया: अनुमति के आधार पर ऐप्स फ़िल्टर करें — कैमरा, माइक, लोकेशन आदि।
+• 🔎 New: filter your apps by permission — Camera, Mic, Location and more.
 
-• 📱 ऐप जानकारी अब एक ही शीट में, पूरे विवरण के साथ।
+• 📱 App info is now one sheet, with the full details built in.
 
-• 🧊 फ्रीजर में सुधार: टाइल और शॉर्टकट अब कहीं ज़्यादा भरोसेमंद।
+• 🧊 Freezer rework: the tile and shortcuts are far more reliable.
 
-• 🔒 ऐप लॉक अब आपको बाहर नहीं कर सकता।
+• 🔒 App lock can no longer lock you out.

--- a/fastlane/metadata/android/hi-IN/changelogs/1932.txt
+++ b/fastlane/metadata/android/hi-IN/changelogs/1932.txt
@@ -1,11 +1,11 @@
-• 🧊 प्रीइंस्टॉल ऐप फ्रीज करने पर अब उसका डेटा नहीं मिटता — Thor उसे डिसेबल करता है।
+• 🧊 Freezing a preinstalled app no longer wipes its data — Thor disables it, and keeps the data if it must remove it.
 
-• ❄️ फ्रीजर से ऐप हटाने पर वह पहले अनफ्रीज होता है — और न हो सके तो बताता है।
+• ❄️ Removing an app from the Freezer unfreezes it first, on every screen — and says so if it can't.
 
-• 📱 चीनी बाज़ार के ROMs पर ऐप सूची एक ही एंट्री तक सिमटने की समस्या ठीक की।
+• 📱 Fixed the app list collapsing to one entry on Chinese-market ROMs.
 
-• ⏸️ अनसस्पेंड न हो पाने पर Thor अब झूठी सफलता नहीं दिखाता।
+• ⏸️ Thor no longer claims success when it couldn't unsuspend an app.
 
-• 🔄 प्रिविलेज चेक का रिफ्रेश अब Root, Shizuku और Dhizuku तीनों को दोबारा जाँचता है।
+• 🔄 Privilege Check's Refresh re-checks Root, Shizuku and Dhizuku.
 
-• 💖 नया: Thor के विकास में सहयोग के और तरीके।
+• 💖 New: more ways to support Thor's development.

--- a/fastlane/metadata/android/hi-IN/changelogs/1933.txt
+++ b/fastlane/metadata/android/hi-IN/changelogs/1933.txt
@@ -1,13 +1,13 @@
-• ✅ फ्रीज, प्रतिबंध और क्लियर-डेटा अब असली नतीजा बताते हैं।
+• ✅ Freeze, restrict and clear-data now report what really happened.
 
-• 🔒 ऐप लॉक अब ऐप खुलने पर लागू, और Recents में ऐप सूची छिपाता है।
+• 🔒 App lock now covers app start, and hides your app list in Recents.
 
-• 🌍 भाषा चयन अब Android 12 और उससे नीचे भी काम करता है।
+• 🌍 Language picker works on Android 12 and below.
 
-• ⚡ कुछ ROMs पर बल्क कार्रवाई अब हर ऐप पर 15 सेकंड नहीं रुकती।
+• ⚡ Bulk actions no longer stall 15 seconds per app on some ROMs.
 
-• 📦 इंस्टॉलर अब जो बाइट्स इंस्टॉल करता है उन्हें जाँचता है।
+• 📦 The installer verifies the exact bytes it installs.
 
-• 🛠️ खराब सेटिंग्स फ़ाइल से होने वाला क्रैश लूप ठीक किया।
+• 🛠️ Fixed a crash loop from an unreadable settings file.
 
-• 💖 सपोर्ट टियर अब Play से लोड होते हैं — नए टियर बिना अपडेट दिखेंगे।
+• 💖 Support tiers load from Play — new ones appear without an update.

--- a/fastlane/metadata/android/hi-IN/changelogs/1940.txt
+++ b/fastlane/metadata/android/hi-IN/changelogs/1940.txt
@@ -1,13 +1,13 @@
-• 🧊 नया: फ्रीज प्रोफाइल — ऐप्स के समूह सहेजें, एक टैप में फ्रीज या अनफ्रीज करें।
+• 🧊 New: Freeze Profiles — save named groups of apps, freeze or unfreeze in one tap.
 
-• 💾 नया: एक साथ कई ऐप्स का बैकअप या एक्सपोर्ट, .xapk समेत।
+• 💾 New: back up or export several apps at once, including .xapk.
 
-• 🔎 नया: अनुमति के आधार पर ऐप्स फ़िल्टर करें — कैमरा, माइक, लोकेशन आदि।
+• 🔎 New: filter your apps by permission — Camera, Mic, Location and more.
 
-• 🧊 प्रीइंस्टॉल ऐप फ्रीज करने पर अब उसका डेटा नहीं मिटता।
+• 🧊 Freezing a preinstalled app no longer wipes its data.
 
-• ✅ फ्रीज, प्रतिबंध और क्लियर-डेटा अब असली नतीजा बताते हैं।
+• ✅ Freeze, restrict and clear-data now report what really happened.
 
-• 🔒 ऐप लॉक अब ऐप खुलने पर लागू, और Recents में ऐप सूची छिपाता है।
+• 🔒 App lock covers app start and hides your app list in Recents.
 
-• 📱 ऐप जानकारी अब एक ही शीट में, पूरे विवरण के साथ।
+• 📱 App info is one sheet, with the full details built in.


### PR DESCRIPTION
Reverts `112a215e` from #362.

The four hi-IN changelogs were translated without sign-off and are being dropped rather than reviewed.

### What this does and does not do

The files go **back to English — they are not deleted.** The locale still needs a file for every version code: `supply` enumerates locales from the metadata directory and sends an *empty* what's-new for any locale missing one, which would blank Hindi users' release notes rather than leave the previous ones in place. English is the correct placeholder, and `test-changelog-locale-parity.sh` stays green (verified locally — 10 test files, 0 failed).

The rest of `hi-IN` — `title.txt`, `short_description.txt`, `full_description.txt` — is owner-authored Hindi and is untouched. Net effect: a Hindi store listing with English release notes, which is exactly the state before #362.

If you'd rather remove the Hindi locale from Play altogether, that's a different change — say the word and I'll do it properly (the whole `hi-IN` directory, not just the changelogs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hindi locale release notes with English translations.
  * Documented freeze profiles, batch backup and export, `.xapk` support, permission filtering, and consolidated app information.
  * Added notes on improved freezing reliability, app-lock privacy, action-result reporting, language selection, performance, installer verification, and crash recovery.
  * Included fixes for preinstalled-app data preservation, freezer removal, app-list display, suspend reporting, and privilege checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->