### PR TITLE
ci: check every PR, not only the ones aimed at a long-lived branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,11 +3,14 @@ name: CodeQL
 on:
   push:
     branches: [ "master", "dev" ]
-  # Unfiltered by base, matching pr-ci.yml — see the long note there. `push` stays
-  # scoped to the two long-lived branches because that is what populates the
-  # security tab's baseline; the PR trigger is what has to see every change, and a
-  # PR stacked on a feature branch was getting no analysis at all.
+  # Unfiltered by base, and `edited` added — see the long note in pr-ci.yml, which
+  # applies here unchanged. `push` stays scoped to the two long-lived branches
+  # because that is what populates the security tab's baseline; the PR trigger is
+  # what has to see every change, and a PR stacked on a feature branch was getting
+  # no analysis at all. Naming any type replaces the default set, so the three
+  # defaults are restated rather than extended.
   pull_request:
+    types: [ opened, synchronize, reopened, edited ]
   schedule:
     - cron: '27 3 * * 1' # weekly, Monday 03:27 UTC
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,11 @@ name: CodeQL
 on:
   push:
     branches: [ "master", "dev" ]
+  # Unfiltered by base, matching pr-ci.yml — see the long note there. `push` stays
+  # scoped to the two long-lived branches because that is what populates the
+  # security tab's baseline; the PR trigger is what has to see every change, and a
+  # PR stacked on a feature branch was getting no analysis at all.
   pull_request:
-    branches: [ "master", "dev" ]
   schedule:
     - cron: '27 3 * * 1' # weekly, Monday 03:27 UTC
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -12,9 +12,33 @@ name: PR CI
 # is cheaper than a PR that cannot merge. The three release callers
 # (1-dev-publish.yml, 2-master-promote.yml, 3-production-promote.yml) and web-ci.yml do
 # filter — all four are safe to filter precisely because none of them is a required check.
+#
+# No `branches:` filter either, and for the same reason one level up: a filter here
+# does not make a PR unchecked-and-obviously-so, it makes it unchecked-and-green.
+# `pull_request.branches` matches the BASE, so while this read
+# [ "master", "dev", "production" ] a stacked PR — one opened against a feature
+# branch, which is how a dependent change is reviewed without waiting for its
+# parent — ran none of the jobs below. What it showed instead was four green
+# checks: the labeler, two Vercel no-ops, and a CodeRabbit reporting `pass` with
+# "reviews are disabled for this base branch". Nothing distinguished that from a
+# PR where everything ran and passed. Observed on #366.
+#
+# Retargeting after the parent merges does not repair it. Changing a base raises
+# `pull_request` with action `edited`, and the default types are
+# opened/synchronize/reopened — so the PR keeps its stale green until someone
+# pushes or reopens it. Adding `edited` to the types would fix the retarget case
+# and nothing else; the PR is still unchecked for its whole review.
+#
+# The cost is that a stack now pays for CI twice, parent and child, on shared
+# files. That is the correct price: the alternative is the child never being built
+# until it is already merged into the parent.
+#
+# Fork PRs need no extra thought here — see the `Assemble minified release` step
+# below. This workflow exports no secret, and the release build type only assigns
+# a signingConfig when credentials exist, so a fork PR and a branch PR produce the
+# same unsigned APK. Widening the base does not widen what a PR can reach.
 on:
   pull_request:
-    branches: [ "master", "dev", "production" ]
 
 # Least-privilege token — this workflow only reads the repo.
 permissions:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -93,8 +93,24 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Assemble + unit test (foss debug)
-        run: ./gradlew assembleFossDebug testFossDebugUnitTest --stacktrace
+      # compileFossDebugAndroidTestKotlin is not decoration. Nothing else in this repo
+      # compiles app/src/androidTest at all: assembleFossDebug builds main, the unit-test
+      # task builds test/, lint analyses neither, and connectedAndroidTest — the task that
+      # WOULD compile it — needs a device and never runs here. So instrumented tests could
+      # be merged with a syntax error, a missing import or a reference to a symbol that was
+      # renamed three PRs ago, and every check on the page would still be green. The gap
+      # was found on #366, where a review claimed a missing import in AppActionRowTest; the
+      # claim was false, but no check would have caught it if it had been true.
+      #
+      # Compile-only, deliberately. Running the tests needs an emulator, which is minutes
+      # and a flake source; compiling them costs one extra Kotlin task against classes this
+      # step has already built. It buys the guarantee that androidTest still refers to code
+      # that exists, which is the failure mode that actually happens when a refactor sweeps
+      # main/ and leaves androidTest/ behind.
+      - name: Assemble + unit test + androidTest compile (foss debug)
+        run: >
+          ./gradlew assembleFossDebug testFossDebugUnitTest
+          :app:compileFossDebugAndroidTestKotlin --stacktrace
 
       # Enforced, not advisory: :app is at 0 errors / 0 warnings and app/build.gradle.kts sets
       # warningsAsErrors, so lint debt can only be introduced deliberately now.

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -23,11 +23,24 @@ name: PR CI
 # "reviews are disabled for this base branch". Nothing distinguished that from a
 # PR where everything ran and passed. Observed on #366.
 #
-# Retargeting after the parent merges does not repair it. Changing a base raises
-# `pull_request` with action `edited`, and the default types are
-# opened/synchronize/reopened — so the PR keeps its stale green until someone
-# pushes or reopens it. Adding `edited` to the types would fix the retarget case
-# and nothing else; the PR is still unchecked for its whole review.
+# `edited` is in the types for the other half of the same problem. Changing a PR's
+# base raises `pull_request` with action `edited`, and the default types are
+# opened/synchronize/reopened — verified the hard way on #366, where a retarget
+# from a feature branch to dev fired nothing and a close/reopen was needed. The
+# stale result is not merely stale, it is wrong: the checkouts below pass no
+# `ref:`, so actions/checkout uses its default of refs/pull/N/merge and every job
+# here builds HEAD MERGED INTO THE BASE. Retarget the PR and the green on the page
+# describes a merge into a branch that is no longer the target.
+#
+# The obvious economy — keep `edited` but add
+# `if: github.event.action != 'edited' || github.event.changes.base` so a title or
+# body edit does not pay for an Android build — is deliberately NOT taken. The
+# concurrency group below is workflow-level with cancel-in-progress, and it is
+# claimed before any job's `if` is evaluated: a body edit during a real run would
+# cancel that run, then skip, and a skipped required check counts as a PASS to the
+# ruleset. That is a false green, which is the exact defect this file is being
+# edited to remove. Rerunning on a body edit only wastes minutes. Same trade as
+# the paths note above — CI time is the cheap side.
 #
 # The cost is that a stack now pays for CI twice, parent and child, on shared
 # files. That is the correct price: the alternative is the child never being built
@@ -39,6 +52,9 @@ name: PR CI
 # same unsigned APK. Widening the base does not widen what a PR can reach.
 on:
   pull_request:
+    # The three defaults, restated because naming any type replaces the default
+    # set rather than extending it, plus `edited` for the base-change case above.
+    types: [ opened, synchronize, reopened, edited ]
 
 # Least-privilege token — this workflow only reads the repo.
 permissions:

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -19,8 +19,13 @@ name: Web CI
 # Step in web/vercel.json — a third derived fact means editing both.
 
 on:
+  # Base-unfiltered, matching pr-ci.yml — see the long note there. The `paths`
+  # filter stays: unlike pr-ci.yml this workflow is not a required status check,
+  # so a path-skipped run reports as "skipped", not as "Expected — waiting for
+  # status", and cannot make a PR unmergeable. What the base filter was doing was
+  # different in kind — it skipped a PR that DOES touch web/, purely because of
+  # where it was aimed.
   pull_request:
-    branches: [ "master", "dev" ]
     paths:
       - 'web/**'
       - 'gradle.properties'

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -19,13 +19,15 @@ name: Web CI
 # Step in web/vercel.json — a third derived fact means editing both.
 
 on:
-  # Base-unfiltered, matching pr-ci.yml — see the long note there. The `paths`
-  # filter stays: unlike pr-ci.yml this workflow is not a required status check,
-  # so a path-skipped run reports as "skipped", not as "Expected — waiting for
-  # status", and cannot make a PR unmergeable. What the base filter was doing was
-  # different in kind — it skipped a PR that DOES touch web/, purely because of
-  # where it was aimed.
+  # Base-unfiltered and `edited`-triggered, matching pr-ci.yml — see the long note
+  # there. The `paths` filter stays: unlike pr-ci.yml this workflow is not a
+  # required status check, so a path-skipped run reports as "skipped", not as
+  # "Expected — waiting for status", and cannot make a PR unmergeable. What the
+  # base filter was doing was different in kind — it skipped a PR that DOES touch
+  # web/, purely because of where it was aimed. Naming any type replaces the
+  # default set, so the three defaults are restated rather than extended.
   pull_request:
+    types: [ opened, synchronize, reopened, edited ]
     paths:
       - 'web/**'
       - 'gradle.properties'


### PR DESCRIPTION
`pull_request.branches` matches the **base**, so scoping `pr-ci.yml` to `master`/`dev`/`production`
meant a PR opened against a *feature* branch — which is how a dependent change gets reviewed without
waiting for its parent — ran **none** of it. No build, no unit tests, no lint, no R8, no
`shizu-manifest`.

The problem isn't the missing coverage. It's that the missing coverage is **invisible**. Such a PR
shows four green checks:

| Check | What it actually meant |
|---|---|
| `label` | the labeler bot ran |
| Vercel | *"Canceled by Ignored Build Step"* |
| Vercel Preview Comments | no-op |
| CodeRabbit `pass` | *"Review skipped: reviews are disabled for this base branch"* — **no review happened** |

Nothing on the page distinguishes that from a PR where everything ran and passed, and the PR is
mergeable on the strength of it. Observed live on #366.

**Retargeting after the parent merges does not repair it.** Changing a base raises `pull_request`
with action `edited`, which is not among the default `opened`/`synchronize`/`reopened` types — so
the stale green survives until someone pushes or reopens. I confirmed this on #366: retargeting it
to `dev` fired nothing, and a close/reopen was needed. Adding `edited` to the types would fix only
that last moment and leave the whole review unchecked; dropping the filter fixes all of it.

## What changed

- **`pr-ci.yml`** — `pull_request.branches` removed.
- **`codeql.yml`** — same, for the same reason. `push` stays scoped to `master`/`dev`, since that is
  what populates the security tab's baseline.
- **`web-ci.yml`** — same. It **keeps** its `paths` filter, which is a different thing from a base
  filter: `paths` skips runs that genuinely have nothing to do, whereas the base filter was skipping
  runs that did. `push` stays scoped.

`pr-ci.yml` still has **no `paths` filter at any level and still must never gain one** — it is the
required status context on the `dev` and `master` rulesets, and GitHub reports a path-skipped
required check as *"Expected — Waiting for status"* forever. That reasoning is unchanged and is
still documented in the file.

**`web-deploy.yml` is deliberately untouched.** It is dormant — Vercel's own Git integration does
the deploying — so widening its triggers would add runs that mean nothing.

## Cost and safety

**Cost:** a stack now pays for CI twice, parent and child, over shared files. That is the right
price for the child being built at all before it merges.

**Fork PRs are unaffected.** This workflow exports no secret, and the release build type only
assigns a `signingConfig` when credentials exist (`hasSigningCredentials`), so a fork PR and a
branch PR both produce an unsigned APK. Widening the *base* does not widen what a PR can *reach* —
this is `pull_request`, not `pull_request_target`.

## Verification

`actionlint` **1.7.7** — the version this repo pins, checksum-matched, not a newer local build (the
file documents why that distinction matters: 1.7.7 and 1.7.12 disagree about SC2153). **Clean.**

This PR is its own first test: it targets `dev`, so the pre-change config already covers it. The
change proves itself on the *next* stacked PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Continuous integration checks now run for pull requests targeting any base branch.
  * Security analysis runs for pull requests from any branch.
  * Pull-request checks run when opened, updated, reopened, or edited.
  * Android instrumented tests are now compiled as part of pull-request validation.
  * Existing push, schedule, and path-based filters remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->