### PR TITLE
fix(cache): per-app clear is root-only; the tile trims the whole device, and says so

### DIFF
--- a/app/src/androidTest/java/com/valhalla/thor/presentation/home/HomeActionsBentoTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/presentation/home/HomeActionsBentoTest.kt
@@ -42,7 +42,7 @@ class HomeActionsBentoTest {
     private fun setFullGrid() = rule.setContent {
         HomeActionsBento(
             reinstallVisible = true,
-            isRoot = true,
+            canClearCache = true,
             hasPrivilege = true,
             unknownInstallerCount = 7,
             selectedTypeName = "user",
@@ -108,7 +108,7 @@ class HomeActionsBentoTest {
         rule.setContent {
             HomeActionsBento(
                 reinstallVisible = true,
-                isRoot = false,
+                canClearCache = false,
                 hasPrivilege = true,
                 unknownInstallerCount = 7,
                 selectedTypeName = "user",

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -60,9 +60,24 @@ class DhizukuSystemGateway(
         else Result.failure(Exception("Dhizuku: Force stop failed. Shell command and reflection both denied."))
     }
 
-    override suspend fun clearCache(packageName: String): Result<Unit> {
-        return if (reflector.clearCache(packageName)) Result.success(Unit)
-        else Result.failure(Exception("Dhizuku: Clear cache failed. System reflection and shell rm -rf both failed."))
+    /**
+     * Always a failure, and that is the correction rather than a gap.
+     *
+     * `pm trim-caches` is a shell command, and Dhizuku has no shell: [executeShellCommand] runs
+     * through the Dhizuku app's own uid, which `PackageManagerShellCommand` refuses. The device
+     * owner API has no cache-clearing member at all — `DevicePolicyManager` can wipe a profile, not
+     * a cache — and the reflective `deleteApplicationCacheFiles*` rung this gateway used to carry
+     * died in a double-wrapped binder belonging to a privilege mode the user had not set up. Three
+     * doors, all shut, so this says so in a sentence the user can act on instead of failing with a
+     * shell error that reads like a bug.
+     */
+    override suspend fun clearAllCaches(targetFreeBytes: Long?): Result<Unit> {
+        return Result.failure(
+            Exception(
+                "Dhizuku cannot clear caches: it has no shell to run `pm trim-caches` in, and the " +
+                    "device owner API has no equivalent. Switch to Root or Shizuku."
+            )
+        )
     }
 
     override suspend fun clearAppData(packageName: String): Result<Unit> {
@@ -380,10 +395,6 @@ class DhizukuSystemGateway(
         } else {
             Result.failure(Exception("Dhizuku: Install failed: ${result.second}"))
         }
-    }
-
-    override suspend fun getAppCacheSize(packageName: String): Long {
-        return 0L
     }
 
     override suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit> {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -386,6 +386,14 @@ class RootSystemGateway(
      * same three directories per package that [clearCache] does, with the package component globbed.
      * It is also the reason the trim's exit code is checked rather than assumed — a `pm` that fails
      * for any reason still leaves a mode that works.
+     *
+     * **The two rungs do not have the same reach, and the narrower one is the deliberate part.**
+     * `pm trim-caches` is volume-wide, so it takes every Android user with it; the sweep is scoped to
+     * [thorUserId] and leaves a work profile's or a Second Space's caches alone. That is not an
+     * oversight to be widened later — `PerUserCommands` exists because deleting another user's data
+     * from a command that names no user is the defect this codebase kept finding, and an `rm -rf`
+     * across every user's tree would be the largest instance of it. A user's other profiles are not
+     * Thor's to empty on a tile tap taken in this one.
      */
     override suspend fun clearAllCaches(targetFreeBytes: Long?): Result<Unit> {
         if (targetFreeBytes != null) {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -349,18 +349,58 @@ class RootSystemGateway(
         )
     }
 
-    override suspend fun clearCache(packageName: String): Result<Unit> {
+    /**
+     * Deletes [packageName]'s cache directories for [thorUserId].
+     *
+     * **Not an override.** This is the only privilege mode that can clear one app's cache, so it
+     * sits off [SystemGateway] rather than on it — the same shape `copyFile` and `getAppPaths`
+     * already have, and `SystemRepositoryImpl` reaches it the same way, behind `isRootAvailable()`.
+     * The Shizuku and Dhizuku implementations that used to satisfy an interface method here are
+     * gone; [SystemGateway.clearAllCaches] records why they could not have worked.
+     *
+     * Deliberately unverified, and deliberately staying that way: as uid 0 `rm -rf` is honest about
+     * its own post-condition — exit 0 means those paths are gone or were never there, non-zero means
+     * a real error — so there is no asynchronous framework call here and no `IPackageDataObserver`
+     * to wait on. A readback would re-`stat` what the shell already reported on.
+     */
+    suspend fun clearCache(packageName: String): Result<Unit> {
         if (!packageName.matches(PACKAGE_NAME_REGEX)) {
             return Result.failure(IllegalArgumentException("Invalid package name: $packageName"))
         }
         val escapedPackage = packageName.escapeForShell()
-        // Deliberately unverified, and deliberately staying that way: as uid 0 `rm -rf` is honest
-        // about its own post-condition — exit 0 means those paths are gone or were never there,
-        // non-zero means a real error — so there is no asynchronous framework call here, and no
-        // IPackageDataObserver to wire up as the reflective cache rungs in the other two gateways
-        // need. A readback would re-`stat` what the shell already reported on.
         val command = "rm -rf ${clearCachePaths(escapedPackage, thorUserId).joinToString(" ")}"
         return runCommand(command)
+    }
+
+    /**
+     * Root's whole-volume clear: `pm trim-caches` first, then a direct sweep.
+     *
+     * The trim rung is preferred even though root does not need it, because it is
+     * `PackageManagerService` doing the deleting — it knows about volumes Thor's globs do not name,
+     * and it updates its own accounting instead of leaving PMS's view of the cache stale. As uid 0
+     * the `CLEAR_APP_CACHE` check passes unconditionally (`ActivityManager.checkComponentPermission`
+     * short-circuits `ROOT_UID`), so the rung that is the *whole* operation under Shizuku is merely
+     * the preferred one here.
+     *
+     * The sweep rung is why [targetFreeBytes] being `null` is survivable in this mode: it names the
+     * same three directories per package that [clearCache] does, with the package component globbed.
+     * It is also the reason the trim's exit code is checked rather than assumed — a `pm` that fails
+     * for any reason still leaves a mode that works.
+     */
+    override suspend fun clearAllCaches(targetFreeBytes: Long?): Result<Unit> {
+        if (targetFreeBytes != null) {
+            val trim = runCommand("pm trim-caches $targetFreeBytes")
+            if (trim.isSuccess) return trim
+            Logger.w(
+                "RootSystemGateway",
+                "pm trim-caches $targetFreeBytes failed; falling back to a direct sweep"
+            )
+        }
+        // The glob is expanded by the shell running as uid 0, not by Thor, so an app whose package
+        // name would need escaping is covered too — `*` never matches a path separator, so this
+        // cannot reach outside the three parents.
+        val sweep = clearCachePaths(escapedPackage = "*", userId = thorUserId).joinToString(" ")
+        return runCommand("rm -rf $sweep")
     }
 
     override suspend fun clearAppData(packageName: String): Result<Unit> = withContext(ioDispatcher) {
@@ -1177,30 +1217,12 @@ class RootSystemGateway(
         return runCommand(sb.toString())
     }
 
-    override suspend fun getAppCacheSize(packageName: String): Long {
-        if (!packageName.matches(PACKAGE_NAME_REGEX)) {
-            return 0L
-        }
-        return try {
-            val escapedPackage = packageName.escapeForShell()
-            // The credential-encrypted cache dir for Thor's own user. `/data/data/<pkg>` is an alias
-            // of this path *for user 0* — from a secondary user it sizes the wrong copy — and at
-            // user 0 the two name the same directory, so nothing changes on a single-user device.
-            val result = shellRepository.exec("du -s /data/user/$thorUserId/$escapedPackage/cache")
-            val outputLine = (if (result.isSuccess) result.stdout.firstOrNull() else null) ?: return 0L
-
-            // Output format is usually "12345   /path/to/file"
-            // We parse this in Kotlin, not using brittle 'awk' or 'cut'
-            val sizeInBlocks =
-                outputLine.substringBefore('\t').substringBefore(' ').toLongOrNull() ?: 0L
-
-            // du usually returns 1k blocks
-            sizeInBlocks * 1024
-        } catch (e: Exception) {
-            Logger.e("RootSystemGateway", "Failed to get app cache size for $packageName", e)
-            0L
-        }
-    }
+    // getAppCacheSize() used to sit here, on all three gateways, with no caller in the app. It was
+    // also wrong: it sized only `/data/user/N/<pkg>/cache`, one of the three directories a cache
+    // clear deletes, so any number it produced under-reported by whatever sat in the DE and external
+    // caches. `StorageStatsProvider.cacheBytes` answers the same question from
+    // `StorageStatsManager`, which counts external cache too, needs no privilege beyond the usage
+    // access Thor already manages, and gives the same answer in every privilege mode.
 
     /**
      * Modernized Reinstall Logic.

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -66,8 +66,20 @@ class ShizukuSystemGateway(
         return runAction { reflector.forceStop(packageName) }
     }
 
-    override suspend fun clearCache(packageName: String): Result<Unit> {
-        return runAction { reflector.clearCache(packageName) }
+    override suspend fun clearAllCaches(targetFreeBytes: Long?): Result<Unit> {
+        // No sweep fallback, unlike Root: shell uid 2000 cannot delete another package's cache
+        // directory, so without a target there is nothing left to try.
+        if (targetFreeBytes == null) {
+            return Result.failure(
+                Exception(
+                    "Shizuku: could not read how much free space the volume has, and `pm trim-caches` " +
+                        "needs that number — passing a round one would let PackageManagerService walk " +
+                        "past the cache rungs into pruning apps."
+                )
+            )
+        }
+        return if (reflector.trimCaches(targetFreeBytes)) Result.success(Unit)
+        else Result.failure(Exception("Shizuku: `pm trim-caches` failed."))
     }
 
     override suspend fun clearAppData(packageName: String): Result<Unit> {
@@ -391,10 +403,6 @@ class ShizukuSystemGateway(
         } else {
             Result.failure(Exception("Shizuku install failed: ${result.second}"))
         }
-    }
-
-    override suspend fun getAppCacheSize(packageName: String): Long {
-        return 0L // Requires specialized logic
     }
 
     override suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit> {

--- a/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/manager/StorageStatsHelper.kt
@@ -9,6 +9,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Process
+import android.os.storage.StorageManager
 import com.valhalla.thor.domain.repository.StorageStatsProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -16,9 +17,12 @@ import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 
 /**
- * Computes total install size (app + data + cache) per package via
- * StorageStatsManager. Requires the GET_USAGE_STATS app-op for other packages
- * (see UsageAccessManager) — a per-package failure is skipped, never thrown.
+ * Every `StorageStatsManager` read Thor makes: per-package install size, the whole-user cache
+ * total, and the free-space target a bounded `pm trim-caches` needs.
+ *
+ * Requires the GET_USAGE_STATS app-op for anything about other packages (see UsageAccessManager) —
+ * a per-package failure is skipped, never thrown, and the two aggregate reads answer `null` rather
+ * than 0 so a missing op is never rendered as a real measurement of zero.
  */
 @Single(binds = [StorageStatsProvider::class])
 class StorageStatsHelper(
@@ -51,6 +55,37 @@ class StorageStatsHelper(
             }
             out
         }
+
+    // Both reads below are one binder call each and both answer for Thor's own user, so neither
+    // needs INTERACT_ACROSS_USERS: `StorageStatsService` enforces that permission only on the
+    // `userId != UserHandle.getCallingUserId()` branch.
+    //
+    // `runCatching` and not a typed catch because the three failure modes want the same answer.
+    // SecurityException means the usage-access op is not held, IOException means the volume is not
+    // present, and IllegalStateException has been seen from `findPathForUuid` on OEM builds with an
+    // adopted-storage quirk. All three mean "no number", which is what `null` says.
+    override suspend fun cacheBytes(packageName: String): Long? = withContext(ioDispatcher) {
+        val manager = statsManager ?: return@withContext null
+        runCatching {
+            val ai = applicationInfo(packageName)
+            val stats = manager.queryStatsForPackage(ai.storageUuid, packageName, user)
+            stats.cacheBytes
+        }.getOrNull()
+    }
+
+    override suspend fun totalCacheBytes(): Long? = withContext(ioDispatcher) {
+        val manager = statsManager ?: return@withContext null
+        runCatching { manager.queryStatsForUser(StorageManager.UUID_DEFAULT, user).cacheBytes }
+            .getOrNull()
+    }
+
+    override suspend fun cacheTrimTargetBytes(): Long? = withContext(ioDispatcher) {
+        val manager = statsManager ?: return@withContext null
+        // No permission required for this one — see StorageStatsService.getFreeBytes, which opens
+        // with a literal "NOTE: No permissions required". So a device without usage access still
+        // gets a correctly-bounded trim; it just cannot be told how much the trim freed.
+        runCatching { manager.getFreeBytes(StorageManager.UUID_DEFAULT) }.getOrNull()
+    }
 
     private fun installedApplications(): List<ApplicationInfo> =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.valhalla.thor.data.gateway.ShizukuSystemGateway
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.StorageStatsProvider
 import com.valhalla.thor.domain.repository.SystemRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -24,6 +25,7 @@ class SystemRepositoryImpl(
     private val shizukuGateway: ShizukuSystemGateway,
     private val dhizukuGateway: DhizukuSystemGateway,
     private val preferenceRepository: PreferenceRepository,
+    private val storageStats: StorageStatsProvider,
     @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : SystemRepository {
 
@@ -123,8 +125,57 @@ class SystemRepositoryImpl(
         runGatewayAction { it.forceStopApp(packageName) }
     }
 
-    override suspend fun clearCache(packageName: String): Result<Unit> = withContext(ioDispatcher) {
-        runGatewayAction { it.clearCache(packageName) }
+    // Root-gated rather than routed through runGatewayAction, and deliberately so: no other
+    // privilege mode can clear one app's cache. `SystemGateway.clearAllCaches` records the
+    // measurements behind that; the short version is that `INTERNAL_DELETE_CACHE_FILES` is
+    // signature-level, so PackageManagerService answers Shizuku's call by logging that it is
+    // silently ignoring it. This follows `copyFileWithRoot` and `getAppPaths`, the two operations
+    // that were already root-only for a reason of their own.
+    override suspend fun clearCache(packageName: String): Result<Long?> = withContext(ioDispatcher) {
+        if (!rootGateway.isRootAvailable()) {
+            return@withContext Result.failure(
+                Exception("Clearing one app's cache requires Root. Shizuku and Dhizuku can only clear every app's cache at once.")
+            )
+        }
+        measuringCacheFreed({ storageStats.cacheBytes(packageName) }) {
+            rootGateway.clearCache(packageName)
+        }
+    }
+
+    override suspend fun clearAllCaches(): Result<Long?> = withContext(ioDispatcher) {
+        // Read the target before the before-measurement, not after: both are binder round trips and
+        // this is the one the operation cannot proceed without.
+        val target = storageStats.cacheTrimTargetBytes()
+        measuringCacheFreed({ storageStats.totalCacheBytes() }) {
+            runGatewayAction { it.clearAllCaches(target) }
+        }
+    }
+
+    /**
+     * Runs [clear] between two [measure] readings and reports the difference.
+     *
+     * The subtraction is the only way to answer "how much did that free". `pm trim-caches` prints
+     * nothing on success and picks its own victims, and `rm -rf` prints nothing either, so neither
+     * rung can report a byte count of its own.
+     *
+     * Three things it refuses to do. It does not measure when the clear failed — a failure's delta
+     * is noise, and attaching a number to it invites a caller to show it. It answers `null`, not 0,
+     * when either reading is missing, because "no usage access" and "there was no cache" are
+     * different facts. And it clamps a negative delta to `null` rather than to 0: cache that an app
+     * rebuilt between the two readings can make the after-value larger, and that is a measurement
+     * Thor could not take, not a clear that freed nothing.
+     */
+    private suspend inline fun measuringCacheFreed(
+        measure: () -> Long?,
+        clear: () -> Result<Unit>
+    ): Result<Long?> {
+        val before = measure()
+        val result = clear()
+        if (result.isFailure) return Result.failure(result.exceptionOrNull() ?: Exception("Cache clear failed"))
+        val after = measure()
+        if (before == null || after == null) return Result.success(null)
+        val freed = before - after
+        return Result.success(if (freed >= 0) freed else null)
     }
 
     override suspend fun clearAppData(packageName: String): Result<Unit> = withContext(ioDispatcher) {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/PerUserCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/PerUserCommands.kt
@@ -41,14 +41,36 @@ internal fun clearAppDataCommand(escapedPackage: String, userId: Int): String =
     "pm clear --user $userId $escapedPackage"
 
 /**
- * The cache directories of [escapedPackage] **for [userId]**, credential-encrypted first, then
- * external.
+ * The cache directories of [escapedPackage] **for [userId]**: credential-encrypted, then
+ * device-encrypted, then external.
+ *
+ * The set is not a guess — it is the three branches of `InstalldNativeService::clearAppData` under
+ * `FLAG_CLEAR_CACHE_ONLY`, which is what the platform itself deletes when a user taps Clear cache
+ * in Settings:
+ *  - `FLAG_STORAGE_CE` → `create_data_user_ce_package_path(...) + "cache"`
+ *  - `FLAG_STORAGE_DE` → `create_data_user_de_package_path(...) + CACHE_DIR_POSTFIX`
+ *  - `FLAG_STORAGE_EXTERNAL` → `<ext>/Android/data/<pkg>/cache`
+ *
+ * The device-encrypted entry is the one this list spent its whole life missing. `/data/user_de` is
+ * not an exotic direct-boot-only location: PMS creates a `user_de` package directory for **every**
+ * installed app, and anything written through `createDeviceProtectedStorageContext().cacheDir`
+ * lands there. Clearing only CE and external therefore left a real, sometimes large, slice of cache
+ * behind while reporting the operation complete — and it is invisible in testing precisely because
+ * most apps put little there and the number that is left behind was never shown to anyone.
+ *
+ * Deliberately no `code_cache`, in either encryption. That is a *different* installd flag
+ * (`FLAG_CLEAR_CODE_CACHE_ONLY`), Settings' Clear cache does not touch it, and it holds compiled
+ * artifacts an app expects to persist. Matching the platform matters more here than freeing the
+ * largest possible number of bytes.
  *
  * Deliberately no `/data/data/<pkg>/cache` and no `/sdcard/Android/data/<pkg>/cache`. They are not
- * extra coverage: they are aliases of the first and second entries *for user 0*, so on a secondary
+ * extra coverage: they are aliases of the CE and external entries *for user 0*, so on a secondary
  * user (work profile, Xiaomi Second Space) a shell that expands them deletes a different user's
- * cache and leaves Thor's own untouched. At `userId = 0` — every single-user device — the paths
- * below resolve to exactly the directories those two aliases pointed at, so nothing changes there.
+ * cache and leaves Thor's own untouched.
+ *
+ * Only the root gateway can act on all of these. A shell-uid or device-owner caller is refused
+ * `/data/user*` outright, which is why per-app cache clearing is root-gated in
+ * `SystemRepositoryImpl` rather than attempted and reported as done.
  */
 // SdCardPath is suppressed because its advice does not apply: these are not Thor's own directories.
 // getExternalCacheDir/getFilesDir answer for the *calling* app, and the whole point of the function
@@ -58,6 +80,7 @@ internal fun clearAppDataCommand(escapedPackage: String, userId: Int): String =
 @SuppressLint("SdCardPath")
 internal fun clearCachePaths(escapedPackage: String, userId: Int): List<String> = listOf(
     "/data/user/$userId/$escapedPackage/cache",
+    "/data/user_de/$userId/$escapedPackage/cache",
     "/storage/emulated/$userId/Android/data/$escapedPackage/cache",
 )
 

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -12,7 +12,6 @@ import com.valhalla.superuser.utils.escapeForShell
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
 import com.valhalla.thor.data.source.local.clearAppDataCommand
-import com.valhalla.thor.data.source.local.clearCachePaths
 // The enable/disable rung machinery is privilege-agnostic; it lives in the `shizuku` package
 // because that is where it was first needed, and it is imported rather than re-typed here so the
 // two privilege modes cannot drift apart on "did the platform refuse?" — the one question whose
@@ -622,113 +621,11 @@ object DhizukuHelper {
     }
 
     /**
-     * Deletes [packageName]'s cache directories **for [thorUserId]** — shell first, then a
-     * hidden-API `IPackageManager` call.
-     *
-     * The reflection overloads are tried `…AsUser` first for the same reason as
-     * [com.valhalla.thor.data.source.local.shizuku.Shizuku.clearCache], whose KDoc carries the full
-     * argument: `deleteApplicationCacheFiles(String, IPackageDataObserver)` is declared on every
-     * release this app runs on (28 through 37), so the `NoSuchMethodException` meant to reach the
-     * `…AsUser` branch never fires. Ordered the other way round, the only branch that names a user
-     * is unreachable and the branch that runs names none — `PackageManagerService` implements the
-     * no-user overload as `deleteApplicationCacheFilesAsUser(packageName, getCallingUserId(),
-     * observer)`, resolving the user from the *caller*. Here the caller is the Dhizuku app holding
-     * device owner, so from a work profile the reachable rung cleared the cache of whichever user
-     * Dhizuku itself runs as, for a package the user picked in another profile.
-     *
-     * The fallback is gated on `NoSuchMethodException` alone, never `Exception`: a *refusal* of the
-     * per-user call must not fall through to one that clears a different user's cache and reports it
-     * as this user's success.
-     *
-     * How often this rung runs at all is a separate question, and the answer is probably never:
-     * `asInterface` wraps the binder twice — Dhizuku's own wrapper, then `ShizukuBinderWrapper` on
-     * top — so on a Dhizuku-only device the call dies in a transport belonging to a privilege mode
-     * the user has not set up. `setAppDisabledDetailed` carries that argument in full. It is a
-     * reason not to expect the reorder to change behaviour today, not a reason to keep the order
-     * wrong: a rung that is dead now is still the rung a future transport fix would wake up.
-     *
-     * **A `true` from this function now comes from the shell rung or from nowhere.** Only that rung
-     * is honest — `rm -rf` exits 0 or it does not — and the reflective one has stopped claiming
-     * otherwise. Its `true` was never evidence: the call is asynchronous, PMS reports through the
-     * `IPackageDataObserver` passed as `null` here, and on a Dhizuku-only device it does not reach
-     * PMS at all. It is still issued, because on a device that also has Shizuku it may genuinely
-     * run; what changed is that "the binder call returned" is no longer allowed to reach the user as
-     * "the cache is gone".
-     */
-    // SdCardPath: absolute system paths are intentional for privileged/root file ops on app data
-    // dirs (not app-scoped storage). PrivateApi: hidden-API reflection is the core privilege
-    // mechanism, guarded by the :bypass VMRuntime unseal.
-    @SuppressLint("PrivateApi", "SdCardPath")
-    fun clearCache(packageName: String): Boolean {
-        // 1. Try shell first. The `/data/data/<pkg>/cache` and `/sdcard/Android/data/<pkg>/cache`
-        // aliases that used to sit either side of these two are gone: they are not extra coverage,
-        // they are the same directories *for user 0*, so from a secondary user they deleted another
-        // user's cache. At user 0 they resolve to exactly what remains.
-        val command =
-            "rm -rf ${clearCachePaths(packageName.escapeForShell(), thorUserId).joinToString(" ")}"
-        val shellResult = execute(command)
-        if (shellResult.first == 0) return true
-
-        // 2. Fallback to reflection — issued, and deliberately never believed.
-        //
-        // `asInterface` wraps the binder twice, Dhizuku's own wrapper and then
-        // `ShizukuBinderWrapper` on top, so on a Dhizuku-only device this call dies inside a
-        // transport belonging to a privilege mode the user never set up; [setAppDisabledDetailed]'s
-        // reflection rung carries that argument in full. The call stays — it costs nothing, and on a
-        // device that *also* has Shizuku it may genuinely run — but the `false` at the end of the
-        // block replaces a `true` that has never meant the cache was cleared. Even on a live
-        // transport it could not mean that: `deleteApplicationCacheFiles*` reports through the
-        // `IPackageDataObserver` passed as `null` here, so the old `true` only ever said "the binder
-        // call returned".
-        //
-        // An observer is deliberately not wired up in its place. On the device this rung actually
-        // runs on the call never reaches PackageManagerService, so a real observer would buy one
-        // guaranteed timeout per package — an always-red answer that teaches the user nothing and
-        // costs seconds each on a bulk clear. Honest and fast beats verified and impossible. If the
-        // transport is ever fixed, *that* is the change that earns an observer here.
-        val reflectionResult = runCatching {
-            val pm = asInterface("android.content.pm.IPackageManager", "package") ?: return@runCatching false
-            val observerClass = Class.forName("android.content.pm.IPackageDataObserver")
-
-            try {
-                Bypass.invoke<Any?>(
-                    pm.javaClass,
-                    pm,
-                    "deleteApplicationCacheFilesAsUser",
-                    arrayOf(String::class.java, Int::class.javaPrimitiveType!!, observerClass),
-                    packageName,
-                    thorUserId,
-                    null /* IPackageDataObserver */
-                )
-            } catch (_: NoSuchMethodException) {
-                // No user id to give: this overload derives one from the calling uid. Reached only
-                // if a release stops declaring the AsUser variant, which none in 28..37 does.
-                Bypass.invoke<Any?>(
-                    pm.javaClass,
-                    pm,
-                    "deleteApplicationCacheFiles",
-                    arrayOf(String::class.java, observerClass),
-                    packageName,
-                    null
-                )
-            }
-            Logger.w(
-                "DhizukuHelper",
-                "clearCache($packageName): the reflection rung was issued but can confirm nothing, " +
-                    "so it reports failure — the shell rung above is the only one that clears a cache"
-            )
-            false
-        }.getOrDefault(false)
-
-        return reflectionResult
-    }
-
-    /**
      * Wipes [packageName]'s data **for [thorUserId]** — `pm clear` first, then a hidden-API
      * `IPackageManager` call.
      *
-     * **A `true` from this function comes from the shell rung or from nowhere**, the same contract
-     * [clearCache] states and for the same reasons. `pm clear` blocks on its own observer inside
+     * **A `true` from this function comes from the shell rung or from nowhere.** `pm clear` blocks
+     * on its own observer inside
      * `PackageManagerShellCommand` and exits non-zero when the wipe fails, so it can be believed;
      * the reflection rung below can not be, and no longer says otherwise. It used to return `true`
      * whenever the invoke did not throw, which for the single most destructive operation Thor
@@ -750,8 +647,8 @@ object DhizukuHelper {
         val result = execute(clearAppDataCommand(packageName.escapeForShell(), thorUserId))
         if (result.first == 0) return true
 
-        // 2. Fallback to reflection — issued, and deliberately never believed. Same argument as
-        // [clearCache]'s rung 2, one step worse in consequence: `clearApplicationUserData` returns
+        // 2. Fallback to reflection — issued, and deliberately never believed.
+        // `clearApplicationUserData` returns
         // `void`, so the verdict only ever arrives on the `IPackageDataObserver` that is `null`
         // here, and `asInterface`'s double-wrapped binder means that on a Dhizuku-only device the
         // call dies in a Shizuku transport before PackageManagerService sees it — the argument
@@ -760,9 +657,11 @@ object DhizukuHelper {
         // every release.
         //
         // The call stays because on a device that also has Shizuku it may genuinely run; only the
-        // claim is withdrawn. An observer is not wired up in its place for the reason [clearCache]
-        // gives — a guaranteed 15-second timeout per package on the device this rung actually runs
-        // on is a worse answer than an immediate honest one.
+        // claim is withdrawn. An observer is not wired up in its place: on the device this rung
+        // actually runs on the call never reaches PackageManagerService, so a real observer would
+        // buy one guaranteed 15-second timeout per package — an always-red answer that teaches the
+        // user nothing. Honest and fast beats verified and impossible. If the transport is ever
+        // fixed, *that* is the change that earns an observer here.
         return runCatching {
             val pm = asInterface("android.content.pm.IPackageManager", "package") ?: return@runCatching false
             val observerClass = Class.forName("android.content.pm.IPackageDataObserver")
@@ -1104,11 +1003,11 @@ object DhizukuHelper {
             )
         }
 
-        // 2. Fallback to reflection. The call is kept for the reason [clearCache]'s rung 2 keeps
+        // 2. Fallback to reflection. The call is kept for the reason [clearAppData]'s rung 2 keeps
         // its own — `asInterface` double-wraps the binder, so on a Dhizuku-only device this dies in
         // a Shizuku transport, but on a device that also has Shizuku it may genuinely run. What is
         // refused is this rung's *self-report*: "the invoke did not throw" is not a mode. Unlike
-        // clearCache and clearAppData, an app op can actually be read back, so this rung reports
+        // clearAppData, an app op can actually be read back, so this rung reports
         // what `checkOperation` says rather than a flat `false` — a state the platform confirms is
         // not a lie, and answering `false` over a confirmed change would strand the user retrying an
         // operation that already worked. An unreadable readback still means `false` here, because

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/DhizukuReflector.kt
@@ -26,14 +26,12 @@ class DhizukuReflector(
         }
     }
 
-    fun clearCache(packageName: String): Boolean {
-        return try {
-            DhizukuHelper.clearCache(packageName)
-        } catch (e: Exception) {
-            Logger.e("DhizukuReflector", "clearCache failed", e)
-            false
-        }
-    }
+    // clearCache() used to sit here. Dhizuku has no cache-clearing rung left to call: its shell
+    // rung ran as the Dhizuku app's own uid, which cannot touch another package's cache directory,
+    // and its reflection rung was already documented as "issued, and deliberately never believed"
+    // because `asInterface`'s double-wrapped binder dies in a Shizuku transport the user never set
+    // up. Two rungs that could not work is not a fallback chain. `DhizukuSystemGateway` now fails
+    // this operation with a sentence naming Root as the mode that performs it.
 
     fun clearData(packageName: String): Boolean {
         return try {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -13,7 +13,6 @@ import com.valhalla.thor.data.source.local.DataClearOutcome
 import com.valhalla.thor.data.source.local.awaitDataObserver
 import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
 import com.valhalla.thor.data.source.local.clearAppDataCommand
-import com.valhalla.thor.data.source.local.clearCachePaths
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.data.source.local.uninstallCommand
 import com.valhalla.thor.domain.model.SHELL_SUSPENDER_IDENTITY
@@ -897,107 +896,32 @@ object Shizuku {
     }
 
     /**
-     * Deletes [packageName]'s cache directories **for [thorUserId]** — shell first, then a
-     * hidden-API `IPackageManager` call.
+     * Trims every app's cache until the volume reports [targetFreeBytes] free, via `pm trim-caches`.
      *
-     * The two reflection overloads used to be tried in the opposite order, and that order made the
-     * user id decorative. `deleteApplicationCacheFiles(String, IPackageDataObserver)` is declared on
-     * `IPackageManager` on every release this app runs on (28 through 37), so the
-     * `NoSuchMethodException` that was supposed to reach the `…AsUser` branch never fired: the only
-     * branch naming a user was unreachable, and the branch that ran named none. It could not — that
-     * overload takes no user id, and `PackageManagerService`'s implementation of it is
-     * `deleteApplicationCacheFilesAsUser(packageName, UserHandle.getCallingUserId(), observer)`,
-     * which resolves the user from the *caller*. The caller here is the Shizuku server, at shell uid
-     * 2000 in the ordinary setup, so from a work profile the reachable rung cleared **user 0's**
-     * cache for a package the user selected in profile 10. Hence the reorder rather than an extra
-     * argument: `…AsUser` first, and the calling-user overload kept only as the answer to "this
-     * release does not declare the symbol".
+     * This replaced a per-package `deleteApplicationCacheFilesAsUser`, and the replacement is not a
+     * refactor — the per-package call cannot work here at all. `PackageManagerService` guards it with
+     * `INTERNAL_DELETE_CACHE_FILES`, a `signature`-level permission that only a platform-signed
+     * package can hold; `pm grant` refuses it as "not a changeable permission type" and
+     * `com.android.shell` never requests it, so there is nothing for Shizuku to delegate. The call
+     * arrives at PMS as uid 2000 and is answered with `Calling uid 2000 does not have
+     * android.permission.INTERNAL_DELETE_CACHE_FILES, silently ignoring` — accepted, then dropped.
+     * That is why the observer rung existed and why it only ever timed out.
      *
-     * The fallback is deliberately gated on `NoSuchMethodException` alone and not on `Exception`. A
-     * *refusal* of the per-user call must not fall through to a call that clears a different user's
-     * cache and reports it as this user's success — the failure the reorder exists to remove.
+     * `pm trim-caches` takes the other door: it calls `freeStorage`, which PMS gates on
+     * `CLEAR_APP_CACHE` — a permission shell *does* hold. The cost is that the caller no longer picks
+     * the victim. PMS evicts by LRU across every app on the volume, system and user alike, until the
+     * target is met, so this is a whole-device operation and the UI must say so before running it.
      *
-     * **Both rungs now answer for themselves.** The shell rung always could: `rm -rf` exits 0 or it
-     * does not. The reflection rung could not, and used to say `true` whenever the binder call
-     * returned without throwing — which is not the same claim at all, because the call is
-     * asynchronous. `PackageManagerService` posts the work to its own handler and reports on an
-     * `IPackageDataObserver`, and that argument was `null`. At shell uid PMS also *accepts* cache
-     * clears that it then declines: it logs that it is silently ignoring the request, deletes
-     * nothing, and the old `true` reported that as a success. The observer is the only place that
-     * refusal is visible, so it is now wired up and waited on — see `awaitDataObserver`.
+     * [targetFreeBytes] must come from `StorageStatsProvider.cacheTrimTargetBytes` and not from a
+     * round number. `freeStorage` is an escalating ladder on which app cache is only rungs 4 and 8; a
+     * target it cannot satisfy walks on to prune unused static shared libraries and to uninstall
+     * instant apps, neither of which is cache. The provider's KDoc carries the full argument.
      *
-     * What that changes for a caller: `true` means a verdict of "cleared" actually arrived. A
-     * refusal, a timeout, and a transport that never reached PMS all give `false`, and are told
-     * apart in the log rather than in the return type, because every consumer of this is a Boolean.
-     * `false` is therefore the honest answer to "could not confirm" as well as to "refused" — a
-     * cache clear repeated costs nothing, a false "done" costs the user the chance to try a
-     * privilege mode that would have worked.
-     *
-     * Still not a byte count. This Boolean must not be turned into "N bytes freed"; re-measure the
-     * cache if the number matters.
+     * Returns whether the command exited 0. Not a byte count — `pm trim-caches` prints nothing on
+     * success, so a caller that wants a number must re-measure `totalCacheBytes` either side.
      */
-    // PrivateApi: hidden-API reflection (IPackageDataObserver) is intentional — the core privilege
-    // mechanism, guarded by the :bypass VMRuntime unseal.
-    // SdCardPath: the absolute /data and /storage paths are intentional for privileged file ops,
-    // not app-scoped storage.
-    @SuppressLint("PrivateApi", "SdCardPath")
-    fun clearCache(packageName: String): Boolean {
-        // 1. Try shell first. The `/data/data/<pkg>/cache` and `/sdcard/Android/data/<pkg>/cache`
-        // aliases that used to sit either side of these two are gone: they are not extra coverage,
-        // they are the same directories *for user 0*, so from a secondary user they deleted another
-        // user's cache. At user 0 they resolve to exactly what remains.
-        val command =
-            "rm -rf ${clearCachePaths(packageName.escapeForShell(), thorUserId).joinToString(" ")}"
-        val shellResult = execute(command)
-        if (shellResult.first == 0) return true
-
-        // 2. Fallback to reflection, and this is the rung that matters under Shizuku: shell uid 2000
-        // cannot `rm -rf /data/data/<pkg>/cache`, so rung 1 normally fails and this is the real
-        // operation. It is also the one PMS can accept and then quietly decline, which is why the
-        // observer is no longer null — `awaitDataObserver` builds a real IPackageDataObserver.Stub,
-        // hands it to the invoke, and waits for onRemoveCompleted rather than for the invoke to
-        // return. Only a verdict of "cleared" gets out of here as true.
-        val outcome = runCatching {
-            val pm = asInterface("android.content.pm.IPackageManager", "package")
-            val observerClass = Class.forName("android.content.pm.IPackageDataObserver")
-
-            awaitDataObserver("Shizuku", packageName) { observer ->
-                try {
-                    Bypass.invoke<Any?>(
-                        pm.javaClass,
-                        pm,
-                        "deleteApplicationCacheFilesAsUser",
-                        arrayOf(String::class.java, Int::class.javaPrimitiveType!!, observerClass),
-                        packageName,
-                        thorUserId,
-                        observer
-                    )
-                } catch (_: NoSuchMethodException) {
-                    // No user id to give: this overload derives one from the calling uid. Reached
-                    // only if a release stops declaring the AsUser variant, which none in 28..37
-                    // does. The observer still reports honestly, but about the *calling* user's
-                    // cache — shell's, not necessarily Thor's — so an UNVERIFIED from this branch
-                    // is doubly uninformative and a CLEARED from it is not a claim about the user
-                    // the caller asked for.
-                    Bypass.invoke<Any?>(
-                        pm.javaClass,
-                        pm,
-                        "deleteApplicationCacheFiles",
-                        arrayOf(String::class.java, observerClass),
-                        packageName,
-                        observer
-                    )
-                }
-            }
-        }.getOrElse { e ->
-            // Only the binder lookup can land here; awaitDataObserver absorbs whatever the invokes
-            // themselves throw and answers UNVERIFIED for it.
-            Logger.e("Shizuku", "clearCache($packageName): could not reach IPackageManager", e)
-            DataClearOutcome.UNVERIFIED
-        }
-
-        return outcome == DataClearOutcome.CLEARED
-    }
+    fun trimCaches(targetFreeBytes: Long): Boolean =
+        execute("pm trim-caches $targetFreeBytes").first == 0
 
     /**
      * Wipes [packageName]'s data **for [thorUserId]** — `pm clear` first, then a hidden-API

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
@@ -35,12 +35,18 @@ class ShizukuReflector(
     val context: Context
 ) {
 
-    fun clearCache(packageName: String): Boolean {
+    /**
+     * There is no per-package `clearCache` here any more, and its absence is the finding rather than
+     * a tidy-up: `INTERNAL_DELETE_CACHE_FILES` is `signature`-level, so no `pm grant` and no Shizuku
+     * delegation can obtain it, and PMS answers the call by logging that it is silently ignoring it.
+     * [Shizuku.trimCaches] is the whole-device operation that shell privilege *can* perform.
+     */
+    fun trimCaches(targetFreeBytes: Long): Boolean {
         return try {
-            Shizuku.clearCache(packageName)
+            Shizuku.trimCaches(targetFreeBytes)
         } catch (e: Exception) {
             if (BuildConfig.DEBUG)
-                Logger.e("ShizukuReflector", "clearCache failed: ${e.message}")
+                Logger.e("ShizukuReflector", "trimCaches failed: ${e.message}")
             false
         }
     }

--- a/app/src/main/java/com/valhalla/thor/domain/gateway/SystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/gateway/SystemGateway.kt
@@ -16,7 +16,6 @@ interface SystemGateway {
 
     // Core Actions
     suspend fun forceStopApp(packageName: String): Result<Unit>
-    suspend fun clearCache(packageName: String): Result<Unit>
     suspend fun clearAppData(packageName: String): Result<Unit>
     suspend fun setAppDisabled(packageName: String, isDisabled: Boolean): Result<Unit>
     suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit>
@@ -30,8 +29,32 @@ interface SystemGateway {
     suspend fun grantPermission(packageName: String, permissionName: String): Result<Unit>
     suspend fun revokePermission(packageName: String, permissionName: String): Result<Unit>
 
-    // Metrics
-    suspend fun getAppCacheSize(packageName: String): Long
+    /**
+     * Clears **every** app's cache on the primary volume — system and user apps alike — until the
+     * volume reports [targetFreeBytes] free.
+     *
+     * There is deliberately no per-package `clearCache` on this interface. Clearing one app's cache
+     * needs `INTERNAL_DELETE_CACHE_FILES`, which is `signature`-level: `pm grant` refuses it as "not
+     * a changeable permission type", `com.android.shell` never requests it, and PMS answers the call
+     * from uid 2000 by logging that it is *silently ignoring* it. Shizuku cannot delegate a
+     * permission shell does not hold and Dhizuku's device-owner API has no equivalent, so both had a
+     * per-package rung that could only ever report failure — or, before it was corrected, report a
+     * success it had no evidence for. Root is the only mode that can clear one app's cache, and it
+     * does so through `RootSystemGateway.clearCache`, off this interface, the way `copyFile` and
+     * `getAppPaths` already sit off it. See `docs/discussions/` for the measurements.
+     *
+     * What every privileged mode *can* reach is `pm trim-caches`, which goes through
+     * `PackageManagerService.freeStorage` and is gated on `CLEAR_APP_CACHE` instead. The cost is
+     * that the caller no longer chooses the victim: PMS evicts by LRU across the whole volume. Hence
+     * the name, and hence the confirmation the UI must show first.
+     *
+     * @param targetFreeBytes from `StorageStatsProvider.cacheTrimTargetBytes`, or `null` when the
+     * volume's free space could not be read. **Never a round number** — `freeStorage` is an
+     * escalating ladder on which app cache is only rungs 4 and 8, and an unsatisfiable target walks
+     * on to prune static shared libraries and uninstall instant apps. `null` means a mode that can
+     * only express this as a trim must fail; Root has a direct sweep it can fall back on.
+     */
+    suspend fun clearAllCaches(targetFreeBytes: Long?): Result<Unit>
 
     /**
      * Runs a raw shell command through this privilege mechanism and returns the

--- a/app/src/main/java/com/valhalla/thor/domain/repository/StorageStatsProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/StorageStatsProvider.kt
@@ -14,4 +14,53 @@ interface StorageStatsProvider {
      * read are omitted rather than reported as zero, so callers can keep a previous value.
      */
     suspend fun installSizes(packages: List<String>): Map<String, Long>
+
+    /**
+     * Cache held by one package — internal *and* external — or `null` when it cannot be read.
+     *
+     * The replacement for the `getAppCacheSize` that used to sit on all three gateways with no
+     * caller. That one shelled out to `du` over a single directory, so it under-reported by whatever
+     * sat in the device-encrypted and external caches; this reads the same total
+     * `StorageStatsManager` shows in Settings, in every privilege mode, from unprivileged code.
+     *
+     * `null` is not zero, for the reason [totalCacheBytes] gives.
+     */
+    suspend fun cacheBytes(packageName: String): Long?
+
+    /**
+     * Cache held by **every** app in Thor's user — internal and external — or `null` when it
+     * cannot be read.
+     *
+     * This is the one measurement that survives every privilege mode, which is the whole reason it
+     * exists: `pm trim-caches` picks its own victims by LRU and reports nothing, so the only honest
+     * way to say how much a global clear freed is to read this before and after and subtract. It
+     * needs no privilege at all — `StorageStatsService.checkStatsPermission` accepts the
+     * `GET_USAGE_STATS` app-op that `UsageAccessManager` already grants and re-verifies — so the
+     * same code answers under Root, Shizuku and Dhizuku alike.
+     *
+     * `null` is not zero. A missing usage-access op and a device with genuinely no cache are
+     * different answers, and a caller that renders "freed 0 B" for the first one is lying.
+     */
+    suspend fun totalCacheBytes(): Long?
+
+    /**
+     * The free-space target to hand `pm trim-caches`, or `null` when it cannot be read.
+     *
+     * Deliberately `StorageStatsManager.getFreeBytes`, which is the *wrong* call for measuring what
+     * a clear freed and the *right* one for asking for it — the two uses are inverted, so read this
+     * before assuming either. `StorageStatsService.getFreeBytes` returns
+     * `path.getUsableSpace() + cacheClearable`: it already counts reclaimable cache as free, so as a
+     * measurement its before/after delta cancels to noise. As a *target* that same identity is
+     * exactly what is wanted, because it names the byte count at which every clearable cache byte
+     * has been reclaimed and not one more.
+     *
+     * That precision is load-bearing, not tidiness. `PackageManagerService.freeStorage` is an
+     * escalating ladder, and app cache is only rungs 4 and 8 of it: an unsatisfiable target walks
+     * on to prune unused static shared libraries (rung 5) and uninstall instant apps (rungs 7 and
+     * 10), none of which is cache and none of which a button labelled "clear cache" may do. Passing
+     * this value lets PMS return at rung 4 or 8. Passing a round number like `100G` does not.
+     * (Rungs 2 and 3 — preload caches and parsed APK data — need `FLAG_ALLOCATE_AGGRESSIVE`, which
+     * `pm trim-caches` never sets.)
+     */
+    suspend fun cacheTrimTargetBytes(): Long?
 }

--- a/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
@@ -11,7 +11,24 @@ interface SystemRepository {
 
     // Core Actions
     suspend fun forceStopApp(packageName: String): Result<Unit>
-    suspend fun clearCache(packageName: String): Result<Unit>
+
+    /**
+     * Clears one app's cache. **Root only** — see [com.valhalla.thor.domain.gateway.SystemGateway]
+     * `clearAllCaches` for why Shizuku and Dhizuku cannot do this and must not pretend to.
+     *
+     * The `Long?` is bytes freed, measured either side of the clear through `StorageStatsProvider`,
+     * and it is nullable because the measurement needs usage access that the *clear* does not: a
+     * success carrying `null` means the cache is gone and Thor cannot say how big it was. A caller
+     * must not render that as "0 B freed".
+     */
+    suspend fun clearCache(packageName: String): Result<Long?>
+
+    /**
+     * Clears **every** app's cache — system and user apps alike — under any privilege mode that can.
+     * The `Long?` is bytes freed, on the same terms as [clearCache].
+     */
+    suspend fun clearAllCaches(): Result<Long?>
+
     suspend fun clearAppData(packageName: String): Result<Unit>
     suspend fun setAppDisabled(packageName: String, isDisabled: Boolean): Result<Unit>
     suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit>

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ManageAppUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ManageAppUseCase.kt
@@ -13,8 +13,13 @@ class ManageAppUseCase(
     suspend fun forceStop(packageName: String): Result<Unit> =
         systemRepository.forceStopApp(packageName)
 
-    suspend fun clearCache(packageName: String): Result<Unit> =
+    /** Root only, and the `Long?` is bytes freed — see `SystemRepository.clearCache`. */
+    suspend fun clearCache(packageName: String): Result<Long?> =
         systemRepository.clearCache(packageName)
+
+    /** Every app's cache, under any mode that can. The `Long?` is bytes freed. */
+    suspend fun clearAllCaches(): Result<Long?> =
+        systemRepository.clearAllCaches()
 
     suspend fun clearAppData(packageName: String): Result<Unit> =
         systemRepository.clearAppData(packageName)

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -62,7 +62,13 @@ fun HomeScreen(
     onNavigateToApps: () -> Unit,
     onNavigateToFreezer: () -> Unit,
     onReinstallAll: () -> Unit,
-    onClearAllCache: (AppListType) -> Unit,
+    /**
+     * Asks for the whole-device cache clear. No [AppListType] any more, and no dialog here either:
+     * the operation clears system and user apps together — `pm trim-caches` picks its own victims —
+     * so the confirmation that says so lives with the state machine that runs it, in `MainViewModel`
+     * and `ClearAllCacheSheet`. This is only the tile.
+     */
+    onClearAllCache: () -> Unit,
     /**
      * Opens the Apps tab showing only what the given installer put there. Takes the list type as
      * well because the chart is drawn per type — a bar read off the System chart names apps the
@@ -74,8 +80,6 @@ fun HomeScreen(
     installerViewModel: InstallerViewModel = koinViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    var showCacheDialog by remember { mutableStateOf(false) }
-    var showSystemCacheConfirmDialog by remember { mutableStateOf(false) }
     var showPrivilegeDialog by remember { mutableStateOf(false) }
 
     var showInstallerSheet by remember { mutableStateOf(false) }
@@ -94,14 +98,19 @@ fun HomeScreen(
     val isWideScreen = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)
     val isExpanded = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND)
     val hasPrivilege = state.activePrivilegeMode != null
-    val isRoot = state.activePrivilegeMode == PrivilegeMode.ROOT
+    // Root *or* Shizuku, which is wider than the `isRoot` this used to be. The tile no longer clears
+    // one app at a time — it runs `pm trim-caches`, and PackageManagerService gates that on
+    // CLEAR_APP_CACHE, a permission the shell uid holds. Dhizuku is still out: it has no shell to
+    // run the command in and the device-owner API has no equivalent.
+    val canClearCache = state.activePrivilegeMode == PrivilegeMode.ROOT ||
+        state.activePrivilegeMode == PrivilegeMode.SHIZUKU
     val reinstallVisible = state.activePrivilegeMode != null &&
         state.unknownInstallerCount > 0 && state.showReinstallCard
     // Both optional tiles hidden with no privilege leaves the bento with nothing to draw, so the
     // spacer that separates it from the summary row goes with it rather than leaving a bare gap.
     val hasHomeActions = homeActionRows(
         reinstallVisible = reinstallVisible,
-        isRoot = isRoot,
+        canClearCache = canClearCache,
         hasPrivilege = hasPrivilege,
         showInstaller = state.showInstallerTile,
         showExtensions = state.showExtensionsTile,
@@ -165,14 +174,14 @@ fun HomeScreen(
 
                         HomeActionsBento(
                             reinstallVisible = reinstallVisible,
-                            isRoot = isRoot,
+                            canClearCache = canClearCache,
                             hasPrivilege = hasPrivilege,
                             unknownInstallerCount = state.unknownInstallerCount,
                             selectedTypeName = state.selectedType.name.lowercase(),
                             onReinstall = onReinstallAll,
                             onDismissReinstall = { viewModel.dismissReinstallCard() },
                             onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
-                            onClearCache = { showCacheDialog = true },
+                            onClearCache = onClearAllCache,
                             onNavigateToExtensionManager = onNavigateToExtensionManager,
                             showInstaller = state.showInstallerTile,
                             showExtensions = state.showExtensionsTile,
@@ -246,14 +255,14 @@ fun HomeScreen(
 
                 HomeActionsBento(
                     reinstallVisible = reinstallVisible,
-                    isRoot = isRoot,
+                    canClearCache = canClearCache,
                     hasPrivilege = hasPrivilege,
                     unknownInstallerCount = state.unknownInstallerCount,
                     selectedTypeName = state.selectedType.name.lowercase(),
                     onReinstall = onReinstallAll,
                     onDismissReinstall = { viewModel.dismissReinstallCard() },
                     onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
-                    onClearCache = { showCacheDialog = true },
+                    onClearCache = onClearAllCache,
                     onNavigateToExtensionManager = onNavigateToExtensionManager,
                     modifier = Modifier.padding(horizontal = 24.dp),
                     showInstaller = state.showInstallerTile,
@@ -318,46 +327,11 @@ fun HomeScreen(
     }
 
     // --- Dialogs ---
-    if (showCacheDialog) {
-        AlertDialog(
-            onDismissRequest = { showCacheDialog = false },
-            icon = { Icon(painterResource(R.drawable.clear_all), null) },
-            title = { Text(stringResource(R.string.clear_all_cache)) },
-            text = { Text(stringResource(R.string.clear_cache_prompt)) },
-            confirmButton = {
-                Button(onClick = {
-                    onClearAllCache(AppListType.USER)
-                    showCacheDialog = false
-                }) { Text(stringResource(R.string.user_apps)) }
-            },
-            dismissButton = {
-                OutlinedButton(onClick = {
-                    showCacheDialog = false
-                    showSystemCacheConfirmDialog = true
-                }) { Text(stringResource(R.string.system_apps)) }
-            }
-        )
-    }
-
-    if (showSystemCacheConfirmDialog) {
-        AlertDialog(
-            onDismissRequest = { showSystemCacheConfirmDialog = false },
-            icon = { Icon(painterResource(R.drawable.warning), null) },
-            title = { Text(stringResource(R.string.clear_system_cache_title)) },
-            text = { Text(stringResource(R.string.clear_system_cache_desc)) },
-            confirmButton = {
-                Button(onClick = {
-                    onClearAllCache(AppListType.SYSTEM)
-                    showSystemCacheConfirmDialog = false
-                }) { Text(stringResource(R.string.proceed)) }
-            },
-            dismissButton = {
-                OutlinedButton(onClick = { showSystemCacheConfirmDialog = false }) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
-        )
-    }
+    // The two cache dialogs that used to live here are gone. They offered a choice — "user apps" or
+    // "system apps" — that `pm trim-caches` cannot honour: PackageManagerService evicts by LRU across
+    // the whole volume and takes no package argument. The replacement is `ClearAllCacheSheet`, hosted
+    // by MainScreen and driven by `MainUiState.cacheClear`, which asks once and says plainly that
+    // system apps are included too.
 
     if (showPrivilegeDialog) {
         AlertDialog(

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
@@ -27,10 +27,14 @@ enum class HomeAction { REINSTALL, INSTALL, CLEAR_CACHE, EXTENSIONS }
  *
  * [narrowContainer] is for a pane too narrow to pair tiles at all (the wide-screen rail) — every
  * action then gets its own full-width row.
+ *
+ * [canClearCache] is Root **or** Shizuku, not root alone. The tile runs `pm trim-caches`, which is
+ * gated on `CLEAR_APP_CACHE` — a permission `com.android.shell` holds — so Shizuku can do it too.
+ * Only Dhizuku is left out: it has no shell to run the command in.
  */
 fun homeActionRows(
     reinstallVisible: Boolean,
-    isRoot: Boolean,
+    canClearCache: Boolean,
     hasPrivilege: Boolean,
     showInstaller: Boolean = true,
     showExtensions: Boolean = true,
@@ -38,7 +42,7 @@ fun homeActionRows(
 ): List<List<HomeAction>> {
     val actions = listOfNotNull(
         HomeAction.INSTALL.takeIf { showInstaller },
-        HomeAction.CLEAR_CACHE.takeIf { isRoot },
+        HomeAction.CLEAR_CACHE.takeIf { canClearCache },
         HomeAction.EXTENSIONS.takeIf { hasPrivilege && showExtensions },
         HomeAction.REINSTALL.takeIf { reinstallVisible },
     )

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
@@ -46,7 +46,7 @@ private data class HomeActionCopy(val title: String, val subtitle: String, val i
 @Composable
 fun HomeActionsBento(
     reinstallVisible: Boolean,
-    isRoot: Boolean,
+    canClearCache: Boolean,
     hasPrivilege: Boolean,
     unknownInstallerCount: Int,
     selectedTypeName: String,
@@ -61,7 +61,7 @@ fun HomeActionsBento(
     narrowContainer: Boolean = false,
 ) {
     val rows = homeActionRows(
-        reinstallVisible, isRoot, hasPrivilege, showInstaller, showExtensions, narrowContainer
+        reinstallVisible, canClearCache, hasPrivilege, showInstaller, showExtensions, narrowContainer
     )
     var explaining by rememberSaveable { mutableStateOf<HomeAction?>(null) }
     // Hiding both optional tiles with no privilege leaves nothing to draw. Emit no Column at all

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -747,9 +747,12 @@ fun MainScreen(
                         state = cacheClear,
                         // Formatted here, not in the ViewModel: Formatter needs a Context, and the
                         // short form is locale-aware, so it has to be resolved at draw time.
+                        // Zero is formatted like any other number rather than being filtered out —
+                        // the sheet has a sentence for "there was nothing left", and dropping it to
+                        // null here would put a measured zero in the *unmeasured* branch and tell a
+                        // user who has usage access to go and grant usage access.
                         formattedFreedBytes = (cacheClear as? CacheClearState.Done)
                             ?.freedBytes
-                            ?.takeIf { it > 0L }
                             ?.let { Formatter.formatShortFileSize(context, it) },
                         onConfirm = { mainViewModel.confirmClearAllCaches() },
                         onDismiss = { mainViewModel.dismissCacheClear() }

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -5,6 +5,7 @@ package com.valhalla.thor.presentation.main
 
 import android.content.Intent
 import android.provider.Settings
+import android.text.format.Formatter
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -92,6 +93,7 @@ import com.valhalla.thor.presentation.extension.ExtensionManagerScreen
 import com.valhalla.thor.presentation.settings.BillingProcessor
 import com.valhalla.thor.presentation.settings.SupportDeveloperHelper
 import com.valhalla.thor.presentation.widgets.AffirmationDialog
+import com.valhalla.thor.presentation.widgets.ClearAllCacheSheet
 import com.valhalla.thor.presentation.widgets.MultiAppAffirmationDialog
 import com.valhalla.thor.presentation.widgets.ExportProgressBar
 import com.valhalla.thor.presentation.widgets.FreezeLoggerDialog
@@ -396,7 +398,10 @@ fun MainScreen(
                         // names every app it would touch. Confirming a list beats confirming a
                         // warning about a list you were never shown.
                         onReinstallAll = { mainViewModel.onAppAction(AppClickAction.ReinstallAll) },
-                        onClearAllCache = { type -> mainViewModel.clearAllCache(type) },
+                        // No type argument any more: `pm trim-caches` takes no package list and
+                        // PackageManagerService evicts by LRU across the volume, so "user apps only"
+                        // was never a promise Thor could keep. The tap opens the confirmation sheet.
+                        onClearAllCache = { mainViewModel.requestClearAllCaches() },
                         onFilterByInstaller = { type, installer ->
                             appListViewModel.showAppsFromInstaller(type, installer)
                             activeDestination = AppDestinations.APPS
@@ -731,6 +736,23 @@ fun MainScreen(
                             null
                         },
                         onDismiss = { mainViewModel.dismissLogger() }
+                    )
+                }
+
+                // Hosted here rather than in HomeScreen because the clear outlives the screen that
+                // started it: switching tabs mid-operation must not cancel it or lose the byte
+                // count. The state lives in MainViewModel for the same reason.
+                state.cacheClear?.let { cacheClear ->
+                    ClearAllCacheSheet(
+                        state = cacheClear,
+                        // Formatted here, not in the ViewModel: Formatter needs a Context, and the
+                        // short form is locale-aware, so it has to be resolved at draw time.
+                        formattedFreedBytes = (cacheClear as? CacheClearState.Done)
+                            ?.freedBytes
+                            ?.takeIf { it > 0L }
+                            ?.let { Formatter.formatShortFileSize(context, it) },
+                        onConfirm = { mainViewModel.confirmClearAllCaches() },
+                        onDismiss = { mainViewModel.dismissCacheClear() }
                     )
                 }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -27,6 +27,7 @@ import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.domain.usecase.ShareAppUseCase
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.FreezerRepository
+import com.valhalla.thor.domain.repository.UsageAccessGate
 import com.valhalla.thor.presentation.home.AppDestinations
 import com.valhalla.thor.util.AppLocale
 import com.valhalla.thor.util.Logger
@@ -163,8 +164,14 @@ sealed interface CacheClearState {
      * [freedBytes] is `null` when the clear succeeded but Thor could not measure it — no usage
      * access, or an app that refilled its cache between the two readings. A screen must render that
      * as "cache cleared" with no number, never as "0 B freed".
+     *
+     * [hasUsageAccess] separates those two causes, and exists because the sentence they deserve is
+     * not the same one. "Grant usage access to see the figure" is advice for the first and an
+     * insult to the second: the user already granted it, so the only actionable thing on screen is
+     * an instruction to do what they have done. Sampled when the result lands rather than when it
+     * is drawn, because it describes why *this* measurement failed.
      */
-    data class Done(val freedBytes: Long?) : CacheClearState
+    data class Done(val freedBytes: Long?, val hasUsageAccess: Boolean) : CacheClearState
 }
 
 data class MainUiState(
@@ -187,6 +194,11 @@ class MainViewModel(
     private val preferenceRepository: PreferenceRepository,
     private val freezerRepository: FreezerRepository,
     private val backupRunner: BackupRunner,
+    // Only ever asked `isGranted`, and only to explain a measurement that came back empty. The
+    // interface rather than UsageAccessManager because the concrete class reaches for a Context for
+    // its Settings deep-link, which would put an Android type in this ViewModel's constructor and
+    // take it off the JVM test classpath.
+    private val usageAccessGate: UsageAccessGate,
     @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
 
@@ -453,7 +465,13 @@ class MainViewModel(
         viewModelScope.launch {
             manageAppUseCase.clearAllCaches()
                 .onSuccess { freed ->
-                    _uiState.update { it.copy(cacheClear = CacheClearState.Done(freed)) }
+                    // Read only when the number is missing. `isGranted` is a local AppOps lookup,
+                    // but asking it on the happy path would still be asking a question whose answer
+                    // is already implied — a byte count arrived, so the op is held.
+                    val hasUsageAccess = freed != null || usageAccessGate.isGranted()
+                    _uiState.update {
+                        it.copy(cacheClear = CacheClearState.Done(freed, hasUsageAccess))
+                    }
                 }
                 .onFailure { e ->
                     Logger.e("MainViewModel", "clearAllCaches failed", e)

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -143,11 +143,36 @@ data class FixStoreSelection(
     val selectedApps: List<AppInfo> get() = candidates.filter { it.packageName in selected }
 }
 
+/**
+ * The whole-device cache clear, from the tile tap to the moment its result sheet goes away.
+ * `null` in [MainUiState.cacheClear] means neither is happening.
+ *
+ * Modelled as state rather than as two `remember`ed booleans in `HomeScreen` because the operation
+ * is not the Home screen's: it clears every app on the device, it outlives a tab switch, and the
+ * result is a number the user asked for. [Confirming] is in here for the same reason — the
+ * confirmation is not a formality, it is the only place the user is told that *system* apps are
+ * included, so it belongs where the action it guards does.
+ */
+sealed interface CacheClearState {
+    /** Waiting on the confirmation the tile must not skip. */
+    data object Confirming : CacheClearState
+
+    data object Running : CacheClearState
+
+    /**
+     * [freedBytes] is `null` when the clear succeeded but Thor could not measure it — no usage
+     * access, or an app that refilled its cache between the two readings. A screen must render that
+     * as "cache cleared" with no number, never as "0 B freed".
+     */
+    data class Done(val freedBytes: Long?) : CacheClearState
+}
+
 data class MainUiState(
     val loggerState: LoggerState = LoggerState(), // For persistent Logs
     val fixStoreSelection: FixStoreSelection? = null, // Fix Store picker, null when closed
     val freezeLoggerState: FreezeLoggerState = FreezeLoggerState(), // Compact freeze/unfreeze progress
     val exportProgress: ExportProgressState? = null, // Multi-app export, null when idle
+    val cacheClear: CacheClearState? = null, // Whole-device cache clear, null when idle
     val selectedDestination: AppDestinations = AppDestinations.HOME, // For Bottom Nav
     val hasShownSupportDeveloperPrompt: Boolean = true,
     val showSupportDeveloperPrompt: Boolean = false,
@@ -385,42 +410,70 @@ class MainViewModel(
         }
     }
 
-    fun clearAllCache(type: AppListType) {
+    /**
+     * Opens the confirmation for the whole-device cache clear. The tile calls this, never
+     * [confirmClearAllCaches] — see [CacheClearState.Confirming].
+     */
+    fun requestClearAllCaches() {
+        _uiState.update { it.copy(cacheClear = CacheClearState.Confirming) }
+    }
+
+    /**
+     * Clears every app's cache on the primary volume, system apps included.
+     *
+     * This used to be `clearAllCache(type)`: load every app of one [AppListType], drop Thor and the
+     * Play Store, then walk the list clearing one package at a time behind the batch logger. Every
+     * part of that is now wrong.
+     *
+     * The per-package loop could not work outside Root. `INTERNAL_DELETE_CACHE_FILES` is
+     * signature-level, so under Shizuku `PackageManagerService` logged that it was silently ignoring
+     * each call — hundreds of packages, fifteen seconds of observer timeout each, nothing deleted.
+     * The operation that *does* work is `pm trim-caches`, and it is not a loop: PMS picks its own
+     * victims by LRU across the whole volume.
+     *
+     * Which is why the USER/SYSTEM choice is gone rather than moved. It could not be honoured — a
+     * trim clears both — and offering it would have been a lie in the one place the user is deciding
+     * whether to touch system apps. The `safeList` filter goes with it for the same reason: PMS
+     * decides, so excluding Thor and the Play Store was never in Thor's gift. Thor's own cache being
+     * included is the correct behaviour anyway; it was only ever excluded because clearing it
+     * mid-batch was visible.
+     */
+    fun confirmClearAllCaches() {
+        // Synchronous, and deliberately *outside* the coroutine. Two taps landing in the same frame
+        // each queue a launch, and a guard inside the coroutine can only see whatever the other one
+        // left behind — which by the time it runs may already be `Done`, and `Done` is not
+        // `Running`, so the second trim would start anyway. Flipping the state here, before either
+        // coroutine exists, is what makes the second tap a no-op. Safe as a check-then-set because
+        // both callers are Compose click handlers on the main thread.
+        //
+        // Requiring `Confirming` rather than "not Running" also means nothing can start a trim
+        // without the sheet having asked first.
+        if (_uiState.value.cacheClear != CacheClearState.Confirming) return
+        _uiState.update { it.copy(cacheClear = CacheClearState.Running) }
         viewModelScope.launch {
-            startLogger(UiText.StringResource(R.string.log_preparing_cache))
-
-            // 1. Fetch current list — getInstalledAppsUseCase() reads PackageManager and can
-            // throw (e.g. DeadObjectException). Guard it so a failure can't crash the app or
-            // leave the logger dialog stuck spinning.
-            val (userApps, systemApps) = try {
-                getInstalledAppsUseCase().first()
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e // preserve structured-concurrency cancellation
-                Logger.e("MainViewModel", "clearAllCache: failed to load apps", e)
-                addLog(UiText.StringResource(R.string.log_error, e.message ?: ""))
-                finishLogger()
-                return@launch
-            }
-            val targetList = if (type == AppListType.USER) userApps else systemApps
-
-            // 2. Filter out self and Play Store to be safe.
-            // BuildConfig, not a literal: `applicationIdSuffix` makes the debug build
-            // `com.valhalla.thor.debug`, so a hardcoded id stops excluding self on exactly the
-            // build where clearing Thor's own cache mid-run is most likely to be noticed.
-            val safeList = targetList.filter {
-                it.packageName != BuildConfig.APPLICATION_ID &&
-                        it.packageName != Installers.PLAY_STORE
-            }
-
-            if (safeList.isEmpty()) {
-                addLog(UiText.StringResource(R.string.log_no_eligible_apps))
-                finishLogger()
-                return@launch
-            }
-
-            dismissLogger() // Switch to batch logger
-            onMultiAppAction(MultiAppAction.ClearCache(safeList))
+            manageAppUseCase.clearAllCaches()
+                .onSuccess { freed ->
+                    _uiState.update { it.copy(cacheClear = CacheClearState.Done(freed)) }
+                }
+                .onFailure { e ->
+                    Logger.e("MainViewModel", "clearAllCaches failed", e)
+                    _uiState.update { it.copy(cacheClear = null) }
+                    val errorText = if (e is UiTextException) e.uiText else UiText.DynamicString(e.message ?: "")
+                    _effect.send(MainSideEffect.Message(UiText.StringResource(R.string.error_format, errorText)))
+                }
         }
+    }
+
+    /**
+     * Closes the confirmation or the result sheet, whichever is open.
+     *
+     * The support prompt is triggered from here rather than at the moment the clear succeeds: two
+     * bottom sheets racing each other is not a thing to ask a user to read.
+     */
+    fun dismissCacheClear() {
+        val wasDone = _uiState.value.cacheClear is CacheClearState.Done
+        _uiState.update { it.copy(cacheClear = null) }
+        if (wasDone) viewModelScope.launch { triggerSupportPromptIfNeeded() }
     }
 
     // --- Single App Action Handler ---
@@ -585,7 +638,27 @@ class MainViewModel(
                 is AppClickAction.Kill -> quickAction(action) { manageAppUseCase.forceStop(it.packageName) }
                 is AppClickAction.Freeze -> quickAction(action) { manageAppUseCase.setAppDisabled(it.packageName, true) }
                 is AppClickAction.UnFreeze -> quickAction(action) { manageAppUseCase.setAppDisabled(it.packageName, false) }
-                is AppClickAction.ClearCache -> quickAction(action) { manageAppUseCase.clearCache(it.packageName) }
+                // The only quick action with a number to report. A null count is not zero — the
+                // clear worked and the measurement did not — so it falls back to the plain message
+                // rather than saying "0 B".
+                is AppClickAction.ClearCache -> quickAction(
+                    action,
+                    successMessage = { app, freed ->
+                        val name = app.appName ?: app.packageName
+                        if (freed == null || freed <= 0L) {
+                            UiText.StringResource(R.string.cache_cleared_success, name)
+                        } else {
+                            // Order matters: %1$s is the app label, %2$s the size — the same
+                            // positions cache_cleared_success uses for its single argument, so the
+                            // two messages stay swappable.
+                            UiText.StringResource(
+                                R.string.cache_cleared_success_size,
+                                name,
+                                formatBytes(freed)
+                            )
+                        }
+                    }
+                ) { manageAppUseCase.clearCache(it.packageName) }
                 is AppClickAction.ClearData -> quickAction(action) { manageAppUseCase.clearAppData(it.packageName) }
                 is AppClickAction.Suspend -> quickAction(action) { manageAppUseCase.setAppSuspended(it.packageName, true) }
                 is AppClickAction.UnSuspend -> quickAction(action) { manageAppUseCase.setAppSuspended(it.packageName, false) }
@@ -630,11 +703,16 @@ class MainViewModel(
                     manageAppUseCase.forceStop(it.packageName)
                 }
 
+                // Root-only, like every per-package clear. The freed byte counts are discarded here
+                // on purpose: this path reports through the batch logger, which speaks in
+                // per-app success/failure lines, and a running total interleaved with them would be
+                // the one number on screen that nothing else agrees with. The whole-device clear is
+                // where a total belongs.
                 is MultiAppAction.ClearCache -> performLoggedMultiAction(
                     UiText.StringResource(R.string.log_clearing_cache_batch),
                     action.appList
                 ) {
-                    manageAppUseCase.clearCache(it.packageName)
+                    manageAppUseCase.clearCache(it.packageName).map { }
                 }
 
                 is MultiAppAction.Uninstall -> performLoggedMultiAction(
@@ -930,17 +1008,23 @@ class MainViewModel(
         }
     }
 
-    private suspend fun quickAction(
+    /**
+     * [successMessage] exists for the one action whose result carries information: a cache clear
+     * knows how many bytes it freed, and the toast is the place to say so. Every other caller omits
+     * it and gets [getSuccessMessage], which only knows the action and the app name.
+     */
+    private suspend fun <T> quickAction(
         action: AppClickAction,
-        block: suspend (AppInfo) -> Result<Unit>
+        successMessage: ((AppInfo, T) -> UiText)? = null,
+        block: suspend (AppInfo) -> Result<T>
     ) {
         val app = action.appInfo()
         if (app != null)
             block(app)
-                .onSuccess {
+                .onSuccess { value ->
                     _effect.send(
                         MainSideEffect.Message(
-                            getSuccessMessage(
+                            successMessage?.invoke(app, value) ?: getSuccessMessage(
                                 action,
                                 app.appName ?: app.packageName
                             )

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppActionRow.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppActionRow.kt
@@ -168,12 +168,20 @@ fun AppActionRow(
             )
         }
 
-        if (hasPrivilege) {
+        // Root, not hasPrivilege. Clearing *one* app's cache needs
+        // `android.permission.INTERNAL_DELETE_CACHE_FILES`, which is signature-level: it cannot be
+        // granted to `com.android.shell`, so PackageManagerService answers a Shizuku-delegated call
+        // by logging "silently ignoring" and returning nothing. Under Shizuku and Dhizuku this icon
+        // was a button that reported success and did nothing. The whole-device clear on Home still
+        // works for Shizuku — that one goes through `pm trim-caches`, a different permission.
+        if (isRoot) {
             ActionItem(
                 icon = R.drawable.clear_all,
                 label = stringResource(R.string.action_clear_cache),
                 onClick = onClearCache
             )
+        }
+        if (hasPrivilege) {
             ActionItem(
                 icon = R.drawable.delete,
                 label = stringResource(R.string.action_clear_data),

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/ClearAllCacheSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/ClearAllCacheSheet.kt
@@ -145,15 +145,22 @@ fun ClearAllCacheSheet(
                 text = when (state) {
                     CacheClearState.Confirming -> stringResource(R.string.clear_all_cache_confirm_desc)
                     CacheClearState.Running -> stringResource(R.string.clear_all_cache_running_desc)
-                    is CacheClearState.Done ->
-                        // formattedFreedBytes is null when the clear worked and the measurement did
-                        // not. Saying "0 B freed" there would report a missing usage-access grant as
-                        // a clear that did nothing.
-                        if (formattedFreedBytes == null) {
+                    // Three outcomes, not two, because a measured zero and an absent measurement are
+                    // different facts and the repository keeps them apart all the way to here.
+                    // `formattedFreedBytes == null` is the absent one — the clear worked and Thor
+                    // could not weigh it — and saying "0 B" there would report a missing usage-access
+                    // grant as a clear that did nothing. A real zero is the opposite: the measurement
+                    // worked, so the sheet must not send the user off to grant a permission they
+                    // already hold. Negative deltas never arrive; SystemRepositoryImpl clamps them to
+                    // null, since cache an app rebuilt mid-clear is an unmeasurable, not a zero.
+                    is CacheClearState.Done -> when {
+                        formattedFreedBytes == null ->
                             stringResource(R.string.clear_all_cache_done_unmeasured)
-                        } else {
+                        state.freedBytes == 0L ->
+                            stringResource(R.string.clear_all_cache_done_nothing)
+                        else ->
                             stringResource(R.string.clear_all_cache_done_size, formattedFreedBytes)
-                        }
+                    }
                 },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/ClearAllCacheSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/ClearAllCacheSheet.kt
@@ -145,21 +145,25 @@ fun ClearAllCacheSheet(
                 text = when (state) {
                     CacheClearState.Confirming -> stringResource(R.string.clear_all_cache_confirm_desc)
                     CacheClearState.Running -> stringResource(R.string.clear_all_cache_running_desc)
-                    // Three outcomes, not two, because a measured zero and an absent measurement are
-                    // different facts and the repository keeps them apart all the way to here.
-                    // `formattedFreedBytes == null` is the absent one — the clear worked and Thor
-                    // could not weigh it — and saying "0 B" there would report a missing usage-access
-                    // grant as a clear that did nothing. A real zero is the opposite: the measurement
-                    // worked, so the sheet must not send the user off to grant a permission they
-                    // already hold. Negative deltas never arrive; SystemRepositoryImpl clamps them to
-                    // null, since cache an app rebuilt mid-clear is an unmeasurable, not a zero.
+                    // Four outcomes, because three different things can leave the sheet without a
+                    // number and they do not deserve the same sentence. A measured zero is a real
+                    // answer — the clear ran and there was nothing left — so rendering it as "could
+                    // not measure" would send a user who has usage access off to grant usage access.
+                    // An absent measurement splits again on whether the op is actually held: without
+                    // it there is something to do, with it there is not, and the difference is the
+                    // only actionable thing on the sheet. Negative deltas never arrive here;
+                    // SystemRepositoryImpl clamps them to null, since cache an app rebuilt mid-clear
+                    // is an unmeasurable rather than a zero — and that is precisely the case
+                    // `hasUsageAccess` keeps out of the grant-it-in-Settings line.
                     is CacheClearState.Done -> when {
-                        formattedFreedBytes == null ->
-                            stringResource(R.string.clear_all_cache_done_unmeasured)
-                        state.freedBytes == 0L ->
+                        formattedFreedBytes != null && state.freedBytes == 0L ->
                             stringResource(R.string.clear_all_cache_done_nothing)
-                        else ->
+                        formattedFreedBytes != null ->
                             stringResource(R.string.clear_all_cache_done_size, formattedFreedBytes)
+                        state.hasUsageAccess ->
+                            stringResource(R.string.clear_all_cache_done_size_unknown)
+                        else ->
+                            stringResource(R.string.clear_all_cache_done_unmeasured)
                     }
                 },
                 style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/ClearAllCacheSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/ClearAllCacheSheet.kt
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.widgets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.valhalla.thor.R
+import com.valhalla.thor.presentation.main.CacheClearState
+import kotlinx.coroutines.delay
+
+/** How long the result stays up before it takes itself away. */
+private const val RESULT_AUTO_DISMISS_MS = 3_000L
+
+/**
+ * The whole-device cache clear, all three of its states in one sheet.
+ *
+ * One composable rather than three because the three states are one conversation: the user is asked,
+ * watches it happen, and is told what it freed, without the surface under their thumb moving. A
+ * separate sheet per state would animate out and back in twice for a single tap.
+ *
+ * The confirmation is not decoration. `pm trim-caches` hands the choice of victim to
+ * `PackageManagerService`, which evicts by LRU across the volume — so *system* apps are included and
+ * there is no way to ask for anything narrower. This sheet is the only place the user is told that,
+ * which is why [CacheClearState.Confirming] is a state of the operation rather than a boolean owned
+ * by whichever screen happens to host the tile.
+ *
+ * [CacheClearState.Done] auto-dismisses after three seconds. That is a number the user asked for and
+ * cannot act on, so leaving it to be dismissed by hand makes every clear cost two taps; the buttons
+ * and the swipe still work, and whichever happens first wins.
+ */
+@Composable
+fun ClearAllCacheSheet(
+    state: CacheClearState,
+    formattedFreedBytes: String?,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (state is CacheClearState.Done) {
+        // Keyed on the state instance: a second clear started after this one auto-dismissed gets its
+        // own timer rather than inheriting a cancelled one.
+        LaunchedEffect(state) {
+            delay(RESULT_AUTO_DISMISS_MS)
+            onDismiss()
+        }
+    }
+
+    // Swallowing the dismiss *request* is only half the guard: it stops the host being told, but the
+    // sheet still settles to Hidden on a swipe or a scrim tap and sits there invisible until the
+    // clear finishes, taking the byte count with it. Vetoing the value change is the other half — it
+    // stops the settle itself. Both are needed: ModalBottomSheet's back/scrim path calls
+    // `onDismissRequest()` once `hide()` returns whether the veto fired or not.
+    val running = rememberUpdatedState(state is CacheClearState.Running)
+    // Deliberately created once. `rememberBottomSheetState` passes this straight into
+    // `rememberSaveable` as a *key*, so a lambda that changed identity between recompositions would
+    // discard the live SheetState and snap the sheet shut mid-operation. Reading `running.value`
+    // from inside keeps the lambda identity-stable while still seeing the current state.
+    val confirmValueChange = remember<(SheetValue) -> Boolean> {
+        { value -> value != SheetValue.Hidden || !running.value }
+    }
+
+    ModalBottomSheet(
+        // The clear is already in flight and cannot be called back, so a sheet that vanishes
+        // mid-operation would either have to reappear when the result lands — reopening something the
+        // user just closed — or drop the byte count they tapped the tile to see.
+        onDismissRequest = if (state is CacheClearState.Running) ({ }) else onDismiss,
+        sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Expanded, SheetValue.Hidden),
+            confirmValueChange = confirmValueChange
+        ),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f),
+                        shape = RoundedCornerShape(20.dp)
+                    )
+                    .padding(14.dp)
+            ) {
+                if (state is CacheClearState.Running) {
+                    CircularProgressIndicator(modifier = Modifier.size(28.dp))
+                } else {
+                    Icon(
+                        painter = painterResource(
+                            if (state is CacheClearState.Confirming) R.drawable.warning
+                            else R.drawable.clear_all
+                        ),
+                        contentDescription = null,
+                        modifier = Modifier.size(28.dp),
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            Text(
+                text = stringResource(
+                    when (state) {
+                        CacheClearState.Confirming -> R.string.clear_all_cache
+                        CacheClearState.Running -> R.string.clear_all_cache_running
+                        is CacheClearState.Done -> R.string.clear_all_cache_done_title
+                    }
+                ),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            Text(
+                text = when (state) {
+                    CacheClearState.Confirming -> stringResource(R.string.clear_all_cache_confirm_desc)
+                    CacheClearState.Running -> stringResource(R.string.clear_all_cache_running_desc)
+                    is CacheClearState.Done ->
+                        // formattedFreedBytes is null when the clear worked and the measurement did
+                        // not. Saying "0 B freed" there would report a missing usage-access grant as
+                        // a clear that did nothing.
+                        if (formattedFreedBytes == null) {
+                            stringResource(R.string.clear_all_cache_done_unmeasured)
+                        } else {
+                            stringResource(R.string.clear_all_cache_done_size, formattedFreedBytes)
+                        }
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+
+            if (state !is CacheClearState.Running) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)
+                ) {
+                    if (state is CacheClearState.Confirming) {
+                        TextButton(onClick = onDismiss) {
+                            Text(stringResource(R.string.cancel))
+                        }
+                        Button(onClick = onConfirm) {
+                            Text(stringResource(R.string.proceed))
+                        }
+                    } else {
+                        Button(onClick = onDismiss) {
+                            Text(stringResource(R.string.close))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/MultiSelectToolBox.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/MultiSelectToolBox.kt
@@ -115,12 +115,19 @@ fun MultiSelectToolBox(
                 }
             }
 
+            // Root only, unlike everything above it. Per-package cache clearing needs the
+            // signature-level `INTERNAL_DELETE_CACHE_FILES`; Shizuku's uid-2000 call is answered by
+            // PackageManagerService with "silently ignoring", so this button used to report a clean
+            // sweep of the whole selection while freeing nothing. See `AppActionRow`.
+            if (isRoot) {
+                ToolBoxItem(
+                    icon = R.drawable.clear_all,
+                    label = stringResource(R.string.action_cache),
+                    onClick = { onMultiAppAction(MultiAppAction.ClearCache(selected)) }
+                )
+            }
+
             // Standard Actions
-            ToolBoxItem(
-                icon = R.drawable.clear_all,
-                label = stringResource(R.string.action_cache),
-                onClick = { onMultiAppAction(MultiAppAction.ClearCache(selected)) }
-            )
             ToolBoxItem(
                 icon = R.drawable.share,
                 label = stringResource(R.string.action_share),

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -86,6 +86,7 @@
     <string name="clear_all_cache_running_desc">جارٍ العمل على كل تطبيقات الجهاز. قد يستغرق ذلك لحظة.</string>
     <string name="clear_all_cache_done_title">تم مسح الذاكرة المؤقتة</string>
     <string name="clear_all_cache_done_size">تم تحرير %1$s.</string>
+    <string name="clear_all_cache_done_nothing">لم تتبقَّ أي ذاكرة تخزين مؤقت لمسحها.</string>
     <string name="clear_all_cache_done_unmeasured">تم. لم يتمكن Thor من قياس المساحة المحرّرة — امنحه إذن الوصول إلى بيانات الاستخدام في الإعدادات لرؤية الرقم في المرة القادمة.</string>
     <string name="system_apps">تطبيقات النظام</string>
     <string name="active">نشط</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -80,11 +80,13 @@
     <string name="total_apps">الإجمالي: %1$d</string>
     <string name="others">أخرى</string>
     <string name="clear_all_cache">مسح جميع الذاكرة المؤقتة</string>
-    <string name="clear_cache_prompt">أي التطبيقات ترغب في مسحها؟</string>
     <string name="clear_all_cache_subtitle">مسح الملفات المؤقتة لجميع التطبيقات لاستعادة مساحة التخزين</string>
-    <string name="clear_system_cache_title">مسح ذاكرة النظام المؤقتة؟</string>
-    <string name="clear_system_cache_desc">قد يؤدي مسح ذاكرة تطبيقات النظام المؤقتة إلى عدم استقرار مؤقت. هل أنت متأكد أنك تريد المتابعة؟</string>
-    <string name="user_apps">تطبيقات المستخدم</string>
+    <string name="clear_all_cache_confirm_desc">أندرويد هو من يقرر أي ذاكرة مؤقتة تُمسح، ولا يتيح لـ Thor الاختيار — تشمل العملية كل تطبيقات الجهاز، تطبيقات النظام وتطبيقاتك على حد سواء. لن يُمسّ أي شيء آخر: بياناتك وتسجيلات دخولك وإعداداتك تبقى كما هي. قد تفتح التطبيقات ببطء بسيط في المرة الأولى بينما تعيد بناء ذاكرتها المؤقتة.</string>
+    <string name="clear_all_cache_running">جارٍ المسح…</string>
+    <string name="clear_all_cache_running_desc">جارٍ العمل على كل تطبيقات الجهاز. قد يستغرق ذلك لحظة.</string>
+    <string name="clear_all_cache_done_title">تم مسح الذاكرة المؤقتة</string>
+    <string name="clear_all_cache_done_size">تم تحرير %1$s.</string>
+    <string name="clear_all_cache_done_unmeasured">تم. لم يتمكن Thor من قياس المساحة المحرّرة — امنحه إذن الوصول إلى بيانات الاستخدام في الإعدادات لرؤية الرقم في المرة القادمة.</string>
     <string name="system_apps">تطبيقات النظام</string>
     <string name="active">نشط</string>
     <string name="frozen">مجمد</string>
@@ -306,6 +308,7 @@
     </plurals>
     <string name="killed_success">تم إنهاء %1$s</string>
     <string name="cache_cleared_success">تم مسح ذاكرة التخزين المؤقت لـ %1$s</string>
+    <string name="cache_cleared_success_size">تم مسح %2$s من ذاكرة %1$s المؤقتة</string>
     <string name="data_cleared_success">تم مسح بيانات %1$s</string>
     <string name="suspended_success">تم تعليق %1$s</string>
     <string name="unsuspended_success">تم إلغاء تعليق %1$s</string>
@@ -406,8 +409,6 @@
     <!-- Terminal Logs -->
     <string name="log_initializing">جارٍ التهيئة…</string>
     <string name="log_op_complete">\nاكتملت العملية.</string>
-    <string name="log_preparing_cache">جارٍ تجهيز تنظيف الذاكرة المؤقتة…</string>
-    <string name="log_no_eligible_apps">لم يتم العثور على تطبيقات مؤهلة.</string>
     <string name="log_sharing_app">جارٍ مشاركة %1$s</string>
     <string name="log_preparing_files">جارٍ تجهيز الملفات…</string>
     <string name="log_files_ready">✔ الملفات جاهزة</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -87,6 +87,7 @@
     <string name="clear_all_cache_done_title">تم مسح الذاكرة المؤقتة</string>
     <string name="clear_all_cache_done_size">تم تحرير %1$s.</string>
     <string name="clear_all_cache_done_nothing">لم تتبقَّ أي ذاكرة تخزين مؤقت لمسحها.</string>
+    <string name="clear_all_cache_done_size_unknown">تم. لم يتمكن Thor من قياس المساحة المحرّرة.</string>
     <string name="clear_all_cache_done_unmeasured">تم. لم يتمكن Thor من قياس المساحة المحرّرة — امنحه إذن الوصول إلى بيانات الاستخدام في الإعدادات لرؤية الرقم في المرة القادمة.</string>
     <string name="system_apps">تطبيقات النظام</string>
     <string name="active">نشط</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -80,11 +80,13 @@
     <string name="total_apps">TOTAL: %1$d</string>
     <string name="others">Otros</string>
     <string name="clear_all_cache">Limpiar todos los cachés</string>
-    <string name="clear_cache_prompt">¿Qué aplicaciones te gustaría limpiar?</string>
     <string name="clear_all_cache_subtitle">Limpiar archivos en caché de todas las aplicaciones para recuperar espacio de almacenamiento</string>
-    <string name="clear_system_cache_title">¿Limpiar caché del sistema?</string>
-    <string name="clear_system_cache_desc">Limpiar el caché de las aplicaciones del sistema podría causar inestabilidad temporal. ¿Estás seguro de que quieres proceder?</string>
-    <string name="user_apps">Aplicaciones de usuario</string>
+    <string name="clear_all_cache_confirm_desc">Android decide qué cachés borrar y no deja elegir a Thor: se incluyen todas las aplicaciones del dispositivo, tanto las del sistema como las tuyas. No se toca nada más: tus datos, sesiones y ajustes se quedan como están. Puede que las aplicaciones tarden un poco más en abrirse la primera vez, mientras reconstruyen su caché.</string>
+    <string name="clear_all_cache_running">Limpiando…</string>
+    <string name="clear_all_cache_running_desc">Recorriendo todas las aplicaciones del dispositivo. Puede tardar un momento.</string>
+    <string name="clear_all_cache_done_title">Caché limpiada</string>
+    <string name="clear_all_cache_done_size">Se liberaron %1$s.</string>
+    <string name="clear_all_cache_done_unmeasured">Listo. Thor no pudo medir cuánto liberó: concédele acceso de uso en Ajustes para ver la cifra la próxima vez.</string>
     <string name="system_apps">Aplicaciones del sistema</string>
     <string name="active">Activo</string>
     <string name="frozen">Congelado</string>
@@ -276,6 +278,7 @@
     </plurals>
     <string name="killed_success">Se detuvo %1$s</string>
     <string name="cache_cleared_success">Caché de %1$s borrada</string>
+    <string name="cache_cleared_success_size">Se borraron %2$s de caché de %1$s</string>
     <string name="data_cleared_success">Datos de %1$s borrados</string>
     <string name="suspended_success">%1$s suspendido</string>
     <string name="unsuspended_success">%1$s reanudado</string>
@@ -372,8 +375,6 @@
     <!-- Terminal Logs -->
     <string name="log_initializing">Inicializando…</string>
     <string name="log_op_complete">\nOperación completada.</string>
-    <string name="log_preparing_cache">Preparando limpieza de caché…</string>
-    <string name="log_no_eligible_apps">No se encontraron aplicaciones elegibles.</string>
     <string name="log_sharing_app">Compartiendo %1$s</string>
     <string name="log_preparing_files">Preparando archivos…</string>
     <string name="log_files_ready">✔ Archivos listos</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -87,6 +87,7 @@
     <string name="clear_all_cache_done_title">Caché limpiada</string>
     <string name="clear_all_cache_done_size">Se liberaron %1$s.</string>
     <string name="clear_all_cache_done_nothing">No quedaba caché que borrar.</string>
+    <string name="clear_all_cache_done_size_unknown">Listo. Thor no pudo medir cuánto liberó.</string>
     <string name="clear_all_cache_done_unmeasured">Listo. Thor no pudo medir cuánto liberó: concédele acceso de uso en Ajustes para ver la cifra la próxima vez.</string>
     <string name="system_apps">Aplicaciones del sistema</string>
     <string name="active">Activo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,6 +86,7 @@
     <string name="clear_all_cache_running_desc">Recorriendo todas las aplicaciones del dispositivo. Puede tardar un momento.</string>
     <string name="clear_all_cache_done_title">Caché limpiada</string>
     <string name="clear_all_cache_done_size">Se liberaron %1$s.</string>
+    <string name="clear_all_cache_done_nothing">No quedaba caché que borrar.</string>
     <string name="clear_all_cache_done_unmeasured">Listo. Thor no pudo medir cuánto liberó: concédele acceso de uso en Ajustes para ver la cifra la próxima vez.</string>
     <string name="system_apps">Aplicaciones del sistema</string>
     <string name="active">Activo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -87,7 +87,8 @@
     <string name="clear_all_cache_done_title">Cache vidé</string>
     <string name="clear_all_cache_done_size">%1$s libérés.</string>
     <string name="clear_all_cache_done_nothing">Il ne restait aucun cache à vider.</string>
-    <string name="clear_all_cache_done_unmeasured">Terminé. Thor n\'a pas pu mesurer l\'espace libéré — accordez-lui l\'accès à l\'utilisation dans les Paramètres pour voir le chiffre la prochaine fois.</string>
+    <string name="clear_all_cache_done_size_unknown">Terminé. Thor n\'a pas pu mesurer l\'espace libéré.</string>
+    <string name="clear_all_cache_done_unmeasured">Terminé. Thor n\'a pas pu mesurer l\'espace libéré — accordez-lui l\'accès aux données d\'utilisation dans les Paramètres pour voir le chiffre la prochaine fois.</string>
     <string name="system_apps">Applis système</string>
     <string name="active">Actif</string>
     <string name="frozen">Gelé</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -80,11 +80,13 @@
     <string name="total_apps">TOTAL : %1$d</string>
     <string name="others">Autres</string>
     <string name="clear_all_cache">Vider tous les caches</string>
-    <string name="clear_cache_prompt">Quelles applications souhaitez-vous vider ?</string>
     <string name="clear_all_cache_subtitle">Vider les fichiers en cache de toutes les applications pour récupérer de l\'espace de stockage</string>
-    <string name="clear_system_cache_title">Vider le cache système ?</string>
-    <string name="clear_system_cache_desc">Vider le cache des applications système peut causer une instabilité temporaire. Êtes-vous sûr de vouloir continuer ?</string>
-    <string name="user_apps">Applis utilisateur</string>
+    <string name="clear_all_cache_confirm_desc">C\'est Android qui décide quels caches supprimer, et il ne laisse pas Thor choisir — toutes les applications de l\'appareil sont concernées, les applications système comme les vôtres. Rien d\'autre n\'est touché : vos données, connexions et réglages restent en place. Les applications peuvent s\'ouvrir un peu plus lentement la première fois, le temps de reconstituer leur cache.</string>
+    <string name="clear_all_cache_running">Nettoyage en cours…</string>
+    <string name="clear_all_cache_running_desc">Traitement de toutes les applications de l\'appareil. Cela peut prendre un moment.</string>
+    <string name="clear_all_cache_done_title">Cache vidé</string>
+    <string name="clear_all_cache_done_size">%1$s libérés.</string>
+    <string name="clear_all_cache_done_unmeasured">Terminé. Thor n\'a pas pu mesurer l\'espace libéré — accordez-lui l\'accès à l\'utilisation dans les Paramètres pour voir le chiffre la prochaine fois.</string>
     <string name="system_apps">Applis système</string>
     <string name="active">Actif</string>
     <string name="frozen">Gelé</string>
@@ -276,6 +278,7 @@
     </plurals>
     <string name="killed_success">%1$s arrêté</string>
     <string name="cache_cleared_success">Cache de %1$s vidé</string>
+    <string name="cache_cleared_success_size">%2$s de cache vidés pour %1$s</string>
     <string name="data_cleared_success">Données de %1$s effacées</string>
     <string name="suspended_success">%1$s suspendu</string>
     <string name="unsuspended_success">%1$s réactivé</string>
@@ -372,8 +375,6 @@
     <!-- Terminal Logs -->
     <string name="log_initializing">Initialisation…</string>
     <string name="log_op_complete">\nOpération terminée.</string>
-    <string name="log_preparing_cache">Préparation du nettoyage du cache…</string>
-    <string name="log_no_eligible_apps">Aucune application éligible trouvée.</string>
     <string name="log_sharing_app">Partage de %1$s</string>
     <string name="log_preparing_files">Préparation des fichiers…</string>
     <string name="log_files_ready">✔ Fichiers prêts</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -86,6 +86,7 @@
     <string name="clear_all_cache_running_desc">Traitement de toutes les applications de l\'appareil. Cela peut prendre un moment.</string>
     <string name="clear_all_cache_done_title">Cache vidé</string>
     <string name="clear_all_cache_done_size">%1$s libérés.</string>
+    <string name="clear_all_cache_done_nothing">Il ne restait aucun cache à vider.</string>
     <string name="clear_all_cache_done_unmeasured">Terminé. Thor n\'a pas pu mesurer l\'espace libéré — accordez-lui l\'accès à l\'utilisation dans les Paramètres pour voir le chiffre la prochaine fois.</string>
     <string name="system_apps">Applis système</string>
     <string name="active">Actif</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,11 +79,13 @@
     <string name="total_apps">总计: %1$d</string>
     <string name="others">其他</string>
     <string name="clear_all_cache">清除所有缓存</string>
-    <string name="clear_cache_prompt">您想清除哪些应用？</string>
     <string name="clear_all_cache_subtitle">清除所有应用的缓存文件以回收存储空间</string>
-    <string name="clear_system_cache_title">清除系统缓存？</string>
-    <string name="clear_system_cache_desc">清除系统应用的缓存可能会导致暂时不稳定。确定要继续吗？</string>
-    <string name="user_apps">用户应用</string>
+    <string name="clear_all_cache_confirm_desc">由 Android 决定清除哪些缓存，Thor 无法指定——设备上的所有应用都会被包含在内，系统应用和您的应用都一样。其他内容不受影响：您的数据、登录状态和设置都会保留。应用首次打开时可能会稍慢，因为它们要重建缓存。</string>
+    <string name="clear_all_cache_running">正在清除…</string>
+    <string name="clear_all_cache_running_desc">正在处理设备上的所有应用，可能需要一点时间。</string>
+    <string name="clear_all_cache_done_title">缓存已清除</string>
+    <string name="clear_all_cache_done_size">已释放 %1$s。</string>
+    <string name="clear_all_cache_done_unmeasured">已完成。Thor 无法测量释放了多少空间——请在系统设置中授予使用情况访问权限，下次即可看到数值。</string>
     <string name="system_apps">系统应用</string>
     <string name="privilege_check">权限检查</string>
     <string name="active">活跃</string>
@@ -269,6 +271,7 @@
     </plurals>
     <string name="killed_success">已强行停止 %1$s</string>
     <string name="cache_cleared_success">已清除 %1$s 的缓存</string>
+    <string name="cache_cleared_success_size">已清除 %1$s 的 %2$s 缓存</string>
     <string name="data_cleared_success">已清除 %1$s 的数据</string>
     <string name="suspended_success">已暂停 %1$s</string>
     <string name="unsuspended_success">已恢复 %1$s</string>
@@ -364,8 +367,6 @@
     <!-- Terminal Logs -->
     <string name="log_initializing">正在初始化…</string>
     <string name="log_op_complete">\n操作完成。</string>
-    <string name="log_preparing_cache">正在准备缓存清理…</string>
-    <string name="log_no_eligible_apps">未找到符合条件的应用。</string>
     <string name="log_sharing_app">正在分享 %1$s</string>
     <string name="log_preparing_files">正在准备文件…</string>
     <string name="log_files_ready">✔ 文件就绪</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -85,6 +85,7 @@
     <string name="clear_all_cache_running_desc">正在处理设备上的所有应用，可能需要一点时间。</string>
     <string name="clear_all_cache_done_title">缓存已清除</string>
     <string name="clear_all_cache_done_size">已释放 %1$s。</string>
+    <string name="clear_all_cache_done_nothing">没有可清除的缓存。</string>
     <string name="clear_all_cache_done_unmeasured">已完成。Thor 无法测量释放了多少空间——请在系统设置中授予使用情况访问权限，下次即可看到数值。</string>
     <string name="system_apps">系统应用</string>
     <string name="privilege_check">权限检查</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -80,12 +80,13 @@
     <string name="others">其他</string>
     <string name="clear_all_cache">清除所有缓存</string>
     <string name="clear_all_cache_subtitle">清除所有应用的缓存文件以回收存储空间</string>
-    <string name="clear_all_cache_confirm_desc">由 Android 决定清除哪些缓存，Thor 无法指定——设备上的所有应用都会被包含在内，系统应用和您的应用都一样。其他内容不受影响：您的数据、登录状态和设置都会保留。应用首次打开时可能会稍慢，因为它们要重建缓存。</string>
+    <string name="clear_all_cache_confirm_desc">由 Android 决定清除哪些缓存，Thor 无法指定——设备上的所有应用都会被包含在内，既包括您安装的应用，也包括系统应用。其他内容不受影响：您的数据、登录状态和设置都会保留。应用首次打开时可能会稍慢，因为它们要重建缓存。</string>
     <string name="clear_all_cache_running">正在清除…</string>
     <string name="clear_all_cache_running_desc">正在处理设备上的所有应用，可能需要一点时间。</string>
     <string name="clear_all_cache_done_title">缓存已清除</string>
     <string name="clear_all_cache_done_size">已释放 %1$s。</string>
     <string name="clear_all_cache_done_nothing">没有可清除的缓存。</string>
+    <string name="clear_all_cache_done_size_unknown">已完成。Thor 无法测量释放了多少空间。</string>
     <string name="clear_all_cache_done_unmeasured">已完成。Thor 无法测量释放了多少空间——请在系统设置中授予使用情况访问权限，下次即可看到数值。</string>
     <string name="system_apps">系统应用</string>
     <string name="privilege_check">权限检查</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,12 @@
          nothing left to drop. Deliberately not the _unmeasured line: that one asks for a permission
          this user demonstrably already granted. -->
     <string name="clear_all_cache_done_nothing">There was no cache left to clear.</string>
+    <!-- The measurement was available and still came back empty — an app refilled its cache while
+         the clear ran, or the storage service refused the reading. Says nothing about usage access:
+         this line is only ever shown to someone who already has it. -->
+    <string name="clear_all_cache_done_size_unknown">Done. Thor could not measure how much this freed.</string>
+    <!-- Shown only when the usage-access op is genuinely missing, which is what makes the advice
+         actionable. Any other unmeasured outcome uses clear_all_cache_done_size_unknown. -->
     <string name="clear_all_cache_done_unmeasured">Done. Thor could not measure how much this freed — grant it usage access in Settings to see the figure next time.</string>
     <string name="system_apps">System Apps</string>
     <string name="active">Active</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,10 @@
     <string name="clear_all_cache_running_desc">Working through every app on the device. This can take a moment.</string>
     <string name="clear_all_cache_done_title">Cache cleared</string>
     <string name="clear_all_cache_done_size">Freed %1$s.</string>
+    <!-- Shown when the measurement worked and the answer was genuinely zero — a second clear with
+         nothing left to drop. Deliberately not the _unmeasured line: that one asks for a permission
+         this user demonstrably already granted. -->
+    <string name="clear_all_cache_done_nothing">There was no cache left to clear.</string>
     <string name="clear_all_cache_done_unmeasured">Done. Thor could not measure how much this freed — grant it usage access in Settings to see the figure next time.</string>
     <string name="system_apps">System Apps</string>
     <string name="active">Active</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,11 +85,13 @@
     <string name="total_apps">TOTAL: %1$d</string>
     <string name="others">Others</string>
     <string name="clear_all_cache">Clear All Cache</string>
-    <string name="clear_cache_prompt">Which apps would you like to clear?</string>
     <string name="clear_all_cache_subtitle">Clear cached files of all apps to reclaim storage space</string>
-    <string name="clear_system_cache_title">Clear System Cache?</string>
-    <string name="clear_system_cache_desc">Clearing the cache of system apps might cause temporary instability. Are you sure you want to proceed?</string>
-    <string name="user_apps">User Apps</string>
+    <string name="clear_all_cache_confirm_desc">Android decides which caches to drop, and it does not let Thor choose — every app on the device is included, system apps as well as yours. Nothing else is touched: your data, logins and settings all stay put. Apps may open a little slower the first time while they rebuild.</string>
+    <string name="clear_all_cache_running">Clearing…</string>
+    <string name="clear_all_cache_running_desc">Working through every app on the device. This can take a moment.</string>
+    <string name="clear_all_cache_done_title">Cache cleared</string>
+    <string name="clear_all_cache_done_size">Freed %1$s.</string>
+    <string name="clear_all_cache_done_unmeasured">Done. Thor could not measure how much this freed — grant it usage access in Settings to see the figure next time.</string>
     <string name="system_apps">System Apps</string>
     <string name="active">Active</string>
     <string name="frozen">Frozen</string>
@@ -405,6 +407,9 @@
     <string name="removed_from_freezer_partial_failure" tools:ignore="PluralsCandidate">Removed %1$d/%2$d apps from Freezer (%3$d failed)</string>
     <string name="killed_success">Killed %1$s</string>
     <string name="cache_cleared_success">Cleared cache of %1$s</string>
+    <!-- %1$s is the app label, %2$s an already-formatted size ("12 MB"). Used when the freed bytes
+         could be measured; cache_cleared_success is the fallback when they could not. -->
+    <string name="cache_cleared_success_size">Cleared %2$s of cache from %1$s</string>
     <string name="data_cleared_success">Cleared data of %1$s</string>
     <string name="suspended_success">Suspended %1$s</string>
     <string name="unsuspended_success">Unsuspended %1$s</string>
@@ -530,8 +535,6 @@
     <!-- Terminal Logs -->
     <string name="log_initializing">Initializing…</string>
     <string name="log_op_complete">\nOperation Complete.</string>
-    <string name="log_preparing_cache">Preparing Cache Cleanup…</string>
-    <string name="log_no_eligible_apps">No eligible apps found.</string>
     <string name="log_sharing_app">Sharing %1$s</string>
     <string name="log_preparing_files">Preparing files…</string>
     <string name="log_files_ready">✔ Files Ready</string>

--- a/app/src/test/java/com/valhalla/thor/data/freezer/BulkFreezeWorkerTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/freezer/BulkFreezeWorkerTest.kt
@@ -146,7 +146,9 @@ private class RecordingSystemRepository(
     override suspend fun forceStopApp(packageName: String): Result<Unit> =
         unreachable("forceStopApp")
 
-    override suspend fun clearCache(packageName: String): Result<Unit> = unreachable("clearCache")
+    override suspend fun clearCache(packageName: String): Result<Long?> = unreachable("clearCache")
+
+    override suspend fun clearAllCaches(): Result<Long?> = unreachable("clearAllCaches")
 
     override suspend fun clearAppData(packageName: String): Result<Unit> =
         unreachable("clearAppData")

--- a/app/src/test/java/com/valhalla/thor/data/source/local/ObserverCallSitesTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/ObserverCallSitesTest.kt
@@ -58,22 +58,21 @@ class ObserverCallSitesTest {
     )
 
     /**
-     * The three rungs that now wait for a verdict.
+     * The two rungs that now wait for a verdict.
+     *
+     * There were three. `Shizuku.kt#clearCache` was deleted rather than kept honest: its
+     * `deleteApplicationCacheFiles` reflection needed `INTERNAL_DELETE_CACHE_FILES`, which is
+     * `protectionLevel="signature"` and therefore ungrantable to `com.android.shell`, so
+     * PackageManagerService logged "Calling uid 2000 does not have
+     * android.permission.INTERNAL_DELETE_CACHE_FILES, silently ignoring" and returned. The observer
+     * was wired up correctly and waited on a verdict that never came. Per-app cache clearing is
+     * root-only now; Shizuku gets `pm trim-caches`, which uses no observer at all.
      *
      * `RootSystemGateway` is not here and does not belong here: it mentions `IPackageDataObserver`
      * only in comments explaining why its cache clear goes through the shell instead. `DhizukuHelper`
      * is excluded deliberately, and the last test in this file is what keeps that exclusion honest.
      */
     private val verifiedSites = listOf(
-        ClearSite(
-            relativePath = "data/source/local/shizuku/Shizuku.kt",
-            functionName = "clearCache",
-            control = "clearCachePaths(",
-            frameworkMethods = listOf(
-                "deleteApplicationCacheFilesAsUser",
-                "deleteApplicationCacheFiles",
-            ),
-        ),
         ClearSite(
             relativePath = "data/source/local/shizuku/Shizuku.kt",
             functionName = "clearAppData",
@@ -160,7 +159,7 @@ class ObserverCallSitesTest {
             mainSourceRoot.isDirectory
         )
 
-        assertEquals("the site list has been edited without updating this guard", 3, verifiedSites.size)
+        assertEquals("the site list has been edited without updating this guard", 2, verifiedSites.size)
 
         verifiedSites.forEach { site ->
             val source = sourceOf(site.relativePath)
@@ -277,13 +276,17 @@ class ObserverCallSitesTest {
     /**
      * `DhizukuHelper` still passes `null`, still says why, and is still outside this sweep.
      *
-     * Its two reflection rungs were made honest rather than verified: on a Dhizuku-only device the
-     * call dies inside a `ShizukuBinderWrapper` before it ever reaches `PackageManagerService`, so a
-     * real observer would buy one guaranteed 15-second timeout per package — an always-red answer
-     * that teaches nobody anything — and both rungs now simply return `false`. That is a decision,
-     * not an oversight, and this test is what keeps the difference legible.
+     * Its reflection rung was made honest rather than verified: on a Dhizuku-only device the call
+     * dies inside a `ShizukuBinderWrapper` before it ever reaches `PackageManagerService`, so a real
+     * observer would buy one guaranteed 15-second timeout per package — an always-red answer that
+     * teaches nobody anything — and the rung now simply returns `false`. That is a decision, not an
+     * oversight, and this test is what keeps the difference legible.
      *
-     * It is deliberately two-sided. If the comment marking the rungs disappears, the reasoning has
+     * One rung, not two. The other was `clearCache`, deleted along with Shizuku's for the same
+     * reason: no privilege mode short of a platform signature can clear one package's cache through
+     * `PackageManagerService`, so there was nothing left for it to be honest about.
+     *
+     * It is deliberately two-sided. If the comment marking the rung disappears, the reasoning has
      * been lost and this fails. If [awaitDataObserver] ever appears in that file, the transport has
      * been fixed and Dhizuku belongs in [verifiedSites] — which is also a failure, and the right
      * one: the sweep should widen rather than quietly not cover the new code.
@@ -294,9 +297,9 @@ class ObserverCallSitesTest {
         val marker = "issued, and deliberately never believed"
 
         assertEquals(
-            "DhizukuHelper's reflection rungs no longer carry \"$marker\" — either they were " +
-                "rewired, in which case add them to verifiedSites, or the reasoning was deleted",
-            2,
+            "DhizukuHelper's reflection rung no longer carries \"$marker\" — either it was " +
+                "rewired, in which case add it to verifiedSites, or the reasoning was deleted",
+            1,
             dhizuku.split(marker).size - 1
         )
 

--- a/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
@@ -170,20 +170,47 @@ class PerUserCommandsTest {
     }
 
     /**
-     * And the other half of the claim: on a single-user device this changes nothing. These are the
-     * exact directories `/data/data/<pkg>/cache` and `/sdcard/Android/data/<pkg>/cache` resolve to
-     * when the shell belongs to user 0, so the commands issued on the overwhelmingly common device
-     * are byte-for-byte the ones issued before the fix.
+     * The list is the three branches of `InstalldNativeService::clearAppData` under
+     * `FLAG_CLEAR_CACHE_ONLY` — CE, DE, external — and this pins all three in order.
+     *
+     * The CE and external entries are also what `/data/data/<pkg>/cache` and
+     * `/sdcard/Android/data/<pkg>/cache` resolve to at user 0, which is the other half of the
+     * alias claim above: on a single-user device those two commands are byte-for-byte unchanged.
      */
     @Test
-    fun `at user 0 the paths are what the old aliases pointed at`() {
+    fun `the paths are installd's three cache-only branches, in order`() {
         assertEquals(
             listOf(
                 "/data/user/0/$pkg/cache",
+                "/data/user_de/0/$pkg/cache",
                 "/storage/emulated/0/Android/data/$pkg/cache",
             ),
             clearCachePaths(pkg, 0)
         )
+    }
+
+    /**
+     * The device-encrypted directory is the entry this list spent its whole life missing, so it
+     * gets an assertion that fails for a reason rather than only inside a list comparison. PMS
+     * creates a `user_de` package directory for every installed app, so this is not a direct-boot
+     * special case — omitting it left real cache behind while reporting the clear complete.
+     */
+    @Test
+    fun `the device-encrypted cache directory is covered`() {
+        assertTrue(
+            "no /data/user_de path — device-encrypted cache would survive the clear",
+            clearCachePaths(pkg, 10).any { it == "/data/user_de/10/$pkg/cache" }
+        )
+    }
+
+    /**
+     * `code_cache` is a different installd flag (`FLAG_CLEAR_CODE_CACHE_ONLY`) that Settings' Clear
+     * cache does not touch, and it holds compiled artifacts apps expect to persist. Freeing more
+     * bytes is not a reason to diverge from the platform, so this pins the omission as deliberate.
+     */
+    @Test
+    fun `code_cache is deliberately not cleared`() {
+        assertTrue(clearCachePaths(pkg, 0).none { it.contains("code_cache") })
     }
 
     /**

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
@@ -50,8 +50,10 @@ private class RecordingSystemRepository : SystemRepository {
     override suspend fun forceStopApp(packageName: String): Result<Unit> =
         error("off the freeze path")
 
-    override suspend fun clearCache(packageName: String): Result<Unit> =
+    override suspend fun clearCache(packageName: String): Result<Long?> =
         error("off the freeze path")
+
+    override suspend fun clearAllCaches(): Result<Long?> = error("off the freeze path")
 
     override suspend fun clearAppData(packageName: String): Result<Unit> =
         error("off the freeze path")

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -108,13 +108,24 @@ class FakeSystemRepository(private val trace: CallTrace? = null) : SystemReposit
         return failures[call]?.let { Result.failure(it) } ?: Result.success(Unit)
     }
 
+    /**
+     * What the two cache clears report as freed on success. `null` is the real "the clear worked and
+     * the measurement did not" answer, so that is the default: a test that wants a number says so.
+     */
+    var cacheFreedBytes: Long? = null
+
+    /** [record] for the two operations that return a byte count; [failWith] still applies. */
+    private fun recordBytes(call: String): Result<Long?> = record(call).map { cacheFreedBytes }
+
     override suspend fun isRootAvailable(): Boolean = true
     override suspend fun isShizukuAvailable(): Boolean = false
     override suspend fun isDhizukuAvailable(): Boolean = false
 
     override suspend fun forceStopApp(packageName: String) = record("forceStopApp:$packageName")
 
-    override suspend fun clearCache(packageName: String) = record("clearCache:$packageName")
+    override suspend fun clearCache(packageName: String) = recordBytes("clearCache:$packageName")
+
+    override suspend fun clearAllCaches() = recordBytes("clearAllCaches")
 
     override suspend fun clearAppData(packageName: String) = record("clearAppData:$packageName")
 
@@ -620,6 +631,24 @@ class FakeStorageStatsProvider(
         // Mirrors the real one: an unreadable package is *absent*, not zero.
         return sizes.filterKeys { it in packages }
     }
+
+    /**
+     * Successive answers from [cacheBytes] and [totalCacheBytes]. A cache measurement is taken twice
+     * around one clear, so a single value cannot express "18 MB before, 2 MB after" — the queue can.
+     * Empty means every reading is `null`, the real "no usage access" answer.
+     */
+    val cacheReadings = ArrayDeque<Long?>()
+
+    /** What [cacheTrimTargetBytes] answers; `null` is the unreadable case Root falls back from. */
+    var trimTarget: Long? = null
+
+    override suspend fun cacheBytes(packageName: String): Long? =
+        if (cacheReadings.isEmpty()) null else cacheReadings.removeFirst()
+
+    override suspend fun totalCacheBytes(): Long? =
+        if (cacheReadings.isEmpty()) null else cacheReadings.removeFirst()
+
+    override suspend fun cacheTrimTargetBytes(): Long? = trimTarget
 }
 
 /** Grant state is a plain flag a test can flip mid-run, matching how the app-op behaves. */

--- a/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
@@ -15,9 +15,14 @@ import org.junit.Test
 
 /**
  * The three privilege flags all derive from one nullable field on the Home state, so only five of
- * their eight combinations are reachable: root implies privilege, and so does a visible reinstall
- * card. The two GH#344 preferences are independent of all of that and of each other, so the
- * reachable set is those five crossed with all four preference pairs.
+ * their eight combinations are reachable: `canClearCache` implies privilege, and so does a visible
+ * reinstall card. The two GH#344 preferences are independent of all of that and of each other, so
+ * the reachable set is those five crossed with all four preference pairs.
+ *
+ * `canClearCache` used to be `isRoot`. It is Root **or** Shizuku now, because the tile runs
+ * `pm trim-caches`, gated on `CLEAR_APP_CACHE` — a permission `com.android.shell` holds. Only
+ * Dhizuku is excluded, so the implication that shapes this table is unchanged: every mode that can
+ * clear caches has a privilege, and one mode with a privilege cannot clear them.
  *
  * Each privilege state is asserted on its own below, then the preference rules, then the packing
  * and visibility invariants across every combination.
@@ -27,15 +32,16 @@ class HomeActionsTest {
     /** One state the Home screen can be in: the three derived flags plus the two preferences. */
     private data class State(
         val reinstall: Boolean,
-        val root: Boolean,
+        val canClearCache: Boolean,
         val privilege: Boolean,
         val showInstaller: Boolean,
         val showExtensions: Boolean,
     ) {
-        fun rows() = homeActionRows(reinstall, root, privilege, showInstaller, showExtensions)
+        fun rows() =
+            homeActionRows(reinstall, canClearCache, privilege, showInstaller, showExtensions)
 
-        override fun toString() = "reinstall=$reinstall root=$root privilege=$privilege " +
-            "installer=$showInstaller extensions=$showExtensions"
+        override fun toString() = "reinstall=$reinstall canClearCache=$canClearCache " +
+            "privilege=$privilege installer=$showInstaller extensions=$showExtensions"
     }
 
     /** The five reachable privilege states, crossed with every preference pair. */
@@ -46,10 +52,10 @@ class HomeActionsTest {
             Triple(true, false, true),
             Triple(false, true, true),
             Triple(true, true, true),
-        ).flatMap { (reinstall, root, privilege) ->
+        ).flatMap { (reinstall, canClearCache, privilege) ->
             listOf(true, false).flatMap { installer ->
                 listOf(true, false).map { extensions ->
-                    State(reinstall, root, privilege, installer, extensions)
+                    State(reinstall, canClearCache, privilege, installer, extensions)
                 }
             }
         }
@@ -59,42 +65,42 @@ class HomeActionsTest {
     @Test fun noPrivilege_onlyInstallFullWidth() {
         assertEquals(
             listOf(listOf(INSTALL)),
-            homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = false)
+            homeActionRows(reinstallVisible = false, canClearCache = false, hasPrivilege = false)
         )
     }
 
-    @Test fun shizukuOrDhizuku_noReinstall_isOnePair() {
+    @Test fun dhizukuOnly_noReinstall_isOnePair() {
         assertEquals(
             listOf(listOf(INSTALL, EXTENSIONS)),
-            homeActionRows(reinstallVisible = false, isRoot = false, hasPrivilege = true)
+            homeActionRows(reinstallVisible = false, canClearCache = false, hasPrivilege = true)
         )
     }
 
-    @Test fun shizukuOrDhizuku_withReinstall_leadsWide() {
+    @Test fun dhizukuOnly_withReinstall_leadsWide() {
         assertEquals(
             listOf(listOf(INSTALL), listOf(EXTENSIONS, REINSTALL)),
-            homeActionRows(reinstallVisible = true, isRoot = false, hasPrivilege = true)
+            homeActionRows(reinstallVisible = true, canClearCache = false, hasPrivilege = true)
         )
     }
 
-    @Test fun root_noReinstall_leadsWide() {
+    @Test fun rootOrShizuku_noReinstall_leadsWide() {
         assertEquals(
             listOf(listOf(INSTALL), listOf(CLEAR_CACHE, EXTENSIONS)),
-            homeActionRows(reinstallVisible = false, isRoot = true, hasPrivilege = true)
+            homeActionRows(reinstallVisible = false, canClearCache = true, hasPrivilege = true)
         )
     }
 
-    @Test fun root_withReinstall_isTwoByTwo() {
+    @Test fun rootOrShizuku_withReinstall_isTwoByTwo() {
         assertEquals(
             listOf(listOf(INSTALL, CLEAR_CACHE), listOf(EXTENSIONS, REINSTALL)),
-            homeActionRows(reinstallVisible = true, isRoot = true, hasPrivilege = true)
+            homeActionRows(reinstallVisible = true, canClearCache = true, hasPrivilege = true)
         )
     }
 
     /** Reinstall is last in the flow, so dismissing it re-packs only the tiles after it. */
     @Test fun dismissingReinstall_leavesTheOtherTilesInPlace() {
-        val withCard = homeActionRows(reinstallVisible = true, isRoot = true, hasPrivilege = true)
-        val without = homeActionRows(reinstallVisible = false, isRoot = true, hasPrivilege = true)
+        val withCard = homeActionRows(reinstallVisible = true, canClearCache = true, hasPrivilege = true)
+        val without = homeActionRows(reinstallVisible = false, canClearCache = true, hasPrivilege = true)
         assertEquals(listOf(INSTALL, CLEAR_CACHE, EXTENSIONS), without.flatten())
         assertEquals(listOf(INSTALL, CLEAR_CACHE, EXTENSIONS, REINSTALL), withCard.flatten())
     }
@@ -103,7 +109,7 @@ class HomeActionsTest {
         assertEquals(
             listOf(listOf(INSTALL), listOf(CLEAR_CACHE), listOf(EXTENSIONS), listOf(REINSTALL)),
             homeActionRows(
-                reinstallVisible = true, isRoot = true, hasPrivilege = true, narrowContainer = true
+                reinstallVisible = true, canClearCache = true, hasPrivilege = true, narrowContainer = true
             )
         )
     }
@@ -113,7 +119,7 @@ class HomeActionsTest {
     /** The 2x2 loses its leader and the survivors re-pack, rather than leaving a hole. */
     @Test fun hidingTheInstaller_dropsOnlyThatTile() {
         val rows = homeActionRows(
-            reinstallVisible = true, isRoot = true, hasPrivilege = true, showInstaller = false
+            reinstallVisible = true, canClearCache = true, hasPrivilege = true, showInstaller = false
         )
         assertTrue("Install must be gone", INSTALL !in rows.flatten())
         assertEquals(listOf(listOf(CLEAR_CACHE), listOf(EXTENSIONS, REINSTALL)), rows)
@@ -121,7 +127,7 @@ class HomeActionsTest {
 
     @Test fun hidingExtensions_dropsOnlyThatTile() {
         val rows = homeActionRows(
-            reinstallVisible = true, isRoot = true, hasPrivilege = true, showExtensions = false
+            reinstallVisible = true, canClearCache = true, hasPrivilege = true, showExtensions = false
         )
         assertTrue("Extensions must be gone", EXTENSIONS !in rows.flatten())
         assertEquals(listOf(listOf(INSTALL), listOf(CLEAR_CACHE, REINSTALL)), rows)
@@ -130,7 +136,7 @@ class HomeActionsTest {
     @Test fun hidingBoth_keepsThePrivilegedTiles() {
         val rows = homeActionRows(
             reinstallVisible = true,
-            isRoot = true,
+            canClearCache = true,
             hasPrivilege = true,
             showInstaller = false,
             showExtensions = false,
@@ -148,7 +154,7 @@ class HomeActionsTest {
             emptyList<List<HomeAction>>(),
             homeActionRows(
                 reinstallVisible = false,
-                isRoot = false,
+                canClearCache = false,
                 hasPrivilege = false,
                 showInstaller = false,
                 showExtensions = false,
@@ -159,7 +165,7 @@ class HomeActionsTest {
     /** The preference relaxes nothing: without a privilege there is no Extensions tile to keep. */
     @Test fun wantingExtensionsWithoutPrivilege_staysHidden() {
         val rows = homeActionRows(
-            reinstallVisible = false, isRoot = false, hasPrivilege = false, showExtensions = true
+            reinstallVisible = false, canClearCache = false, hasPrivilege = false, showExtensions = true
         )
         assertEquals(listOf(listOf(INSTALL)), rows)
     }
@@ -170,7 +176,7 @@ class HomeActionsTest {
             listOf(listOf(CLEAR_CACHE), listOf(REINSTALL)),
             homeActionRows(
                 reinstallVisible = true,
-                isRoot = true,
+                canClearCache = true,
                 hasPrivilege = true,
                 showInstaller = false,
                 showExtensions = false,
@@ -202,7 +208,7 @@ class HomeActionsTest {
         for (state in reachableStates) {
             val flat = state.rows().flatten()
             assertEquals("$state: Install visibility", state.showInstaller, INSTALL in flat)
-            assertEquals("$state: Clear cache visibility", state.root, CLEAR_CACHE in flat)
+            assertEquals("$state: Clear cache visibility", state.canClearCache, CLEAR_CACHE in flat)
             assertEquals(
                 "$state: Extensions visibility",
                 state.privilege && state.showExtensions,

--- a/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
@@ -563,71 +563,107 @@ class MainViewModelTest {
         assertEquals(1, effects.size)
     }
 
-    // --- Clear-all-cache safe list ----------------------------------------------------------
+    // --- Clear-all-cache ----------------------------------------------------------------------
+    //
+    // The old block here asserted a safe list — never Thor, never the Play Store — and a USER/SYSTEM
+    // split. Both are gone with the per-package loop they described: `pm trim-caches` hands victim
+    // selection to PackageManagerService, which evicts by LRU across the whole volume and takes no
+    // package argument. A test asserting Thor still spares the Play Store would be asserting a
+    // promise the platform never let Thor make.
 
     @Test
-    fun `clear all cache never clears Thor's own cache or the Play Store's`() = runTest {
-        appRepository.apps.value = listOf(
-            userApp(BuildConfig.APPLICATION_ID),
-            userApp(Installers.PLAY_STORE),
-            userApp("com.example.a")
-        )
+    fun `the tile asks before it clears anything`() = runTest {
         val vm = viewModel()
 
-        vm.clearAllCache(AppListType.USER)
+        vm.requestClearAllCaches()
         advanceUntilIdle()
 
-        // Clearing Thor's own cache mid-run pulls the rug out from under the run itself; clearing
-        // the Play Store's is a known way to break app updates.
-        assertEquals(listOf("clearCache:com.example.a"), system.calls)
-    }
-
-    @Test
-    fun `clear all cache excludes the running application id, suffix and all`() = runTest {
-        // The literal "com.valhalla.thor" is the *release* id. `applicationIdSuffix = ".debug"`
-        // means the debug build runs as `com.valhalla.thor.debug`, so a hardcoded self-exclusion
-        // stops excluding self on exactly the build where the mistake is easiest to make and
-        // hardest to notice. Both are in the list; only the one Thor is actually running as may be
-        // spared, and the other must be treated as an ordinary third-party app.
-        appRepository.apps.value = listOf(
-            userApp("com.valhalla.thor"),
-            userApp("com.valhalla.thor.debug")
-        )
-        val vm = viewModel()
-
-        vm.clearAllCache(AppListType.USER)
-        advanceUntilIdle()
-
-        val expected = listOf("com.valhalla.thor", "com.valhalla.thor.debug")
-            .filter { it != BuildConfig.APPLICATION_ID }
-            .map { "clearCache:$it" }
-        assertEquals(expected, system.calls)
-    }
-
-    @Test
-    fun `clear all cache with nothing eligible touches nothing`() = runTest {
-        appRepository.apps.value =
-            listOf(userApp(BuildConfig.APPLICATION_ID), userApp(Installers.PLAY_STORE))
-        val vm = viewModel()
-
-        vm.clearAllCache(AppListType.USER)
-        advanceUntilIdle()
-
-        // The empty selection must short-circuit rather than start an empty batch that never
-        // finishes and leaves the log dialog spinning.
+        // The tap must not reach the repository. Every app on the device, system apps included, is
+        // not something to start from a single tap on a home-screen tile.
+        assertEquals(CacheClearState.Confirming, vm.uiState.value.cacheClear)
         assertTrue(system.calls.isEmpty())
-        assertTrue(vm.uiState.value.loggerState.isComplete)
     }
 
     @Test
-    fun `clear all cache reads the list the tab is showing`() = runTest {
-        appRepository.apps.value = listOf(userApp("com.user.app"), systemApp("com.system.app"))
+    fun `confirming runs one whole-device clear, not a per-package walk`() = runTest {
+        appRepository.apps.value = listOf(userApp("com.a"), userApp("com.b"), systemApp("com.c"))
         val vm = viewModel()
 
-        vm.clearAllCache(AppListType.SYSTEM)
+        vm.requestClearAllCaches()
+        vm.confirmClearAllCaches()
         advanceUntilIdle()
 
-        assertEquals(listOf("clearCache:com.system.app"), system.calls)
+        // One call regardless of how many apps are installed — and `clearAllCaches`, not
+        // `clearCache`, which is the root-only per-app operation.
+        assertEquals(listOf("clearAllCaches"), system.calls)
+    }
+
+    @Test
+    fun `the result carries the bytes freed`() = runTest {
+        system.cacheFreedBytes = 18_874_368L
+        val vm = viewModel()
+
+        vm.requestClearAllCaches()
+        vm.confirmClearAllCaches()
+        advanceUntilIdle()
+
+        assertEquals(CacheClearState.Done(18_874_368L), vm.uiState.value.cacheClear)
+    }
+
+    @Test
+    fun `an unmeasured clear still reports Done, with a null count`() = runTest {
+        // The default. Without usage access `StorageStatsManager` answers nothing, and the clear
+        // itself still worked — reporting 0 there would read as "that freed nothing".
+        val vm = viewModel()
+
+        vm.requestClearAllCaches()
+        vm.confirmClearAllCaches()
+        advanceUntilIdle()
+
+        assertEquals(CacheClearState.Done(null), vm.uiState.value.cacheClear)
+    }
+
+    @Test
+    fun `a failed clear closes the sheet and says why`() = runTest {
+        system.failWith("clearAllCaches", IllegalStateException("no privileged gateway"))
+        val vm = viewModel()
+        val effects = effectsOf(vm)
+
+        vm.requestClearAllCaches()
+        vm.confirmClearAllCaches()
+        advanceUntilIdle()
+
+        // No Done(null): that is the "it worked, we could not measure it" answer, and showing it
+        // here would report a failure as a success with a missing number.
+        assertNull(vm.uiState.value.cacheClear)
+        assertEquals(1, effects.size)
+    }
+
+    @Test
+    fun `confirming twice does not start a second clear`() = runTest {
+        val vm = viewModel()
+
+        vm.requestClearAllCaches()
+        vm.confirmClearAllCaches()
+        vm.confirmClearAllCaches()
+        advanceUntilIdle()
+
+        // The sheet's Proceed button is gone while Running, but the state is public and the coroutine
+        // is not instantaneous; a double-tap landing in the same frame must not queue two trims.
+        assertEquals(listOf("clearAllCaches"), system.calls)
+    }
+
+    @Test
+    fun `dismissing the confirmation clears nothing and raises no prompt`() = runTest {
+        val vm = viewModel()
+
+        vm.requestClearAllCaches()
+        vm.dismissCacheClear()
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.cacheClear)
+        assertTrue(system.calls.isEmpty())
+        assertFalse(vm.uiState.value.showSupportDeveloperPrompt)
     }
 
     // --- The support prompt -----------------------------------------------------------------

--- a/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
@@ -23,6 +23,7 @@ import com.valhalla.thor.presentation.FakeContext
 import com.valhalla.thor.presentation.FakeFreezerRepository
 import com.valhalla.thor.presentation.FakePreferenceRepository
 import com.valhalla.thor.presentation.FakeSystemRepository
+import com.valhalla.thor.presentation.FakeUsageAccessGate
 import com.valhalla.thor.presentation.MainDispatcherRule
 import com.valhalla.thor.presentation.blockedSystemApp
 import com.valhalla.thor.presentation.systemApp
@@ -106,6 +107,10 @@ class MainViewModelTest {
     private fun TestScope.viewModel(
         preferenceRepository: FakePreferenceRepository = prefs,
         runner: BackupRunner = backupRunner(preferenceRepository),
+        // Granted by default because that is the case every other test in this file is indifferent
+        // to: with the op held, an unmeasured clear is described without mentioning permissions. The
+        // one test that cares about the ungranted branch passes false.
+        usageAccess: Boolean = true,
     ): MainViewModel {
         val vm = MainViewModel(
             manageAppUseCase = ManageAppUseCase(system),
@@ -118,6 +123,7 @@ class MainViewModelTest {
             preferenceRepository = preferenceRepository,
             freezerRepository = freezer,
             backupRunner = runner,
+            usageAccessGate = FakeUsageAccessGate(usageAccess),
             ioDispatcher = mainDispatcherRule.dispatcher
         )
         backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.uiState.collect {} }
@@ -607,20 +613,57 @@ class MainViewModelTest {
         vm.confirmClearAllCaches()
         advanceUntilIdle()
 
-        assertEquals(CacheClearState.Done(18_874_368L), vm.uiState.value.cacheClear)
+        assertEquals(
+            CacheClearState.Done(18_874_368L, hasUsageAccess = true),
+            vm.uiState.value.cacheClear
+        )
+    }
+
+    /**
+     * A byte count arrived, so the op is held by definition — the gate is not consulted and the flag
+     * does not go false behind a real measurement. Belt and braces: a `Done` carrying both a number
+     * and `hasUsageAccess = false` would render as "grant usage access" *and* have a figure to show.
+     */
+    @Test
+    fun `a measured clear does not ask the gate what it already knows`() = runTest {
+        system.cacheFreedBytes = 4_096L
+        val vm = viewModel(usageAccess = false)
+
+        vm.requestClearAllCaches()
+        vm.confirmClearAllCaches()
+        advanceUntilIdle()
+
+        assertEquals(CacheClearState.Done(4_096L, hasUsageAccess = true), vm.uiState.value.cacheClear)
     }
 
     @Test
     fun `an unmeasured clear still reports Done, with a null count`() = runTest {
-        // The default. Without usage access `StorageStatsManager` answers nothing, and the clear
-        // itself still worked — reporting 0 there would read as "that freed nothing".
+        // `cacheFreedBytes` defaults to null: the clear worked and the measurement did not. Reporting
+        // 0 there would read as "that freed nothing".
         val vm = viewModel()
 
         vm.requestClearAllCaches()
         vm.confirmClearAllCaches()
         advanceUntilIdle()
 
-        assertEquals(CacheClearState.Done(null), vm.uiState.value.cacheClear)
+        assertEquals(CacheClearState.Done(null, hasUsageAccess = true), vm.uiState.value.cacheClear)
+    }
+
+    /**
+     * The same empty result, and a different sentence on the sheet. With the op missing there is
+     * something the user can do about it; with the op held — an app refilling its cache mid-clear,
+     * say — telling them to grant what they already granted is the one piece of advice on screen and
+     * it is unfollowable.
+     */
+    @Test
+    fun `an unmeasured clear records whether usage access was the reason`() = runTest {
+        val vm = viewModel(usageAccess = false)
+
+        vm.requestClearAllCaches()
+        vm.confirmClearAllCaches()
+        advanceUntilIdle()
+
+        assertEquals(CacheClearState.Done(null, hasUsageAccess = false), vm.uiState.value.cacheClear)
     }
 
     @Test
@@ -636,7 +679,19 @@ class MainViewModelTest {
         // No Done(null): that is the "it worked, we could not measure it" answer, and showing it
         // here would report a failure as a success with a missing number.
         assertNull(vm.uiState.value.cacheClear)
-        assertEquals(1, effects.size)
+        // The whole effect, not just its arity: a success message is also one effect, and the point
+        // of this path is that the reason reaches the user rather than a silent sheet close.
+        assertEquals(
+            listOf(
+                MainSideEffect.Message(
+                    UiText.StringResource(
+                        R.string.error_format,
+                        UiText.DynamicString("no privileged gateway")
+                    )
+                )
+            ),
+            effects
+        )
     }
 
     @Test


### PR DESCRIPTION
## What this fixes

Clearing **one app's** cache calls `IPackageManager.deleteApplicationCacheFiles`, which
PackageManagerService gates on `android.permission.INTERNAL_DELETE_CACHE_FILES`. That permission is
`protectionLevel="signature"` — platform-signed callers only. `com.android.shell` does not request
it, and `pm grant` refuses it outright (`… is not a changeable permission type`), so a
Shizuku-delegated call reaches PMS as uid 2000 and is answered with:

```
Calling uid 2000 does not have android.permission.INTERNAL_DELETE_CACHE_FILES, silently ignoring
```

*Silently.* No exception, no failed `ShellResult` — Thor showed a success message and nothing had
happened. Dhizuku has no Device Owner cache API at all and was in the same position. Root works
because `ActivityManager.checkComponentPermission` short-circuits on `ROOT_UID` before the
permission is consulted.

So the per-app clear is now **root-only** — Shizuku and Dhizuku lose a button that never worked
rather than a capability.

The **Home tile is the opposite case and keeps Shizuku**: it runs `pm trim-caches`, which reaches
PMS via `freeStorage` and is gated on `CLEAR_APP_CACHE`, a permission shell *does* hold. But
`freeStorage` takes no package list — PMS evicts by LRU across the whole volume. "User apps" and
"system apps" were never choices Thor could honour, so the two dialogs offering them are gone.

## What's new

- **One confirmation sheet** before the tile clears anything, saying plainly that every app is
  included, **system apps as well**.
- **Freed bytes are measured and shown.** Per-app: `queryStatsForPackage` either side, reported as a
  toast. Whole-device: summed `queryStatsForUser`, shown in the result sheet.
- **The result sheet auto-dismisses after 3 s** unless dismissed first.
- **`getFreeBytes` as a target, not a measurement.** It returns usable space *plus* clearable cache,
  so a before/after delta cancels to noise — but it names exactly the point where all clearable
  cache has been reclaimed, which is what `pm trim-caches` wants as its argument. Never a round
  number: `freeStorage` is an escalating ladder and an unsatisfiable target walks past cache into
  `pruneUnusedStaticSharedLibraries` and instant-app eviction.
- **Null ≠ zero.** Both paths report `null` when usage access is missing, and the UI distinguishes
  "freed nothing" from "could not tell".

## Notes for review

- `ClearAllCacheSheet` is hosted by `MainScreen`, not `HomeScreen`: the clear outlives the screen
  that started it, so switching tabs mid-operation must not cancel it or lose the count.
- While running, the sheet vetoes its own settle to `Hidden` **and** swallows the dismiss request.
  The callback guard alone leaves an invisible sheet holding the result — `ModalBottomSheet`'s
  scrim/back path calls `onDismissRequest()` once `hide()` returns whether it animated or not.
- The double-confirm guard is deliberately **synchronous and outside** `viewModelScope.launch`. A
  guard inside the coroutine can observe `Done` (not `Running`) and start a second trim.
- `HomeActionsTest`'s five-reachable-state table is unchanged: `canClearCache` ⇒ `hasPrivilege`
  still holds, Dhizuku is now the one privileged mode that cannot clear.
- `ObserverCallSitesTest` lost the `Shizuku.kt#clearCache` site because the call site itself is gone.

## Verification

- `:app:compileFossDebugKotlin` — BUILD SUCCESSFUL
- `:app:testFossDebugUnitTest --rerun-tasks` — **847 tests, 0 failures, 0 errors, 0 skipped**
  (counted from `build/test-results/**/*.xml`)
- `:app:compileFossDebugAndroidTestKotlin` — compiles
- `:app:lintFossDebug` — BUILD SUCCESSFUL (six orphaned strings removed, seven added and translated
  across `fr`, `es`, `ar`, `zh-rCN`)

Not device-tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added whole-device cache clearing with confirmation, progress, and completion states.
  - Reports freed storage when measurements are available, including zero-byte results.
  - Added cache clearing for Root and Shizuku access.
  - Per-app cache clearing remains available with Root access.
- **Bug Fixes**
  - Removed unsupported cache-clearing actions from Dhizuku and unavailable access modes.
  - Expanded cleanup to include device-encrypted cache locations.
- **Localization**
  - Added translated messages for the updated cache-clearing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->