### PR TITLE
fix(export): stop .xapk export refusing every app whose game data it cannot read

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/repository/AppBundleBuilderImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppBundleBuilderImpl.kt
@@ -128,26 +128,26 @@ class AppBundleBuilderImpl(
                 // because the XAPK manifest has to carry this number.
                 val totalApkSize = apkFiles.sumOf { it.length() }
 
-                // Only .xapk carries expansions. The export sheet disables the .xapk chip on an
-                // Undetermined probe, so in practice this format is not even selectable then — but
-                // that gate is in the UI, and this is the only place that knows whether the bundle
-                // it is about to write is complete. Treating Undetermined as "no expansions" would
-                // make a lost privilege between rendering the chip and pressing Export produce a
-                // silently OBB-less .xapk, which is GH#164 reached from a new direction. So it
-                // fails instead, and the chip becomes defence in depth rather than the whole
-                // defence. (`autoFor` never returns XAPK, so no caller reaches this by default.)
+                // Only .xapk carries expansions, so only .xapk pays for the probe.
                 val probe = if (format == BundleFormat.XAPK) {
                     systemRepository.probeObb(appInfo.packageName)
                 } else {
                     ObbProbe.None
                 }
-                if (probe is ObbProbe.Undetermined) {
-                    throw IOException(
-                        "whether this app has game data could not be determined, so a .xapk " +
-                            "might be incomplete"
-                    )
-                }
-                val obbFiles = (probe as? ObbProbe.Present)?.files.orEmpty()
+                // An Undetermined probe used to throw here, and the export sheet disabled the .xapk
+                // chip to match: a verdict of "we could not tell" refused the whole format. That is
+                // fail-closed on *unknowability*, and it turned the ordinary case into an error —
+                // most apps have no expansion files at all, so most of the time the answer we could
+                // not read was "there is nothing to read". Per the owner we proceed instead: an
+                // .xapk built for an app that has no game data is a correct .xapk, and one built
+                // for an app that does is no worse than the .apk export the user would otherwise
+                // fall back to.
+                //
+                // The line this draws is between *unknown* and *known lost*, and only the second
+                // half of it moved. `requireStagedExpansions` below still throws, because Present
+                // means the probe measured real files and a copy that then fails is data we know we
+                // are dropping. That is GH#164, and it stays fatal.
+                val obbFiles = expansionsToPack(format, probe)
 
                 // Every failure below throws rather than returning a Result: this whole block is
                 // inside the try, so a `return@withContext Result.failure(...)` is an ordinary
@@ -179,10 +179,10 @@ class AppBundleBuilderImpl(
                                 "${Formatter.formatShortFileSize(context, shortfall)} more is needed"
                         )
                     }
-                    stageExpansions(appInfo.packageName, obbFiles, obbStagingDir)
-                        ?: throw IOException(
-                            "this app's game data could not be read, so the .xapk would be incomplete"
-                        )
+                    requireStagedExpansions(
+                        requested = obbFiles,
+                        staged = stageExpansions(appInfo.packageName, obbFiles, obbStagingDir)
+                    )
                 }
 
                 // Source path *and* staged name together: stagedApkNames renames a leaf collision,
@@ -578,6 +578,57 @@ internal fun obbCopyCommand(
     // the read just as effectively as a link at the leaf, and passes a test aimed at the leaf.
     return "[ ! -L '$sourceDir' ] && [ ! -L '$source' ] && " +
         "cp -f '$source' '$destPath' && chmod 644 '$destPath'"
+}
+
+/**
+ * Which expansion files this bundle should try to pack — the probe verdict turned into a list.
+ *
+ * Three inputs, one list, and the interesting arm is [ObbProbe.Undetermined] → empty. It reads like
+ * the mistake the tri-state exists to prevent, so it is worth being explicit about why it is not:
+ *
+ *  - [ObbProbe.Present] is the only verdict that names files, so it is the only one that can
+ *    produce a non-empty list.
+ *  - [ObbProbe.None] means the probe looked and found nothing.
+ *  - [ObbProbe.Undetermined] means the probe could not look. Packing nothing is the *only* thing
+ *    this function can do with that; what changed is that the export no longer refuses instead.
+ *
+ * The verdicts stay distinguishable — `Undetermined` is still not `None`, the sheet still says so,
+ * and `SystemRepositoryImpl.probeObb` logs the reason — they just no longer have distinct *blocking*
+ * consequences. The fatal case moved to [requireStagedExpansions], which fires when the probe did
+ * name files and the copy then failed: that is loss we can prove, and it is still an error.
+ *
+ * [format] is read rather than assumed. `.apks` has no expansion convention, and `zipSourcesFor`
+ * already drops expansions for it — this makes the same rule true one step earlier, so an `.apks`
+ * export never stages a byte it will not ship.
+ */
+internal fun expansionsToPack(format: BundleFormat, probe: ObbProbe): List<ObbFile> =
+    if (format != BundleFormat.XAPK) {
+        emptyList()
+    } else {
+        (probe as? ObbProbe.Present)?.files.orEmpty()
+    }
+
+/**
+ * The staged expansions, or a failed export — the one place where not having the game data is still
+ * fatal.
+ *
+ * [requested] is [expansionsToPack]'s output, so a non-empty list means the probe *measured* those
+ * files: it read their names and their sizes off the device. `stageExpansions` returning null after
+ * that is not "there was nothing there", it is "we could not copy what we saw", and writing the
+ * .xapk anyway hands the user an archive that installs a game which then cannot start. That is
+ * GH#164, and it is exactly the case an Undetermined probe is *not*.
+ *
+ * Empty [requested] short-circuits, so the caller does not have to prove it only calls this on the
+ * path where there was something to stage.
+ */
+internal fun requireStagedExpansions(
+    requested: List<ObbFile>,
+    staged: List<ZipSource>?
+): List<ZipSource> {
+    if (requested.isEmpty()) return emptyList()
+    return staged ?: throw IOException(
+        "this app's game data could not be read, so the .xapk would be incomplete"
+    )
 }
 
 /**

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -1111,6 +1111,16 @@ internal fun writeEntriesWithinBudget(
  * got their own bytes hashed and then confirmed. The guard covered the microseconds and missed the
  * span it was written for.
  *
+ * The whole script is wrapped in `( … )` so the abort ends the *subshell*. Today both callers hand
+ * this to `ShizukuHelper.execute` / `DhizukuHelper.execute`, which spawn a fresh `sh` per command,
+ * so a bare `exit` would only end a process that was about to end anyway. That is a property of the
+ * current callers, not of this function, and it is exactly the assumption that broke
+ * `obbProbeCommand`: routed through the root gateway instead, the same shape kills Odin's single
+ * long-lived `su` session mid-script — libsu never appends its end marker, the real exit code is
+ * lost, and the *next* unrelated privileged command fails too. A script that ends its own subshell
+ * is safe on every transport, so the transport stops being something a caller has to know.
+ * `RootSystemGateway.installViaSession` is the same wrap for the same reason.
+ *
  * @param digests staged absolute path to its expected lowercase SHA-256 hex.
  */
 internal fun integrityGuardedInstall(
@@ -1123,6 +1133,7 @@ internal fun integrityGuardedInstall(
     require(digests.isNotEmpty()) { "refusing to build an unguarded privileged install" }
 
     val sb = StringBuilder()
+    sb.append("(\n")
     for ((path, expected) in digests) {
         sb.append("H=$(sha256sum ").append(path.escapeForShell())
             .append(" 2>/dev/null | cut -d' ' -f1)\n")
@@ -1130,6 +1141,10 @@ internal fun integrityGuardedInstall(
             .append("echo 'staged APK failed its integrity check' 1>&2; ")
             .append("exit ").append(INTEGRITY_CHECK_EXIT_CODE).append("; fi\n")
     }
-    sb.append(installCommand)
+    sb.append(installCommand).append("\n")
+    // The subshell's status is the install's status, so the caller's `result.first == 0` still reads
+    // `pm`'s exit code and a failed hash still surfaces as INTEGRITY_CHECK_EXIT_CODE. Nothing may be
+    // appended after this line.
+    sb.append(")\n")
     return sb.toString()
 }

--- a/app/src/main/java/com/valhalla/thor/data/repository/ObbProbeParser.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/ObbProbeParser.kt
@@ -114,6 +114,9 @@ private val PACKAGE_NAME = Regex("[A-Za-z0-9_]+(\\.[A-Za-z0-9_]+)*")
  *    directory is tested the same way before the loop starts: a `-L` test only ever examines a path's
  *    **final component**, so guarding the leaves does nothing about a link one level up.
  *  - **[SENTINEL_END] is printed last** so a truncated reply is detectable.
+ *  - **The whole script runs inside a subshell**, so the six `exit 0`s below end the *subshell*
+ *    rather than the shell that is running it. See the comment at the `(` for why that is not a
+ *    style choice.
  *
  * [externalStorageDir] comes from `Environment.getExternalStorageDirectory().absolutePath` rather
  * than a hardcoded `/storage/emulated/0` — but Thor runs against a single `thorUserId` (see
@@ -129,6 +132,21 @@ internal fun obbProbeCommand(externalStorageDir: String, packageName: String): S
     val parent = "$externalStorageDir/Android/obb"
     val dir = "$parent/$packageName"
     return buildString {
+        // Run the whole thing in a subshell so our `exit` codes exit the SUBSHELL, not the shell
+        // that is running the script. Under root that shell is Odin's single long-lived `su`
+        // session — every privileged command in the app goes through it — so a top-level `exit`
+        // kills it before libsu appends its end-marker, leaving it unable to read the real exit
+        // code (it falls back to 1) and breaking the *next* root command too.
+        //
+        // That failure is invisible from here and reads as a bug somewhere else entirely:
+        // `parseObbProbe` refuses a non-zero exit before it ever looks at the sentinel, so the
+        // commonest verdict of all — [SENTINEL_NODIR], "this app has no game data" — came back as
+        // `Undetermined("the privileged shell exited with code 1")`. The one branch below with no
+        // `exit` is the successful listing, which is why apps that *did* have an OBB worked and the
+        // ~70% that do not failed. Under Shizuku/Dhizuku the script gets a fresh `sh` per command
+        // and the wrap costs nothing; `RootSystemGateway.installViaSession` is the same wrap for
+        // the same reason and is the pattern to copy.
+        append("(\n")
         append("ls -1 '").append(parent).append("' >/dev/null 2>&1 || { echo ")
         append(SENTINEL_NOPRIV).append("; exit 0; }\n")
         // The directory itself, before the leaves: `for f in '<dir>'/*` expands *through* a
@@ -168,6 +186,10 @@ internal fun obbProbeCommand(externalStorageDir: String, packageName: String): S
         append("done\n")
         append("echo \"THOR_OTHER \$n\"\n")
         append("echo ").append(SENTINEL_END).append("\n")
+        // Closes the subshell opened at the top. Nothing may be appended after this line: an `exit`
+        // outside the parentheses is the defect this wrap exists to prevent, and
+        // `ObbProbeParserTest` asserts the script ends here for exactly that reason.
+        append(")\n")
     }
 }
 
@@ -179,9 +201,16 @@ internal fun isUsablePackageName(value: String): Boolean = PACKAGE_NAME.matches(
  *
  * The order of the checks is the contract, in two parts.
  *
- * All four early sentinels are tested before `THOR_END`, because each of their branches `exit 0`
- * without ever reaching the `echo THOR_END` at the bottom of the script. Only the listing path prints
- * the sentinel, so only the listing path may require it.
+ * All **five** early sentinels — [SENTINEL_NOPRIV], [SENTINEL_BADNAME], [SENTINEL_STATFAIL],
+ * [SENTINEL_SYMLINK], [SENTINEL_NODIR] — are tested before `THOR_END`, because each of their
+ * branches `exit 0` without ever reaching the `echo THOR_END` at the bottom of the script. (Six
+ * `exit 0`s, five sentinels: [SENTINEL_SYMLINK] has a branch for the package directory and another
+ * for a leaf.) Only the listing path prints the sentinel, so only the listing path may require it.
+ *
+ * Those `exit`s are *early returns from a subshell*, which is the only shape that is safe here —
+ * see the `(` in [obbProbeCommand]. Bare, they ended the caller's shell instead, and under root
+ * that shell is shared with the rest of the app. This KDoc used to describe them as bare and
+ * intentional, and miscounted them; both are fixed rather than merely reworded.
  *
  * `THOR_NODIR` is then the one sentinel that is not believed on sight, because it is the only one
  * whose verdict is [ObbProbe.None] — every other reading of a corrupt reply fails closed, so only

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.StorageStatsProvider
 import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -311,10 +312,27 @@ class SystemRepositoryImpl(
                 }
             )
 
-        return executeShellCommand(command).fold(
+        val verdict = executeShellCommand(command).fold(
             onSuccess = { (exitCode, output) -> parseObbProbe(exitCode, output) },
             onFailure = { ObbProbe.Undetermined(it.message ?: "no privileged shell is available") }
         )
+        // The verdict is the only thing a user or a bug report can see about this, and until now it
+        // reached them as a UI state with the reason thrown away — "Thor can't read this app's game
+        // data" for a shell failure, a truncated reply and a genuinely unreadable directory alike.
+        // One line at the single exit, on the reason string the sealed type already carries, is what
+        // makes an Undetermined on a device answerable rather than guessable. Logged for every
+        // verdict, not just the bad one: "we probed and got None" and "we never probed" are the two
+        // states a silent log cannot tell apart.
+        Logger.d(
+            "SystemRepo",
+            "obb probe for $packageName: " + when (verdict) {
+                is ObbProbe.None -> "None"
+                is ObbProbe.Present ->
+                    "Present(${verdict.files.size} obb, ${verdict.otherEntryCount} other)"
+                is ObbProbe.Undetermined -> "Undetermined(${verdict.reason})"
+            }
+        )
+        return verdict
     }
 
     private companion object {

--- a/app/src/main/java/com/valhalla/thor/data/util/ApksMetadataGenerator.kt
+++ b/app/src/main/java/com/valhalla/thor/data/util/ApksMetadataGenerator.kt
@@ -98,13 +98,28 @@ class ApksMetadataGenerator {
         @SerialName("icon") val icon: String? = null,
         @SerialName("split_apks") val splitApks: List<XapkSplitApk> = emptyList(),
         /**
-         * Null, never an empty list.
+         * An empty list, never null — so an OBB-less `.xapk` carries `"expansions":[]`.
          *
-         * `xapkJson` sets `encodeDefaults = true`, so a defaulted `emptyList()` would write
-         * `"expansions":[]` into every OBB-less `.xapk`. `explicitNulls = false` drops a null
-         * instead, leaving bundles for apps without expansion files byte-for-byte as they were.
+         * This was the other way round, on the reasoning that leaving the key out kept those
+         * bundles byte-identical to what shipped before the feature existed. The reasoning was
+         * sound and the conclusion was still the riskier of the two, because it optimised for
+         * Thor's diff rather than for the readers:
+         *
+         *  - `[]` is the only encoding that survives a null check, a truthiness check and a type
+         *    check simultaneously, which is the union of what the reference `.xapk` installers
+         *    actually do. APK Extractor emits it; **nothing** emits `null`.
+         *  - `expansions` is optional in every parser read for this, so an absent key is *also*
+         *    accepted — but "accepted by the five we read" is a weaker claim than "the shape the
+         *    ecosystem already produces".
+         *  - Thor's own reader (`BundleAnalysis`) declares it non-null with an `emptyList()`
+         *    default, so `[]` parses there with no change.
+         *
+         * `xapkJson` sets `encodeDefaults = true`, which is what makes the default *emit* rather
+         * than vanish; see the comment on `xapkJson` for why that config is not negotiable. The
+         * `.apks` manifest goes through the plain `Json` (`encodeDefaults = false`), so its bytes
+         * are unchanged — a value equal to its declared default is still dropped there.
          */
-        @SerialName("expansions") val expansions: List<XapkExpansion>? = null
+        @SerialName("expansions") val expansions: List<XapkExpansion> = emptyList()
     )
 
     fun generateJson(appInfo: AppInfo) = Json.encodeToString(
@@ -143,8 +158,8 @@ class ApksMetadataGenerator {
      * [iconName] must name an entry the builder actually writes at the zip root; pass null when it
      * wrote none, so the field is left out rather than pointing a reader at a missing entry.
      * [staged] is the same contract for the APKs — see [xapkManifest].
-     * [expansions] is what the builder actually packed into `Android/obb/<pkg>/`; an empty list
-     * leaves the key out of the JSON altogether rather than writing `"expansions":[]`.
+     * [expansions] is what the builder actually packed into `Android/obb/<pkg>/`; an empty list is
+     * written as `"expansions":[]` rather than omitted — see [XapkManifest.expansions].
      */
     fun generateManifestJson(
         appInfo: AppInfo,
@@ -199,9 +214,9 @@ class ApksMetadataGenerator {
             versionCode = appInfo.versionCode.toString(),
             versionName = appInfo.versionName ?: "",
             splitApks = splitApks,
-            // takeIf, not the list itself: see XapkManifest.expansions. An empty list here would
-            // be encoded as `"expansions":[]` by xapkJson's encodeDefaults.
-            expansions = expansions.takeIf { it.isNotEmpty() }
+            // The list itself, empty or not. There used to be a `takeIf { it.isNotEmpty() }` here
+            // to null it out; see XapkManifest.expansions for why `[]` is the better wire shape.
+            expansions = expansions
         )
     }
 

--- a/app/src/main/java/com/valhalla/thor/domain/model/ObbProbe.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ObbProbe.kt
@@ -36,7 +36,17 @@ sealed interface ObbProbe {
      * The active privilege could not read `Android/obb` at all — the Dhizuku device-owner process,
      * a gateway failure, a truncated reply.
      *
-     * **Never treat this as [None].** It is the whole reason this type is a tri-state.
+     * **Never treat this as [None].** It is the whole reason this type is a tri-state: [None] is a
+     * measurement and this is the absence of one, they carry different [reason]s, and the export
+     * sheet and the log say different things about them.
+     *
+     * What they no longer carry is different *blocking* consequences. Export used to refuse `.xapk`
+     * outright on this verdict, which made the commonest situation on the device — an app with no
+     * expansion files, probed through a shell that could not answer — an error. Per the owner it now
+     * packs nothing and proceeds, and the export is fatal only where loss is *provable*: see
+     * `requireStagedExpansions`, which fires when [Present] named files and the copy then failed.
+     * Reading this as "so it is basically [None]" is the fold this type exists to prevent; the two
+     * agree on one narrow question (how many expansions to pack) and on nothing else.
      */
     data class Undetermined(val reason: String) : ObbProbe
 }

--- a/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
@@ -49,7 +49,27 @@ interface SystemRepository {
     suspend fun grantPermission(packageName: String, permissionName: String): Result<Unit>
     suspend fun revokePermission(packageName: String, permissionName: String): Result<Unit>
 
-    // Raw shell execution via the active privilege gateway (used by extensions).
+    /**
+     * Raw shell execution via the active privilege gateway (used by extensions).
+     *
+     * **A multi-line [command] that can `exit` must wrap itself in `( … )`.** This is the seam every
+     * command builder in the app crosses, and it is the one place the rule can be stated once.
+     *
+     * The transports are not alike and the difference is invisible from the call site. Shizuku and
+     * Dhizuku spawn a fresh `sh` per command, so a top-level `exit` only ends a process that was
+     * about to end anyway. Root does not: `RootSystemGateway` writes into Odin's single long-lived
+     * `su` session, which every privileged command in the app shares. A top-level `exit` there kills
+     * that session mid-script — libsu never appends its end marker, so it cannot read the real exit
+     * code and falls back to 1, and the *next*, unrelated privileged command fails with "Root shell
+     * unavailable".
+     *
+     * Both halves of that are silent. The caller sees a plausible non-zero exit code, and the damage
+     * lands on whatever runs next. `ObbProbeParser.obbProbeCommand` shipped with six bare `exit 0`s
+     * and presented as "OBB detection is broken for most apps"; the fix was one pair of parentheses.
+     * `RootSystemGateway.installViaSession` and `integrityGuardedInstall` are the wrap to copy.
+     *
+     * @return the exit code and combined output, or a failure when no privileged shell is available.
+     */
     suspend fun executeShellCommand(command: String): Result<Pair<Int, String?>>
 
     /**

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -112,16 +112,12 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
         obbProbe = systemRepository.probeObb(appInfo.packageName)
     }
 
-    // Keyed on `format` as well as on the verdict, so the invariant "XAPK is never the selection
-    // once the probe says Undetermined" holds whichever of the two moved last. Keyed on the verdict
-    // alone it would depend on the chip's `enabled` being the only way `format` can change — a
-    // guarantee that lives in a sibling composable and would break silently if that changed.
-    // Terminates because formatOptions.first() is autoFor(), which is only ever APK or APKS.
-    LaunchedEffect(obbProbe, format) {
-        if (obbProbe is ObbProbe.Undetermined && format == BundleFormat.XAPK) {
-            format = formatOptions.first()
-        }
-    }
+    // There used to be a LaunchedEffect here that forced the selection off XAPK whenever the probe
+    // came back Undetermined. It went with the chip's `enabled` gate below and with the matching
+    // throw in AppBundleBuilderImpl: together they made "Thor could not read Android/obb" refuse the
+    // format outright. Most apps have no expansion files, so the verdict we could not read was
+    // usually "there is nothing to read", and the refusal fired on the ordinary case. Per the owner
+    // the export proceeds and says what it did; see `shouldWarnUnreadableObb`.
 
     val runExport = {
         exporting = true
@@ -256,18 +252,16 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
             )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 formatOptions.forEach { option ->
-                    // `is Undetermined` is false while obbProbe is still null, so the chip stays
-                    // enabled for the length of the probe rather than flickering disabled and back.
-                    // A selection made in that window is re-checked by the builder, which fails the
-                    // export rather than writing an incomplete bundle.
-                    val xapkBlocked = option == BundleFormat.XAPK && obbProbe is ObbProbe.Undetermined
                     FilterChip(
                         selected = option == format,
                         onClick = { format = option },
-                        // Disabled, not hidden. Under the "only offer .xapk when the OBB is
-                        // capturable" policy a vanishing chip would leave the user with no way to
-                        // learn why the format they came for is missing.
-                        enabled = !exporting && !xapkBlocked,
+                        // Only the export in flight disables a chip now. The probe verdict no longer
+                        // does: a disabled .xapk chip was how "we could not read Android/obb" reached
+                        // the user, and it read as "this app cannot be exported as .xapk" when the
+                        // truth was usually that there was nothing to pack. The verdict is still
+                        // shown — as a note under the row, which the user can act on — rather than
+                        // enforced as a refusal.
+                        enabled = !exporting,
                         // A file extension, not copy — the same token in every locale, so it is
                         // built from BundleFormat rather than from a translated string.
                         label = { Text(".${option.extension}") },
@@ -277,17 +271,6 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
                         )
                     )
                 }
-            }
-
-            // Sits under the chip row, not under the explain text, because it explains why a
-            // chip the user can see cannot be pressed.
-            if (obbProbe is ObbProbe.Undetermined) {
-                Text(
-                    text = stringResource(R.string.export_xapk_unavailable),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp)
-                )
             }
 
             // Plain-language explanation of the selected format, plus what the .xapk will actually
@@ -305,29 +288,37 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
-            val present = obbProbe as? ObbProbe.Present
-            if (format == BundleFormat.XAPK && present != null) {
-                val totalObbBytes = present.files.sumOf { it.sizeBytes }
-                if (totalObbBytes > 0) {
-                    Text(
-                        text = stringResource(
-                            R.string.export_obb_included,
-                            Formatter.formatShortFileSize(context, totalObbBytes)
-                        ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                if (present.otherEntryCount > 0) {
-                    // Not a refusal. The format cannot carry anything but .obb files, so a bundle
-                    // without those extras is complete by the format's own definition — the user is
-                    // told, and decides.
-                    Text(
-                        text = stringResource(R.string.export_obb_partial),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+            // The three OBB notes, in the order the user needs them: how much is going in, what is
+            // being left out, and — the case this fix is about — that we could not tell either way.
+            // All three are notes and none of them blocks the Export button.
+            val obbBytesToShow = obbSizeBytesToShow(format, obbProbe)
+            if (obbBytesToShow > 0) {
+                Text(
+                    text = stringResource(
+                        R.string.export_obb_included,
+                        Formatter.formatShortFileSize(context, obbBytesToShow)
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (shouldNotePartialObb(format, obbProbe)) {
+                // Not a refusal. The format cannot carry anything but .obb files, so a bundle
+                // without those extras is complete by the format's own definition — the user is
+                // told, and decides.
+                Text(
+                    text = stringResource(R.string.export_obb_partial),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (shouldWarnUnreadableObb(format, obbProbe)) {
+                Text(
+                    text = stringResource(R.string.export_xapk_no_game_data),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
             }
 
             // Destination
@@ -426,3 +417,47 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
         }
     }
 }
+
+/**
+ * How many bytes of game data the sheet should tell the user are going in, or 0 for "say nothing".
+ *
+ * Hoisted out of the composable so the three OBB notes are decidable without a device. Each takes
+ * the probe as `ObbProbe?` because **null is a fourth state at this layer and only at this layer**:
+ * the probe is in flight. It is not [ObbProbe.Undetermined] — that is an answer — and a sheet that
+ * treated it as one would flash a "could not read" note for the length of every probe.
+ *
+ * [format] is read rather than assumed, because the chips are live: the user can select `.apk`
+ * after the probe has already answered `Present`, and a size line still on screen would be
+ * describing bytes that container does not carry.
+ */
+internal fun obbSizeBytesToShow(format: BundleFormat, probe: ObbProbe?): Long {
+    if (format != BundleFormat.XAPK) return 0L
+    val present = probe as? ObbProbe.Present ?: return 0L
+    return present.files.sumOf { it.sizeBytes }
+}
+
+/**
+ * Whether to note that the app's `Android/obb` holds entries the `.xapk` format cannot carry.
+ *
+ * Distinct from [obbSizeBytesToShow] being 0: a directory can hold nothing but subdirectories, in
+ * which case there are no bytes to announce and there is still something being left behind. That is
+ * [ObbProbe.Present] with an empty `files` and a non-zero `otherEntryCount`, and it is the reason
+ * these are two functions rather than one.
+ */
+internal fun shouldNotePartialObb(format: BundleFormat, probe: ObbProbe?): Boolean =
+    format == BundleFormat.XAPK && (probe as? ObbProbe.Present)?.otherEntryCount?.let { it > 0 } == true
+
+/**
+ * Whether to note that Thor could not read the app's game data at all.
+ *
+ * This is what is left of the old refusal. `Undetermined` used to disable the `.xapk` chip, force
+ * the selection away from it, and throw in the builder; now it prints one line and the user decides.
+ * The verdict is still not [ObbProbe.None] — that prints nothing, because nothing is what there is
+ * to say — which is the distinction `ObbProbe` exists to keep.
+ *
+ * Gated on [format] because the note is about what a `.xapk` will contain. An `.apk`/`.apks` export
+ * never carries expansions, so telling the user we could not read them would be answering a question
+ * they did not ask.
+ */
+internal fun shouldWarnUnreadableObb(format: BundleFormat, probe: ObbProbe?): Boolean =
+    format == BundleFormat.XAPK && probe is ObbProbe.Undetermined

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -536,7 +536,7 @@
     <string name="export_explain_apk">يقوم Thor بحفظ هذا التطبيق كملف تثبيت فردي (.apk) في المجلد أدناه. استخدمه لنسخ التطبيق احتياطيًا أو إعادة تثبيته لاحقًا.</string>
     <string name="export_explain_apks">يأتي هذا التطبيق في أجزاء متعددة ومقسمة، تُحزم في حزمة واحدة (.apks) في المجلد أدناه. يمكنك إعادة تثبيتها في أي وقت باستخدام مثبت Thor.</string>
     <string name="export_explain_xapk">يحزم Thor أجزاء هذا التطبيق في ملف ‎.xapk واحد داخل المجلد أدناه، وهي صيغة تفهمها برامج التثبيت الأخرى أيضًا. تُضمَّن بيانات اللعبة (ملفات OBB) عندما يستطيع وضع الوصول الحالي قراءتها.</string>
-    <string name="export_xapk_unavailable">لا يستطيع Thor قراءة بيانات اللعبة لهذا التطبيق حاليًا — وغالبًا يعني ذلك أنه يحتاج إلى الروت أو Shizuku. وملف ‎.xapk بدونها سيثبّت لعبة لا تعمل.</string>
+    <string name="export_xapk_no_game_data">لا يستطيع Thor قراءة بيانات اللعبة لهذا التطبيق حاليًا — وغالبًا يعني ذلك أنه يحتاج إلى الروت أو Shizuku. وسيُنشأ ملف ‎.xapk على أي حال، بدونها.</string>
     <string name="export_obb_included">يتضمن %1$s من بيانات اللعبة.</string>
     <string name="export_obb_partial">بعض العناصر في مجلد بيانات هذا التطبيق ليست ملفات توسعة ولن تُضمَّن.</string>
     <string name="export_format">الصيغة</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -502,7 +502,7 @@
     <string name="export_explain_apk">Thor guarda esta aplicación como un único archivo de instalación (.apk) en la carpeta de abajo. Úsala para hacer una copia de seguridad o reinstalarla más tarde.</string>
     <string name="export_explain_apks">Esta aplicación consta de varias partes divididas, que se agrupan en un único paquete (.apks) en la carpeta de abajo. Reinstálala en cualquier momento con el instalador de Thor.</string>
     <string name="export_explain_xapk">Thor empaqueta las partes de esta app en un único .xapk en la carpeta de abajo, un formato que otros instaladores también entienden. Los datos del juego (archivos OBB) se incluyen cuando el modo de acceso actual de Thor puede leerlos.</string>
-    <string name="export_xapk_unavailable">Thor no puede leer los datos del juego de esta app ahora mismo; normalmente eso significa que hace falta root o Shizuku. Un .xapk sin ellos instalaría un juego que no funciona.</string>
+    <string name="export_xapk_no_game_data">Thor no puede leer los datos del juego de esta app ahora mismo; normalmente eso significa que hace falta root o Shizuku. El .xapk se creará igualmente, sin ellos.</string>
     <string name="export_obb_included">Incluye %1$s de datos del juego.</string>
     <string name="export_obb_partial">Algunos elementos de la carpeta de datos de esta app no son archivos de expansión y no se incluirán.</string>
     <string name="export_format">Formato</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -502,7 +502,7 @@
     <string name="export_explain_apk">Thor enregistre cette application sous forme d\'un fichier d\'installation unique (.apk) dans le dossier ci-dessous. Utilisez-le pour sauvegarder l\'application ou la réinstaller plus tard.</string>
     <string name="export_explain_apks">Cette application est composée de plusieurs parties distinctes, regroupées dans un seul paquet (.apks) dans le dossier ci-dessous. Réinstallez-la à tout moment avec l\'installateur de Thor.</string>
     <string name="export_explain_xapk">Thor regroupe les parties de cette app dans un seul .xapk dans le dossier ci-dessous, un format que d\'autres installeurs comprennent aussi. Les données de jeu (fichiers OBB) sont incluses lorsque le mode d\'accès actuel de Thor peut les lire.</string>
-    <string name="export_xapk_unavailable">Thor ne peut pas lire les données de jeu de cette app pour l\'instant — le plus souvent, cela signifie qu\'il faut root ou Shizuku. Un .xapk sans elles installerait un jeu qui ne fonctionne pas.</string>
+    <string name="export_xapk_no_game_data">Thor ne peut pas lire les données de jeu de cette app pour l\'instant — le plus souvent, cela signifie qu\'il faut root ou Shizuku. Le .xapk sera quand même créé, sans elles.</string>
     <string name="export_obb_included">Inclut %1$s de données de jeu.</string>
     <string name="export_obb_partial">Certains éléments du dossier de données de cette app ne sont pas des fichiers d\'extension et ne seront pas inclus.</string>
     <string name="export_format">Format</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -494,7 +494,7 @@
     <string name="export_explain_apk">Thor 将此应用保存为单个安装文件 (.apk) 到下方文件夹中。您可以使用它备份应用或在以后重新安装。</string>
     <string name="export_explain_apks">此应用包含多个拆分部分，它们会被打包为一个捆绑包 (.apks) 并保存到下方文件夹中。可随时使用 Thor 安装程序重新安装。</string>
     <string name="export_explain_xapk">Thor 会把此应用的各个部分打包成下方文件夹中的单个 .xapk，其他安装器也能识别这种格式。当 Thor 当前的访问方式可以读取时，游戏数据（OBB 文件）会一并打包。</string>
-    <string name="export_xapk_unavailable">Thor 暂时无法读取该应用的游戏数据——通常这说明需要 Root 或 Shizuku。缺少游戏数据的 .xapk 装上后游戏也无法运行。</string>
+    <string name="export_xapk_no_game_data">Thor 暂时无法读取该应用的游戏数据——通常这说明需要 Root 或 Shizuku。.xapk 仍会照常打包，只是不含这些数据。</string>
     <string name="export_obb_included">包含 %1$s 游戏数据。</string>
     <string name="export_obb_partial">此应用游戏数据文件夹中有些内容不是扩展文件，不会被打包。</string>
     <string name="export_format">格式</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -494,7 +494,7 @@
     <string name="export_explain_apk">Thor 将此应用保存为单个安装文件 (.apk) 到下方文件夹中。您可以使用它备份应用或在以后重新安装。</string>
     <string name="export_explain_apks">此应用包含多个拆分部分，它们会被打包为一个捆绑包 (.apks) 并保存到下方文件夹中。可随时使用 Thor 安装程序重新安装。</string>
     <string name="export_explain_xapk">Thor 会把此应用的各个部分打包成下方文件夹中的单个 .xapk，其他安装器也能识别这种格式。当 Thor 当前的访问方式可以读取时，游戏数据（OBB 文件）会一并打包。</string>
-    <string name="export_xapk_no_game_data">Thor 暂时无法读取该应用的游戏数据——通常这说明需要 Root 或 Shizuku。.xapk 仍会照常打包，只是不含这些数据。</string>
+    <string name="export_xapk_no_game_data">Thor 暂时无法读取该应用的游戏数据——通常这说明需要 Root 或 Shizuku。仍会照常打包 .xapk，只是不含这些数据。</string>
     <string name="export_obb_included">包含 %1$s 游戏数据。</string>
     <string name="export_obb_partial">此应用游戏数据文件夹中有些内容不是扩展文件，不会被打包。</string>
     <string name="export_format">格式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,8 +199,15 @@
     <!-- Shown for every ObbProbe.Undetermined, which is more than a missing privilege: a failed,
          empty, truncated or malformed reply from a shell Thor *does* have lands here too. So it
          states what is certainly true (Thor cannot read the data now) and offers the usual cause
-         without asserting it — the same mistake as the explain string this feature retracted. -->
-    <string name="export_xapk_unavailable">Thor can\'t read this app\'s game data right now — usually that means root or Shizuku access is needed. A .xapk without it would install a game that doesn\'t run.</string>
+         without asserting it — the same mistake as the explain string this feature retracted.
+
+         Renamed from export_xapk_unavailable, because it no longer describes anything unavailable.
+         The old copy said a .xapk "would install a game that doesn't run", which was a refusal
+         written as a warning: it asserted the app *has* game data, and Undetermined is precisely
+         the verdict that cannot say so. Most apps have none, so most of the time the sentence was
+         false as well as blocking. The rename is deliberate — a translation carried over under the
+         old key would keep promising a broken install. -->
+    <string name="export_xapk_no_game_data">Thor can\'t read this app\'s game data right now — usually that means root or Shizuku access is needed. The .xapk will still be built, without it.</string>
     <string name="export_obb_included">Includes %1$s of game data.</string>
     <string name="export_obb_partial">Some items in this app\'s game data folder aren\'t expansion files and won\'t be included.</string>
     <string name="export_format">Format</string>

--- a/app/src/test/java/com/valhalla/thor/data/repository/AppBundleBuilderTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/AppBundleBuilderTest.kt
@@ -4,11 +4,15 @@
 package com.valhalla.thor.data.repository
 
 import com.valhalla.thor.domain.model.BundleFormat
+import com.valhalla.thor.domain.model.ObbFile
+import com.valhalla.thor.domain.model.ObbProbe
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
+import java.io.IOException
 
 /**
  * What goes into the zip, in what order, and under what name.
@@ -126,6 +130,75 @@ class AppBundleBuilderTest {
             command,
             command.startsWith("[ ! -L '$dir' ] && [ ! -L '$dir/main.obb' ] && cp -f ")
         )
+    }
+
+    @Test
+    fun `an unreadable probe packs nothing instead of refusing the export`() {
+        // The owner's regression test. `build` used to throw IOException on Undetermined and the
+        // export sheet disabled the .xapk chip to match, so "Thor could not read Android/obb" —
+        // which for ~70% of apps means "there was nothing there to read" — came back as a failed
+        // export. Undetermined now packs nothing and the export proceeds.
+        assertEquals(
+            emptyList<ObbFile>(),
+            expansionsToPack(BundleFormat.XAPK, ObbProbe.Undetermined("no privileged shell"))
+        )
+
+        // The other side of the same boundary, in the same test: if this arm ever also returned
+        // empty, the assertion above would still pass while the feature packed no expansions at
+        // all. Present is the only verdict that can name files, and it must still name them.
+        val files = listOf(ObbFile("main.1.com.example.game.obb", 4L), ObbFile("patch.1.obb", 8L))
+        assertEquals(
+            files,
+            expansionsToPack(BundleFormat.XAPK, ObbProbe.Present(files, otherEntryCount = 0))
+        )
+    }
+
+    @Test
+    fun `nothing is packed for a probe that found nothing or a format that carries nothing`() {
+        // None is a real measurement, and it means the same list as Undetermined by a different
+        // route. Pinned separately so that collapsing the two arms is a visible edit.
+        assertEquals(emptyList<ObbFile>(), expansionsToPack(BundleFormat.XAPK, ObbProbe.None))
+
+        // .apks has no expansion convention and zipSourcesFor already drops them; this makes the
+        // rule true a step earlier, so an .apks export never stages bytes it will not ship. Present
+        // deliberately, because APKS + None would pass on the wrong arm.
+        val files = listOf(ObbFile("main.1.com.example.game.obb", 4L))
+        assertEquals(
+            emptyList<ObbFile>(),
+            expansionsToPack(BundleFormat.APKS, ObbProbe.Present(files, otherEntryCount = 0))
+        )
+    }
+
+    @Test
+    fun `a copy that fails after the probe measured files is still fatal`() {
+        // This is GH#164 and it did NOT get relaxed. Present means the probe read those names and
+        // sizes off the device, so a null from stageExpansions is data we know we are dropping —
+        // as opposed to Undetermined, which is data we cannot prove exists.
+        val requested = listOf(ObbFile("main.1.com.example.game.obb", 4L))
+
+        val thrown = assertThrows(IOException::class.java) {
+            requireStagedExpansions(requested = requested, staged = null)
+        }
+        // The message, not just the type: an IOException from somewhere else in this call would
+        // satisfy a type-only assertion while this guard was gone.
+        assertEquals(
+            "this app's game data could not be read, so the .xapk would be incomplete",
+            thrown.message
+        )
+    }
+
+    @Test
+    fun `staged expansions pass through, and nothing requested needs nothing staged`() {
+        // The passing side of the guard above. Without it, `throw` unconditionally would be green.
+        val staged = listOf(ZipSource(File("/tmp/s/main.obb"), "Android/obb/com.example.game/main.obb"))
+        assertEquals(
+            staged,
+            requireStagedExpansions(listOf(ObbFile("main.obb", 4L)), staged)
+        )
+
+        // And the short-circuit: an app with no expansions reaches this with null from a staging
+        // step that was never run. Throwing there would fail every ordinary .xapk export.
+        assertEquals(emptyList<ZipSource>(), requireStagedExpansions(emptyList(), null))
     }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/data/repository/ObbProbeParserTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/ObbProbeParserTest.kt
@@ -85,6 +85,50 @@ class ObbProbeParserTest {
     }
 
     @Test
+    fun `the probe script runs entirely inside a subshell`() {
+        // The regression test for the bug the owner reported. Under root this script is written
+        // into Odin's single long-lived `su` session, so a bare top-level `exit 0` killed that
+        // session: libsu's end-marker never ran, the exit code came back as 1, and parseObbProbe
+        // refused the reply before reading the THOR_NODIR sitting on stdout. "This app has no game
+        // data" — the ~70% case — was delivered as "could not determine", and the next unrelated
+        // root command failed too.
+        val command = obbProbeCommand("/storage/emulated/0", "com.example.game")!!.trim()
+
+        assertTrue(command, command.startsWith("("))
+        assertTrue(command, command.endsWith(")"))
+
+        // Both sides, in the same test: a wrap that swallowed a branch would pass the two
+        // assertions above while producing a script that answers nothing. The absent branch and
+        // the readable branch are the two the whole feature turns on.
+        assertTrue(command, command.contains("echo $SENTINEL_NODIR; exit 0; }"))
+        assertTrue(command, command.contains("stat -c '${PREFIX_OBB}%s %n'"))
+    }
+
+    @Test
+    fun `every exit in the probe script sits inside the subshell`() {
+        // startsWith("(") / endsWith(")") alone would still pass if someone appended a seventh
+        // branch after the closing paren and then a trailing `)` of their own. This pins each
+        // `exit` to the interior, and pins the count so that adding a branch is a decision someone
+        // has to make deliberately rather than by copying the line above it.
+        val command = obbProbeCommand("/storage/emulated/0", "com.example.game")!!.trim()
+
+        val open = command.indexOf('(')
+        val close = command.lastIndexOf(')')
+        assertEquals(command, 0, open)
+        assertEquals(command, command.length - 1, close)
+
+        var found = 0
+        var at = command.indexOf("exit ")
+        while (at >= 0) {
+            assertTrue("an exit at $at is outside the subshell: $command", at in (open + 1) until close)
+            found++
+            at = command.indexOf("exit ", at + 1)
+        }
+        // NOPRIV, package-dir SYMLINK, NODIR, leaf SYMLINK, BADNAME, STATFAIL.
+        assertEquals(command, 6, found)
+    }
+
+    @Test
     fun `the stat call in the command fails closed`() {
         val command = obbProbeCommand("/storage/emulated/0", "com.example.game")!!
 

--- a/app/src/test/java/com/valhalla/thor/data/repository/StagedInstallTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/StagedInstallTest.kt
@@ -427,6 +427,37 @@ class StagedInstallTest {
     }
 
     @Test
+    fun `the integrity guard runs inside a subshell`() {
+        // Same class of defect as obbProbeCommand's, caught before it had a victim: a top-level
+        // `exit` in a script that reaches the root gateway ends Odin's shared `su` session instead
+        // of the script. Both of this function's callers currently spawn a fresh process per
+        // command, so this is defence against a future third caller, not a live bug — which is
+        // precisely why nothing would have reddened when someone added one.
+        val script = integrityGuardedInstall(
+            listOf("/sdcard/x/base.apk" to "aa".repeat(32)),
+            "pm install --user 0 -r -g '/sdcard/x/base.apk'"
+        ).trim()
+
+        assertTrue(script, script.startsWith("("))
+        assertTrue(script, script.endsWith(")"))
+
+        // Both sides in one test: a wrap that dropped the guard or the install would satisfy the
+        // two assertions above while producing a script that verifies nothing or installs nothing.
+        assertTrue(script, script.contains("sha256sum"))
+        assertTrue(script, script.contains("exit $INTEGRITY_CHECK_EXIT_CODE"))
+        assertTrue(script, script.contains("pm install --user 0 -r -g '/sdcard/x/base.apk'"))
+
+        // And the `exit` has to be *interior*. startsWith/endsWith alone still passes if a branch
+        // is appended after the closing paren with a paren of its own.
+        val open = script.indexOf('(')
+        val close = script.lastIndexOf(')')
+        assertEquals(script, 0, open)
+        assertEquals(script, script.length - 1, close)
+        assertTrue(script, script.indexOf("exit $INTEGRITY_CHECK_EXIT_CODE") in (open + 1) until close)
+        assertTrue(script, script.indexOf("pm install") in (open + 1) until close)
+    }
+
+    @Test
     fun `a path holding a quote cannot end the guard's own argument`() {
         // The staging dir name is ours, but the file names inside come from the picked archive.
         val script = integrityGuardedInstall(

--- a/app/src/test/java/com/valhalla/thor/data/util/ApksMetadataGeneratorTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/util/ApksMetadataGeneratorTest.kt
@@ -273,12 +273,16 @@ class ApksMetadataGeneratorTest {
     }
 
     /**
-     * `encodeDefaults` is true on `xapkJson`, so a defaulted `emptyList()` would write
-     * `"expansions":[]` into every `.xapk` Thor produces — changing the bytes of bundles this
-     * feature does not touch. The field is nullable precisely so absence stays absence.
+     * The inverse of what this file used to assert.
+     *
+     * The key used to be omitted when there were no expansions, so that OBB-less bundles stayed
+     * byte-identical to what shipped before the feature. `[]` is the better wire shape: it is the
+     * only encoding that survives a null check, a truthiness check and a type check at once, and it
+     * is what APK Extractor already emits — `null` is emitted by nobody. `encodeDefaults = true` on
+     * `xapkJson` is what makes a defaulted `emptyList()` appear rather than vanish.
      */
     @Test
-    fun xapkManifest_omitsExpansionsEntirelyWhenThereAreNone() {
+    fun xapkManifest_writesAnEmptyExpansionsArrayWhenThereAreNone() {
         val json = ApksMetadataGenerator().generateManifestJson(
             appInfo = app(),
             totalSize = 123L,
@@ -287,9 +291,72 @@ class ApksMetadataGeneratorTest {
         )
 
         // Guard that this is the .xapk overload and not the .apks one, which uses a different Json
-        // instance: without it the assertion below passes for the wrong reason.
+        // instance: without it the assertions below pass for the wrong reason.
         assertTrue(json, json.contains("\"total_size\":123"))
+        assertTrue(json, json.contains("\"expansions\":[]"))
+        // Not `"expansions":null`. `explicitNulls = false` would drop that, so the two failures are
+        // indistinguishable from the `contains("expansions")` this test used to do.
+        assertFalse(json, json.contains("\"expansions\":null"))
+
+        // The entry that actually decides whether a no-OBB .xapk installs. cubehouse's installer
+        // throws "Cannot find base APK in manifest.json!" without it, and adhu2018's hard-subscripts
+        // `manifest["split_apks"]` *inside* the no-expansions branch — so the OBB-less bundle is
+        // precisely the one that reaches that code. Thor emits it, and this pins it.
+        val parsed = parseXapkManifest(json)!!
+        assertEquals("base.apk", parsed.baseApkFile())
+        assertTrue(parsed.expansions.isEmpty())
+    }
+
+    /**
+     * The base entry's id comes from *which path it is*, not from what the file happens to be called.
+     *
+     * Found by mutation: replacing `if (apk.sourcePath == basePath) "base"` with a plain
+     * `splitIdFor(...)` killed nothing, because `splitIdFor` strips `.apk` and every fixture in this
+     * file names the base APK `base.apk` — so the two agreed by coincidence on every case tested.
+     * They stop agreeing the moment the base is named anything else, which happens on ROMs that
+     * rename it and on any app whose base path is not `.../base.apk`. That is the case where
+     * cubehouse's installer throws `Cannot find base APK in manifest.json!` and adhu2018's
+     * hard-subscripts a `split_apks` list with no `"base"` in it.
+     */
+    @Test
+    fun xapkManifest_idsTheBaseApkFromItsPathEvenWhenItIsNotNamedBaseApk() {
+        val oddBase = "$baseDir/com.example.app.apk"
+        val json = ApksMetadataGenerator().generateManifestJson(
+            appInfo = app(
+                splits = listOf("$baseDir/split_config.arm64_v8a.apk"),
+                publicSourceDir = oddBase
+            ),
+            totalSize = 123L,
+            iconName = "icon.png",
+            staged = staged(oddBase, "$baseDir/split_config.arm64_v8a.apk")
+        )
+
+        val parsed = parseXapkManifest(json)!!
+        // Both sides: the base is found under its own file name, and the split beside it keeps the
+        // id derived from its path — a rule that identified *everything* as base would also pass a
+        // baseApkFile() assertion on its own.
+        assertEquals("com.example.app.apk", parsed.baseApkFile())
+        assertEquals(
+            listOf("com.example.app.apk", "split_config.arm64_v8a.apk"),
+            parsed.splitApkFiles()
+        )
+        // splitIdFor strips the `split_` prefix and the `.apk` suffix and nothing else, so the id
+        // is `config.arm64_v8a` rather than `arm64_v8a`. Pinned as emitted, not as guessed.
+        assertTrue(json, json.contains("\"id\":\"config.arm64_v8a\""))
+    }
+
+    /**
+     * The `.apks` manifest goes through the plain `Json`, where `encodeDefaults` is false, so the
+     * same non-null `emptyList()` default is dropped there. Its bytes did not move.
+     */
+    @Test
+    fun apksManifest_stillOmitsExpansionsAltogether() {
+        val json = ApksMetadataGenerator().generateManifestJson(app(), staged("$baseDir/base.apk"))
+
         assertFalse(json, json.contains("expansions"))
+        // The overload guard, inverted from the .xapk test above: total_size is XAPK-only, so its
+        // absence proves this is the .apks writer and the assertion above is about the right bytes.
+        assertFalse(json, json.contains("total_size"))
     }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/ExportFormatGateTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/ExportFormatGateTest.kt
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import com.valhalla.thor.domain.model.BundleFormat
+import com.valhalla.thor.domain.model.ObbFile
+import com.valhalla.thor.domain.model.ObbProbe
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * What the export sheet says about game data, decided without a device.
+ *
+ * The sheet used to *refuse* `.xapk` on an [ObbProbe.Undetermined] verdict — a disabled chip, a
+ * LaunchedEffect that forced the selection back, and a throw in the builder. All three are gone; the
+ * verdict now produces one note and nothing else. The interesting property of these three functions
+ * is therefore what they do **not** do, and that is only checkable by pinning both sides of every
+ * gate: a function that returned `false`/`0` for everything would satisfy every "does not block"
+ * assertion in this file and say nothing to the user at all.
+ *
+ * `probe` is nullable here and nowhere below this layer. Null is "the probe is still in flight",
+ * which is a fourth state the sheet has and the domain does not.
+ */
+class ExportFormatGateTest {
+
+    private val files = listOf(
+        ObbFile("main.1.com.example.game.obb", 4L),
+        ObbFile("patch.1.com.example.game.obb", 6L)
+    )
+
+    // ---- shouldWarnUnreadableObb -----------------------------------------------------------
+
+    @Test
+    fun `an unreadable probe is a note on the xapk chip and silence on the others`() {
+        val probe = ObbProbe.Undetermined("no privileged shell is available")
+
+        assertTrue(shouldWarnUnreadableObb(BundleFormat.XAPK, probe))
+
+        // The other side of the format gate. The note describes what a .xapk will contain, so on a
+        // container that never carries expansions it answers a question the user did not ask.
+        assertFalse(shouldWarnUnreadableObb(BundleFormat.APK, probe))
+        assertFalse(shouldWarnUnreadableObb(BundleFormat.APKS, probe))
+    }
+
+    @Test
+    fun `a probe that answered says nothing, and one still running says nothing either`() {
+        // None is an answer: the app has no game data, and there is nothing to tell the user.
+        assertFalse(shouldWarnUnreadableObb(BundleFormat.XAPK, ObbProbe.None))
+        assertFalse(
+            shouldWarnUnreadableObb(BundleFormat.XAPK, ObbProbe.Present(files, otherEntryCount = 0))
+        )
+
+        // Null is the in-flight state, not a verdict. Treating it as Undetermined would flash this
+        // note on the sheet for the length of every probe and then retract it.
+        assertFalse(shouldWarnUnreadableObb(BundleFormat.XAPK, null))
+    }
+
+    // ---- obbSizeBytesToShow ----------------------------------------------------------------
+
+    @Test
+    fun `the size line sums the measured expansions for a xapk`() {
+        assertEquals(
+            10L,
+            obbSizeBytesToShow(BundleFormat.XAPK, ObbProbe.Present(files, otherEntryCount = 0))
+        )
+
+        // Same verdict, other containers: the bytes exist, they are simply not going into this
+        // archive, so announcing them would be a promise the export does not keep.
+        assertEquals(0L, obbSizeBytesToShow(BundleFormat.APK, ObbProbe.Present(files, 0)))
+        assertEquals(0L, obbSizeBytesToShow(BundleFormat.APKS, ObbProbe.Present(files, 0)))
+    }
+
+    @Test
+    fun `no size line for a verdict that measured nothing`() {
+        assertEquals(0L, obbSizeBytesToShow(BundleFormat.XAPK, ObbProbe.None))
+        assertEquals(0L, obbSizeBytesToShow(BundleFormat.XAPK, ObbProbe.Undetermined("gateway")))
+        assertEquals(0L, obbSizeBytesToShow(BundleFormat.XAPK, null))
+
+        // Present with no .obb files at all — the directory exists and holds only things the format
+        // cannot carry. Zero bytes to announce; see the partial note below, which does fire here.
+        assertEquals(
+            0L,
+            obbSizeBytesToShow(BundleFormat.XAPK, ObbProbe.Present(emptyList(), otherEntryCount = 3))
+        )
+    }
+
+    // ---- shouldNotePartialObb --------------------------------------------------------------
+
+    @Test
+    fun `the partial note fires on entries the format cannot carry, whether or not there are obbs`() {
+        assertTrue(
+            shouldNotePartialObb(BundleFormat.XAPK, ObbProbe.Present(files, otherEntryCount = 2))
+        )
+        // The case that makes this a separate function from obbSizeBytesToShow: nothing to announce
+        // a size for, and still something being left behind.
+        assertTrue(
+            shouldNotePartialObb(
+                BundleFormat.XAPK,
+                ObbProbe.Present(emptyList(), otherEntryCount = 1)
+            )
+        )
+    }
+
+    @Test
+    fun `no partial note when the directory held nothing extra, or was never read`() {
+        assertFalse(
+            shouldNotePartialObb(BundleFormat.XAPK, ObbProbe.Present(files, otherEntryCount = 0))
+        )
+        assertFalse(shouldNotePartialObb(BundleFormat.XAPK, ObbProbe.None))
+        assertFalse(shouldNotePartialObb(BundleFormat.XAPK, ObbProbe.Undetermined("gateway")))
+        assertFalse(shouldNotePartialObb(BundleFormat.XAPK, null))
+
+        // And the format gate, on the arm that would otherwise be true.
+        assertFalse(shouldNotePartialObb(BundleFormat.APKS, ObbProbe.Present(files, 2)))
+    }
+
+    // ---- the three together ----------------------------------------------------------------
+
+    @Test
+    fun `an unreadable probe leaves the xapk offer intact and says exactly one thing`() {
+        // The regression the owner reported, stated at the level the user experiences it. Before the
+        // fix this verdict disabled the .xapk chip and forced the selection away from it; the
+        // formats a sheet offers come from BundleFormat.autoFor plus XAPK and are no longer filtered
+        // by the probe at all, so the only remaining trace of the verdict is one note.
+        val probe = ObbProbe.Undetermined("the privileged shell exited with code 1")
+
+        assertTrue(shouldWarnUnreadableObb(BundleFormat.XAPK, probe))
+        assertEquals(0L, obbSizeBytesToShow(BundleFormat.XAPK, probe))
+        assertFalse(shouldNotePartialObb(BundleFormat.XAPK, probe))
+    }
+}


### PR DESCRIPTION
Follows #376. `.xapk` export refuses to run for any app whose game data the shell cannot
enumerate — which, since #376 merged on 2026-08-10, is **every app on the root rung**, because the
probe itself is what breaks the shell.

The owner reported it from device testing: *"if i try to backup an app without obb it is failing
even with shizuku and root access because xapk generation is failing."*

## Bug 1 — the probe killed the shared root shell

Odin's root channel is **one long-lived `su` session**. `ObbProbeParser.obbProbeCommand` emitted six
bare top-level `exit 0`s. A top-level `exit` there terminates the **session**, not the command, so
libsu's end marker never runs, `StreamGobbler.OUT` returns its `NO_RESULT_CODE`, and the caller sees
a synthetic non-zero exit. Two consequences, and the second is the worse one:

- the probe reports `Undetermined` on the *most common* input — an app with no OBB directory, which
  takes the very first early exit;
- **the root shell is now dead for everything after it.** Any privileged action taken after opening
  an export sheet — freeze, force-stop, clear cache — failed with "Root shell unavailable" until the
  connection was rebuilt. That surfaced as an unrelated bug.

The script is now wrapped in `( … )`, so every `exit` leaves the subshell and the session survives.
Shizuku was never affected: `ShizukuHelper.execute` spawns a fresh `sh` per command.

**A sweep of the class found a second violator.** Three builders on `dev` emit `exit`:
`obbProbeCommand` (the live bug), `RootSystemGateway.installViaSession` (already wrapped — the only
precedent on this branch), and `InstallerRepositoryImpl.integrityGuardedInstall`, which was
unwrapped and latent only because both of its callers happen to spawn a fresh process. Wrapped
defensively, and the rule is now written down in `SystemRepository.executeShellCommand`'s KDoc —
the seam every one of these builders crosses, and previously the one place that said nothing about
it.

## Bug 2 — "can't read the game data" was treated as "the export is impossible"

Independent of bug 1, `Undetermined` was **fatal**: `AppBundleBuilderImpl.build` threw, and the
export sheet **disabled the `.xapk` chip outright**. That is wrong on the merits even with a healthy
shell — most Play titles ship no OBB at all, and Dhizuku's device-owner process structurally cannot
see another package's external directories, so it can only ever answer `Undetermined`.

`Undetermined` now means *proceed without game data*, matching what the owner asked for: check
whether the OBB is readable; if not, continue normally; if it is, show the size.

| probe verdict | before | after |
|---|---|---|
| `None` (no OBB dir) | built fine | unchanged |
| `Present` (readable) | bundled, size shown | unchanged |
| `Undetermined` (unreadable) | **build threw, chip disabled** | **builds without game data, chip enabled, note shown** |
| copy fails mid-export | fatal | **still fatal** — deliberately |

The last row is the one that stays strict: if the probe said the data is *there* and the copy then
fails, the `.xapk` would install a game that cannot run, and that is worth failing for.

The user-facing string was **renamed**, not edited in place: `export_xapk_unavailable` →
`export_xapk_no_game_data`. The old English read *"A .xapk without it would install a game that
doesn't run"*; the new one reads *"The .xapk will still be built, without it."* A translation
carried over under the old key would have kept promising a broken install in four languages, so the
rename forces each locale to be retranslated rather than silently inheriting a now-false sentence.
All four locales (ar, es, fr, zh-rCN) are updated in this PR; none falls back to English.

## `"expansions":[]`

An OBB-less `.xapk` now writes an explicit empty `expansions` array rather than omitting the key.
All three encodings (omit / `[]` / `null`) are equivalent in the five third-party parsers read, so
this is a margin call rather than a fix — `[]` is the one that is unambiguous to a reader doing a
key lookup. The `.apks` manifest bytes are unchanged, and that is asserted rather than assumed.

**The real cliff is `split_apks` with `id == "base"`** — cubehouse's installer rejects an archive
without it (*"Cannot find base APK in manifest.json!"*). Thor already emits it on both paths, but
**the guarantee was untested**: replacing the whole conditional with a plain `splitIdFor(...)`
killed zero tests, because `splitIdFor` strips `.apk` and every fixture named the base `base.apk`,
so the two rules agreed by coincidence on every case covered. They diverge the moment the base APK
is named anything else — which is exactly the archive that gets rejected. Now pinned by a test with
an oddly-named base.

## Gate

937 → **953** tests (74 → 75 XML files), 0 failures / 0 errors / 0 skipped. Lint unchanged at
0 Error / 0 Warning / 6 Hint. `assembleFossDebug` green. Every behavioural change proven by
mutation, all `0 → N`: subshell wrap `0 → 2`; `integrityGuardedInstall` `0 → 2`; builder policy
`0 → 4` (one mutant literally restores the old `Undetermined` refusal); sheet gates `0 → 5`;
`expansions` encoding killed.

## ⚠️ Desk-verified only — please run these before merging

#376 reached `dev` desk-verified with nine device checks unrun, and this is the bug that came out of
that. Repeating it on the fix would be a poor trade. The full list is in the working notes; these
are the ones that matter:

- [ ] **The root session survives a probe.** Export a no-OBB app as `.xapk`, then immediately run
      any privileged action (freeze / force-stop / clear cache). This is the single most important
      check — it is the half of bug 1 that surfaced elsewhere.
- [ ] **A no-OBB app under root**, then **under Shizuku**. Expect success, no game-data note, and
      `obb probe for <pkg>: None` in logcat — `None`, not `Undetermined`.
- [ ] **An OBB-bearing app under root and Shizuku.** Expect "Includes N MB of game data", the OBB
      present in the archive, and `expansions` listing it with `file == install_path`.
- [ ] **A produced no-OBB `.xapk` installs in SAI.** The encoding argument here is from reading five
      parsers, not from running them.
- [ ] **Dhizuku:** `Undetermined` is expected, and the export must now succeed anyway with the chip
      pressable. Before this change that combination was impossible.
- [ ] **`integrityGuardedInstall` under Shizuku and Dhizuku.** The subshell wrap there is
      behaviour-neutral by argument, not by measurement — install a split app through each rung, and
      confirm a corrupted staged APK still aborts with exit 90.

The `.xapk` chip's `enabled` expression has **no** automated coverage after this change: post-fix it
reads `enabled = !exporting`, and a helper wrapping it would have to ignore its own parameters,
which this build rejects (`warningsAsErrors`). Recorded rather than papered over with a
constant-true test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * XAPK exports can proceed when game-data detection is inconclusive, with clear notes about missing or unreadable data.
  * XAPK manifests now explicitly include an empty expansions list when no expansion files are available.
  * Export screens provide more accurate expansion-size and partial-data information.

* **Bug Fixes**
  * Confirmed detected expansion files remain required when staging fails.
  * Improved reliability of privileged installation and game-data checks.

* **Localization**
  * Updated Arabic, Spanish, French, Chinese, and English messages to clarify that XAPK files may still be created without unreadable game data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->