### PR TITLE
docs(backup): finish the throttle retraction the source got and the docs did not

### DIFF
--- a/docs/follow-ups/README.md
+++ b/docs/follow-ups/README.md
@@ -172,11 +172,14 @@ detail?"* Every row appears in both — this section adds an order, not new work
 **Read the bands, not the exact numbers.** The gap between 3 and 5 is noise; the gap between band A
 and band C is not.
 
-**Bands A and B are built, and #23 is built but has never run on a device — start at #24.** #23 is
-reviewed and open as **PR #379** into `dev` (six review slices, six fixers, a five-lens re-review,
-zero blockers, 1467 tests) — but *"has run on a device"* is the bar for closing #51, and 21 checks say
-it has not, so **do not close #51 on that merge**. Alongside it, **PR #378** fixes the `.xapk` OBB
-probe that the deferred device checks on #164's second half let through. Rows 24 and 25 are the same
+**Bands A and B are built, and #23 is merged but has never run on a device — start at #24.** #23
+merged into `dev` 2026-08-12 as **PR #379** (`940480ef`; six review slices, six fixers, a five-lens
+re-review, an adjudicated automated review — 13 findings, 9 refuted, 0 blockers — and 1473 tests).
+**Merged is not shipped**: the 21 device checks in the linked doc are unrun, so nothing here reaches
+users until a backup has been taken *and* restored on hardware. Alongside it, **PR #378**
+(`0fd72541`) fixes the `.xapk` OBB probe that the deferred device checks on #164's second half let
+through. GH#51 itself needs no action — its author closed it as `not_planned` on 2026-08-04, before
+either merge, so the old *"do not close #51"* guard is moot. Rows 24 and 25 are the same
 Room migration described twice, so they are sequenced together or neither. Every numbered row from 1
 to 22 has shipped except band A #10, which is half done and waiting on a device diagnostic. ~~The one thing band B leaves behind is
 the **release-notes line** retracting band A #1's capability removal, which is due on the `master`
@@ -228,7 +231,7 @@ argument, not the status. **None of it has run on a device.**
 
 | # | Item | Kind | Effort | Why here |
 |:-:|---|---|---|---|
-| 23 | [#51 phase 2 — app **data** backup](app-data-backup-and-xapk-export.md) | feature | 5–8 d | ✅ **built, desk-verified, zero device checks run.** `.thorbak` = a zip holding `thorbak.json` + `app.xapk` + one AES-256-GCM member per storage class, on a reusable WorkManager foreground-job seam. ⚠️ **Two things block a `store` release**: the Play Console **Foreground Service declaration** for `FOREGROUND_SERVICE_DATA_SYNC` (demo bulk APK export, *not* backup — Play cannot root a device), and the device checks in the linked doc. **Reviewed 2026-08-12** — six slices, six fixers, then a five-lens re-review with an adversarial verifier per finding: **1362 → 1467 tests**, 2 Criticals fixed (both were ways to produce an *unrestorable* backup, both caused by nothing on the branch writing an archive and then restoring it), **0 blockers** at the end. ⚠️ The one thing the review could not reach is the one that matters: `ThorJobLauncher` → WorkManager → privileged shell, the region that actually replaces app data, is exercised by **no test in this repo** and cannot be on the JVM. **Merge on the review; do not ship until a backup has been restored on hardware** |
+| 23 | [#51 phase 2 — app **data** backup](app-data-backup-and-xapk-export.md) | feature | 5–8 d | ✅ **MERGED to `dev` 2026-08-12 as PR #379 (`940480ef`) — desk-verified, zero device checks run.** `.thorbak` = a zip holding `thorbak.json` + `app.xapk` + one AES-256-GCM member per storage class, on a reusable WorkManager foreground-job seam. ⚠️ **Two things block a `store` release**: the Play Console **Foreground Service declaration** for `FOREGROUND_SERVICE_DATA_SYNC` (demo bulk APK export, *not* backup — Play cannot root a device), and the device checks in the linked doc. **Reviewed 2026-08-12** — six slices, six fixers, then a five-lens re-review with an adversarial verifier per finding: **1362 → 1467 tests**, 2 Criticals fixed (both were ways to produce an *unrestorable* backup, both caused by nothing on the branch writing an archive and then restoring it), **0 blockers** at the end. ⚠️ The one thing the review could not reach is the one that matters: `ThorJobLauncher` → WorkManager → privileged shell, the region that actually replaces app data, is exercised by **no test in this repo** and cannot be on the JVM. **Merged on the review; do not ship until a backup has been restored on hardware** |
 | 24 | [#178 — app tagging + per-app notes](../feature-request-roadmap.md) | feature | 3–5 d | **Demand is no longer zero** — two users, one thread. Notes and tags are one Room migration, so build them together or neither |
 | 25 | Change history + update history | feature | medium–large | Room has no event table and `AppEntity` overwrites the version on every scan, so *both* need the same new table. Do them as one piece of work |
 | 26 | [`BulkFreezeRunner` concurrency tests](bulk-freeze-runner-concurrency-tests.md) | tests | medium | Still blocked: 3 of 4 collaborators need a seam before the runner can be built in a JVM test |

--- a/docs/follow-ups/app-data-backup-and-xapk-export.md
+++ b/docs/follow-ups/app-data-backup-and-xapk-export.md
@@ -376,7 +376,7 @@ Each was raised, verified, and deliberately kept. Filing them would invite a reg
   because `launchGuarded` runs `block` through `coroutineScope`, which *reports* it at the call site.
   A scope-level handler would have swallowed it instead, which is the opposite trade.
 - **`signerSha256` reads `apkContentsSigners` only, never `signingCertificateHistory`.** Deliberate;
-  the rationale is at `AppDataArchiveGatewayImpl.kt:288-290`. An archive taken before a signing-key
+  the rationale is on `AppDataArchiveGatewayImpl.signerSha256` itself. An archive taken before a signing-key
   rotation is refused with `SIGNER_MISMATCH` after the rotation, and **that is the check working**.
   Consulting the history would let a rotated key match an older archive, which is the one thing the
   check exists to stop, so **do not implement rotation-history matching** — the "fix" inverts the

--- a/docs/follow-ups/app-data-backup-and-xapk-export.md
+++ b/docs/follow-ups/app-data-backup-and-xapk-export.md
@@ -375,6 +375,17 @@ Each was raised, verified, and deliberately kept. Filing them would invite a reg
   on. Still the decision after the #379 review: a child coroutine's failure now reaches `onFailure`
   because `launchGuarded` runs `block` through `coroutineScope`, which *reports* it at the call site.
   A scope-level handler would have swallowed it instead, which is the opposite trade.
+- **`signerSha256` reads `apkContentsSigners` only, never `signingCertificateHistory`.** Deliberate;
+  the rationale is at `AppDataArchiveGatewayImpl.kt:288-290`. An archive taken before a signing-key
+  rotation is refused with `SIGNER_MISMATCH` after the rotation, and **that is the check working**.
+  Consulting the history would let a rotated key match an older archive, which is the one thing the
+  check exists to stop, so **do not implement rotation-history matching** — the "fix" inverts the
+  anti-exfiltration guard.
+- **`AppArchiveStoreImpl.openArchive`'s broad `catch (e: Exception)` has no `CancellationException`
+  rethrow arm**, unlike three sibling sites in the same file. Harmless, and re-raising it is
+  file-local consistency only: the whole `try` sits inside `withContext(ioDispatcher)`, which
+  discards the block's value and rethrows the job's own cancellation on exit, so a cancelled backup
+  never reaches the caller as `NoDestination`. Adding the arm changes no observable behaviour.
 
 ### Two durable traps this branch paid for
 

--- a/docs/superpowers/plans/2026-08-10-app-backup-and-restore-implementation.md
+++ b/docs/superpowers/plans/2026-08-10-app-backup-and-restore-implementation.md
@@ -54,7 +54,7 @@ Read these before Task 1. Each is a decision made at plan time that the spec lef
 
 7. **The new privileged operations go on two narrow ports, not onto `SystemRepository`.** §6 requires the probe to run on *the same privileged surface* as the work, which reads like "add the methods to `SystemRepository`". Doing that breaks the build in two places that have nothing to do with backup: `FreezeAppUseCaseTest.kt:33` and `BulkFreezeWorkerTest.kt:121` each hand-write a `RecordingSystemRepository` implementing the interface in full, so every added member is a compile error in both. Instead `AppDataProbe` (Task 6, the two read-only questions) is **implemented by `SystemRepositoryImpl` itself** — so §6's property holds: the probe and the work run through the same object, the same `runGatewayAction`, the same active gateway — while `AppDataArchiveGateway` (Task 9) carries the archive-specific surface that was never system-wide to begin with. Neither widens an interface a test double already implements.
 
-8. **Progress is published to an in-memory registry, never through `setProgress` (§9.2 taken literally).** Every `setProgress` call is a row written to WorkManager's SQLite database, and WorkManager throttles observers to roughly one update a second; a gigabyte copied in 1 MiB chunks would attempt a thousand writes on the hot path. `JobRegistry` (Task 8) holds a `StateFlow` per job id and the ViewModel collects it directly. The consequence is that progress does not survive process death — which costs nothing, because an archive job's key lives in that same process (`ArchiveKeyHolder`) and so a killed job cannot resume either. WorkManager's own persisted `WorkInfo.State` stays the source of truth for *running / succeeded / failed*.
+8. **Progress is published to an in-memory registry, never through `setProgress` (§9.2 taken literally).** Every `setProgress` call is a row written to WorkManager's SQLite database, and WorkManager does **not** coalesce the observer emissions behind those rows; a gigabyte copied in 1 MiB chunks would attempt a thousand writes on the hot path, each with an emission behind it. (This line originally claimed WorkManager throttles observers to roughly one update a second. It does not — that guarantee was invented. The 1/s in this feature is Thor's own, on `ThorJobWorker`'s notification publish.) `JobRegistry` (Task 8) holds a `StateFlow` per job id and the ViewModel collects it directly. The consequence is that progress does not survive process death — which costs nothing, because an archive job's key lives in that same process (`ArchiveKeyHolder`) and so a killed job cannot resume either. WorkManager's own persisted `WorkInfo.State` stays the source of truth for *running / succeeded / failed*.
 
 9. **One work chain for every archive job, `APPEND_OR_REPLACE` (§9.3).** The unique work name deliberately excludes the target, so jobs *serialise* and peak disk stays at one storage class however many backups the user queues. Per-target dedup — the double-tap defence — moves to `jobTag(kind, target)` and `getWorkInfosByTag`, which is also how the UI reattaches to a running job after a rotation. `APPEND_OR_REPLACE` rather than `APPEND` so one failed or cancelled job cannot wedge the chain permanently.
 
@@ -2818,7 +2818,7 @@ Spec §9. This is the reusable half of the WorkManager decision: the owner's req
 
 **Two spec rules that shape everything below — get them wrong and the code looks fine:**
 
-- **§9.2: progress does not go through `Data`.** `setProgress` is an SQLite write per call, so WorkManager throttles it to roughly 1/s. Progress goes to an in-memory `JobRegistry` the UI observes directly. `Data` is used only for the worker's **input** (package name, class ids, salt — none of it secret) and for one **failure output** string.
+- **§9.2: progress does not go through `Data`.** `setProgress` is an SQLite write per call and WorkManager does not coalesce the resulting observer emissions. (An earlier version of this line said WorkManager throttles it to roughly 1/s; it does not.) Progress goes to an in-memory `JobRegistry` the UI observes directly. `Data` is used only for the worker's **input** (package name, class ids, salt — none of it secret) and for one **failure output** string.
 - **§9.3: one chain, `APPEND_OR_REPLACE`.** The unique work name does **not** contain the target. All archive jobs share one name so they *serialise*, which is what keeps peak disk at one storage class no matter how many the user starts. `APPEND_OR_REPLACE` rather than `APPEND` so a previously failed or cancelled job cannot wedge the chain forever.
 
 **Files:**
@@ -3014,8 +3014,8 @@ import org.junit.Test
 
 /**
  * Progress lives here rather than in WorkManager's `Data` (§9.2): `setProgress` is an SQLite write
- * per call, throttled to roughly 1/s, so a byte-level bar routed through it is both slow and a write
- * amplifier on a job already saturating the disk.
+ * per call, and WorkManager does not coalesce the observer emissions behind those writes, so a
+ * byte-level bar routed through it is a write amplifier on a job already saturating the disk.
  */
 class JobRegistryTest {
 
@@ -3177,9 +3177,9 @@ import org.koin.core.annotation.Single
 /**
  * Where a running job's progress lives: in memory, for the life of the process.
  *
- * **Not `setProgress`.** Every `setProgress` call is a write to WorkManager's SQLite database, so
- * WorkManager throttles observers to roughly one update a second — a backup that copies a gigabyte in
- * 1 MiB chunks would try to write a thousand rows. §9.2 puts progress here instead: the worker
+ * **Not `setProgress`.** Every `setProgress` call is a write to WorkManager's SQLite database, and a
+ * backup that copies a gigabyte in 1 MiB chunks would write a thousand rows — with an observer
+ * emission behind each one, because WorkManager does **not** coalesce them. §9.2 puts progress here instead: the worker
  * publishes, the ViewModel collects the same `StateFlow`, and nothing touches the disk.
  *
  * The cost of that choice is that progress does not survive process death. That is acceptable because
@@ -3468,7 +3468,7 @@ abstract class ThorJobWorker(
      * Report progress to the UI and the notification.
      *
      * `setProgress` is deliberately absent — see [JobRegistry]. Calling it here would put an SQLite
-     * write on the copy loop's hot path and cap observed updates at roughly one a second.
+     * write on the copy loop's hot path, one per emission, since WorkManager coalesces none of them.
      */
     protected fun publish(progress: ThorJobProgress) {
         registry.publish(id, progress)

--- a/docs/superpowers/specs/2026-08-10-app-backup-and-restore-design.md
+++ b/docs/superpowers/specs/2026-08-10-app-backup-and-restore-design.md
@@ -409,9 +409,14 @@ The spec sketches how the APK/XAPK export batch would sit on this seam; it does 
 
 WorkManager's `Data` is written to its own SQLite database. Putting the passphrase or the derived
 key there writes the secret to disk in the clear — disqualifying. And `setProgress` is an SQLite
-write per call, so even non-secret progress is worth coarsening — **which Thor does itself**, to
-roughly 1/s on the notification and to one update per storage class on the progress callback.
-WorkManager promises no throttling of its own; it coalesces nothing.
+write per call, which is the second reason progress does not travel that way: it goes to an
+in-memory `JobRegistry` instead, so there is no per-update disk write left to coarsen.
+
+What Thor does coarsen is the **notification**, and only that: at most one update per second, plus
+an immediate one whenever the stage changes, so a phase boundary is never held back by the timer.
+`JobRegistry` is updated on **every** `publish` call — it is a `StateFlow` the sheet collects, and
+throttling it would cost the screen the accuracy it exists to show. WorkManager promises no
+throttling of its own; it coalesces nothing.
 
 ### 9.3 What WorkManager is and is not doing here
 

--- a/docs/superpowers/specs/2026-08-10-app-backup-and-restore-design.md
+++ b/docs/superpowers/specs/2026-08-10-app-backup-and-restore-design.md
@@ -1,9 +1,11 @@
 # App backup and restore — design
 
 **Date:** 2026-08-10
-**Status:** design approved in conversation, not yet built.
+**Status:** **BUILT** — merged to `dev` 2026-08-12 as PR #379 (`940480ef`). Desk-verified only: the
+21 device checks in the tracker are unrun, so this is on `dev` but must not ship to users yet.
 **Scope:** row 23 of `docs/follow-ups/README.md` — GH#51 phase 2, "app **data** backup". Phase 1
-(APK/`.apks`/`.xapk` export) already shipped; #164's OBB half is in flight as PR #376.
+(APK/`.apks`/`.xapk` export) already shipped; #164's OBB half merged as PR #376 (`91100e58`), with
+its hardware follow-up in PR #378 (`0fd72541`).
 **Tracker:** `docs/follow-ups/app-data-backup-and-xapk-export.md`
 
 ---
@@ -407,7 +409,9 @@ The spec sketches how the APK/XAPK export batch would sit on this seam; it does 
 
 WorkManager's `Data` is written to its own SQLite database. Putting the passphrase or the derived
 key there writes the secret to disk in the clear — disqualifying. And `setProgress` is an SQLite
-write per call, so even non-secret progress is throttled to roughly 1/s or to class boundaries.
+write per call, so even non-secret progress is worth coarsening — **which Thor does itself**, to
+roughly 1/s on the notification and to one update per storage class on the progress callback.
+WorkManager promises no throttling of its own; it coalesces nothing.
 
 ### 9.3 What WorkManager is and is not doing here
 


### PR DESCRIPTION
Docs only. No code, no tests, no build inputs.

## Why

`650f55f7` (on the now-merged #379) retracted an invented claim — *"WorkManager throttles observers to roughly one update a second"* — from `JobRegistry.kt`, `ThorJobWorker.kt` and `JobRegistryTest.kt`, and stopped at the source tree. **Five copies survived in the plan document**, two of them inside code blocks that quote the very comments that commit corrected. The plan therefore contradicted the code it produced, and a reader of the plan still learned a false fact about the platform.

This is the branch's own dominant defect class — a retraction applied where the claim was found and never swept across its class — and it is the reason the durable rule is *grep the literal, not the function*.

Ground truth:
- WorkManager makes no throttling promise and **coalesces nothing**; every `setProgress` write carries an observer emission.
- The 1/s in this feature is Thor's own `NOTIFICATION_INTERVAL_MS` (`ThorJobWorker.kt:25`), on the notification publish.
- The per-class coarsening is `BackupAppArchiveUseCase`'s one `onProgress` per `DataClass`.

## What changed

| File | Change |
|---|---|
| `docs/superpowers/plans/…-implementation.md` | 5 sites retracted (lines 57, 2821, 3017, 3181, 3471), two of them embedded KDoc now matching what shipped |
| `docs/superpowers/specs/…-design.md` | §9.2 **clarified, not retracted** — see below. Stale header fixed: it said *"not yet built"* on the branch that built it, and called #376 *"in flight"* |
| `docs/follow-ups/README.md` | row 23 and the `## Do next` preamble read as an open PR; now merged. GH#51 note corrected |
| `docs/follow-ups/app-data-backup-and-xapk-export.md` | two #379 review findings added to the **do-not-file** list |

### §9.2 was not in this class

Worth stating because the tempting "fix" is wrong: the design doc's §9.2 **named no agent**, and *"or to class boundaries"* is something WorkManager cannot do — so both halves already described what shipped. It is only made explicit that **Thor** is the one coarsening, so it cannot be misread as a platform guarantee.

### GH#51

Needs no action either way. Its author closed it as `not_planned` on **2026-08-04**, before either merge, so the long-standing *"do not close #51 on the merge"* guard is moot — #379 carried no closing reference and the merge did not touch it. Flagging separately that the feature shipped for a request its requester had withdrawn.

### Two decisions, not defects

Added to the do-not-file list so a future review does not "fix" them into regressions:
- **`signerSha256` reads `apkContentsSigners` only.** Matching `signingCertificateHistory` would let a rotated key match an older archive — the one thing the check exists to stop.
- **`AppArchiveStoreImpl.openArchive` has no `CancellationException` rethrow arm.** `withContext` already rethrows the job's cancellation on exit; adding the arm changes no observable behaviour.

## Verification

Markdown only — nothing on the compile or test path. Post-edit sweep for the literal across the whole repo returns only the retraction text itself (the lines that say *"It does not"*).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated backup and restore documentation to reflect the feature’s merged status and remaining device verification requirements.
  * Documented APK signing-key rotation behavior and archive validation limitations.
  * Clarified cancellation handling during archive operations.
  * Corrected WorkManager progress documentation, including notification and callback update frequency.
  * Updated follow-up notes for OBB export fixes, merged work, and outstanding release blockers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->