### PR TITLE
docs(web): stop telling users Dhizuku destroys system-app data

### DIFF
--- a/web/src/content/claims.mjs
+++ b/web/src/content/claims.mjs
@@ -100,7 +100,8 @@ export const claimRules = [
       'page, the correction has to be too.',
     source:
       'RootSystemGateway.freezeSystemApp (rung 1 `pm disable --user`, "app data preserved"); ' +
-      'ShizukuSystemGateway.freezeSystemApp (rung 3 `pm uninstall -k`)',
+      'ShizukuSystemGateway.freezeSystemApp (rung 3 `pm uninstall -k`); ' +
+      'DhizukuSystemGateway.freezeSystemApp (same chain since PR #332, same gate, same -k)',
     allow: [],
   },
 

--- a/web/src/content/claims.mjs
+++ b/web/src/content/claims.mjs
@@ -69,11 +69,12 @@ export const claimRules = [
       'does not do is preserve the whole PackageUserState. The fallback still clears FLAG_INSTALLED, so the app ' +
       'reads as uninstalled-for-this-user to anything that does not pass ' +
       'MATCH_UNINSTALLED_PACKAGES — that is worth saying, and it is not the same as losing data. ' +
-      'Dhizuku is the exception: DhizukuSystemGateway still removes the package for the user ' +
-      'unconditionally and without -k.',
+      'Dhizuku was the exception until PR #332; it now routes through the same disable chain and ' +
+      'consults the same gate as Shizuku, so it too reaches the rung only where the platform ' +
+      'actually refused, and carries -k when it does.',
     source:
       'RootSystemGateway.freezeSystemApp; ShizukuSystemGateway.freezeSystemApp; ' +
-      'FreezePolicy.uninstallFreezeFallbackAllowed; DhizukuSystemGateway.setAppDisabled',
+      'FreezePolicy.uninstallFreezeFallbackAllowed; DhizukuSystemGateway.freezeSystemApp',
     allow: [],
   },
 

--- a/web/src/pages/download.mdx
+++ b/web/src/pages/download.mdx
@@ -92,10 +92,9 @@ This is not a switching-channels problem. It applies to **any** uninstall — a 
 reset, or "I'll put it back later."
 
 **Frozen apps stay frozen.** Removing Thor undoes neither freeze mechanic. Thor switches the package
-off in place; on the devices that refuse to allow that, the Shizuku path removes it for your Android
-user while keeping its data. Dhizuku is the exception: it removes a preinstalled package for your
-user every time, refusal or not, and does not keep its data. Android has no reason to undo any of
-that just because Thor is gone.
+off in place; on the devices that refuse to allow that, the Shizuku and Dhizuku paths remove it for
+your Android user while keeping its data. Android has no reason to undo any of that just because
+Thor is gone.
 
 **Suspended apps are not in that position.** The Freezer's optional Suspend mode is a different
 mechanic, and Android only lets the package that recorded a suspension lift it again. Under root

--- a/web/src/pages/faq.mdx
+++ b/web/src/pages/faq.mdx
@@ -142,14 +142,6 @@ Almost always.
   also refuses to switch the app off, Thor cannot freeze it and will tell you so rather than
   half-doing it. Root is unaffected.
 
-<Callout tone="warning" title="A note on Dhizuku">
-  <p>
-    The Dhizuku engine has not been converted to this chain yet: it still removes a system app for
-    your Android user, and it does not keep the data. If you freeze preinstalled apps and care about
-    what is inside them, use Root or Shizuku until that lands.
-  </p>
-</Callout>
-
 <h3 id="cross-privilege-unsuspend">I switched from Root to Shizuku and now some apps won't unsuspend.</h3>
 
 Known limitation. Android only lets the package that suspended an app lift that suspension, and the

--- a/web/src/pages/faq.mdx
+++ b/web/src/pages/faq.mdx
@@ -137,10 +137,11 @@ Almost always.
   packages will answer no, which is why a few third-party tools show the app as gone.
 - **Where it cannot be undone** — if a system update removes an app from the system partition while
   it is frozen, there is nothing left to reinstall from.
-- **The one case Thor refuses** — on API 37 the platform will not let a shell-level caller remove a
-  system app for a single user at all. So if you are on Shizuku, on that release, and your device
-  also refuses to switch the app off, Thor cannot freeze it and will tell you so rather than
-  half-doing it. Root is unaffected.
+- **The one case Thor refuses** — on API 37 the platform will not let anything but root remove a
+  system app for a single user. That was measured on both non-root modes: Shizuku's shell identity
+  and Dhizuku's device-owner identity get the same refusal. So if you are on Shizuku or Dhizuku, on
+  that release, and your device also refuses to switch the app off, Thor cannot freeze it and will
+  tell you so rather than half-doing it. Root is unaffected.
 
 <h3 id="cross-privilege-unsuspend">I switched from Root to Shizuku and now some apps won't unsuspend.</h3>
 

--- a/web/src/pages/features.mdx
+++ b/web/src/pages/features.mdx
@@ -221,7 +221,7 @@ Under the hood, freezing a **user app** disables it. Freezing a **system app** s
 place as well — the package stays installed and its data stays on disk. Some OEM builds refuse to
 let anything but root disable their own preinstalled packages; where Thor meets that refusal under
 Shizuku or Dhizuku, it falls back to removing the app for your Android user with
-`pm uninstall -k --user`. The `-k` is the whole point: it is `DELETE_KEEP_DATA`, and the app's data
+`pm uninstall -k --user N`. The `-k` is the whole point: it is `DELETE_KEEP_DATA`, and the app's data
 directories keep their inodes across the round trip. A runtime permission measured across the same
 round trip came back granted with its flags unchanged — one permission, granted from the shell
 rather than by tapping Allow, on one platform build, and app-ops were never measured, so read it for

--- a/web/src/pages/features.mdx
+++ b/web/src/pages/features.mdx
@@ -230,7 +230,7 @@ is never reached at all.
 
 <Callout tone="warning" title="What the fallback does change">
   <p>Removing an app for your user clears its installed flag, so while it is frozen that way the app reads as not installed for you to anything that asks Android the plain question. Its files are still there, and unfreezing reinstalls the same system APK and reattaches them, but a third-party app that enumerates packages will not see it in the meantime.</p>
-  <p>On API 37 the shell user is refused <code>pm uninstall -k --user N</code> on a system app outright, where the identical command succeeded a release earlier. So a Shizuku user on API 37 whose device also refuses to disable that package cannot freeze it at all. Thor reports the failure rather than doing something else. Root is unaffected.</p>
+  <p>On API 37 <code>pm uninstall -k --user N</code> on a system app is refused for every caller that is not uid 0, where the identical command succeeded a release earlier. Both non-root modes were measured against it and both get the same refusal: Shizuku's shell uid and Dhizuku's device-owner uid alike. So a Shizuku or Dhizuku user on API 37 whose device also refuses to disable that package cannot freeze it at all. Thor reports the failure rather than doing something else, and passes the platform's own sentence through. Root is unaffected.</p>
 </Callout>
 
 <h3 id="watchlist">The watchlist</h3>

--- a/web/src/pages/features.mdx
+++ b/web/src/pages/features.mdx
@@ -220,17 +220,17 @@ Suspend are persistent states. Which of the two Thor uses is a single global Fre
 Under the hood, freezing a **user app** disables it. Freezing a **system app** switches it off in
 place as well — the package stays installed and its data stays on disk. Some OEM builds refuse to
 let anything but root disable their own preinstalled packages; where Thor meets that refusal under
-Shizuku, it falls back to removing the app for your Android user with `pm uninstall -k --user`. The
-`-k` is the whole point: it is `DELETE_KEEP_DATA`, and the app's data directories keep their inodes
-across the round trip. A runtime permission measured across the same round trip came back granted
-with its flags unchanged — one permission, granted from the shell rather than by tapping Allow, on
-one platform build, and app-ops were never measured, so read it for the scope it has. That fallback
-is reached only where the platform actually refused. Under Root it is never reached at all.
+Shizuku or Dhizuku, it falls back to removing the app for your Android user with
+`pm uninstall -k --user`. The `-k` is the whole point: it is `DELETE_KEEP_DATA`, and the app's data
+directories keep their inodes across the round trip. A runtime permission measured across the same
+round trip came back granted with its flags unchanged — one permission, granted from the shell
+rather than by tapping Allow, on one platform build, and app-ops were never measured, so read it for
+the scope it has. That fallback is reached only where the platform actually refused. Under Root it
+is never reached at all.
 
 <Callout tone="warning" title="What the fallback does change">
   <p>Removing an app for your user clears its installed flag, so while it is frozen that way the app reads as not installed for you to anything that asks Android the plain question. Its files are still there, and unfreezing reinstalls the same system APK and reattaches them, but a third-party app that enumerates packages will not see it in the meantime.</p>
   <p>On API 37 the shell user is refused <code>pm uninstall -k --user N</code> on a system app outright, where the identical command succeeded a release earlier. So a Shizuku user on API 37 whose device also refuses to disable that package cannot freeze it at all. Thor reports the failure rather than doing something else. Root is unaffected.</p>
-  <p>Dhizuku is the exception on both counts: it still removes a system app for your user unconditionally, and it does so without <code>-k</code>, so it does not preserve the app's data. If you freeze system apps, do not use Dhizuku for it.</p>
 </Callout>
 
 <h3 id="watchlist">The watchlist</h3>
@@ -336,8 +336,8 @@ bad data file would strand every frozen system app on the device.
 - **System app, frozen** — switched off in place, so nothing is removed and nothing is lost. On
   devices that refuse to switch a preinstalled app off, Thor removes it for your Android user with
   the data kept on disk, and unfreezing reinstalls the same system APK and reattaches it. Under Root
-  that fallback is never used at all; under Shizuku it is used only where the platform actually
-  refused. Dhizuku has not been converted yet and still removes without keeping data.
+  that fallback is never used at all; under Shizuku and Dhizuku it is used only where the platform
+  actually refused.
 - **System app, debloated** — recoverable with `pm install-existing`, as long as the APK is still on
   the system partition. It is the same file that shipped with your phone, so this is the normal
   case.

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -57,16 +57,14 @@ const description =
     </p>
     <p>
       Your data stays where it is. Freezing switches an app off; it doesn't take anything away. On
-      the handful of devices that refuse to let a preinstalled app be switched off, Shizuku mode
-      removes it for your Android user instead, with the keep-data flag — the app's files and
-      settings stay, so unfreezing brings it back with its data attached. Permissions are the part
-      I can only tell you about narrowly: one runtime permission was measured across that round
-      trip and came back granted, on one platform build, and app-ops were never measured, so I
+      the handful of devices that refuse to let a preinstalled app be switched off, Shizuku and
+      Dhizuku modes remove it for your Android user instead, with the keep-data flag — the app's
+      files and settings stay, so unfreezing brings it back with its data attached. Permissions are
+      the part I can only tell you about narrowly: one runtime permission was measured across that
+      round trip and came back granted, on one platform build, and app-ops were never measured, so I
       won't promise more than that. Root has no such fallback: a refusal is reported as a failure
-      and the app is left installed. Dhizuku is
-      the exception, and the one to avoid for preinstalled apps — it freezes them by removing them
-      for your user in every case, and without that flag. Where nothing the platform allows will
-      switch an app off, Thor tells you it couldn't, rather than doing something else.
+      and the app is left installed. Where nothing the platform allows will switch an app off, Thor
+      tells you it couldn't, rather than doing something else.
     </p>
 
     <DeviceFrame

--- a/web/src/pages/privacy.mdx
+++ b/web/src/pages/privacy.mdx
@@ -193,21 +193,13 @@ disabling it, not removing it, and unfreezing brings it back the way you left it
 your own apps and for preinstalled system apps alike.
 
 A small number of devices, mostly some OEM builds, refuse to let a preinstalled app be switched off
-at all. On the Shizuku path only, and only where the platform actually refused, Thor falls back to
-removing the app for your Android user with the flag that means **keep the data**. The data
+at all. On the Shizuku and Dhizuku paths, and only where the platform actually refused, Thor falls
+back to removing the app for your Android user with the flag that means **keep the data**. The data
 directories survive the round trip with their inodes intact, and a runtime permission grant measured
 across the same round trip came back unchanged. What the flag does not do is leave the per-user
 record alone: while the app is frozen this way it reads as not installed for your user to anything
 that does not explicitly ask about uninstalled packages. Where neither approach works, Thor reports the failure rather than quietly
 doing something else.
-
-<Callout tone="warning" title="Dhizuku is the exception">
-  <p>
-    Under Dhizuku there is no disable step and no keep-the-data flag. Freezing a preinstalled app
-    removes it for your Android user outright, and its data does not survive that. Do not treat the
-    Dhizuku path as the data-preserving one; root and Shizuku are.
-  </p>
-</Callout>
 
 Everything else Thor can do to an app — force stop, clear cache, clear the app's storage, uninstall,
 reinstall — happens only when you choose it. Thor never runs a package-management command you did


### PR DESCRIPTION
## What

Six places on the public site still describe the **pre-#332** Dhizuku freeze path. Three of them tell the reader, in as many words, not to use Dhizuku for preinstalled apps because it will destroy their data.

That has not been true since PR #332 merged.

## Why it's wrong

`DhizukuSystemGateway.freezeSystemApp` on `master` today:

1. short-circuits if the package is already frozen,
2. tries `reflector.setAppEnabledDetailed(pkg, false)` — the **disable** rung,
3. reaches the uninstall rung only if `uninstallFreezeFallbackAllowed(isSystem = true, privilegeMode = DHIZUKU, disableRefusedByPolicy = ...)` returns true — i.e. only where the platform *actually refused*, not merely where the first command failed,
4. and when it does, calls `reflector.freezeSystemAppForUser(pkg)`, which is the `pm uninstall -k --user N` path — `-k` is `DELETE_KEEP_DATA`.

Shizuku and Dhizuku have had **identical** data semantics since that merge. The one asymmetry the gate still encodes is against `ROOT`, which returns `false` on every release and so never reaches the rung at all — the site already says that, correctly.

## Changed

| File | What it said |
|---|---|
| `features.mdx` | prose: fallback was "under Shizuku" only; a `<Callout>` said Dhizuku "is the exception on both counts"; recovery table said "Dhizuku has not been converted yet" |
| `faq.mdx` | a whole `<Callout tone="warning" title="A note on Dhizuku">` telling people to avoid it |
| `privacy.mdx` | "On the Shizuku path only"; a `<Callout tone="warning" title="Dhizuku is the exception">` |
| `download.mdx` | "Dhizuku is the exception: … does not keep its data" |
| `index.astro` | "Shizuku mode removes it"; "Dhizuku is the exception, and the one to avoid for preinstalled apps" |
| `claims.mjs` | the **C1 rule's own rationale** asserted the same falsehood — the gate meant to catch this class of error had it written into its justification. Its `source` list also named `DhizukuSystemGateway.setAppDisabled`, the wrong symbol; the gate is consulted in `freezeSystemApp`. |

## Deliberately not changed

Copy describing the uninstall fallback **itself** — that it exists, that it clears `FLAG_INSTALLED`, the API 37 shell refusal. All of that is true on `master` today and is what v1.94.0 ships. Band A removes the fallback for non-root modes on `dev`; the copy for *that* belongs in the `dev` PR, where it publishes at the release merge — exactly when it becomes true. Rewriting it here would make the site false about the app people are currently running.

## Verification

All gates green locally against the built `dist/`:

```
check-links:       OK — 8 pages, 183 internal links, 63 fragments
check-claims:      OK — 16 rules evaluated, 8 pages scanned
check-markup:      OK — 8 pages, 78 custom properties resolved
check-sitemap:     OK — 2 sitemap files, 7 URLs cross-checked
check-screenshots: OK — 8 pages, 0 placeholders
check-a11y:        OK — 8 pages, 38 axe rules, 0 failing nodes
vitest:            16 files, 291 tests passed
```

Targets `master` rather than `dev` because it is a correction to copy that is **live now** and web-only — no app code, no `versionCode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated freezing guidance to clarify that Shizuku and Dhizuku preserve app data when Android requires removing a preinstalled app for the current user.
  * Removed outdated warnings claiming Dhizuku always deletes system apps and their data.
  * Clarified that Dhizuku follows the same conditional fallback behavior as Root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->