### PR TITLE
feat(backup): both archive surfaces are sheets, and a job notification reopens its own

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -373,6 +373,17 @@
             android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
+        <!-- Where a tap on a running backup/restore notification lands: it asks the UI to reopen that
+             job's sheet, then resumes Thor's task. Deliberately WITHOUT the taskAffinity="" and
+             singleInstance above — those keep FreezerLaunchActivity out of Thor's task, and resuming
+             that task is this activity's entire purpose. -->
+        <activity
+            android:name=".presentation.launcher.JobSheetLaunchActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
         <!-- Stormbringer bridge: lets the (LSPosed) launcher hook ask Thor to unsuspend a frozen
              app on launch. exported so the hook's process can reach it; access is bounded to
              Freezer packages inside the provider (the caller runs in the launcher, so it can't be

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -374,14 +374,25 @@
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <!-- Where a tap on a running backup/restore notification lands: it asks the UI to reopen that
-             job's sheet, then resumes Thor's task. Deliberately WITHOUT the taskAffinity="" and
-             singleInstance above — those keep FreezerLaunchActivity out of Thor's task, and resuming
-             that task is this activity's entire purpose. -->
+             job's sheet, then resumes Thor's task.
+
+             taskAffinity="" is load-bearing, not copied decoration. excludeFromRecents applies to the
+             task this activity *roots*, so without it a tap made while no Thor task exists (the user
+             exited with back, or swiped Thor away, while the foreground service kept the job running)
+             roots a recents-excluded task with Thor's own affinity — and the launcher-shaped resume then
+             lands HomeActivity inside that same task. Nothing re-derives the task's base intent
+             afterwards, so Thor stays missing from Recents for the life of the task and is reachable
+             only from the launcher icon. Its own task is throwaway; the NEW_TASK launcher intent still
+             finds and resumes Thor's by affinity, which is what FreezerLaunchActivity above relies on.
+
+             No launchMode, unlike FreezerLaunchActivity: singleInstance there keeps one tile tap from
+             stacking on another, and noHistory already finishes this one inside onCreate. -->
         <activity
             android:name=".presentation.launcher.JobSheetLaunchActivity"
             android:exported="false"
             android:excludeFromRecents="true"
             android:noHistory="true"
+            android:taskAffinity=""
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
         <!-- Stormbringer bridge: lets the (LSPosed) launcher hook ask Thor to unsuspend a frozen

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/AppArchiveWorker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/AppArchiveWorker.kt
@@ -21,6 +21,7 @@ import com.valhalla.thor.domain.model.KDF_ITERATIONS
 import com.valhalla.thor.domain.model.ObbPlacement
 import com.valhalla.thor.domain.model.ObbProbe
 import com.valhalla.thor.domain.model.RESTORE_PACKAGE_KEY
+import com.valhalla.thor.domain.model.RESTORE_URI_KEY
 import com.valhalla.thor.domain.model.ThorJobKind
 import com.valhalla.thor.domain.model.captureName
 import com.valhalla.thor.domain.model.evaluateArchiveRestoreGate
@@ -68,7 +69,8 @@ internal class ArchiveBackupWorker(
     private val bundleBuilder: AppBundleBuilder,
     private val systemRepository: SystemRepository,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
-) : ThorJobWorker(appContext, params, notifications, registry, keys) {
+    sheetTargets: JobSheetTargets,
+) : ThorJobWorker(appContext, params, notifications, registry, keys, sheetTargets) {
 
     override val kind = ThorJobKind.ARCHIVE_BACKUP
 
@@ -91,6 +93,18 @@ internal class ArchiveBackupWorker(
     override val initialLabel: String
         get() = inputData.getString(BACKUP_PACKAGE_KEY).orEmpty()
 
+    /**
+     * Same package name, same reason as [initialLabel]: this is read on the way into `doWork()`, ahead
+     * of `setForeground`, so it cannot afford a `PackageManager` round trip. `runJob` replaces it with
+     * the real label as soon as it has one — see the `retargetSheet` call below. Until then a tap on
+     * the notification opens a sheet headed with the application id, which is what `initialLabel`
+     * already puts in the shade beside it.
+     */
+    override val sheetTarget: JobSheetTarget?
+        get() = inputData.getString(BACKUP_PACKAGE_KEY)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { JobSheetTarget.Backup(packageName = it, appLabel = it) }
+
     override suspend fun runJob(): Result {
         val request = ArchiveBackupRequest.fromMap(inputData.keyValueMap)
             ?: return fail("this backup's request could not be read")
@@ -99,6 +113,16 @@ internal class ArchiveBackupWorker(
             ?: return fail("this backup's key is no longer in memory — start it again")
         val appInfo = appRepository.getAppDetails(request.packageName)
             ?: return fail("${request.packageName} is not installed")
+
+        // The label is now known, so the sheet a notification tap opens can be headed with it instead
+        // of `com.supercell.clashofclans`. `AppBackupViewModel.start` writes what it is handed straight
+        // into state and never looks the name up itself, so this is the only place that can fix it.
+        retargetSheet(
+            JobSheetTarget.Backup(
+                packageName = request.packageName,
+                appLabel = appInfo.appName ?: request.packageName,
+            )
+        )
 
         var bundle: File? = null
         return try {
@@ -209,12 +233,26 @@ internal class ArchiveRestoreWorker(
     private val appRepository: AppRepository,
     private val installedFacts: ReadInstalledAppFactsUseCase,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
-) : ThorJobWorker(appContext, params, notifications, registry, keys) {
+    sheetTargets: JobSheetTargets,
+) : ThorJobWorker(appContext, params, notifications, registry, keys, sheetTargets) {
 
     override val kind = ThorJobKind.ARCHIVE_RESTORE
 
     override val initialLabel: String
         get() = inputData.getString(RESTORE_PACKAGE_KEY).orEmpty()
+
+    /**
+     * The archive URI, which is all the restore sheet needs — it re-opens the file and re-reads the
+     * header for itself, exactly as it would after the picker. Unlike the backup side there is nothing
+     * better to learn later, so no `retargetSheet` call follows.
+     *
+     * The URI is a task-scoped SAF grant, so this is only ever handed to a sheet inside the same
+     * process and the same task. It is never persisted anywhere — see [JobSheetTargets].
+     */
+    override val sheetTarget: JobSheetTarget?
+        get() = inputData.getString(RESTORE_URI_KEY)
+            ?.takeIf { it.isNotBlank() }
+            ?.let(JobSheetTarget::Restore)
 
     override suspend fun runJob(): Result {
         val request = ArchiveRestoreRequest.fromMap(inputData.keyValueMap)

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/JobSheetTargets.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/JobSheetTargets.kt
@@ -6,8 +6,10 @@ package com.valhalla.thor.data.backup.job
 import com.valhalla.thor.domain.model.ThorJobKind
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.receiveAsFlow
 import org.koin.core.annotation.Single
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -49,42 +51,78 @@ sealed interface JobSheetTarget {
  * `CONFLATED`, so a tap that lands before `MainViewModel` exists (app lock, or the process starting to
  * host the trampoline) is held rather than lost, and a second tap replaces the first instead of
  * queueing a duplicate sheet.
+ *
+ * The channel carries the **kind**, not the target. Delivery therefore resolves against [live] at the
+ * moment the UI is listening, which is the only way to get two things right at once: a tap held through
+ * the app-lock screen must not open a sheet for a job that finished while the user was unlocking, and a
+ * tap that lands between a worker's two [set] calls must show the label the worker has *now*, not the
+ * package name it had then. A buffered payload gets both wrong, and the first one silently — the sheet
+ * opens on a dead job and simply fails to read its archive.
  */
 @Single
 class JobSheetTargets {
 
-    private val live = ConcurrentHashMap<ThorJobKind, JobSheetTarget>()
+    /**
+     * The live target per kind, tagged with the id of the job that owns the slot.
+     *
+     * [jobId] is what makes [clear] safe, and it is not decoration: `JobSheetTarget` is a data class, so
+     * a `remove(kind, target)` keyed on the target alone compares by **value**. Cancel a backup and
+     * immediately restart the same app and both workers hold an equal `Backup(pkg, label)` — the
+     * predecessor's cleanup would then match the successor's entry and erase it, which is the exact
+     * stranding the compare-and-remove exists to prevent. A `WorkSpec` id is unique per work request and
+     * stable across a retry of one, so it distinguishes the pair the value cannot.
+     */
+    private class Live(val jobId: UUID, val target: JobSheetTarget)
 
-    private val _requests = Channel<JobSheetTarget>(Channel.CONFLATED)
+    private val live = ConcurrentHashMap<ThorJobKind, Live>()
 
-    /** Emits once per notification tap on a job that is still running. */
-    val requests: Flow<JobSheetTarget> = _requests.receiveAsFlow()
+    private val _requests = Channel<ThorJobKind>(Channel.CONFLATED)
 
-    /** Replaces the target for [target]'s kind. A worker calls this as it starts, and again if it learns a better label. */
-    fun set(target: JobSheetTarget) {
-        live[target.kind] = target
+    /**
+     * Emits once per notification tap on a job that is **still running when the UI collects it**.
+     *
+     * `mapNotNull` is the liveness re-check: a request whose job has since ended resolves to nothing and
+     * the tap degrades to the plain resume the trampoline already performed.
+     */
+    val requests: Flow<JobSheetTarget> = _requests.receiveAsFlow().mapNotNull { live[it]?.target }
+
+    /**
+     * Publishes [target] as [jobId]'s, replacing whatever held that kind's slot.
+     *
+     * A worker calls this as it starts, and again if it learns a better label. Both calls pass the same
+     * [jobId], so the second is an update rather than a second owner.
+     */
+    fun set(jobId: UUID, target: JobSheetTarget) {
+        live[target.kind] = Live(jobId, target)
     }
 
     /**
-     * Drops [target] **only if it is still the live one**.
+     * Drops [kind]'s target **only if [jobId] still owns it**.
      *
-     * The compare-and-remove is the point. Jobs of one kind serialise through `THOR_JOB_CHAIN`, but
-     * `APPEND_OR_REPLACE` and cancellation mean a finishing worker's `finally` can run after its
-     * successor has already published. A plain `remove(kind)` there would erase the running job's
-     * target and leave its notification opening nothing.
+     * Jobs of one kind serialise through `THOR_JOB_CHAIN`, but `APPEND_OR_REPLACE` and cancellation both
+     * mean a finishing worker's `finally` can run after its successor has published. An unconditional
+     * `remove(kind)` there would erase the running job's target and leave its notification opening
+     * nothing; so would a compare on the target's value, whenever the two jobs describe the same work.
+     *
+     * `computeIfPresent` rather than a get-then-remove: returning null from the remapping function
+     * removes the mapping, and `ConcurrentHashMap` holds the bin lock across the test and the removal,
+     * so a successor publishing concurrently either loses the race cleanly or is never seen by it.
+     *
+     * Safe to call from a worker that never published — no entry carries its id, so nothing matches.
      */
-    fun clearIfStill(target: JobSheetTarget) {
-        live.remove(target.kind, target)
+    fun clear(kind: ThorJobKind, jobId: UUID) {
+        live.computeIfPresent(kind) { _, current -> if (current.jobId == jobId) null else current }
     }
 
     /**
      * Asks the UI to open [kind]'s sheet.
      *
      * @return false when no job of that kind is live — nothing was requested and the caller should
-     *   fall back to plain "open the app".
+     *   fall back to plain "open the app". A true is not a promise that a sheet appears: the job can
+     *   still end between here and the collector, which [requests] resolves by dropping the request.
      */
     fun requestOpen(kind: ThorJobKind): Boolean {
-        val target = live[kind] ?: return false
-        return _requests.trySend(target).isSuccess
+        if (!live.containsKey(kind)) return false
+        return _requests.trySend(kind).isSuccess
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/JobSheetTargets.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/JobSheetTargets.kt
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.backup.job
+
+import com.valhalla.thor.domain.model.ThorJobKind
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import org.koin.core.annotation.Single
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Which sheet a running job's notification should reopen, and with what.
+ *
+ * Not a route and not `Parcelable`: this never leaves the process. See [JobSheetTargets] for why.
+ */
+sealed interface JobSheetTarget {
+
+    val kind: ThorJobKind
+
+    /** [appLabel] is the app's real name, because `AppBackupViewModel.start` writes it into state verbatim. */
+    data class Backup(val packageName: String, val appLabel: String) : JobSheetTarget {
+        override val kind = ThorJobKind.ARCHIVE_BACKUP
+    }
+
+    /** [uriString] is the archive the job is reading — the same string the sheet would get from the picker. */
+    data class Restore(val uriString: String) : JobSheetTarget {
+        override val kind = ThorJobKind.ARCHIVE_RESTORE
+    }
+}
+
+/**
+ * The handoff from a running job to the UI that a tap on its notification asks for.
+ *
+ * **Why a holder rather than intent extras.** `HomeActivity` is `standard` launchMode and there is no
+ * `onNewIntent` anywhere in `app/src/main` — `pendingRestoreUri` is read once, `by lazy`, from the
+ * intent the activity was *created* with. So a notification that resumes an existing task delivers its
+ * extras to nothing: either they are dropped, or a component-targeted intent stacks a second
+ * `HomeActivity` on top of the live one. Both are worse than carrying the payload in memory. The
+ * notification therefore carries only [ThorJobKind.id]; everything the sheet needs is looked up here.
+ *
+ * The consequence is honest and deliberate: if Thor's process has died, [live] is empty and
+ * [requestOpen] returns false, so the tap just opens the app. A job whose notification is showing has
+ * a foreground service holding the process up, so that window is narrow — and the alternative
+ * (persisting a SAF URI whose grant is scoped to the task that received it) would produce a sheet that
+ * cannot read its own archive.
+ *
+ * `CONFLATED`, so a tap that lands before `MainViewModel` exists (app lock, or the process starting to
+ * host the trampoline) is held rather than lost, and a second tap replaces the first instead of
+ * queueing a duplicate sheet.
+ */
+@Single
+class JobSheetTargets {
+
+    private val live = ConcurrentHashMap<ThorJobKind, JobSheetTarget>()
+
+    private val _requests = Channel<JobSheetTarget>(Channel.CONFLATED)
+
+    /** Emits once per notification tap on a job that is still running. */
+    val requests: Flow<JobSheetTarget> = _requests.receiveAsFlow()
+
+    /** Replaces the target for [target]'s kind. A worker calls this as it starts, and again if it learns a better label. */
+    fun set(target: JobSheetTarget) {
+        live[target.kind] = target
+    }
+
+    /**
+     * Drops [target] **only if it is still the live one**.
+     *
+     * The compare-and-remove is the point. Jobs of one kind serialise through `THOR_JOB_CHAIN`, but
+     * `APPEND_OR_REPLACE` and cancellation mean a finishing worker's `finally` can run after its
+     * successor has already published. A plain `remove(kind)` there would erase the running job's
+     * target and leave its notification opening nothing.
+     */
+    fun clearIfStill(target: JobSheetTarget) {
+        live.remove(target.kind, target)
+    }
+
+    /**
+     * Asks the UI to open [kind]'s sheet.
+     *
+     * @return false when no job of that kind is live — nothing was requested and the caller should
+     *   fall back to plain "open the app".
+     */
+    fun requestOpen(kind: ThorJobKind): Boolean {
+        val target = live[kind] ?: return false
+        return _requests.trySend(target).isSuccess
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobNotifications.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobNotifications.kt
@@ -36,8 +36,10 @@ class ThorJobNotifications(private val context: Context) {
      * [build] runs up to once a second for the whole of a multi-gigabyte job, and
      * `PendingIntent.getActivity` is an IPC to ActivityManager. Eager and immutable rather than a lazy
      * cache because two IPCs at construction cost less than reasoning about a map mutated from a
-     * worker thread — and `ThorJobNotifications` is only constructed when a job or the trampoline
-     * first asks for it, not on the launch path.
+     * worker thread — and the only thing that constructs `ThorJobNotifications` is a worker Koin builds
+     * when WorkManager actually runs a job, so this is never on the launch path. (Not the trampoline,
+     * which an earlier version of this sentence also listed: `JobSheetLaunchActivity` resolves
+     * `JobSheetTargets` and nothing else, so it pays for none of this.)
      *
      * Naming a `presentation` class from `data` is the one upward reference here, and it is the
      * existing shape for this: `AnyFileOpenerManager` names `PortableInstallerActivity` for the same

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobNotifications.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobNotifications.kt
@@ -4,7 +4,9 @@
 package com.valhalla.thor.data.backup.job
 
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationChannelCompat
@@ -15,6 +17,7 @@ import androidx.work.WorkManager
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.ThorJobKind
 import com.valhalla.thor.domain.model.ThorJobProgress
+import com.valhalla.thor.presentation.launcher.JobSheetLaunchActivity
 import com.valhalla.thor.util.Logger
 import java.util.UUID
 import org.koin.core.annotation.Single
@@ -26,6 +29,37 @@ class ThorJobNotifications(private val context: Context) {
 
     // Hoisted out of the per-tick path — each from() call is a system service lookup.
     private val notificationManager = NotificationManagerCompat.from(context)
+
+    /**
+     * The tap targets, built once per kind rather than per tick.
+     *
+     * [build] runs up to once a second for the whole of a multi-gigabyte job, and
+     * `PendingIntent.getActivity` is an IPC to ActivityManager. Eager and immutable rather than a lazy
+     * cache because two IPCs at construction cost less than reasoning about a map mutated from a
+     * worker thread — and `ThorJobNotifications` is only constructed when a job or the trampoline
+     * first asks for it, not on the launch path.
+     *
+     * Naming a `presentation` class from `data` is the one upward reference here, and it is the
+     * existing shape for this: `AnyFileOpenerManager` names `PortableInstallerActivity` for the same
+     * reason — an `Intent` needs a component, and the component is an Activity. The alternative is a
+     * `SystemGateway`-style interface whose only implementation returns one class literal.
+     */
+    private val contentIntents: Map<ThorJobKind, PendingIntent> =
+        ThorJobKind.entries.associateWith { kind ->
+            PendingIntent.getActivity(
+                context,
+                // The notification id doubles as the request code, so the two kinds get distinct
+                // PendingIntents instead of one overwriting the other's extras. Request code 0 is
+                // BulkResultNotifier's; these start at BASE_NOTIFICATION_ID.
+                notificationId(kind),
+                Intent(context, JobSheetLaunchActivity::class.java)
+                    .putExtra(JobSheetLaunchActivity.EXTRA_JOB_KIND, kind.id),
+                // IMMUTABLE: nothing outside Thor has any business filling in this intent, and API 31+
+                // requires one of the two to be named explicitly. UPDATE_CURRENT so a rebuilt intent
+                // replaces the extras of a notification the system is still showing.
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        }
 
     init {
         // Channel creation is idempotent; calling it once here avoids an IPC on every notification
@@ -102,6 +136,10 @@ class ThorJobNotifications(private val context: Context) {
             setOngoing(true)
             setOnlyAlertOnce(true)
             setSilent(true)
+            // Reopens the sheet this job belongs to. Not setAutoCancel(true) with it: the job is still
+            // running after the tap, and the row is this job's only surface — dismissing it on tap
+            // would leave a foreground service with nothing showing for it.
+            setContentIntent(contentIntents.getValue(kind))
             // An unknown total is an indeterminate bar, never a bar sitting at 0%.
             val percent = progress.percent
             if (percent == null) setProgress(0, 0, true) else setProgress(100, percent, false)

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobWorker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobWorker.kt
@@ -61,15 +61,6 @@ abstract class ThorJobWorker(
     private var lastNotifyMs = 0L
     private var lastNotifyStage: ThorJobStage? = null
 
-    /**
-     * The target actually published, which is not always [sheetTarget].
-     *
-     * [retargetSheet] replaces it, and the `finally` clears *this* rather than [sheetTarget] — clearing
-     * the initial value would leave the improved one live after the job ended, and its notification is
-     * gone by then, so nothing would ever remove it.
-     */
-    private var publishedTarget: JobSheetTarget? = null
-
     final override suspend fun getForegroundInfo(): ForegroundInfo =
         notifications.foregroundInfo(
             kind,
@@ -134,11 +125,13 @@ abstract class ThorJobWorker(
             // both the setForeground-failed path and the cancellation-during-setForeground path.
             notifications.cancel(kind)
             //
-            // sheetTarget: compare-and-remove, so a successor that has already published its own
-            // target keeps it. Must follow nothing in particular, but must not be skipped on the
-            // cancellation path — a cancelled job's notification is gone, so a target left behind
-            // would be reopened by a *future* notification of the same kind, showing the wrong app.
-            publishedTarget?.let(sheetTargets::clearIfStill)
+            // sheetTarget: keyed on this job's id, so a successor that has already published keeps
+            // its own target even when the two describe the same work and compare equal. Called
+            // unconditionally — a worker that never published owns no entry, so nothing matches.
+            // Must not be skipped on the cancellation path: a cancelled job's notification is gone,
+            // so a target left behind would be reopened by a *future* notification of the same kind
+            // and would show the wrong app.
+            sheetTargets.clear(kind, id)
         }
     }
 
@@ -147,10 +140,12 @@ abstract class ThorJobWorker(
      *
      * A backup's `Data` holds only the package name, so the sheet a tap opens would be titled with an
      * application id until the worker resolves the real label. This is how it stops being.
+     *
+     * Always this worker's own [id], which is what keeps the `finally` from clearing a successor's
+     * entry — see [JobSheetTargets.clear].
      */
     protected fun retargetSheet(target: JobSheetTarget) {
-        publishedTarget = target
-        sheetTargets.set(target)
+        sheetTargets.set(id, target)
     }
 
     /**

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobWorker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobWorker.kt
@@ -41,6 +41,7 @@ abstract class ThorJobWorker(
     private val notifications: ThorJobNotifications,
     private val registry: JobRegistry,
     private val keyHolder: ArchiveKeyHolder,
+    private val sheetTargets: JobSheetTargets,
 ) : CoroutineWorker(appContext, params) {
 
     protected abstract val kind: ThorJobKind
@@ -48,11 +49,26 @@ abstract class ThorJobWorker(
     /** Shown before the job knows anything about sizes. */
     protected abstract val initialLabel: String
 
+    /**
+     * Which sheet this job's notification reopens, or null if its input `Data` did not carry enough to
+     * say. Read once at the top of [doWork]; a subclass that learns more later calls [retargetSheet].
+     */
+    protected abstract val sheetTarget: JobSheetTarget?
+
     protected abstract suspend fun runJob(): Result
 
     // Throttle state — one ThorJobWorker instance per WorkManager execution, so fields are safe.
     private var lastNotifyMs = 0L
     private var lastNotifyStage: ThorJobStage? = null
+
+    /**
+     * The target actually published, which is not always [sheetTarget].
+     *
+     * [retargetSheet] replaces it, and the `finally` clears *this* rather than [sheetTarget] — clearing
+     * the initial value would leave the improved one live after the job ended, and its notification is
+     * gone by then, so nothing would ever remove it.
+     */
+    private var publishedTarget: JobSheetTarget? = null
 
     final override suspend fun getForegroundInfo(): ForegroundInfo =
         notifications.foregroundInfo(
@@ -63,6 +79,10 @@ abstract class ThorJobWorker(
 
     final override suspend fun doWork(): Result {
         return try {
+            // Before setForeground, so the notification cannot be tapped before the target it points
+            // at exists. Inside the try so the finally below is the single owner of removing it.
+            sheetTarget?.let(::retargetSheet)
+
             // setForeground is inside the outer try so that a CancellationException from it —
             // or from getForegroundInfo() — still reaches finally and all three cleanups run.
             // On API 31+ a foreground service cannot be started from the background; the inner
@@ -113,7 +133,24 @@ abstract class ThorJobWorker(
             // the id it owns via setForeground — this is a no-op there and the actual cleanup on
             // both the setForeground-failed path and the cancellation-during-setForeground path.
             notifications.cancel(kind)
+            //
+            // sheetTarget: compare-and-remove, so a successor that has already published its own
+            // target keeps it. Must follow nothing in particular, but must not be skipped on the
+            // cancellation path — a cancelled job's notification is gone, so a target left behind
+            // would be reopened by a *future* notification of the same kind, showing the wrong app.
+            publishedTarget?.let(sheetTargets::clearIfStill)
         }
+    }
+
+    /**
+     * Republish this job's sheet target after learning something better than its input `Data` carried.
+     *
+     * A backup's `Data` holds only the package name, so the sheet a tap opens would be titled with an
+     * application id until the worker resolves the real label. This is how it stops being.
+     */
+    protected fun retargetSheet(target: JobSheetTarget) {
+        publishedTarget = target
+        sheetTargets.set(target)
     }
 
     /**

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppArchiveStoreImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppArchiveStoreImpl.kt
@@ -241,12 +241,26 @@ class AppArchiveStoreImpl(
         return false
     }
 
-    @Suppress("DEPRECATION") // See openInLegacyDownloads: this branch only runs below API 29.
     private fun deleteInLegacyDownloads(name: String): Boolean {
-        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-        val file = File(dir, name)
+        val file = File(legacyArchiveDir(), name)
         return file.isFile && file.delete()
     }
+
+    /**
+     * `Downloads/Thor` as a plain `File`, for the two below-API-29 backends.
+     *
+     * One function rather than the folder named twice, because the two callers have to agree or the
+     * feature breaks quietly: [openInLegacyDownloads] creates the `.part` in this directory and
+     * [deleteInLegacyDownloads] is the launch-time sweep that removes it. A sweeper pointed one level
+     * up finds nothing, reports false for every orphan, and leaves both the file and its ledger entry
+     * behind forever.
+     */
+    @Suppress("DEPRECATION") // getExternalStoragePublicDirectory: deprecated at 29, and both callers
+    // are below-29 branches. minSdk is 28, which is the whole reason those branches exist.
+    private fun legacyArchiveDir(): File = File(
+        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+        THOR_DOWNLOADS_SUBDIR,
+    )
 
     /**
      * Records [name] as an unpublished container and returns the callback that forgets it again.
@@ -288,7 +302,14 @@ class AppArchiveStoreImpl(
         val values = ContentValues().apply {
             put(MediaStore.Downloads.DISPLAY_NAME, fileName)
             put(MediaStore.Downloads.MIME_TYPE, THORBAK_MIME)
-            put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+            // Downloads/Thor, not Downloads. This was the bare `DIRECTORY_DOWNLOADS`, which put the
+            // archive in the root of the user's Downloads while `currentTargetLabel()` — resolved by
+            // `AppBundleFileStoreImpl`, which has always written to the subfolder — told them
+            // "Downloads/Thor". See THOR_DOWNLOADS_SUBDIR.
+            put(
+                MediaStore.Downloads.RELATIVE_PATH,
+                "${Environment.DIRECTORY_DOWNLOADS}/$THOR_DOWNLOADS_SUBDIR/",
+            )
             put(MediaStore.Downloads.IS_PENDING, 1)
         }
         val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values) ?: return null
@@ -389,10 +410,11 @@ class AppArchiveStoreImpl(
      * collide by design. [nonCollidingArchiveName] is what stops a second backup of the same version
      * from silently deleting the first, which is the behaviour the other two backends already had.
      */
-    @Suppress("DEPRECATION") // getExternalStoragePublicDirectory: deprecated at 29, and this branch
-    // only runs below 29. minSdk is 28, which is the whole reason the branch exists.
     private suspend fun openInLegacyDownloads(requestedName: String): ArchiveDestination? {
-        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val dir = legacyArchiveDir()
+        // `mkdirs`, and it now matters: Downloads itself always exists, but `Downloads/Thor` may not,
+        // and a null return here is reported to the user as "choose a folder" rather than as a failed
+        // backup. `AppBundleFileStoreImpl.writeToDownloadsLegacy` creates the same directory.
         if (!dir.isDirectory && !dir.mkdirs()) return null
         // Chosen before the partial is created, so the partial is named after the name this archive
         // will actually publish under and the two cannot drift apart.

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppBundleFileStoreImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppBundleFileStoreImpl.kt
@@ -27,6 +27,23 @@ import java.io.InputStream
 import java.io.OutputStream
 
 /**
+ * The subdirectory of public Downloads that every write Thor makes lands in.
+ *
+ * One name with four write sites across two files — this store's MediaStore and legacy paths, and
+ * [AppArchiveStoreImpl]'s — so it is defined once. It had drifted: the two archive backends wrote to
+ * Downloads **root** while `AppArchiveStore.currentTargetLabel()`, which resolves through this store,
+ * told the user *"Downloads/Thor"*. The label was right about the convention and wrong about where the
+ * file went, which is the worst way round for the one caption naming a folder the user then has to
+ * find.
+ *
+ * A `const val` on purpose, so it is inlined and nothing has to load a file facade to read it: the
+ * relative path is assembled inside the functions that need it, never in a top-level `val`. A
+ * top-level `val` touching `Environment` would run on the JVM the moment a test called any other
+ * top-level member of the same file, and `AppArchiveStoreImpl.kt` has three that are JVM-tested.
+ */
+internal const val THOR_DOWNLOADS_SUBDIR = "Thor"
+
+/**
  * Android-backed [AppBundleFileStore]: writes bundles to public Downloads
  * (MediaStore on Q+, legacy external storage otherwise) or a user-picked SAF
  * tree, and builds FileProvider content URIs for sharing. All the framework
@@ -100,7 +117,7 @@ class AppBundleFileStoreImpl(
     @RequiresApi(Build.VERSION_CODES.Q)
     private suspend fun writeToDownloadsMediaStore(source: File, mime: String): String {
         val resolver = context.contentResolver
-        val relativePath = Environment.DIRECTORY_DOWNLOADS + "/Thor/"
+        val relativePath = "${Environment.DIRECTORY_DOWNLOADS}/$THOR_DOWNLOADS_SUBDIR/"
         // MediaStore.insert appends " (1)" instead of overwriting, so delete any same-named
         // entry first. RELATIVE_PATH must match exactly, including the trailing slash.
         val selection =
@@ -137,7 +154,8 @@ class AppBundleFileStoreImpl(
     private suspend fun writeToDownloadsLegacy(source: File): String {
         @Suppress("DEPRECATION")
         val dir = File(
-            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), "Thor"
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            THOR_DOWNLOADS_SUBDIR
         )
         if (!dir.exists()) dir.mkdirs()
         val dest = File(dir, source.name)

--- a/app/src/main/java/com/valhalla/thor/domain/model/ThorJob.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ThorJob.kt
@@ -39,6 +39,18 @@ enum class ThorJobKind(val id: String) {
     ARCHIVE_RESTORE("archive-restore"),
 }
 
+/**
+ * The reverse of [ThorJobKind.id], for the one place a kind crosses a process boundary: the `Intent`
+ * extra a job notification's tap carries.
+ *
+ * Matches on [ThorJobKind.id] rather than `name` or `ordinal` on purpose. An ordinal is silently
+ * wrong the day someone reorders the enum, and a `PendingIntent` outlives the code that made it —
+ * `FLAG_UPDATE_CURRENT` replaces the extras of a live one, but a notification the system is still
+ * showing across an app update is holding whatever the *old* build wrote. Returns null for anything
+ * unrecognised, which the caller reads as "just open the app".
+ */
+fun jobKindFromId(id: String?): ThorJobKind? = ThorJobKind.entries.firstOrNull { it.id == id }
+
 enum class ThorJobStage {
     PREPARING,
     MEASURING,

--- a/app/src/main/java/com/valhalla/thor/domain/repository/ArchiveBreadcrumbStore.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/ArchiveBreadcrumbStore.kt
@@ -51,10 +51,15 @@ interface ArchiveBreadcrumbStore {
      * [read], re-run whenever this store's own [write] or [clear] changes the answer. Emits once on
      * collection, so it is a drop-in for a one-shot read.
      *
-     * It exists because two surfaces show this notice at once. `ArchiveRestore` is registered as a
-     * detail pane, so on an expanded window the restore screen and the Settings section are composed
-     * together: acknowledging the notice on one has to take it off the other, and a screen that reads
-     * once keeps reporting a breadcrumb that has been deleted.
+     * It exists because two surfaces show this notice at once. `ArchiveRestoreSheet` is hosted in
+     * `MainScreen`'s overlay level, so the Settings row carrying the notice stays composed underneath it
+     * at every window size: acknowledging the notice in the sheet has to take it off the section behind,
+     * and a surface that reads once keeps reporting a breadcrumb that has been deleted.
+     *
+     * This sentence used to argue the same conclusion from a detail pane on an expanded window. That was
+     * false in both builds — the route rendered in the detail pane beside an *empty* list pane, so
+     * nothing was next to it — and it is the layout claim `ObserveInterruptedRestoreUseCase` retracts.
+     * Only the mechanism was wrong; the conclusion is now unconditional rather than width-dependent.
      *
      * **In-process only.** The trigger is a call on this instance, not a file watch — which is enough
      * because one process writes breadcrumbs and Koin binds one instance of this within it, workers

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ObserveInterruptedRestoreUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ObserveInterruptedRestoreUseCase.kt
@@ -24,12 +24,19 @@ import org.koin.core.annotation.Factory
  * *"did not finish … restoring it again is the fix"*, and a live restore is neither finished nor a
  * reason to start a second one. §8.5 defines the notice as what *survives* to the next launch.
  *
- * This is not a hypothetical ordering. `ArchiveRestore` is registered as a `detailPane()`, so on an
- * expanded window the user starts a restore in the right-hand pane while the Settings section is
- * composed on the left; the breadcrumb write lands mid-restore, and without this filter the left pane
- * announces failure beside a progress bar reporting normal progress. `ArchiveRestoreViewModel` avoids
- * it by construction — it reads the breadcrumb once, in `init`, so a restore's own breadcrumb never
- * appears on the screen writing it — and this is the same guarantee for every other reader.
+ * This is not a hypothetical ordering, and it is no longer even window-size dependent. Restore is a
+ * bottom sheet hosted by `MainScreen`, so the Settings section carrying this notice stays composed
+ * *underneath* every restore, on every device: the breadcrumb write lands mid-restore and without this
+ * filter the row behind the sheet announces failure while the sheet in front of it reports normal
+ * progress. `ArchiveRestoreViewModel` avoids that by construction — it reads the breadcrumb once, in
+ * `init`, so a restore's own breadcrumb never appears on the surface writing it — and this is the same
+ * guarantee for every other reader.
+ *
+ * The argument used to rest on `ArchiveRestore` being registered as a `detailPane()` and therefore
+ * sitting beside a composed Settings pane on an expanded window. That was wrong about the layout — the
+ * route rendered in the detail pane with an *empty* list pane, so nothing was beside it. The
+ * suppression was load-bearing anyway, on the ordinary "reopen Settings during a restore" path, and
+ * hosting the sheet above the section is what makes it unconditional.
  *
  * The suppression is per package, not global: an interrupted restore of A is still worth reporting
  * while a restore of B runs, and those are different rows in the notice's own history.

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
@@ -55,9 +55,19 @@ import com.valhalla.thor.domain.model.labelKind
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.presentation.settings.PassphraseError
 import com.valhalla.thor.presentation.settings.passphraseErrorText
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
+
+/**
+ * How long the success frame stays up before the sheet closes itself.
+ *
+ * Long enough to read *"Backup saved."* and register it, short enough not to be a dialog the user has
+ * to dismiss. Not a preference and not animated against: if it is ever tuned, the thing to preserve is
+ * that "Got it" is always faster than waiting.
+ */
+private const val SUCCESS_LINGER_MS = 3_000L
 
 /**
  * The user-facing name of a storage class.
@@ -164,17 +174,51 @@ fun AppBackupSheet(packageName: String, appLabel: String, onDismiss: () -> Unit)
                 fontWeight = FontWeight.Bold
             )
 
-            when (state.supported) {
+            // A `when` on conditions rather than on `state.supported`: the sheet has five frames and
+            // only the first two are about support. The order is the order they happen in, and it
+            // settles the one pair that can overlap — `running` outranks a `finished` left over from a
+            // previous job, which the reattach collector in `start()` can pick up before `watch`
+            // clears the banner.
+            when {
                 // Still probing. A spinner, never the refusal panel — see AppBackupUiState.supported.
-                null -> CircularProgressIndicator()
+                state.supported == null -> CircularProgressIndicator()
 
-                false -> Text(
+                state.supported == false -> Text(
                     text = stringResource(R.string.backup_unsupported),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
 
-                true -> {
+                // The form is *gone* while a job runs, not disabled. Six checkboxes, the destination
+                // and its picker, two passphrase fields and a second Back up button used to sit above
+                // the bar with `enabled = false` on each — a form the user can read, cannot use, and
+                // has to scroll past to reach the one thing that is moving.
+                state.running -> BackupRunning(state = state, onBackground = onDismiss)
+
+                // The last frame. `Succeeded` is a `data object`, so it is named rather than smart-cast
+                // out of `state.finished` — which is read through a delegated `state` and would not
+                // smart-cast anyway.
+                state.finished is BackupFinish.Succeeded -> {
+                    // Three seconds, then the sheet closes itself: the archive is written, and the form
+                    // underneath has nothing left to offer except writing it again. Keyed on `Unit`, so
+                    // the timer belongs to this frame — "Got it" removes the frame and cancels the
+                    // timer with it, rather than leaving a dismiss to fire later at whatever the sheet
+                    // has become by then.
+                    LaunchedEffect(Unit) {
+                        delay(SUCCESS_LINGER_MS)
+                        onDismiss()
+                    }
+                    // `onDismiss`, not `viewModel::dismissResult`. Clearing the banner is the right
+                    // thing for a *failure*, which puts the user back on a form they may want to retry
+                    // from; a success has no such form, so this button skips the wait rather than
+                    // returning anywhere.
+                    BackupOutcome(finish = BackupFinish.Succeeded, onDismiss = onDismiss)
+                }
+
+                // Idle, and supported. Every `enabled = !state.running` below is now provably true —
+                // kept rather than simplified to `true`, because the guard is what makes each control
+                // safe on its own if this frame is ever widened again.
+                else -> {
                     CheckRow(
                         checked = state.includeBundle,
                         enabled = !state.running,
@@ -311,37 +355,6 @@ fun AppBackupSheet(packageName: String, appLabel: String, onDismiss: () -> Unit)
                         }
                     }
 
-                    if (state.running) {
-                        val percent = state.progress?.percent
-                        if (percent == null) {
-                            // Indeterminate, never a determinate bar pinned at 0 — see the view-model
-                            // test that names this.
-                            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                        } else {
-                            LinearProgressIndicator(
-                                progress = { percent / 100f },
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
-                        if (state.queued) {
-                            // Says where the job is, and stops there. Every job is appended to one
-                            // chain, and a dependent whose prerequisite fails is cancelled — so
-                            // "starting soon" would be a promise WorkManager has not made.
-                            Text(
-                                text = stringResource(R.string.backup_queued),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        state.progress?.let {
-                            Text(
-                                text = it.label,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-
                     Button(
                         onClick = {
                             viewModel.beginBackup(passphrase.toCharArray(), rememberIt)
@@ -352,11 +365,72 @@ fun AppBackupSheet(packageName: String, appLabel: String, onDismiss: () -> Unit)
                         Text(stringResource(R.string.backup_start))
                     }
 
+                    // Failures and cancels only — the success arm above claims `Succeeded` before this
+                    // frame is reached. Left under the form on purpose: a failed backup is one the user
+                    // may want to retry, and the reason it failed belongs next to the controls that
+                    // would change the retry.
                     state.finished?.let { finish ->
                         BackupOutcome(finish = finish, onDismiss = viewModel::dismissResult)
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * What the sheet is while a job is live: the bar, what it is doing, and a way to leave.
+ *
+ * The Background button is honest about what it does because of where the work runs. The job is a
+ * WorkManager foreground service, so dismissing the sheet drops this sheet's *watcher* and nothing
+ * else — `AppInfoSheet` already says as much about the export sheet it hosts the same way. Reopening
+ * finds the same job again through `runningJobFor`, and the ongoing notification carries the progress
+ * meanwhile, which is what makes leaving a real option rather than an abandonment.
+ *
+ * No Cancel button here, deliberately: the notification already carries one built from
+ * `WorkManager.createCancelPendingIntent`, and a second cancel affordance on a surface that is about
+ * to be dismissed is a control whose result the user would not be watching.
+ */
+@Composable
+private fun BackupRunning(state: AppBackupUiState, onBackground: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        val percent = state.progress?.percent
+        if (percent == null) {
+            // Indeterminate, never a determinate bar pinned at 0 — see the view-model test that names
+            // this.
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        } else {
+            LinearProgressIndicator(
+                progress = { percent / 100f },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        if (state.queued) {
+            // Says where the job is, and stops there. Every job is appended to one chain, and a
+            // dependent whose prerequisite fails is cancelled — so "starting soon" would be a promise
+            // WorkManager has not made.
+            Text(
+                text = stringResource(R.string.backup_queued),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        state.progress?.let {
+            Text(
+                text = it.label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        // Above the button rather than below it: it is the sentence that makes the button's one word
+        // mean something, and a caption under a button is read after it has been pressed.
+        Text(
+            text = stringResource(R.string.backup_background_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Button(onClick = onBackground, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(R.string.backup_background))
         }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
@@ -183,11 +183,24 @@ fun AppBackupSheet(packageName: String, appLabel: String, onDismiss: () -> Unit)
                 // Still probing. A spinner, never the refusal panel — see AppBackupUiState.supported.
                 state.supported == null -> CircularProgressIndicator()
 
-                state.supported == false -> Text(
-                    text = stringResource(R.string.backup_unsupported),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                state.supported == false -> Column(
+                    // 8.dp, not the parent's 16.dp: these are two halves of one answer — what Thor
+                    // cannot do now, and what it will be able to do — so they read as one block.
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.backup_unsupported),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    // `primary`, so the roadmap line does not read as more of the same refusal. This
+                    // is the only surface that shows it — see the comment on the string.
+                    Text(
+                        text = stringResource(R.string.backup_partial_soon),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
 
                 // The form is *gone* while a job runs, not disabled. Six checkboxes, the destination
                 // and its picker, two passphrase fields and a second Back up button used to sit above

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
@@ -252,24 +253,30 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                 )
             }
 
-            header.heldClasses().forEach { dataClass ->
-                // `heldClasses()` is defined as the classes with a member, so this cannot drop a row
-                // the user should have seen; it is here so the size below is read off a member that
-                // exists rather than defaulted to a number nothing measured.
-                val member = header.member(dataClass) ?: return@forEach
-                CheckRow(
-                    checked = dataClass in state.selected,
-                    enabled = !state.running,
-                    label = stringResource(dataClassLabel(dataClass)),
-                    // `Known`, and only `Known`: an archive records the byte count it actually packed,
-                    // so there is no tri-state to render here. Routed through `sizeLabel` anyway so
-                    // every size in this feature is formatted by one function.
-                    detail = sizeLabel(DataClassSize.Known(member.plainBytes)),
-                    onCheckedChange = { viewModel.toggleClass(dataClass) }
-                )
+            // Withdrawn once the job is live rather than drawn disabled, matching `AppBackupSheet`. A
+            // running restore has already been told what to restore, so these rows can no longer change
+            // anything — and a screenful of greyed checkboxes above the bar is a form the user reads,
+            // cannot use, and has to scroll past to find the only thing that is moving.
+            if (!state.running) {
+                header.heldClasses().forEach { dataClass ->
+                    // `heldClasses()` is defined as the classes with a member, so this cannot drop a row
+                    // the user should have seen; it is here so the size below is read off a member that
+                    // exists rather than defaulted to a number nothing measured.
+                    val member = header.member(dataClass) ?: return@forEach
+                    CheckRow(
+                        checked = dataClass in state.selected,
+                        enabled = !state.running,
+                        label = stringResource(dataClassLabel(dataClass)),
+                        // `Known`, and only `Known`: an archive records the byte count it actually
+                        // packed, so there is no tri-state to render here. Routed through `sizeLabel`
+                        // anyway so every size in this feature is formatted by one function.
+                        detail = sizeLabel(DataClassSize.Known(member.plainBytes)),
+                        onCheckedChange = { viewModel.toggleClass(dataClass) }
+                    )
+                }
             }
 
-            if (state.obbOffered) {
+            if (state.obbOffered && !state.running) {
                 // pluralStringResource, not stringResource — this is R.plurals, and the count is
                 // passed twice on purpose: once to pick the quantity, once to fill %1$d.
                 val obbCount = header.appBundle?.obbCount ?: 0
@@ -298,7 +305,15 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                 )
             }
 
-            if (state.refusal == null) {
+            // Where the rows above were, so the bar appears in the space the controls vacated instead
+            // of below everything they left behind.
+            if (state.running) RestoreRunning(state = state)
+
+            // `!state.running` as well as an absent refusal: the passphrase field, the confirmation and
+            // the Restore button are all decisions the job has already taken. The progress bar this
+            // block used to hold has moved out of it — under a refusal it was unreachable anyway, which
+            // is correct today only because a refused restore cannot be running.
+            if (state.refusal == null && !state.running) {
                 if (state.passphraseNeeded) {
                     OutlinedTextField(
                         value = passphrase,
@@ -355,37 +370,6 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                     onCheckedChange = viewModel::setConfirmed
                 )
 
-                if (state.running) {
-                    val percent = state.progress?.percent
-                    if (percent == null) {
-                        // Indeterminate, never a determinate bar pinned at 0 — a bar at 0 % that is
-                        // moving is a different claim from one that has not started.
-                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                    } else {
-                        LinearProgressIndicator(
-                            progress = { percent / 100f },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                    if (state.queued) {
-                        // Says where the job is, and stops there. Every job is appended to one chain,
-                        // and a dependent whose prerequisite fails is cancelled before `doWork` runs —
-                        // so "starting soon" would be a promise WorkManager has not made.
-                        Text(
-                            text = stringResource(R.string.backup_queued),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    state.progress?.let {
-                        Text(
-                            text = it.label,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-
                 Button(
                     onClick = viewModel::beginRestore,
                     enabled = state.canStart,
@@ -396,7 +380,7 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
             }
 
             state.finished?.let { finish ->
-                RestoreOutcome(finish = finish, onDismiss = viewModel::dismissResult)
+                RestoreOutcomeDialog(finish = finish, onDismiss = viewModel::dismissResult)
             }
 
             if (!state.running && state.finished !is RestoreFinish.Succeeded) {
@@ -405,8 +389,8 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                 // picked the wrong backup has to leave the screen to pick another.
                 //
                 // Withdrawn after a *successful* restore, which is the one moment the wrong-file case
-                // cannot apply: the card directly above says "Restore finished. Open the app to check
-                // it works", and offering "Choose a different file" under it puts a destructive
+                // cannot apply: the dialog over this column says "Restore finished. Open the app to
+                // check it works", and offering "Choose a different file" behind it puts a destructive
                 // operation one tap from an app that is now correct. Dismissing the outcome brings it
                 // back, so nothing is lost — the user just has to acknowledge the result first.
                 TextButton(onClick = { picker.launch(arrayOf("*/*")) }) {
@@ -423,7 +407,87 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
 }
 
 /**
+ * What the screen shows while a restore is live: the bar, and what it is working on.
+ *
+ * No Background button, unlike `BackupRunning`'s sheet — this is a screen, so there is nothing to
+ * dismiss, and the Back button at the bottom of the column is already the way out. Leaving is safe for
+ * the same reason it is there: the job is a WorkManager foreground service with its own notification,
+ * and `runningJobFor` re-attaches this screen to it on the way back in.
+ */
+@Composable
+private fun RestoreRunning(state: ArchiveRestoreUiState) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+        val percent = state.progress?.percent
+        if (percent == null) {
+            // Indeterminate, never a determinate bar pinned at 0 — a bar at 0 % that is moving is a
+            // different claim from one that has not started.
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        } else {
+            LinearProgressIndicator(
+                progress = { percent / 100f },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        if (state.queued) {
+            // Says where the job is, and stops there. Every job is appended to one chain, and a
+            // dependent whose prerequisite fails is cancelled before `doWork` runs — so "starting soon"
+            // would be a promise WorkManager has not made.
+            Text(
+                text = stringResource(R.string.backup_queued),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        state.progress?.let {
+            Text(
+                text = it.label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/**
+ * [RestoreOutcome] in a dialog.
+ *
+ * A dialog rather than the card at the foot of the column it used to be, because of how tall the column
+ * is: the title, the archive's three header lines, up to four class rows, the game-data row, the unlock
+ * row, the confirmation row, the bar and the Restore button all sit above it. The sentence saying
+ * whether an app's data came back therefore arrived below the fold, on the one screen where the user is
+ * watching for exactly that — and a restore finishes minutes after the tap that started it, so it is
+ * also the one event here the user is not already looking at the bottom of the screen for. It has to
+ * interrupt rather than wait to be found.
+ *
+ * All three outcomes, not only the success that prompted this. A failure was equally invisible, and one
+ * container for one decision is what keeps the five sentences [RestoreOutcome] documents from drifting
+ * into two shapes.
+ *
+ * No auto-dismiss, deliberately — unlike the backup sheet's success frame, which closes itself after
+ * three seconds. That one has nothing left to say; this one tells the user to go and open the app to
+ * check it works, and may be carrying warnings under it.
+ */
+@Composable
+private fun RestoreOutcomeDialog(finish: RestoreFinish, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = { RestoreOutcome(finish = finish) },
+        confirmButton = {
+            // `restore_outcome_dismiss`, not `restore_interrupted_dismiss`: that one is named and
+            // commented for the §8.5 breadcrumb banner at the top of this screen. Same word today, two
+            // owners, so rewording the breadcrumb's button cannot silently reword this one.
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.restore_outcome_dismiss))
+            }
+        }
+    )
+}
+
+/**
  * How a finished restore is reported.
+ *
+ * The body of [RestoreOutcomeDialog], which owns the dismiss button — so this stays a column of
+ * sentences and nothing else.
  *
  * Three outcomes, five sentences: both failure arms split on [RestoreFinish.workerRan], because what
  * is honest depends on whether anything reached the device.
@@ -443,7 +507,7 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
  * worse one, because it ends by telling the user to run a destructive operation again.
  */
 @Composable
-private fun RestoreOutcome(finish: RestoreFinish, onDismiss: () -> Unit) {
+private fun RestoreOutcome(finish: RestoreFinish) {
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         when (finish) {
             // §8.6: the honest instruction is "open it and check", because no amount of shell exit
@@ -522,12 +586,6 @@ private fun RestoreOutcome(finish: RestoreFinish, onDismiss: () -> Unit) {
                     color = MaterialTheme.colorScheme.error
                 )
             }
-        }
-        // `restore_outcome_dismiss`, not `restore_interrupted_dismiss`: that one is named and commented
-        // for the §8.5 breadcrumb banner at the top of this screen. Same word today, two owners, so
-        // rewording the breadcrumb's button cannot silently reword this one.
-        TextButton(onClick = onDismiss) {
-            Text(stringResource(R.string.restore_outcome_dismiss))
         }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
@@ -10,10 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,12 +18,16 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.rememberViewModelStoreOwner
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.ArchiveRestoreRefusal
 import com.valhalla.thor.domain.model.ArchiveRestoreWarning
@@ -72,7 +74,7 @@ private fun warningLabel(warning: ArchiveRestoreWarning): Int = when (warning) {
  * The `R` half of [ArchiveRestoreMessage], kept here beside [refusalLabel] and [warningLabel] so
  * `ArchiveRestoreViewModel` holds no Android resource ids and stays JVM-testable.
  *
- * Two arms, because the screen draws two kinds of sentence: one this feature wrote and translates, and
+ * Two arms, because the sheet draws two kinds of sentence: one this feature wrote and translates, and
  * one produced below it that arrives already worded. The distinction is deliberate rather than a
  * fallback — see [ArchiveRestoreMessage].
  */
@@ -97,33 +99,43 @@ private fun reasonLabel(reason: ArchiveRestoreReason): Int = when (reason) {
 /**
  * §10's restore entry point.
  *
+ * A [ModalBottomSheet], and the sibling of [AppBackupSheet] rather than a screen: the two halves of
+ * one feature were a sheet and a full-screen route, so backing up an app kept the user where they
+ * were while restoring one navigated them into the Settings tab and back out again. It is hosted at
+ * `MainScreen`'s overlay level, over whatever tab is showing, for the same reason the backup sheet is
+ * hosted at its call site — a restore outlives the surface that started it, and the notification tap
+ * that brings the user back must be able to put it in front of them from any tab.
+ *
  * @param uriString null when the user arrived from Settings and has yet to pick a file. Not defaulted:
  *   a defaulted parameter here would let a call site silently forget the VIEW-delivered URI, and the
- *   only symptom would be a screen that always asks for a file.
+ *   only symptom would be a sheet that always asks for a file.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
-    // The default owner, which here is the `NavEntry` for `ThorRoute.ArchiveRestore` — `MainScreen`
-    // installs `rememberViewModelStoreNavEntryDecorator()` on every back stack it builds, so the
-    // nearest `LocalViewModelStoreOwner` at this call site is the entry, not the Activity. That store
-    // is created when the route is pushed and cleared when it is popped, which is exactly how a visit
-    // to this screen ends, and `ThorRoute.ArchiveRestore` carries `uriString` as part of its key, so
-    // two archives are two keys, two entries and two stores. Both of the things a composition-scoped
-    // owner would have been protecting against are therefore already impossible.
+internal fun ArchiveRestoreSheet(uriString: String?, onDismiss: () -> Unit) {
+    // Scoped to this composable, which is now the same shape `AppBackupSheet` is and for the same
+    // reason. This used to be a `NavEntry` for `ThorRoute.ArchiveRestore`, whose store was created
+    // when the route was pushed, cleared when it was popped, and keyed by the route's own
+    // `uriString` — so the default owner was already per-archive and per-visit. As a sheet it is a
+    // conditional composable inside whichever tab is showing, at one call site reused for every
+    // archive, so the default owner is that tab's entry and outlives it: the next archive's sheet
+    // would get the previous archive's view model back, with its parsed header, its unlocked key and
+    // its ticked confirmation still in place.
     //
-    // This deliberately does **not** copy `AppBackupSheet`, whose `rememberViewModelStoreOwner()` is
-    // correct for a reason this screen does not share: that sheet is a conditional composable inside
-    // another entry's composition, at one call site reused for every app, so its default owner really
-    // does outlive it and really would hand app B's sheet app A's view model. A screen that *is* an
-    // entry does not meet that condition. Scoping here instead bought a risk — the owner keys on the
-    // composite key hash, so a pane-count change (unfolding, resizing a split window) could plausibly
-    // re-key it and reset the screen to "Choose a file", losing the parsed header, the unlocked
-    // passphrase and the ticked confirmation.
-    //
-    // A restore already running survives either way: `runningJobFor` re-attaches to it.
-    val viewModel = koinViewModel<ArchiveRestoreViewModel>()
+    // What this costs is bounded, and it is worth stating because the reasoning ran the other way
+    // while this was a screen. Losing the view model on dismiss drops an unlock — 210,000 PBKDF2
+    // iterations — but the controls that would ask for it again are all inside
+    // `if (state.refusal == null && !state.running)`, so a sheet reopened over a *live* restore
+    // renders the header and the progress bar and never asks: `watchForExistingJob` re-attaches to
+    // the job, exactly as `runningJobFor` did before.
+    val viewModel = koinViewModel<ArchiveRestoreViewModel>(
+        viewModelStoreOwner = rememberViewModelStoreOwner()
+    )
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    var passphrase by remember { mutableStateOf("") }
+    // Keyed on `uriString`, not bare: the sheet stays composed across a change of archive delivered
+    // from outside (a second `.thorbak` opened while it is up), and `open()` clears every field it
+    // owns but cannot reach this one — the same defect the picker callback below documents.
+    var passphrase by remember(uriString) { mutableStateOf("") }
 
     LaunchedEffect(uriString) { uriString?.let(viewModel::open) }
 
@@ -144,11 +156,65 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
         }
     }
 
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        // No partial detent, unlike `AppBackupSheet`'s default state. This sheet's tall frame is a
+        // form of up to a dozen controls that ends in a destructive button, and the two rows a user
+        // has to reach before pressing it — *Replaces what the app has now* and the unlock — are the
+        // last two. A half-height sheet would show the archive's header and hide the consent.
+        sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Expanded, SheetValue.Hidden)
+        ),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shape = RoundedCornerShape(topStart = 48.dp, topEnd = 48.dp),
+        tonalElevation = 0.dp
+    ) {
+        RestoreSheetBody(
+            state = state,
+            viewModel = viewModel,
+            passphrase = passphrase,
+            onPassphraseChange = { passphrase = it },
+            // */* rather than THORBAK_MIME: providers report a .thorbak as octet-stream, zip or
+            // nothing at all depending on which one is answering, and a narrow filter greys out the
+            // file the user is looking straight at.
+            onPickFile = { picker.launch(arrayOf("*/*")) },
+            onDismiss = onDismiss,
+        )
+    }
+}
+
+/**
+ * Everything inside the sheet.
+ *
+ * Split out from [ArchiveRestoreSheet] rather than nested in it so that the sheet's own chrome — the
+ * detents, the shape, the dismissal — reads as five lines instead of being the outermost of eight
+ * indents. The view model is passed down rather than resolved again here: `koinViewModel` at a second
+ * call site would build a second one against whichever owner is nearest, which is the whole thing the
+ * scoping comment above is about.
+ *
+ * @param onPickFile opens the SAF picker the sheet owns. A callback rather than the launcher itself,
+ *   because the any-MIME filter is a decision about which files a provider is allowed to grey out and
+ *   belongs with the callback that handles the result. (Spelled out rather than quoted: the wildcard
+ *   pair ends with the two characters that close a KDoc block, and writing it here truncated the
+ *   comment and produced fifteen "expecting a top level declaration" errors.)
+ */
+@Composable
+private fun RestoreSheetBody(
+    state: ArchiveRestoreUiState,
+    viewModel: ArchiveRestoreViewModel,
+    passphrase: String,
+    onPassphraseChange: (String) -> Unit,
+    onPickFile: () -> Unit,
+    onDismiss: () -> Unit,
+) {
     Column(
         modifier = Modifier
-            .fillMaxSize()
+            .fillMaxWidth()
             .verticalScroll(rememberScrollState())
-            .padding(24.dp),
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 32.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         Text(
@@ -204,10 +270,7 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            // */* rather than THORBAK_MIME: providers report a .thorbak as octet-stream, zip or
-            // nothing at all depending on which one is answering, and a narrow filter greys out the
-            // file the user is looking straight at.
-            OutlinedButton(onClick = { picker.launch(arrayOf("*/*")) }) {
+            OutlinedButton(onClick = onPickFile) {
                 Text(stringResource(R.string.restore_pick_file))
             }
         } else {
@@ -265,7 +328,12 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                     val member = header.member(dataClass) ?: return@forEach
                     CheckRow(
                         checked = dataClass in state.selected,
-                        enabled = !state.running,
+                        // `true`, not `!state.running`. The enclosing `if` already answers that, so a
+                        // condition here would be a control that cannot be reached in its disabled
+                        // state — and reads to the next person as if the row greys out mid-restore
+                        // when in fact it is gone. Every `enabled` below is constant for the same
+                        // reason; the guard is the `if`, once, at the top.
+                        enabled = true,
                         label = stringResource(dataClassLabel(dataClass)),
                         // `Known`, and only `Known`: an archive records the byte count it actually
                         // packed, so there is no tri-state to render here. Routed through `sizeLabel`
@@ -282,7 +350,7 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                 val obbCount = header.appBundle?.obbCount ?: 0
                 CheckRow(
                     checked = state.restoreObb,
-                    enabled = !state.running,
+                    enabled = true, // see the CheckRow above
                     label = pluralStringResource(R.plurals.restore_include_obb, obbCount, obbCount),
                     detail = null,
                     onCheckedChange = viewModel::setRestoreObb
@@ -307,7 +375,7 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
 
             // Where the rows above were, so the bar appears in the space the controls vacated instead
             // of below everything they left behind.
-            if (state.running) RestoreRunning(state = state)
+            if (state.running) RestoreRunning(state = state, onBackground = onDismiss)
 
             // `!state.running` as well as an absent refusal: the passphrase field, the confirmation and
             // the Restore button are all decisions the job has already taken. The progress bar this
@@ -317,7 +385,7 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                 if (state.passphraseNeeded) {
                     OutlinedTextField(
                         value = passphrase,
-                        onValueChange = { passphrase = it },
+                        onValueChange = onPassphraseChange,
                         label = { Text(stringResource(R.string.backup_passphrase)) },
                         visualTransformation = PasswordVisualTransformation(),
                         singleLine = true,
@@ -331,14 +399,15 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                             // Dropped as soon as it is handed over. A String cannot be zeroed, so the
                             // most this can do is stop holding a live reference to one — which is
                             // still the difference between a passphrase that survives until GC and
-                            // one that survives until the screen closes.
-                            passphrase = ""
+                            // one that survives until the sheet closes.
+                            onPassphraseChange("")
                         },
-                        // `!state.loading` as well as `!state.running`: the derivation behind this
-                        // button takes 210,000 PBKDF2 iterations, and the view model refuses a second
-                        // submission while one is in flight. The button has to say so — a control that
-                        // silently discards a tap is the thing that makes a user tap it again.
-                        enabled = passphrase.isNotEmpty() && !state.running && !state.loading,
+                        // `!state.loading`: the derivation behind this button takes 210,000 PBKDF2
+                        // iterations, and the view model refuses a second submission while one is in
+                        // flight. The button has to say so — a control that silently discards a tap is
+                        // the thing that makes a user tap it again. No `!state.running` beside it: the
+                        // enclosing `if` has already established that.
+                        enabled = passphrase.isNotEmpty() && !state.loading,
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Text(stringResource(R.string.restore_unlock))
@@ -351,10 +420,7 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
                             color = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.weight(1f)
                         )
-                        TextButton(
-                            onClick = viewModel::useDifferentPassphrase,
-                            enabled = !state.running
-                        ) {
+                        TextButton(onClick = viewModel::useDifferentPassphrase) {
                             Text(stringResource(R.string.backup_use_different_passphrase))
                         }
                     }
@@ -362,7 +428,7 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
 
                 CheckRow(
                     checked = state.confirmed,
-                    enabled = !state.running,
+                    enabled = true, // the enclosing `if` is the guard
                     // "Replaces", not "restores". A merge is what a user assumes, and it is not what
                     // happens: whatever the app holds now for a selected class is deleted.
                     label = stringResource(R.string.restore_confirm_replace),
@@ -386,36 +452,41 @@ internal fun ArchiveRestoreScreen(uriString: String?, onBack: () -> Unit) {
             if (!state.running && state.finished !is RestoreFinish.Succeeded) {
                 // The way back out of a file that turned out to be the wrong one. Without it the
                 // "choose a file" button is gone for good the moment a header loads, and a user who
-                // picked the wrong backup has to leave the screen to pick another.
+                // picked the wrong backup has to close the sheet to pick another.
                 //
                 // Withdrawn after a *successful* restore, which is the one moment the wrong-file case
                 // cannot apply: the dialog over this column says "Restore finished. Open the app to
                 // check it works", and offering "Choose a different file" behind it puts a destructive
                 // operation one tap from an app that is now correct. Dismissing the outcome brings it
                 // back, so nothing is lost — the user just has to acknowledge the result first.
-                TextButton(onClick = { picker.launch(arrayOf("*/*")) }) {
+                TextButton(onClick = onPickFile) {
                     Text(stringResource(R.string.restore_pick_another))
                 }
             }
         }
 
-        Spacer(Modifier.height(8.dp))
-        OutlinedButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
-            Text(stringResource(R.string.restore_back))
-        }
+        // No Back button at the foot of the column any more. A sheet is dismissed by its scrim, its
+        // drag handle and the system back gesture, all three of which this one honours, so a fourth
+        // affordance would be a button whose only job is to duplicate them — and the one moment
+        // leaving needs explaining is a live restore, which `RestoreRunning` now says in words.
     }
 }
 
 /**
- * What the screen shows while a restore is live: the bar, and what it is working on.
+ * What the sheet shows while a restore is live: the bar, what it is working on, and a way to leave.
  *
- * No Background button, unlike `BackupRunning`'s sheet — this is a screen, so there is nothing to
- * dismiss, and the Back button at the bottom of the column is already the way out. Leaving is safe for
- * the same reason it is there: the job is a WorkManager foreground service with its own notification,
- * and `runningJobFor` re-attaches this screen to it on the way back in.
+ * The Background button is the same one `BackupRunning` carries, and for the same reason — the job is
+ * a WorkManager foreground service, so dismissing this drops the sheet's *watcher* and nothing else.
+ * Reopening finds the same job again through `runningJobFor`, either from Settings or by tapping the
+ * ongoing notification, and that notification carries the progress meanwhile.
+ *
+ * No Cancel button, deliberately: the notification already carries one built from
+ * `WorkManager.createCancelPendingIntent`, and a second cancel on a surface that is about to be
+ * dismissed is a control whose result the user would not be watching. It matters more here than on the
+ * backup side — cancelling a restore part-way is what leaves an app's data half-written.
  */
 @Composable
-private fun RestoreRunning(state: ArchiveRestoreUiState) {
+private fun RestoreRunning(state: ArchiveRestoreUiState, onBackground: () -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
         val percent = state.progress?.percent
         if (percent == null) {
@@ -445,6 +516,19 @@ private fun RestoreRunning(state: ArchiveRestoreUiState) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
+        // Above the button rather than below it, matching `BackupRunning`: it is the sentence that
+        // makes the button's one word mean something, and a caption under a button is read after it
+        // has been pressed. `backup_background_desc` verbatim rather than a restore-specific copy —
+        // it describes what dismissing does, which is the same on both sides, and a second string
+        // saying it would be a second thing to translate and a second thing to drift.
+        Text(
+            text = stringResource(R.string.backup_background_desc),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Button(onClick = onBackground, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(R.string.backup_background))
+        }
     }
 }
 
@@ -454,10 +538,19 @@ private fun RestoreRunning(state: ArchiveRestoreUiState) {
  * A dialog rather than the card at the foot of the column it used to be, because of how tall the column
  * is: the title, the archive's three header lines, up to four class rows, the game-data row, the unlock
  * row, the confirmation row, the bar and the Restore button all sit above it. The sentence saying
- * whether an app's data came back therefore arrived below the fold, on the one screen where the user is
+ * whether an app's data came back therefore arrived below the fold, on the one surface where the user is
  * watching for exactly that — and a restore finishes minutes after the tap that started it, so it is
- * also the one event here the user is not already looking at the bottom of the screen for. It has to
+ * also the one event here the user is not already looking at the bottom of the column for. It has to
  * interrupt rather than wait to be found.
+ *
+ * A dialog *over a sheet*, now that this is one, and it survives the move unchanged because a `Dialog`
+ * is its own window: it renders above the sheet rather than inside its scroll.
+ *
+ * What the move does change is the case where the user takes the Background button. Dismissing drops
+ * this sheet's watcher, so a restore that finishes afterwards reports nowhere — the same trade the
+ * backup sheet's Background button already makes, and the reason §8.5's breadcrumb rather than this
+ * dialog is what covers a restore whose outcome nobody read: an interrupted one leaves the notice in
+ * Settings behind it.
  *
  * All three outcomes, not only the success that prompted this. A failure was equally invisible, and one
  * container for one decision is what keeps the five sentences [RestoreOutcome] documents from drifting
@@ -474,7 +567,7 @@ private fun RestoreOutcomeDialog(finish: RestoreFinish, onDismiss: () -> Unit) {
         text = { RestoreOutcome(finish = finish) },
         confirmButton = {
             // `restore_outcome_dismiss`, not `restore_interrupted_dismiss`: that one is named and
-            // commented for the §8.5 breadcrumb banner at the top of this screen. Same word today, two
+            // commented for the §8.5 breadcrumb banner at the top of this sheet. Same word today, two
             // owners, so rewording the breadcrumb's button cannot silently reword this one.
             TextButton(onClick = onDismiss) {
                 Text(stringResource(R.string.restore_outcome_dismiss))

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
@@ -117,10 +117,13 @@ internal fun ArchiveRestoreSheet(uriString: String?, onDismiss: () -> Unit) {
     // reason. This used to be a `NavEntry` for `ThorRoute.ArchiveRestore`, whose store was created
     // when the route was pushed, cleared when it was popped, and keyed by the route's own
     // `uriString` — so the default owner was already per-archive and per-visit. As a sheet it is a
-    // conditional composable inside whichever tab is showing, at one call site reused for every
-    // archive, so the default owner is that tab's entry and outlives it: the next archive's sheet
-    // would get the previous archive's view model back, with its parsed header, its unlocked key and
-    // its ticked confirmation still in place.
+    // conditional composable in `MainScreen`'s overlay `Box`, a sibling of `NavDisplay` with no
+    // `NavEntry` decorator in scope, so the default owner is the host **Activity**: its store lives
+    // as long as the process, and the next archive's sheet would get the previous archive's view
+    // model back, with its parsed header, its unlocked key and its ticked confirmation still in
+    // place. (An earlier version of this comment said "that tab's entry". Wrong owner — the tab roots
+    // are never popped either, so the lifetime it described is the same one, but the reason a reader
+    // would go looking for it is not.)
     //
     // What this costs is bounded, and it is worth stating because the reasoning ran the other way
     // while this was a screen. Losing the view model on dismiss drops an unlock — 210,000 PBKDF2

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
@@ -273,7 +273,11 @@ private fun RestoreSheetBody(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            OutlinedButton(onClick = onPickFile) {
+            // `header == null` is also true for the whole of a load, so without this gate the prompt
+            // and the spinner above it are drawn together and a tap here starts a second read of a
+            // different file. Disabled rather than hidden: a control that vanishes from under a
+            // finger mid-read is worse than one that visibly cannot be pressed yet.
+            OutlinedButton(onClick = onPickFile, enabled = !state.loading) {
                 Text(stringResource(R.string.restore_pick_file))
             }
         } else {
@@ -462,7 +466,10 @@ private fun RestoreSheetBody(
                 // check it works", and offering "Choose a different file" behind it puts a destructive
                 // operation one tap from an app that is now correct. Dismissing the outcome brings it
                 // back, so nothing is lost — the user just has to acknowledge the result first.
-                TextButton(onClick = onPickFile) {
+                // Gated on `loading` for the same reason as the prompt's button above: this one stays
+                // composed while a *replacement* file is being read, so it is the second way into the
+                // same double-pick.
+                TextButton(onClick = onPickFile, enabled = !state.loading) {
                     Text(stringResource(R.string.restore_pick_another))
                 }
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
@@ -313,6 +313,25 @@ internal class ArchiveRestoreViewModel(
      */
     private var opening: Job? = null
 
+    /**
+     * Which pick the state currently belongs to. Incremented by every accepted [open].
+     *
+     * [opening]'s cancel is not enough on its own, because cancellation is cooperative and the work
+     * being cancelled is blocking I/O this class does not own. Two ways a dead read still writes:
+     * a `ContentResolver` copy or a PBKDF2 loop that finishes its blocking block before noticing,
+     * and — the reachable one — a read that fails for a *real* reason at the moment it is cancelled.
+     * The original exception wins over the cancellation, so `onFailure` runs, and it wrote
+     * `loading = false` plus a `FILE_UNREADABLE` for archive A over archive B's fresh spinner. That
+     * is worse than a stale sentence: `loading = false` re-enables both pick buttons while B is
+     * still being read, which re-opens the very door [opening] closes.
+     *
+     * So the cancel stops the *work* and this stops the *writes*. Checked with [updateForOpen] at
+     * every state write derived from a file, which is the whole of [open]'s block, its `onFailure`,
+     * and [tryRememberedPassphrase] — the last one matters most, because it is what would hand
+     * archive A's unlocked passphrase to a screen showing archive B.
+     */
+    private var openGeneration = 0
+
     init {
         // Not gated on a file being picked: the Settings entry point arrives with no URI, and after a
         // crash that is exactly how the user gets here.
@@ -358,6 +377,9 @@ internal class ArchiveRestoreViewModel(
         // [opening]. `launchGuarded` rethrows CancellationException instead of routing it to
         // `onFailure`, so the cancelled read cannot write a failure over the new one's state.
         opening?.cancel()
+        // Claimed before the reset below, so every write from here on is tagged with this pick and any
+        // write still coming from the one before it is already stale. See [openGeneration].
+        val generation = ++openGeneration
         _uiState.update {
             it.copy(
                 loading = true,
@@ -386,7 +408,7 @@ internal class ArchiveRestoreViewModel(
             // it. Reported as the file being unopenable, which is what a throw on this path means.
             onFailure = {
                 forgetUriIfStill(uriString)
-                _uiState.update {
+                updateForOpen(generation) {
                     it.copy(
                         loading = false,
                         error = ArchiveRestoreMessage.Known(ArchiveRestoreReason.FILE_UNREADABLE),
@@ -394,6 +416,9 @@ internal class ArchiveRestoreViewModel(
                 }
             }
         ) {
+            // The one write here that is *not* file-derived, and so not generation-guarded: whether the
+            // device can restore private data at all is a property of the privilege state, identical for
+            // every archive, and the cache behind it answers the same for both reads.
             val supported = capability.isSupported()
             _uiState.update { it.copy(supported = supported) }
 
@@ -403,7 +428,7 @@ internal class ArchiveRestoreViewModel(
             val source = when (val opened = sources.open(uriString)) {
                 is ArchiveOpenOutcome.Opened -> opened.source
                 ArchiveOpenOutcome.NotAnArchive -> {
-                    _uiState.update {
+                    updateForOpen(generation) {
                         it.copy(
                             loading = false,
                             error = ArchiveRestoreMessage.Known(ArchiveRestoreReason.NOT_AN_ARCHIVE),
@@ -413,7 +438,7 @@ internal class ArchiveRestoreViewModel(
                 }
                 ArchiveOpenOutcome.Unreadable -> {
                     forgetUriIfStill(uriString)
-                    _uiState.update {
+                    updateForOpen(generation) {
                         it.copy(
                             loading = false,
                             error = ArchiveRestoreMessage.Known(ArchiveRestoreReason.FILE_UNREADABLE),
@@ -431,7 +456,7 @@ internal class ArchiveRestoreViewModel(
                 is ArchiveHeaderOutcome.NotAnArchive -> {
                     // `FromBelow`: this sentence names the archive entry that was missing, which is
                     // detail only the reader has. An id here would throw it away.
-                    _uiState.update {
+                    updateForOpen(generation) {
                         it.copy(
                             loading = false,
                             error = ArchiveRestoreMessage.FromBelow(outcome.reason),
@@ -442,8 +467,11 @@ internal class ArchiveRestoreViewModel(
             }
 
             installed = installedFacts(header.packageName)
+            // `installed` is a plain field, so the line above is the one write here that no generation
+            // check can undo — bail rather than let a stale read leave its facts behind a live header.
+            if (generation != openGeneration) return@launchGuarded
             val obbCount = header.appBundle?.obbCount ?: 0
-            _uiState.update { state ->
+            updateForOpen(generation) { state ->
                 state.copy(
                     loading = false,
                     fileName = source.displayName,
@@ -456,7 +484,7 @@ internal class ArchiveRestoreViewModel(
             }
             evaluate()
             watchForExistingJob(header.packageName)
-            tryRememberedPassphrase(header)
+            tryRememberedPassphrase(header, generation)
         }
     }
 
@@ -472,12 +500,28 @@ internal class ArchiveRestoreViewModel(
      * print the same sentence that is already on screen, and any different URI resets the field
      * anyway.
      *
-     * Guarded on equality rather than nulled outright. [open] does not cancel a call already in
-     * flight, so a slow failure for file A must not clear a URI that a later `open(B)` has since
-     * stored — that would let a second `open(B)` re-enter and restart the gate under a loaded header.
+     * Guarded on equality rather than nulled outright: a slow failure for file A must not clear a URI
+     * that a later `open(B)` has since stored, which would let a second `open(B)` re-enter and restart
+     * the gate under a loaded header. [open] does now cancel the read it replaces, so the ordinary
+     * version of that race is gone — but cancellation is cooperative and this guard costs one
+     * comparison, so it stays as the backstop for a failure that lands anyway. See [openGeneration].
      */
     private fun forgetUriIfStill(uriString: String) {
         if (this.uriString == uriString) this.uriString = null
+    }
+
+    /**
+     * Write file-derived state, but only if [generation] is still the pick the user is looking at.
+     *
+     * See [openGeneration]. A no-op is the correct answer for a stale generation: the read that owns
+     * the screen now has already written, or is about to, everything this one would have said.
+     */
+    private inline fun updateForOpen(
+        generation: Int,
+        block: (ArchiveRestoreUiState) -> ArchiveRestoreUiState,
+    ) {
+        if (generation != openGeneration) return
+        _uiState.update(block)
     }
 
     fun toggleClass(dataClass: DataClass) {
@@ -743,7 +787,12 @@ internal class ArchiveRestoreViewModel(
         }
     }
 
-    private suspend fun tryRememberedPassphrase(header: ArchiveHeader) {
+    /**
+     * @param generation the pick this unlock belongs to, checked before every write. The derivation is
+     *   210,000 PBKDF2 iterations, so this is the longest window on the screen for the user to pick a
+     *   different file — and the only one whose stale write would hand a *key* to the wrong archive.
+     */
+    private suspend fun tryRememberedPassphrase(header: ArchiveHeader, generation: Int) {
         // First, and ahead of the vault: this gates the *prompt* as much as the derivation. Asking for
         // a passphrase beside a refusal suggests the passphrase is what went wrong, and there is no
         // passphrase that makes a signer mismatch restorable. The refusals that a later selection
@@ -753,27 +802,35 @@ internal class ArchiveRestoreViewModel(
 
         val stored = vault.recall()
         if (stored == null) {
-            _uiState.update { it.copy(passphraseNeeded = true) }
+            updateForOpen(generation) { it.copy(passphraseNeeded = true) }
             return
         }
 
         when (openArchive.unlock(header, stored)) {
             is ArchiveUnlockOutcome.Unlocked -> {
+                // Generation checked before the key is parked, not just before the flag: `passphrase` is
+                // what `restore()` hands the worker, so a stale write here is the one that would send
+                // archive A's key with archive B's request. Zeroed rather than dropped — this array came
+                // from the vault and nothing else holds it.
+                if (generation != openGeneration) {
+                    stored.fill(' ')
+                    return
+                }
                 wipePassphrase()
                 passphrase = stored
-                _uiState.update { it.copy(unlocked = true, passphraseNeeded = false) }
+                updateForOpen(generation) { it.copy(unlocked = true, passphraseNeeded = false) }
             }
             // §5.4: the vault is a cache. This archive was made with a different passphrase, which is
             // an ordinary state and says nothing about the archive's health — so prompt, silently.
             // `stored` is this class's own array, from `recall()`; nothing else holds it.
             is ArchiveUnlockOutcome.WrongPassphrase -> {
                 stored.fill(' ')
-                _uiState.update { it.copy(passphraseNeeded = true) }
+                updateForOpen(generation) { it.copy(passphraseNeeded = true) }
             }
 
             is ArchiveUnlockOutcome.Unsupported -> {
                 stored.fill(' ')
-                _uiState.update { it.copy(passphraseNeeded = true) }
+                updateForOpen(generation) { it.copy(passphraseNeeded = true) }
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
@@ -300,6 +300,19 @@ internal class ArchiveRestoreViewModel(
     private var watching: Job? = null
     private var reattach: Job? = null
 
+    /**
+     * The in-flight header read, held so [open] can cancel it before starting another.
+     *
+     * Without it, two reads race and split the screen's identity in half: [uriString] is always the
+     * newest pick, while `header` and everything derived from it belong to whichever read finished
+     * last. A slow archive picked first and a small one picked during its load leaves the sheet
+     * showing A's package, classes and unlocked passphrase while the request it builds carries B's
+     * URI — a wrong request the user has no way to see. `AppArchiveWorker` refuses it on a package
+     * mismatch before touching anything, so it is not a data-loss path, but the user is told a
+     * restore may have left their data incomplete for a job that never got past the gate.
+     */
+    private var opening: Job? = null
+
     init {
         // Not gated on a file being picked: the Settings entry point arrives with no URI, and after a
         // crash that is exactly how the user gets here.
@@ -339,6 +352,12 @@ internal class ArchiveRestoreViewModel(
         wipePassphrase()
         reattach?.cancel()
         reattach = null
+        // Cancel-and-replace rather than `if (loading) return`: an early return would silently discard
+        // the file the user just picked, which is the one thing they are certain they asked for.
+        // Cancelling is also what keeps [uriString] and `header` describing the same archive — see
+        // [opening]. `launchGuarded` rethrows CancellationException instead of routing it to
+        // `onFailure`, so the cancelled read cannot write a failure over the new one's state.
+        opening?.cancel()
         _uiState.update {
             it.copy(
                 loading = true,
@@ -360,7 +379,7 @@ internal class ArchiveRestoreViewModel(
             )
         }
 
-        launchGuarded(
+        opening = launchGuarded(
             // Without this the spinner set above is permanent: `loading = true` is written
             // synchronously and every path that clears it lives inside this block, so a throw from the
             // source factory or the header reader left a screen that span until the user backed out of

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
@@ -466,10 +466,15 @@ internal class ArchiveRestoreViewModel(
                 }
             }
 
-            installed = installedFacts(header.packageName)
-            // `installed` is a plain field, so the line above is the one write here that no generation
-            // check can undo — bail rather than let a stale read leave its facts behind a live header.
+            // Into a local, then the guard, then the field. `installed` is a plain field rather than
+            // state, so [updateForOpen] cannot cover it and a write to it is not undone by bailing
+            // afterwards — which is what an earlier version of this did. A dead read that publishes its
+            // facts leaves the gate comparing the live header against the *previous* archive's app:
+            // [evaluate] reads this field on every selection change, so the next `toggleClass` decides
+            // signer and version against facts belonging to a file the user already replaced.
+            val facts = installedFacts(header.packageName)
             if (generation != openGeneration) return@launchGuarded
+            installed = facts
             val obbCount = header.appBundle?.obbCount ?: 0
             updateForOpen(generation) { state ->
                 state.copy(

--- a/app/src/main/java/com/valhalla/thor/presentation/launcher/JobSheetLaunchActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/launcher/JobSheetLaunchActivity.kt
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.launcher
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import com.valhalla.thor.data.backup.job.JobSheetTargets
+import com.valhalla.thor.domain.model.jobKindFromId
+import com.valhalla.thor.util.Logger
+import org.koin.android.ext.android.inject
+
+private const val TAG = "JobSheetLaunchActivity"
+
+/**
+ * What a tap on a running job's notification lands on: ask the UI to reopen that job's sheet, bring
+ * Thor's task forward, get out of the way.
+ *
+ * **Why a trampoline at all.** The notification cannot simply target `HomeActivity` with the payload
+ * in its extras. `HomeActivity` is `standard` launchMode with no `onNewIntent`, and it reads
+ * `pendingRestoreUri` from its creation intent `by lazy` — so a launcher-shaped intent resumes the
+ * live task and drops the extras, while a component-targeted one stacks a second `HomeActivity` over
+ * the first. Handing the request to [JobSheetTargets] instead keeps the notification's intent to a
+ * single `kind` string and leaves the resume exactly as `BulkResultNotifier` already does it.
+ *
+ * An **activity** trampoline is legal from a notification; Android 12's ban covers services and
+ * broadcasts. And unlike [FreezerLaunchActivity] this one takes no `taskAffinity=""` and no
+ * `launchMode` — that pair exists there to *avoid* resuming Thor's task, which is the one thing this
+ * activity is for.
+ *
+ * No `attachBaseContext`/`AppLocale.wrap` override either: it renders nothing and reads no string
+ * resource, so there is no text for a locale to get wrong. Its only output is a log line.
+ */
+// Not a splash screen: a translucent trampoline that finishes inside onCreate.
+@SuppressLint("CustomSplashScreen")
+class JobSheetLaunchActivity : Activity() {
+
+    private val sheetTargets: JobSheetTargets by inject()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Null for an unrecognised id — a PendingIntent written by an older build, say. Falls through
+        // to a plain resume rather than failing the tap.
+        val kind = jobKindFromId(intent?.getStringExtra(EXTRA_JOB_KIND))
+        val requested = kind?.let(sheetTargets::requestOpen) == true
+        if (kind != null && !requested) {
+            // The job is no longer live in this process: it finished, or the process died and this
+            // activity is what restarted it. Either way there is no sheet to reopen and the resume
+            // below is the whole of the tap.
+            Logger.d(TAG, "${kind.id}: no live job to reopen, resuming only")
+        }
+
+        // The same shape BulkResultNotifier.homeIntent() uses, and for the same reason: ACTION_MAIN
+        // plus NEW_TASK on the launch component brings the existing task forward with its state
+        // intact instead of creating a second one. getLaunchIntentForPackage already sets NEW_TASK;
+        // addFlags is belt-and-braces and matches the precedent.
+        val resume = packageManager.getLaunchIntentForPackage(packageName)
+            ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        if (resume != null) {
+            startActivity(resume)
+        } else {
+            // No launchable component for our own package. Not reachable in any shipped build; if it
+            // ever is, the request above is still queued and the next foreground will consume it.
+            Logger.e(TAG, "no launch intent for $packageName; tap resumed nothing")
+        }
+        finish()
+    }
+
+    companion object {
+        /** Carries [com.valhalla.thor.domain.model.ThorJobKind.id]. The only thing the notification's intent holds. */
+        const val EXTRA_JOB_KIND = "com.valhalla.thor.extra.JOB_KIND"
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/launcher/JobSheetLaunchActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/launcher/JobSheetLaunchActivity.kt
@@ -26,9 +26,15 @@ private const val TAG = "JobSheetLaunchActivity"
  * single `kind` string and leaves the resume exactly as `BulkResultNotifier` already does it.
  *
  * An **activity** trampoline is legal from a notification; Android 12's ban covers services and
- * broadcasts. And unlike [FreezerLaunchActivity] this one takes no `taskAffinity=""` and no
- * `launchMode` — that pair exists there to *avoid* resuming Thor's task, which is the one thing this
- * activity is for.
+ * broadcasts.
+ *
+ * It shares [FreezerLaunchActivity]'s `taskAffinity=""` and, unlike it, declares no `launchMode`. An
+ * earlier version of this comment claimed the opposite — that the affinity was omitted on purpose
+ * because "resuming Thor's task is this activity's entire purpose". That was wrong, and backwards: with
+ * Thor's own affinity, a tap arriving when no Thor task exists makes *this* activity root the task, and
+ * `excludeFromRecents` then applies to the task the resumed `HomeActivity` joins. The user gets their
+ * sheet and loses Thor from Recents. The empty affinity puts the trampoline in a throwaway task of its
+ * own, and the `NEW_TASK` launcher intent below resumes Thor's task exactly as before.
  *
  * No `attachBaseContext`/`AppLocale.wrap` override either: it renders nothing and reads no string
  * resource, so there is no text for a locale to get wrong. Its only output is a log line.

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -88,7 +88,8 @@ import com.valhalla.asgard.navigation.AsgardNavigationBar
 import com.valhalla.asgard.navigation.AsgardNavigationRail
 import com.valhalla.thor.presentation.permission.PermissionManagerScreen
 import com.valhalla.thor.presentation.settings.SettingsScreen
-import com.valhalla.thor.presentation.backup.ArchiveRestoreScreen
+import com.valhalla.thor.presentation.backup.AppBackupSheet
+import com.valhalla.thor.presentation.backup.ArchiveRestoreSheet
 import com.valhalla.thor.presentation.extension.ExtensionBrowseScreen
 import com.valhalla.thor.presentation.extension.ExtensionManagerScreen
 import com.valhalla.thor.presentation.settings.BillingProcessor
@@ -176,17 +177,18 @@ fun MainScreen(
 
     val currentBackStack = backStacks[activeTab] ?: homeBackStack
 
-    // Consumed once. rememberSaveable, not remember: after a rotation the route is already on the
-    // back stack, and re-adding it would stack a second copy of the restore screen behind the first.
-    // Settings is the host tab because that is where the Settings entry point pushes the same route —
-    // one tab owns restore, so there is one place a half-finished one is found again.
+    // Consumed once. rememberSaveable, not remember: `MainViewModel` survives a rotation with the
+    // sheet's state on it, so re-running this would reopen a sheet the user had already dismissed.
+    //
+    // No tab switch any more. This used to jump to Settings and push a route there, because the
+    // restore *screen* had to live in some tab's back stack; the sheet is hosted above all four, so
+    // the tab the user opened Thor on is left alone.
     var restoreUriConsumed by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(pendingRestoreUri) {
         val uri = pendingRestoreUri
         if (uri != null && !restoreUriConsumed) {
             restoreUriConsumed = true
-            activeDestination = AppDestinations.SETTINGS
-            settingsBackStack.add(ThorRoute.ArchiveRestore(uri))
+            mainViewModel.openRestoreSheet(uri)
         }
     }
 
@@ -521,23 +523,23 @@ fun MainScreen(
                         onNavigateToExtensionManager = {
                             settingsBackStack.add(ThorRoute.ExtensionManager)
                         },
-                        onNavigateToRestore = {
-                            settingsBackStack.add(ThorRoute.ArchiveRestore())
-                        }
+                        onOpenRestore = { mainViewModel.openRestoreSheet() }
                     )
                 }
 
-                entry<ThorRoute.ArchiveRestore>(
-                    metadata = ListDetailSceneStrategy.detailPane()
-                ) { route ->
-                    ArchiveRestoreScreen(
-                        uriString = route.uriString,
-                        onBack = {
-                            if (currentBackStack.size > 1) {
-                                currentBackStack.removeLastOrNull()
-                            }
+                // A shim, and the only thing left of the restore *route*. Restore is a sheet now
+                // (hosted in GLOBAL OVERLAYS below), so nothing pushes this — but a back stack saved
+                // by the previous build can still hold it: `rememberNavBackStack` state is persisted
+                // for task restoration, which survives an app update. Deleting the route outright
+                // would make that stack fail to deserialise, so the entry stays for one release and
+                // forwards to the sheet instead of rendering anything.
+                entry<ThorRoute.ArchiveRestore> { route ->
+                    LaunchedEffect(route) {
+                        if (currentBackStack.size > 1) {
+                            currentBackStack.removeLastOrNull()
                         }
-                    )
+                        mainViewModel.openRestoreSheet(route.uriString)
+                    }
                 }
 
                 entry<ThorRoute.ExtensionManager>(
@@ -792,6 +794,30 @@ fun MainScreen(
                             ?.let { Formatter.formatShortFileSize(context, it) },
                         onConfirm = { mainViewModel.confirmClearAllCaches() },
                         onDismiss = { mainViewModel.dismissCacheClear() }
+                    )
+                }
+
+                // Restore is a sheet, and it is hosted here rather than in a tab's back stack because
+                // a restore outlives the section it was started from: the Settings row, an incoming
+                // `.thorbak`, and a tap on a running restore's notification all open the same one,
+                // and switching tabs mid-restore must not tear it down. This is also what makes the
+                // suppression in ObserveInterruptedRestoreUseCase load-bearing — the Settings section
+                // really is composed underneath, so it must not announce the restore that is on
+                // screen above it.
+                state.restoreSheet?.let { restore ->
+                    ArchiveRestoreSheet(
+                        uriString = restore.uriString,
+                        onDismiss = { mainViewModel.dismissRestoreSheet() }
+                    )
+                }
+
+                // Only ever opened by a notification tap — see [BackupSheetState]. The in-app route
+                // is the copy the app-info surfaces host themselves.
+                state.backupSheet?.let { backup ->
+                    AppBackupSheet(
+                        packageName = backup.packageName,
+                        appLabel = backup.appLabel,
+                        onDismiss = { mainViewModel.dismissBackupSheet() }
                     )
                 }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -177,19 +177,16 @@ fun MainScreen(
 
     val currentBackStack = backStacks[activeTab] ?: homeBackStack
 
-    // Consumed once. rememberSaveable, not remember: `MainViewModel` survives a rotation with the
-    // sheet's state on it, so re-running this would reopen a sheet the user had already dismissed.
+    // Consumed once, and the once is counted on `MainViewModel` — NOT in a `rememberSaveable` here.
+    // A saveable latch outlives the sheet state it guards, so after process death it would say
+    // "already handled" to a fresh ViewModel that has no sheet, and the archive Thor was opened on
+    // would be dropped silently. See MainViewModel.openRestoreSheetForLaunchUri.
     //
     // No tab switch any more. This used to jump to Settings and push a route there, because the
     // restore *screen* had to live in some tab's back stack; the sheet is hosted above all four, so
     // the tab the user opened Thor on is left alone.
-    var restoreUriConsumed by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(pendingRestoreUri) {
-        val uri = pendingRestoreUri
-        if (uri != null && !restoreUriConsumed) {
-            restoreUriConsumed = true
-            mainViewModel.openRestoreSheet(uri)
-        }
+        pendingRestoreUri?.let(mainViewModel::openRestoreSheetForLaunchUri)
     }
 
     val adaptiveInfo = currentWindowAdaptiveInfoV2()

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -246,6 +246,9 @@ class MainViewModel(
 
     private var pendingSupportPrompt = false
 
+    /** Whether [openRestoreSheetForLaunchUri] has already fired for this ViewModel. See it for why here. */
+    private var launchRestoreUriConsumed = false
+
     // Declared *above* `init`, and it has to stay there.
     //
     // `viewModelScope` runs on `Dispatchers.Main.immediate`, so a collector launched from `init`
@@ -363,6 +366,28 @@ class MainViewModel(
      */
     fun openRestoreSheet(uriString: String? = null) {
         _uiState.update { it.copy(restoreSheet = RestoreSheetState(uriString)) }
+    }
+
+    /**
+     * Open the restore sheet on the `.thorbak` this launch was opened on, at most once.
+     *
+     * The latch belongs here rather than in a `rememberSaveable` in `MainScreen`, and that is a
+     * correctness point, not tidiness: it has to have **the same lifetime as the sheet state it
+     * guards**. `restoreSheet` lives on this ViewModel, which survives a rotation and dies with the
+     * process; a `rememberSaveable` latch survives *both*. So the pair disagreed exactly once — kill the
+     * process while it is backgrounded, return through Recents, and the activity is recreated with the
+     * same VIEW intent and a still-valid task-scoped read grant, but the saved latch said "already
+     * handled" while the fresh ViewModel had no sheet. The archive the user opened Thor on was dropped
+     * with nothing on screen to say so. Sharing one lifetime makes the two answers agree by
+     * construction: rotation keeps both, process death clears both and the sheet reopens.
+     *
+     * Being on the ViewModel is also what makes the no-reopen-after-dismiss half testable, which the
+     * `rememberSaveable` never was.
+     */
+    fun openRestoreSheetForLaunchUri(uriString: String) {
+        if (launchRestoreUriConsumed) return
+        launchRestoreUriConsumed = true
+        openRestoreSheet(uriString)
     }
 
     fun dismissRestoreSheet() {

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -8,6 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.R
 import com.valhalla.thor.data.backup.BackupRunner
+import com.valhalla.thor.data.backup.job.JobSheetTarget
+import com.valhalla.thor.data.backup.job.JobSheetTargets
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
@@ -174,12 +176,42 @@ sealed interface CacheClearState {
     data class Done(val freedBytes: Long?, val hasUsageAccess: Boolean) : CacheClearState
 }
 
+/**
+ * The restore sheet, or null when it is closed.
+ *
+ * A nullable field holding a type with a nullable field, on purpose: the *outer* null means the sheet
+ * is not open, and [uriString] being null means it is open with no archive chosen yet, so the sheet
+ * shows its file picker. Collapsing the two would make "open the restore sheet" and "open the restore
+ * sheet on this file" indistinguishable, which is the difference between the Settings row and a
+ * notification tap.
+ */
+data class RestoreSheetState(val uriString: String? = null)
+
+/**
+ * The backup sheet hosted by `MainScreen`, or null when it is closed.
+ *
+ * Only ever opened by a notification tap. The in-app route to a backup is the sheet the app-info
+ * surfaces host themselves, which owns its own visibility — so this is a *second* host, and the two
+ * can be composed at once if the user backgrounds Thor with a backup sheet open and then taps the
+ * notification. Both watch the same job through `runningJobFor`, so the stacked pair shows the same
+ * progress twice rather than disagreeing; dismissing the top one leaves the original underneath.
+ * Lifting all backup-sheet hosting up here would fix the cosmetics at the cost of threading a
+ * `MainViewModel` call through `onAppAction` on both app-info surfaces, which is not worth it for a
+ * duplicate that requires leaving the sheet open on the way to the shade.
+ *
+ * [appLabel] must be the app's real name: `AppBackupViewModel.start` writes what it is handed straight
+ * into its state and never resolves it.
+ */
+data class BackupSheetState(val packageName: String, val appLabel: String)
+
 data class MainUiState(
     val loggerState: LoggerState = LoggerState(), // For persistent Logs
     val fixStoreSelection: FixStoreSelection? = null, // Fix Store picker, null when closed
     val freezeLoggerState: FreezeLoggerState = FreezeLoggerState(), // Compact freeze/unfreeze progress
     val exportProgress: ExportProgressState? = null, // Multi-app export, null when idle
     val cacheClear: CacheClearState? = null, // Whole-device cache clear, null when idle
+    val restoreSheet: RestoreSheetState? = null, // Archive restore sheet, null when closed
+    val backupSheet: BackupSheetState? = null, // Archive backup sheet reopened from a notification
     val selectedDestination: AppDestinations = AppDestinations.HOME, // For Bottom Nav
     val hasShownSupportDeveloperPrompt: Boolean = true,
     val showSupportDeveloperPrompt: Boolean = false,
@@ -199,6 +231,9 @@ class MainViewModel(
     // its Settings deep-link, which would put an Android type in this ViewModel's constructor and
     // take it off the JVM test classpath.
     private val usageAccessGate: UsageAccessGate,
+    // Where a tap on a running job's notification arrives. A plain in-memory holder, so it costs
+    // nothing to observe and stays on the JVM test classpath.
+    private val jobSheetTargets: JobSheetTargets,
     @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
 
@@ -226,6 +261,7 @@ class MainViewModel(
     init {
         observePreferences()
         observeBackupRun()
+        observeJobSheetRequests()
     }
 
     private fun observePreferences() {
@@ -288,6 +324,53 @@ class MainViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * Reopen the sheet a job notification was tapped on.
+     *
+     * From `init` for the same reason as [observeBackupRun]: the tap is what brings Thor forward, so
+     * this instance is routinely *younger* than the request. `JobSheetTargets` conflates rather than
+     * drops, so a request made before the ViewModel existed is still waiting here — which is the whole
+     * point on the app-lock path, where the trampoline runs minutes before `MainScreen` composes.
+     *
+     * Touches only [_uiState] and the constructor parameter, both live before `init` runs. See the
+     * comment on `_effect` for why that sentence has to be checked and not assumed.
+     */
+    private fun observeJobSheetRequests() {
+        viewModelScope.launch {
+            jobSheetTargets.requests.collect { target ->
+                _uiState.update { state ->
+                    when (target) {
+                        is JobSheetTarget.Backup -> state.copy(
+                            backupSheet = BackupSheetState(target.packageName, target.appLabel)
+                        )
+                        is JobSheetTarget.Restore -> state.copy(
+                            restoreSheet = RestoreSheetState(target.uriString)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Open the restore sheet, on [uriString] if there is one and on its file picker if not.
+     *
+     * The Settings row and `HomeActivity`'s incoming-`.thorbak` intent both land here. It is not a
+     * navigation call any more: the sheet is hosted over whatever tab is showing, so nothing switches
+     * section on the way in.
+     */
+    fun openRestoreSheet(uriString: String? = null) {
+        _uiState.update { it.copy(restoreSheet = RestoreSheetState(uriString)) }
+    }
+
+    fun dismissRestoreSheet() {
+        _uiState.update { it.copy(restoreSheet = null) }
+    }
+
+    fun dismissBackupSheet() {
+        _uiState.update { it.copy(backupSheet = null) }
     }
 
     fun markSupportDeveloperPromptShown() {

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -94,8 +94,11 @@ import org.koin.compose.koinInject
 fun SettingsScreen(
     onNavigateToExtensionManager: () -> Unit,
     // Not defaulted, so the one call site has to supply it. A default would leave a Restore row that
-    // navigates nowhere, and nothing would fail to compile.
-    onNavigateToRestore: () -> Unit,
+    // does nothing, and nothing would fail to compile.
+    //
+    // `onOpen`, not `onNavigateTo`: restore is a bottom sheet hosted by `MainScreen` over whatever
+    // section is showing. Nothing is pushed and this screen stays composed underneath.
+    onOpenRestore: () -> Unit,
     viewModel: SettingsViewModel = koinViewModel()
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -715,12 +718,17 @@ fun SettingsScreen(
                 //
                 // The use case, not `ArchiveBreadcrumbStore.observe()` directly. A live observation of
                 // the raw breadcrumb is *wrong* on this surface: the breadcrumb is written at the start
-                // of the destructive phase, `ArchiveRestore` is registered as a detail pane, and on an
-                // expanded window this section is composed beside it — so a raw observe() renders "did
-                // not finish … restore it again" next to a progress bar reporting normal progress. The
-                // use case holds the notice back while a restore for that app is live, and still takes
-                // it down the moment "Got it" over there clears the breadcrumb. Both of its inputs read
-                // off the main thread.
+                // of the destructive phase, and the restore sheet is hosted by `MainScreen` over
+                // whatever section is showing — so this row stays composed, on every window size,
+                // underneath the restore it describes, and a raw observe() would render "did not finish
+                // … restore it again" beneath a progress bar reporting normal progress. The use case
+                // holds the notice back while a restore for that app is live, and still takes it down
+                // the moment "Got it" in the sheet clears the breadcrumb. Both of its inputs read off
+                // the main thread.
+                //
+                // This was true of the old restore *screen* only in theory and by a different argument
+                // (a detail pane beside a composed list pane, which is not the layout it got). Being a
+                // sheet is what makes the overlap unconditional.
                 val observeInterrupted = koinInject<ObserveInterruptedRestoreUseCase>()
                 val interrupted by remember(observeInterrupted) { observeInterrupted() }
                     .collectAsStateWithLifecycle(initialValue = null)
@@ -738,7 +746,7 @@ fun SettingsScreen(
                     icon = R.drawable.settings_backup_restore,
                     title = stringResource(R.string.restore_title),
                     subtitle = stringResource(R.string.restore_settings_desc),
-                    onClick = onNavigateToRestore
+                    onClick = onOpenRestore
                 )
 
                 // §5.4. The only place "remember it on this device" — offered as a checkbox in the

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -100,6 +100,14 @@
       breadcrumb banner. Identical text today; rewording one must not silently reword the other.
     -->
     <string name="backup_outcome_dismiss">Got it</string>
+    <!--
+      One word, because it is the label the sheet's running frame is built around: while a job is live
+      the sheet shows the bar and this button and nothing else. It dismisses the sheet, which is safe
+      for the reason the sentence below states — the job is a foreground service and the sheet is only
+      watching it.
+    -->
+    <string name="backup_background">Background</string>
+    <string name="backup_background_desc">This keeps running if you close it. The notification shows how far it has got.</string>
 
     <string name="restore_title">Restore a backup</string>
     <string name="restore_pick_prompt">Choose a Thor backup file (.thorbak) to see what it holds.</string>

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -128,7 +128,12 @@
     <string name="restore_unlocked">Unlocked with the saved passphrase.</string>
     <string name="restore_confirm_replace">I understand this replaces the app\'s current data. Anything not in this backup is deleted.</string>
     <string name="restore_start">Restore</string>
-    <string name="restore_back">Back</string>
+    <!--
+      No `restore_back` any more. The restore surface is a bottom sheet, dismissed by its scrim, its
+      drag handle or the back gesture, and its own Background button is what covers leaving a live
+      run — so the button this named had nothing left to do. Deleted rather than left in place because
+      lint's UnusedResources is fatal in this build; there were no translations to strand.
+    -->
     <string name="restore_done">Restore finished. Open the app to check it works.</string>
     <!--
       Heading for the sentences a *successful* run still has to report — game data that could not be

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -15,6 +15,12 @@
 
     <string name="action_backup">Back up</string>
     <string name="backup_unsupported">Thor cannot read another app\'s private data with the access it has right now. This needs root, or Shizuku started from root.</string>
+    <!--
+      Kept separate from backup_unsupported rather than appended to it, because that string is shared
+      with ArchiveRestoreSheet — where the blocker is *writing* private data, and a note about what
+      backup will support is off topic. Only AppBackupSheet renders this one.
+    -->
+    <string name="backup_partial_soon">Coming in Thor 2.0: partial backups without root — the app itself and its files on shared storage, though not its private data.</string>
     <string name="backup_include_bundle">Include the app installer</string>
     <string name="backup_include_bundle_desc">Lets this backup reinstall the app if it is gone.</string>
     <string name="backup_class_ce">App data</string>

--- a/app/src/test/java/com/valhalla/thor/data/backup/FileArchiveBreadcrumbStoreTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/backup/FileArchiveBreadcrumbStoreTest.kt
@@ -163,10 +163,9 @@ class FileArchiveBreadcrumbStoreTest {
 
     @Test
     fun `observe re-emits when the breadcrumb is cleared underneath a collector`() = runTest {
-        // The I2 case. `ArchiveRestore` is a detail pane, so on an expanded window the Settings
-        // banner and the restore screen are composed at the same time: the user acknowledges the
-        // notice over there, and a Settings banner that read once would go on naming an app whose
-        // breadcrumb no longer exists.
+        // The I2 case. The restore sheet is hosted above the Settings section, so its banner and the
+        // sheet are composed at the same time: the user acknowledges the notice in the sheet, and a
+        // Settings banner that read once would go on naming an app whose breadcrumb no longer exists.
         val store = store()
         store.write("com.example.app", "Example")
         val seen = mutableListOf<ArchiveBreadcrumb?>()

--- a/app/src/test/java/com/valhalla/thor/data/backup/job/JobSheetTargetsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/backup/job/JobSheetTargetsTest.kt
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.backup.job
+
+import com.valhalla.thor.domain.model.ThorJobKind
+import com.valhalla.thor.domain.model.jobKindFromId
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The handoff a job notification's tap goes through, and the one decision it can get wrong: reopening
+ * a sheet on the wrong job.
+ *
+ * Testable on a plain JVM because [JobSheetTargets] deliberately holds no Android type — the thing
+ * that *does* need a runtime is the trampoline activity around it, which is why this class exists
+ * separately from it rather than as a field on the activity.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class JobSheetTargetsTest {
+
+    @Test
+    fun `no live job means nothing is requested`() = runTest {
+        val targets = JobSheetTargets()
+
+        // The caller reads the false as "just open the app". Returning true here would leave the
+        // trampoline expecting a sheet that no one is ever going to show.
+        assertFalse(targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP))
+    }
+
+    @Test
+    fun `a tap emits the live target for that kind`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(JobSheetTarget.Backup("com.a", "App A"))
+
+        assertTrue(targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP))
+        assertEquals(JobSheetTarget.Backup("com.a", "App A"), targets.requests.first())
+    }
+
+    @Test
+    fun `the two kinds do not see each other`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(JobSheetTarget.Restore("content://docs/1"))
+
+        // A backup and a restore share one chain but not one notification: each kind has its own id
+        // and its own PendingIntent, so a tap on one must never resolve to the other's target.
+        assertFalse(targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP))
+        assertTrue(targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE))
+    }
+
+    @Test
+    fun `a request survives having no collector`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(JobSheetTarget.Restore("content://docs/1"))
+
+        // The tap is what starts the UI, so this is the ordinary ordering, not a race. CONFLATED
+        // buffers it; the `first()` below is the collector arriving afterwards.
+        assertTrue(targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE))
+
+        assertEquals(JobSheetTarget.Restore("content://docs/1"), targets.requests.first())
+    }
+
+    @Test
+    fun `two taps before anyone collects leave the latest, not a queue of sheets`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(JobSheetTarget.Backup("com.a", "App A"))
+        targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
+        targets.set(JobSheetTarget.Backup("com.b", "App B"))
+        targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
+
+        // Conflated on purpose: the alternative is opening one sheet per impatient tap.
+        assertEquals(JobSheetTarget.Backup("com.b", "App B"), targets.requests.first())
+    }
+
+    @Test
+    fun `retargeting replaces the label a tap will show`() = runTest {
+        val targets = JobSheetTargets()
+        // What the worker can publish before `setForeground`: the package name in both fields.
+        targets.set(JobSheetTarget.Backup("com.supercell.clashofclans", "com.supercell.clashofclans"))
+        // What it publishes once the AppInfo lookup has returned.
+        targets.set(JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"))
+
+        targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
+
+        assertEquals(
+            JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"),
+            targets.requests.first()
+        )
+    }
+
+    @Test
+    fun `a finished job clears its own target`() = runTest {
+        val targets = JobSheetTargets()
+        val target = JobSheetTarget.Restore("content://docs/1")
+        targets.set(target)
+
+        targets.clearIfStill(target)
+
+        // The notification is gone by now, so a target left behind would be reopened by the *next*
+        // restore's notification and show the wrong archive.
+        assertFalse(targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE))
+    }
+
+    @Test
+    fun `a finishing job does not clear its successor's target`() = runTest {
+        val targets = JobSheetTargets()
+        val first = JobSheetTarget.Restore("content://docs/1")
+        targets.set(first)
+
+        // The successor publishes as it starts...
+        val second = JobSheetTarget.Restore("content://docs/2")
+        targets.set(second)
+        // ...and only then does the previous worker's `finally` run. Jobs of one kind serialise
+        // through THOR_JOB_CHAIN, but APPEND_OR_REPLACE and cancellation both make this ordering
+        // reachable, and a plain remove(kind) here would strand the running job's notification.
+        targets.clearIfStill(first)
+
+        assertTrue(targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE))
+        assertEquals(second, targets.requests.first())
+    }
+
+    @Test
+    fun `a kind round-trips through the id a notification carries`() {
+        // The whole contract of the intent extra: every kind must survive the trip out and back, or a
+        // tap silently degrades to "open the app".
+        ThorJobKind.entries.forEach { kind ->
+            assertEquals(kind, jobKindFromId(kind.id))
+        }
+    }
+
+    @Test
+    fun `an unknown or missing id decodes to null`() {
+        assertNull(jobKindFromId(null))
+        assertNull(jobKindFromId(""))
+        // The shape a PendingIntent from a future build might carry, and the shape `name` would give
+        // if someone matched on that instead of `id`.
+        assertNull(jobKindFromId("archive-export"))
+        assertNull(jobKindFromId("ARCHIVE_BACKUP"))
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/backup/job/JobSheetTargetsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/backup/job/JobSheetTargetsTest.kt
@@ -7,16 +7,20 @@ import com.valhalla.thor.domain.model.ThorJobKind
 import com.valhalla.thor.domain.model.jobKindFromId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.UUID
 
 /**
- * The handoff a job notification's tap goes through, and the one decision it can get wrong: reopening
- * a sheet on the wrong job.
+ * The handoff a job notification's tap goes through, and the two decisions it can get wrong: reopening
+ * a sheet on the wrong job, and reopening one on a job that has already ended.
  *
  * Testable on a plain JVM because [JobSheetTargets] deliberately holds no Android type — the thing
  * that *does* need a runtime is the trampoline activity around it, which is why this class exists
@@ -24,6 +28,9 @@ import org.junit.Test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class JobSheetTargetsTest {
+
+    /** Stands in for a `WorkSpec` id. Fixed rather than random so a failure names the same job twice. */
+    private fun jobId(n: Int) = UUID(0L, n.toLong())
 
     @Test
     fun `no live job means nothing is requested`() = runTest {
@@ -37,7 +44,7 @@ class JobSheetTargetsTest {
     @Test
     fun `a tap emits the live target for that kind`() = runTest {
         val targets = JobSheetTargets()
-        targets.set(JobSheetTarget.Backup("com.a", "App A"))
+        targets.set(jobId(1), JobSheetTarget.Backup("com.a", "App A"))
 
         assertTrue(targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP))
         assertEquals(JobSheetTarget.Backup("com.a", "App A"), targets.requests.first())
@@ -46,7 +53,7 @@ class JobSheetTargetsTest {
     @Test
     fun `the two kinds do not see each other`() = runTest {
         val targets = JobSheetTargets()
-        targets.set(JobSheetTarget.Restore("content://docs/1"))
+        targets.set(jobId(1), JobSheetTarget.Restore("content://docs/1"))
 
         // A backup and a restore share one chain but not one notification: each kind has its own id
         // and its own PendingIntent, so a tap on one must never resolve to the other's target.
@@ -57,7 +64,7 @@ class JobSheetTargetsTest {
     @Test
     fun `a request survives having no collector`() = runTest {
         val targets = JobSheetTargets()
-        targets.set(JobSheetTarget.Restore("content://docs/1"))
+        targets.set(jobId(1), JobSheetTarget.Restore("content://docs/1"))
 
         // The tap is what starts the UI, so this is the ordinary ordering, not a race. CONFLATED
         // buffers it; the `first()` below is the collector arriving afterwards.
@@ -69,9 +76,9 @@ class JobSheetTargetsTest {
     @Test
     fun `two taps before anyone collects leave the latest, not a queue of sheets`() = runTest {
         val targets = JobSheetTargets()
-        targets.set(JobSheetTarget.Backup("com.a", "App A"))
+        targets.set(jobId(1), JobSheetTarget.Backup("com.a", "App A"))
         targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
-        targets.set(JobSheetTarget.Backup("com.b", "App B"))
+        targets.set(jobId(2), JobSheetTarget.Backup("com.b", "App B"))
         targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
 
         // Conflated on purpose: the alternative is opening one sheet per impatient tap.
@@ -82,9 +89,9 @@ class JobSheetTargetsTest {
     fun `retargeting replaces the label a tap will show`() = runTest {
         val targets = JobSheetTargets()
         // What the worker can publish before `setForeground`: the package name in both fields.
-        targets.set(JobSheetTarget.Backup("com.supercell.clashofclans", "com.supercell.clashofclans"))
-        // What it publishes once the AppInfo lookup has returned.
-        targets.set(JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"))
+        targets.set(jobId(1), JobSheetTarget.Backup("com.supercell.clashofclans", "com.supercell.clashofclans"))
+        // What it publishes once the AppInfo lookup has returned. Same job, so this is an update.
+        targets.set(jobId(1), JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"))
 
         targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
 
@@ -95,12 +102,29 @@ class JobSheetTargetsTest {
     }
 
     @Test
+    fun `a tap between the two publishes still shows the resolved label`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(jobId(1), JobSheetTarget.Backup("com.supercell.clashofclans", "com.supercell.clashofclans"))
+
+        // The tap lands in the window before the AppInfo lookup returns...
+        targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
+        // ...and the worker resolves the label before the UI is up to collect.
+        targets.set(jobId(1), JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"))
+
+        // Resolved at delivery, not at the tap. Buffering the target instead of the kind would title
+        // the sheet with an application id for a job whose label was known by the time it opened.
+        assertEquals(
+            JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"),
+            targets.requests.first()
+        )
+    }
+
+    @Test
     fun `a finished job clears its own target`() = runTest {
         val targets = JobSheetTargets()
-        val target = JobSheetTarget.Restore("content://docs/1")
-        targets.set(target)
+        targets.set(jobId(1), JobSheetTarget.Restore("content://docs/1"))
 
-        targets.clearIfStill(target)
+        targets.clear(ThorJobKind.ARCHIVE_RESTORE, jobId(1))
 
         // The notification is gone by now, so a target left behind would be reopened by the *next*
         // restore's notification and show the wrong archive.
@@ -110,19 +134,70 @@ class JobSheetTargetsTest {
     @Test
     fun `a finishing job does not clear its successor's target`() = runTest {
         val targets = JobSheetTargets()
-        val first = JobSheetTarget.Restore("content://docs/1")
-        targets.set(first)
+        targets.set(jobId(1), JobSheetTarget.Restore("content://docs/1"))
 
         // The successor publishes as it starts...
         val second = JobSheetTarget.Restore("content://docs/2")
-        targets.set(second)
+        targets.set(jobId(2), second)
         // ...and only then does the previous worker's `finally` run. Jobs of one kind serialise
         // through THOR_JOB_CHAIN, but APPEND_OR_REPLACE and cancellation both make this ordering
-        // reachable, and a plain remove(kind) here would strand the running job's notification.
-        targets.clearIfStill(first)
+        // reachable, and an unconditional clear(kind) here would strand the running job's notification.
+        targets.clear(ThorJobKind.ARCHIVE_RESTORE, jobId(1))
 
         assertTrue(targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE))
         assertEquals(second, targets.requests.first())
+    }
+
+    @Test
+    fun `a finishing job does not clear a successor whose target is identical`() = runTest {
+        val targets = JobSheetTargets()
+        // Cancel a restore and immediately restart the same archive — or cancel a backup and retry the
+        // same app. Both workers then hold an EQUAL target, because JobSheetTarget is a data class.
+        val same = JobSheetTarget.Restore("content://docs/1")
+        targets.set(jobId(1), same)
+        targets.set(jobId(2), same)
+
+        targets.clear(ThorJobKind.ARCHIVE_RESTORE, jobId(1))
+
+        // This is why the slot is keyed on the job id and not on the target's value. A compare-and-
+        // remove on the target alone matches here, erases the running job's entry, and every tap on
+        // its notification for the rest of the job resumes the app with no sheet.
+        assertTrue(targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE))
+        assertEquals(same, targets.requests.first())
+    }
+
+    @Test
+    fun `a worker that never published clears nothing`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(jobId(1), JobSheetTarget.Backup("com.a", "App A"))
+
+        // `ThorJobWorker`'s finally calls clear() unconditionally, including for a job whose input
+        // Data carried no package name to publish. It must not take the live entry with it.
+        targets.clear(ThorJobKind.ARCHIVE_BACKUP, jobId(99))
+
+        assertTrue(targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP))
+    }
+
+    @Test
+    fun `a tap on a job that ends before the UI collects opens nothing`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(jobId(1), JobSheetTarget.Restore("content://docs/1"))
+
+        // App lock is on: the trampoline publishes the request minutes before `MainScreen` composes.
+        targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE)
+        // The restore finishes while the user is still at the biometric prompt, or never unlocks and
+        // comes back later in the same process.
+        targets.clear(ThorJobKind.ARCHIVE_RESTORE, jobId(1))
+
+        val seen = mutableListOf<JobSheetTarget>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            targets.requests.toList(seen)
+        }
+
+        // Liveness is re-checked at delivery. Buffering the target itself would replay a dead job to
+        // whatever view model is built next — a sheet the user did not ask for, on a SAF URI whose
+        // grant died with the task that received it, so it could only fail to read its own archive.
+        assertTrue(seen.isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/ObserveInterruptedRestoreUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/ObserveInterruptedRestoreUseCaseTest.kt
@@ -55,9 +55,9 @@ class ObserveInterruptedRestoreUseCaseTest {
 
     @Test
     fun `nothing is reported while a restore for that app is live`() = runTest {
-        // N1. The user starts a restore in the detail pane, the worker writes the breadcrumb on its way
-        // into the destructive phase, and the Settings section composed beside it must not announce
-        // that the restore "did not finish" over a progress bar reporting normal progress.
+        // N1. The user starts a restore in the sheet, the worker writes the breadcrumb on its way into
+        // the destructive phase, and the Settings section composed underneath it must not announce that
+        // the restore "did not finish" beneath a progress bar reporting normal progress.
         val breadcrumbs = FakeBreadcrumbs(crumb)
         val launcher = FakeLauncher(running = mapOf(crumb.packageName to MutableStateFlow(jobId)))
         val useCase = ObserveInterruptedRestoreUseCase(breadcrumbs, launcher)
@@ -124,9 +124,9 @@ class ObserveInterruptedRestoreUseCaseTest {
     }
 
     @Test
-    fun `Got it on the restore screen takes the notice off the pane beside it`() = runTest {
-        // I2, at this seam, and it must not regress: `ArchiveRestore` is a detail pane, so the screen
-        // that clears the breadcrumb and the section that shows the notice are composed together.
+    fun `Got it in the restore sheet takes the notice off the section behind it`() = runTest {
+        // I2, at this seam, and it must not regress: the restore sheet is hosted above the section, so
+        // the surface that clears the breadcrumb and the row that shows the notice are composed together.
         val breadcrumbs = FakeBreadcrumbs(crumb)
         val useCase = ObserveInterruptedRestoreUseCase(breadcrumbs, FakeLauncher())
         val seen = mutableListOf<ArchiveBreadcrumb?>()

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
@@ -49,6 +49,7 @@ import java.util.Base64
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -205,6 +206,27 @@ class ArchiveRestoreViewModelTest {
         override suspend fun open(uriString: String): ArchiveOpenOutcome {
             opens += uriString
             return byUri[uriString]?.let { ArchiveOpenOutcome.Opened(it) } ?: failure
+        }
+    }
+
+    /**
+     * Like [CountingSources], but the file named in [delays] takes that long to hand back.
+     *
+     * Needed because [CountingSources] answers instantly, so two reads always finish in launch order
+     * and the desync `open` guards against cannot happen through it. The bug is specifically a read
+     * that *started* earlier finishing *later*: a big archive picked first, a small one picked while
+     * it loads. Only a source that suspends can put the two in that order.
+     */
+    private class DelayedSources(
+        private val byUri: Map<String, FakeSource>,
+        private val delays: Map<String, Long> = emptyMap(),
+    ) : ArchiveSourceFactory {
+        val opens = mutableListOf<String>()
+        override suspend fun open(uriString: String): ArchiveOpenOutcome {
+            opens += uriString
+            delays[uriString]?.let { delay(it) }
+            return byUri[uriString]?.let { ArchiveOpenOutcome.Opened(it) }
+                ?: ArchiveOpenOutcome.Unreadable
         }
     }
 
@@ -438,6 +460,47 @@ class ArchiveRestoreViewModelTest {
             assertEquals(listOf(URI, other), sources.opens)
             assertEquals("com.example.other", vm.uiState.value.header?.packageName)
             assertEquals("com.example.other-5.thorbak", vm.uiState.value.fileName)
+        }
+
+    @Test
+    fun `a file picked while a slower one is still loading leaves nothing of the first behind`() =
+        runTest(dispatcher) {
+            // The screen keeps the picked URI in a field and everything else in the state, so two
+            // overlapping reads split its identity: the field is always the newest pick, while the
+            // header and every answer derived from it belong to whichever read finished *last*. Here
+            // the first file is the slow one, so without the cancel the sheet ends up describing the
+            // first archive while the request it would build carries the second one's URI — a wrong
+            // request with nothing on screen to reveal it. `AppArchiveWorker` refuses that on the
+            // package mismatch, so it is not a data-loss path, but the user is told a restore may have
+            // left their data incomplete for a job that never started.
+            //
+            // `advanceTimeBy(1)` first: the read has to be genuinely in flight for this to be the
+            // reported race rather than two calls in one frame. Both URIs therefore appear in `opens`
+            // — the first read is cancelled, not skipped.
+            val other = "content://com.example.docs/document/2"
+            val sources = DelayedSources(
+                byUri = mapOf(
+                    URI to FakeSource(header().encode()),
+                    other to FakeSource(
+                        header(packageName = "com.example.other", versionCode = 5L).encode(),
+                        displayName = "com.example.other-5.thorbak",
+                    ),
+                ),
+                delays = mapOf(URI to 1_000L),
+            )
+            val vm = viewModel(sources = sources)
+
+            vm.open(URI)
+            testScheduler.advanceTimeBy(1)
+            vm.open(other)
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(listOf(URI, other), sources.opens)
+            assertEquals("com.example.other", vm.uiState.value.header?.packageName)
+            assertEquals("com.example.other-5.thorbak", vm.uiState.value.fileName)
+            // Not a leftover of the cancelled read either: the spinner it turned on is the one thing a
+            // cancelled coroutine cannot turn off itself, and the replacement read owns it now.
+            assertFalse(vm.uiState.value.loading)
         }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
@@ -133,6 +133,7 @@ class ArchiveRestoreViewModelTest {
 
     private companion object {
         const val SIGNER = "ABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABAB"
+        const val OTHER_SIGNER = "CDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCDCD"
         const val URI = "content://com.example.docs/document/1"
     }
 
@@ -294,7 +295,12 @@ class ArchiveRestoreViewModelTest {
      * follow-up row to hoist one shared double — deliberately not done mid-plan, because it would
      * reopen two already-green test files.
      */
-    private class FakeArchiveGateway(private val signer: String?) : AppDataArchiveGateway {
+    private class FakeArchiveGateway(
+        private val signer: String?,
+        private val signersByPackage: Map<String, String?> = emptyMap(),
+        private val slowSignerFor: String? = null,
+        private val slowSignerMillis: Long = 1_000L,
+    ) : AppDataArchiveGateway {
         override suspend fun thorUserId(): Int = 0
         override suspend fun externalStorageDir(): String = "/storage/emulated/0"
         override suspend fun stagingFile(name: String): File = File("/tmp/$name")
@@ -328,7 +334,21 @@ class ArchiveRestoreViewModelTest {
         override suspend fun relabelClass(packageName: String, dataClass: DataClass): Boolean = false
 
         override suspend fun appUid(packageName: String): Int? = null
-        override suspend fun signerSha256(packageName: String): String? = signer
+
+        /**
+         * `getOrElse`, not `?:` — an entry mapped explicitly to `null` means "this package is
+         * unsigned", which `?:` would swallow back into the default.
+         *
+         * [slowSignerFor] parks the lookup under [NonCancellable] so it survives the cancellation
+         * of the open it belongs to. An ordinary `delay` would throw on resume and the caller would
+         * never reach the line under test.
+         */
+        override suspend fun signerSha256(packageName: String): String? {
+            if (packageName == slowSignerFor) {
+                withContext(NonCancellable) { delay(slowSignerMillis) }
+            }
+            return signersByPackage.getOrElse(packageName) { signer }
+        }
     }
 
     private class FakeVaultStore(initial: String? = null) : PassphraseVaultStore {
@@ -435,6 +455,7 @@ class ArchiveRestoreViewModelTest {
         breadcrumbs: ArchiveBreadcrumbStore = FakeBreadcrumbs(),
         registry: JobRegistry = JobRegistry(),
         sources: ArchiveSourceFactory = FakeSources(FakeSource(head?.encode())),
+        gateway: AppDataArchiveGateway = FakeArchiveGateway(signer),
     ) = ArchiveRestoreViewModel(
         sources = sources,
         openArchive = OpenArchiveUseCase(cipher, dispatcher),
@@ -449,7 +470,7 @@ class ArchiveRestoreViewModelTest {
         capability = DataArchiveCapabilityCache(probe, FakePrivilege(privilegeState)),
         installedFacts = ReadInstalledAppFactsUseCase(
             appRepository = FakeAppRepository(installedApps),
-            gateway = FakeArchiveGateway(signer),
+            gateway = gateway,
         ),
         vault = PassphraseVault(vaultStore, PlainKeyProvider()),
         launcher = launcher,
@@ -567,6 +588,69 @@ class ArchiveRestoreViewModelTest {
             assertEquals("com.example.other", state.header?.packageName)
             assertEquals("com.example.other-5.thorbak", state.fileName)
             assertFalse(state.loading)
+        }
+
+    @Test
+    fun `a replaced read cannot leave its app's signer behind the new file's header`() =
+        runTest(dispatcher) {
+            // The third late write, and the only one that survives every guard the other two use.
+            // `installed` is a plain field, not part of the state, so `updateForOpen` does not cover it
+            // and there is nothing for a stale generation to decline to write. Ordered wrongly — read,
+            // assign, *then* check the generation — the first file's app facts land after the second
+            // file's read has finished, and the gate spends the rest of the screen's life comparing the
+            // header on screen against the app the previous archive belonged to.
+            //
+            // The assertion is deliberately after a `toggleClass`, not straight after the opens: the
+            // second read runs its own `evaluate()` before the first one resumes, so the state right
+            // after `advanceUntilIdle` looks correct either way. Only the next selection change re-reads
+            // the corrupted field — which is exactly the shape of the bug on a device, where the user
+            // picks a file, picks another, and then unticks a class.
+            //
+            // `NonCancellable` in the gateway for the same reason `LateFailingSources` needs it: an
+            // ordinary `delay` throws on resume into a cancelled coroutine, so the write under test
+            // would never be reached and the test would pass against the bug.
+            val other = "content://com.example.docs/document/2"
+            val sources = CountingSources(
+                byUri = mapOf(
+                    URI to FakeSource(header().encode()),
+                    other to FakeSource(
+                        header(
+                            packageName = "com.example.other",
+                            versionCode = 5L,
+                            signer = OTHER_SIGNER,
+                        ).encode(),
+                        displayName = "com.example.other-5.thorbak",
+                    ),
+                ),
+            )
+            val vm = viewModel(
+                installedApps = listOf(
+                    AppInfo(packageName = "com.example.game", appName = "Game", versionCode = 100L),
+                    AppInfo(packageName = "com.example.other", appName = "Other", versionCode = 5L),
+                ),
+                sources = sources,
+                gateway = FakeArchiveGateway(
+                    signer = SIGNER,
+                    signersByPackage = mapOf(
+                        "com.example.game" to SIGNER,
+                        "com.example.other" to OTHER_SIGNER,
+                    ),
+                    slowSignerFor = "com.example.game",
+                ),
+            )
+
+            vm.open(URI)
+            testScheduler.advanceTimeBy(1)
+            vm.open(other)
+            testScheduler.advanceUntilIdle()
+
+            vm.toggleClass(DataClass.DE)
+
+            val state = vm.uiState.value
+            assertEquals("com.example.other", state.header?.packageName)
+            // Not SIGNER_MISMATCH: the app on screen is signed with exactly what its header declares.
+            // That refusal here would mean the gate is holding `com.example.game`'s signer.
+            assertNull(state.refusal)
         }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
@@ -44,11 +44,13 @@ import com.valhalla.thor.domain.usecase.ReadInstalledAppFactsUseCase
 import com.valhalla.thor.presentation.FakeAppRepository
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.io.IOException
 import java.io.InputStream
 import java.util.Base64
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -59,6 +61,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -225,6 +228,36 @@ class ArchiveRestoreViewModelTest {
         override suspend fun open(uriString: String): ArchiveOpenOutcome {
             opens += uriString
             delays[uriString]?.let { delay(it) }
+            return byUri[uriString]?.let { ArchiveOpenOutcome.Opened(it) }
+                ?: ArchiveOpenOutcome.Unreadable
+        }
+    }
+
+    /**
+     * A source whose read for [throwFor] blocks in a way cancellation cannot interrupt, then throws.
+     *
+     * This models the one late write the cancel in `open` cannot stop, and it is not a contrivance:
+     * the real factory copies through a `ContentResolver`, and a blocking read already inside its
+     * `withContext` block finishes before it notices the job is gone. When that block fails for a
+     * *real* reason the original exception wins over the cancellation, so `onFailure` runs — for an
+     * archive the user has already replaced.
+     *
+     * `NonCancellable` is what makes it deterministic on the JVM. Every ordinary suspension point
+     * throws `CancellationException` on resume, which would mean the throw below is never reached and
+     * the test would pass against the bug it is here to catch.
+     */
+    private class LateFailingSources(
+        private val byUri: Map<String, FakeSource>,
+        private val throwFor: String,
+        private val delayMillis: Long = 1_000L,
+    ) : ArchiveSourceFactory {
+        val opens = mutableListOf<String>()
+        override suspend fun open(uriString: String): ArchiveOpenOutcome {
+            opens += uriString
+            if (uriString == throwFor) {
+                withContext(NonCancellable) { delay(delayMillis) }
+                throw IOException("the provider went away mid-read")
+            }
             return byUri[uriString]?.let { ArchiveOpenOutcome.Opened(it) }
                 ?: ArchiveOpenOutcome.Unreadable
         }
@@ -501,6 +534,39 @@ class ArchiveRestoreViewModelTest {
             // Not a leftover of the cancelled read either: the spinner it turned on is the one thing a
             // cancelled coroutine cannot turn off itself, and the replacement read owns it now.
             assertFalse(vm.uiState.value.loading)
+        }
+
+    @Test
+    fun `a replaced read that fails anyway cannot put its error on the new file's screen`() =
+        runTest(dispatcher) {
+            // The half of the race cancelling does not reach. Cancellation is cooperative, and the work
+            // being cancelled here is blocking I/O this class does not own; when that work fails for a
+            // real reason the original exception wins over the cancellation, so `onFailure` still runs.
+            // Unguarded, it wrote `loading = false` and FILE_UNREADABLE for the archive the user already
+            // replaced — a wrong error, and worse, a `loading = false` that re-enables both pick buttons
+            // while the new file is still being read, which re-opens the door the cancel just shut.
+            val other = "content://com.example.docs/document/2"
+            val sources = LateFailingSources(
+                byUri = mapOf(
+                    other to FakeSource(
+                        header(packageName = "com.example.other", versionCode = 5L).encode(),
+                        displayName = "com.example.other-5.thorbak",
+                    )
+                ),
+                throwFor = URI,
+            )
+            val vm = viewModel(sources = sources)
+
+            vm.open(URI)
+            testScheduler.advanceTimeBy(1)
+            vm.open(other)
+            testScheduler.advanceUntilIdle()
+
+            val state = vm.uiState.value
+            assertNull(state.error)
+            assertEquals("com.example.other", state.header?.packageName)
+            assertEquals("com.example.other-5.thorbak", state.fileName)
+            assertFalse(state.loading)
         }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
@@ -6,10 +6,13 @@ package com.valhalla.thor.presentation.main
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.R
 import com.valhalla.thor.data.backup.BackupRunner
+import com.valhalla.thor.data.backup.job.JobSheetTarget
+import com.valhalla.thor.data.backup.job.JobSheetTargets
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.Installers
 import com.valhalla.thor.domain.model.MultiAppAction
+import com.valhalla.thor.domain.model.ThorJobKind
 import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.usecase.BackupAppsUseCase
 import com.valhalla.thor.domain.usecase.ExportAppUseCase
@@ -111,6 +114,10 @@ class MainViewModelTest {
         // to: with the op held, an unmeasured clear is described without mentioning permissions. The
         // one test that cares about the ungranted branch passes false.
         usageAccess: Boolean = true,
+        // A real one, not a fake: `JobSheetTargets` is a plain in-memory holder with no Android type
+        // on it, so a test can drive a notification tap by calling `requestOpen` on the same instance
+        // the view model is watching. Defaulted so the tests that predate it read unchanged.
+        sheetTargets: JobSheetTargets = JobSheetTargets(),
     ): MainViewModel {
         val vm = MainViewModel(
             manageAppUseCase = ManageAppUseCase(system),
@@ -124,6 +131,7 @@ class MainViewModelTest {
             freezerRepository = freezer,
             backupRunner = runner,
             usageAccessGate = FakeUsageAccessGate(usageAccess),
+            jobSheetTargets = sheetTargets,
             ioDispatcher = mainDispatcherRule.dispatcher
         )
         backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.uiState.collect {} }
@@ -932,5 +940,117 @@ class MainViewModelTest {
             listOf("forceStopApp:com.a", "forceStopApp:com.b", "forceStopApp:com.c", "forceStopApp:com.d"),
             system.calls
         )
+    }
+
+    // --- Job sheets ---------------------------------------------------------------------------
+    //
+    // A tap on a running job's notification has to end with that job's sheet on screen. The tap
+    // itself lands in a trampoline activity that needs an Android runtime, so what is pinned here is
+    // the half that does not: a request published to `JobSheetTargets` becomes sheet state, the right
+    // one, and it is not lost if it arrives before the view model exists.
+
+    @Test
+    fun `a restore request opens the restore sheet on that archive`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(JobSheetTarget.Restore("content://docs/tree/1/thor.thorbak"))
+        val vm = viewModel(sheetTargets = targets)
+
+        targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE)
+        advanceUntilIdle()
+
+        assertEquals(
+            RestoreSheetState("content://docs/tree/1/thor.thorbak"),
+            vm.uiState.value.restoreSheet
+        )
+        // Not the other sheet. Two nullable fields driven by one `when`, so a mis-mapped arm would
+        // put a restore's URI behind a backup sheet with no package name to show.
+        assertNull(vm.uiState.value.backupSheet)
+    }
+
+    @Test
+    fun `a backup request opens the backup sheet with the label the worker resolved`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"))
+        val vm = viewModel(sheetTargets = targets)
+
+        targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
+        advanceUntilIdle()
+
+        // The label is carried, not re-derived: `AppBackupViewModel.start` writes what it is handed
+        // straight into its own state, so a package name arriving here is a package name on screen.
+        assertEquals(
+            BackupSheetState("com.supercell.clashofclans", "Clash of Clans"),
+            vm.uiState.value.backupSheet
+        )
+        assertNull(vm.uiState.value.restoreSheet)
+    }
+
+    @Test
+    fun `a request made before the view model exists is not lost`() = runTest {
+        val targets = JobSheetTargets()
+        targets.set(JobSheetTarget.Restore("content://docs/tree/1/thor.thorbak"))
+
+        // The ordinary case, not an edge case: the tap is what brings Thor forward, so the request is
+        // published while nothing is collecting. `JobSheetTargets` conflates rather than dropping —
+        // a `replay = 0` SharedFlow here would send this to no one and the tap would do nothing.
+        targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE)
+
+        val vm = viewModel(sheetTargets = targets)
+        advanceUntilIdle()
+
+        assertEquals(
+            RestoreSheetState("content://docs/tree/1/thor.thorbak"),
+            vm.uiState.value.restoreSheet
+        )
+    }
+
+    @Test
+    fun `a tap on a job that is no longer live opens nothing`() = runTest {
+        val targets = JobSheetTargets()
+        val vm = viewModel(sheetTargets = targets)
+
+        // Nothing was ever published, or the worker's `finally` has already cleared it. The
+        // trampoline reads the false and resumes the app without a sheet; here the point is that no
+        // *empty* sheet is opened in its place.
+        assertFalse(targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE))
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.restoreSheet)
+        assertNull(vm.uiState.value.backupSheet)
+    }
+
+    @Test
+    fun `dismissing a sheet closes it and leaves the other alone`() = runTest {
+        val targets = JobSheetTargets()
+        val vm = viewModel(sheetTargets = targets)
+
+        vm.openRestoreSheet("content://docs/tree/1/thor.thorbak")
+        targets.set(JobSheetTarget.Backup("com.a", "App A"))
+        targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
+        advanceUntilIdle()
+
+        vm.dismissRestoreSheet()
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.restoreSheet)
+        assertEquals(BackupSheetState("com.a", "App A"), vm.uiState.value.backupSheet)
+
+        vm.dismissBackupSheet()
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.backupSheet)
+    }
+
+    @Test
+    fun `the Settings row opens the sheet with no archive chosen`() = runTest {
+        val vm = viewModel()
+
+        vm.openRestoreSheet()
+        advanceUntilIdle()
+
+        // Open, and open on the file picker. The outer null means "closed", so this has to be a
+        // present state holding a null URI — collapsing the two would make the Settings row and a
+        // dismissed sheet indistinguishable.
+        assertEquals(RestoreSheetState(null), vm.uiState.value.restoreSheet)
     }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
@@ -48,6 +48,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.io.File
 import java.nio.file.Files
+import java.util.UUID
 
 /**
  * Behaviour tests for [MainViewModel] — the one view model in `presentation/` that can be built on
@@ -949,10 +950,13 @@ class MainViewModelTest {
     // the half that does not: a request published to `JobSheetTargets` becomes sheet state, the right
     // one, and it is not lost if it arrives before the view model exists.
 
+    /** Stands in for the publishing worker's `WorkSpec` id. `JobSheetTargetsTest` covers what it is for. */
+    private fun jobId(n: Int) = UUID(0L, n.toLong())
+
     @Test
     fun `a restore request opens the restore sheet on that archive`() = runTest {
         val targets = JobSheetTargets()
-        targets.set(JobSheetTarget.Restore("content://docs/tree/1/thor.thorbak"))
+        targets.set(jobId(1), JobSheetTarget.Restore("content://docs/tree/1/thor.thorbak"))
         val vm = viewModel(sheetTargets = targets)
 
         targets.requestOpen(ThorJobKind.ARCHIVE_RESTORE)
@@ -970,7 +974,7 @@ class MainViewModelTest {
     @Test
     fun `a backup request opens the backup sheet with the label the worker resolved`() = runTest {
         val targets = JobSheetTargets()
-        targets.set(JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"))
+        targets.set(jobId(1), JobSheetTarget.Backup("com.supercell.clashofclans", "Clash of Clans"))
         val vm = viewModel(sheetTargets = targets)
 
         targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
@@ -988,7 +992,7 @@ class MainViewModelTest {
     @Test
     fun `a request made before the view model exists is not lost`() = runTest {
         val targets = JobSheetTargets()
-        targets.set(JobSheetTarget.Restore("content://docs/tree/1/thor.thorbak"))
+        targets.set(jobId(1), JobSheetTarget.Restore("content://docs/tree/1/thor.thorbak"))
 
         // The ordinary case, not an edge case: the tap is what brings Thor forward, so the request is
         // published while nothing is collecting. `JobSheetTargets` conflates rather than dropping —
@@ -1020,12 +1024,53 @@ class MainViewModelTest {
     }
 
     @Test
+    fun `the thorbak a launch was opened on opens the restore sheet once`() = runTest {
+        val vm = viewModel()
+
+        vm.openRestoreSheetForLaunchUri("content://docs/tree/1/thor.thorbak")
+        advanceUntilIdle()
+
+        assertEquals(
+            RestoreSheetState("content://docs/tree/1/thor.thorbak"),
+            vm.uiState.value.restoreSheet
+        )
+
+        // The recomposition case: `MainScreen`'s LaunchedEffect re-runs with the same non-null
+        // `pendingRestoreUri` after the user has dismissed the sheet. It must not come back.
+        vm.dismissRestoreSheet()
+        vm.openRestoreSheetForLaunchUri("content://docs/tree/1/thor.thorbak")
+        advanceUntilIdle()
+
+        assertNull(vm.uiState.value.restoreSheet)
+    }
+
+    @Test
+    fun `a fresh view model reopens the launch thorbak, because a killed process kept the intent`() = runTest {
+        val first = viewModel()
+        first.openRestoreSheetForLaunchUri("content://docs/tree/1/thor.thorbak")
+        advanceUntilIdle()
+
+        // Process death, then a return through Recents: the activity is recreated with the same VIEW
+        // intent and a still-valid task-scoped read grant, and gets a new view model. The latch has to
+        // come back with it, which is the whole reason it does not live in a `rememberSaveable` — that
+        // survives process death while the sheet state does not, so the archive was silently dropped.
+        val second = viewModel()
+        second.openRestoreSheetForLaunchUri("content://docs/tree/1/thor.thorbak")
+        advanceUntilIdle()
+
+        assertEquals(
+            RestoreSheetState("content://docs/tree/1/thor.thorbak"),
+            second.uiState.value.restoreSheet
+        )
+    }
+
+    @Test
     fun `dismissing a sheet closes it and leaves the other alone`() = runTest {
         val targets = JobSheetTargets()
         val vm = viewModel(sheetTargets = targets)
 
         vm.openRestoreSheet("content://docs/tree/1/thor.thorbak")
-        targets.set(JobSheetTarget.Backup("com.a", "App A"))
+        targets.set(jobId(1), JobSheetTarget.Backup("com.a", "App A"))
         targets.requestOpen(ThorJobKind.ARCHIVE_BACKUP)
         advanceUntilIdle()
 


### PR DESCRIPTION
Field feedback from the first hardware run of #51 phase 2 / #164: `.xapk` export works, backup works, restore works, and app **data** was genuinely restored. Three things were wrong around it, and all three are UI or destination, not the engine.

Two more changes landed on top after review of the above: restore stopped being a route and became a sheet like backup, and the notification a running job posts became a way back into that sheet. An adversarial review of *those* then found four bugs, fixed in §6. §7 adds one line of copy to the panel a non-root channel gets.

**All three sheets and the notification taps are now maintainer-verified on a physical device** — see *Device-tested* at the foot, which also lists what that run did not cover.

## 1. The archive went to `Downloads`, not `Downloads/Thor`

`AppArchiveStore.currentTargetLabel()` resolves through `AppBundleFileStoreImpl`, which has always written to the `Thor` subfolder — so the caption said *"Downloads/Thor"* while both archive backends wrote to the root of the user's Downloads. The caption was right about the convention and wrong about the file, which is the worst way round for the one line naming a folder the user then has to go and find.

- The folder name is now one `internal const val THOR_DOWNLOADS_SUBDIR` shared across both files rather than a literal at four write sites.
- `const val`, not a top-level `val`: three top-level members of `AppArchiveStoreImpl.kt` are JVM-tested (`ArchiveDestinationTest`), and a top-level `val` touching `Environment` would run the file facade's `<clinit>` on the first of those calls and hit *"not mocked"*.
- The legacy writer and the launch-time orphan sweep now share one `legacyArchiveDir()`. They are the pair that has to agree: a sweeper pointed one level up finds nothing, returns false for every orphan, and leaves both the `.part` **and** its ledger entry behind forever.
- The MediaStore branch has no orphan delete by design (it records nothing in the ledger), so there was no second sweeper to move.

## 2. The backup sheet, while a job runs

Six checkboxes, the destination row and its picker, two passphrase fields and a second Back-up button used to sit above the progress bar with `enabled = false` on each — a form the user can read, cannot use, and has to scroll past to reach the only thing that is moving. The sheet is now the bar, what it is working on, and one **Background** button.

Background dismisses the sheet, which is honest because of where the work runs: the job is a WorkManager foreground service, so this drops the *sheet's watcher* and nothing else. Reopening finds the same job through `runningJobFor`; the ongoing notification carries the progress meanwhile, including the Cancel action built from `WorkManager.createCancelPendingIntent` — which is why no second cancel affordance was added to a surface that is about to be dismissed.

A success holds the sheet for 3 s and then closes it. The timer is `LaunchedEffect(Unit)` inside the success frame, so **Got it** removes the frame and cancels the timer rather than leaving a dismiss to fire later at whatever the sheet has become. Failures and cancels still render under the form, next to the controls that would change a retry.

The sheet's `when` moved from `state.supported` to conditions, to hold five frames. It also settles the one pair that can overlap: `running` outranks a `finished` left over from a previous job, which `start()`'s reattach collector can pick up before `watch` clears the banner.

## 3. The restore outcome

The outcome rendered as a card at the foot of a column containing the title, the archive's three header lines, up to four class rows, the game-data row, the unlock row, the confirmation row, the bar and the Restore button — so the sentence saying whether the data came back arrived below the fold, on the one surface where that is the only thing being waited for. It is now an `AlertDialog`.

Same withdrawal as the sheet: class rows, game-data row, passphrase field, confirmation and Restore button are gone while a restore runs, and the bar appears in the space they vacated.

## 4. Restore stops being a route

`ArchiveRestoreScreen` is now `ArchiveRestoreSheet`, hosted beside `AppBackupSheet` in `MainScreen`'s global overlays, so it composes over whichever of the four tabs is showing. Consequences:

- The `pendingRestoreUri` path no longer switches tabs to show it.
- The screen's own back affordance is gone, and `restore_back` is deleted with it. An orphaned string is a fatal `UnusedResources` under this project's lint settings, so leaving it was not an option.
- **`ThorRoute.ArchiveRestore` and its entry stay for one release**, as an entry that pops itself and opens the sheet. `rememberNavBackStack` persists for task restoration and that state survives an app update, so a restored stack naming a deleted route would fail to deserialise.
- Four comments that described the old layout are corrected rather than deleted, with the wrong claim retracted. The suppression in `ObserveInterruptedRestoreUseCase` is still load-bearing — it just was not load-bearing for the reason it gave.

## 5. Tapping a job notification reopens its sheet

The row a running backup or restore posts was a dead end. It now reopens the sheet that job belongs to.

The channel is an in-process holder, `JobSheetTargets`, **not** intent extras. `HomeActivity` is `standard` launchMode with no `onNewIntent` anywhere in `app/src/main`, and `pendingRestoreUri` is read `by lazy` from the creation intent — extras arriving on a resume intent are simply dropped. So:

- The `PendingIntent` carries only `ThorJobKind.id`, decoded by `jobKindFromId`. Not `name` or `ordinal`: an ordinal is silently wrong the day the enum is reordered, and a notification the system is still showing across an app update is holding whatever the *old* build wrote. Anything unrecognised returns null, which the caller reads as "just open the app".
- The payload lives in the holder, which the worker publishes to before `setForeground` — so the notification cannot be tapped before the target it points at exists.
- `JobSheetLaunchActivity` is a translucent, `noHistory`, `excludeFromRecents`, `taskAffinity=""` trampoline: resolve the kind, ask the holder to open, resume Thor's task the `BulkResultNotifier.homeIntent()` way, finish. Activity trampolines from a notification are still legal — Android 12 banned the service and broadcast kinds.
- The backup worker republishes its target once `appInfo` resolves, because `AppBackupViewModel.start` writes the `appLabel` it is handed straight into state and never resolves it — a tap before that lookup would otherwise title the sheet with a package name.
- `setContentIntent` without `setAutoCancel(true)`: the job is still running after the tap and the row is its only surface, so dismissing it on tap would leave a foreground service with nothing showing for it.
- The `PendingIntent`s are built once per kind in a property initializer. `build()` runs up to once a second for the whole of a multi-gigabyte job and `PendingIntent.getActivity` is an IPC.

**Honest limit:** if the process died, the holder is empty and the tap just opens the app. Doing better would mean persisting the task-scoped SAF grant, which would produce a restore sheet that cannot read its own archive.

## 6. What review found in §5, and the fixes

An adversarial review of the two commits above raised 13 findings across four lenses; 5 survived refutation. Two were bugs in the very mechanism whose KDoc claimed to prevent them.

**A predecessor could erase its successor's target.** `clearIfStill(target)` compared by value and `JobSheetTarget` is a data class — so cancel a backup, immediately retry the same app, and both workers hold an equal `Backup(pkg, label)`. `remove(key, value)` then matched the *successor's* entry from the predecessor's `finally`, after which every tap on the running job's notification resumed the app with no sheet for the rest of that job. The slot is now tagged with the publishing worker's `WorkSpec` id — unique per work request, stable across a retry of one — and `clear(kind, jobId)` removes only if that id still owns it. `ThorJobWorker.publishedTarget` is gone with it: the id identifies the owner, so the `finally` clears unconditionally and a worker that never published owns nothing to clear.

The test that claimed to pin this passed for a narrower reason than it stated — two different URIs, so it discriminated `remove(key, value)` from `remove(key)` but never reached the equal-value case.

**A tap could open a sheet on a job that had already ended.** The channel buffered the target and nothing invalidated it when the job finished, so with app lock on, a tap held through the biometric screen was replayed to whatever `MainViewModel` was built next — a sheet the user did not ask for, on a URI whose grant died with the task that received it. The channel now carries the *kind* and delivery resolves against the live map, so a dead job's request drops. The same change fixes the other end of that window: a tap landing between a backup worker's two publishes now shows the label the worker has when the sheet **opens**, not the one it had at the tap.

**The trampoline could hide Thor from Recents permanently.** `excludeFromRecents` applies to the task an activity *roots*. Without `taskAffinity=""`, a tap arriving when no Thor task exists — user exited with back, or swiped Thor away, while the foreground service kept the job running — rooted a recents-excluded task with Thor's own affinity, and the launcher-shaped resume put `HomeActivity` inside it. Nothing re-derives a task's base intent afterwards, so Thor stayed missing from Recents for that task's whole life, reachable only from the launcher icon. `FreezerLaunchActivity` has carried `taskAffinity=""` all along; §5 dropped it and wrote a comment arguing the omission was deliberate. That comment was backwards and is retracted in place.

**The `.thorbak` a launch was opened on could be dropped silently.** `restoreUriConsumed` was a `rememberSaveable`, which survives process death; the `restoreSheet` state it guards lives on `MainViewModel`, which does not. Kill the process, return through Recents: the activity is recreated with the same VIEW intent and a still-valid read grant, the saved latch says "already handled", and the fresh ViewModel has no sheet — nothing on screen, and no way back to that archive but re-picking it. **As a route this could not happen**, because the back stack was saveable too; §4 introduced it. The latch moves onto the ViewModel so it and the state it guards have one lifetime: rotation keeps both, process death clears both and the sheet reopens.

Three comments were factually wrong about their own code and are corrected with the wrong claim retracted: the sheet's ViewModel owner is the host **Activity**, not "that tab's entry"; the trampoline resolves `JobSheetTargets` only, so it does not pay for `ThorJobNotifications`' eager `PendingIntent`s; and `ArchiveBreadcrumbStore.observe` still argued from a detail pane on an expanded window — the fifth copy of the claim §4 retracted in four other places, and false at the parent commit too.

Findings deliberately **not** acted on: the stacked-sheet cosmetic (a notification-opened backup sheet can compose over one already open from the app list — noted at `BackupSheetState`), and the absent SAF-grant persistence, for the reason in §5.

## 7. What the refusal panel says, for a channel that cannot read private data

The panel a plain-Shizuku or Dhizuku user gets was entirely about what Thor cannot reach. It now carries the other half of the answer: **Thor 2.0 brings partial backups without root — the app itself and its files on shared storage, though not its private data.**

`backup_partial_soon` is its own string rather than a second sentence on `backup_unsupported`, because `ArchiveRestoreSheet` renders that one too — and there the blocker is *writing* private data, so a note about backup coverage would be answering a question nobody asked. Only `AppBackupSheet` shows the new line. Verified present in the built APK with `aapt2 dump resources`, not just in the source.

## 8. Two file picks that overlap, and the archive the sheet stopped describing

Picking a second file while the first was still loading split the restore sheet's identity in half. The picked URI lives in a ViewModel field and is always the **newest** pick; the header — and the classes, the warnings, the unlocked passphrase, every answer derived from it — belong to whichever read finished **last**. A big archive picked first and a small one picked during its load inverts those two, so the sheet showed A while the request it would enqueue carried B's URI.

`AppArchiveWorker` refuses that on the package mismatch before touching anything, so no data was ever at risk — but only after a 210,000-iteration key derivation, and the user is then told a restore *may have left their data incomplete* about a device nothing touched.

The read is now cancelled and replaced rather than early-returned. An early return would silently discard the file the user just picked, which is the one thing they are certain they asked for; cancelling is what keeps the URI field and the header describing the same archive, so the wrong request disappears at the source instead of relying on the worker to catch it. `launchGuarded` rethrows `CancellationException` instead of routing it to `onFailure`, so a *cleanly* cancelled read cannot write a failure over the replacement's state.

**Cancellation stops the work; it does not stop the writes.** A read that fails for a real reason at the moment it is cancelled propagates its own exception — the original exception wins over the cancellation — so `launchGuarded`'s `onFailure` still runs, and the stale read writes `error` and `loading = false` onto the screen now describing the new file. `loading = false` also re-enables both pick buttons mid-read, so the gate above stops holding. An `openGeneration` counter, claimed before the state reset, tags every write with the pick it came from; a write whose generation is stale is dropped. The remembered-passphrase path is guarded the same way, and wipes the passphrase it read rather than leaking it when it loses the race.

**`installed` is a plain field, and ordering is the whole of the guard there.** It is not part of the UI state, so `updateForOpen` does not cover it and a stale generation has nothing to decline to write; the fix is to read into a local, check the generation, and only then assign. The first version of this bailed out *after* assigning, which fixes nothing — and the consequence is worse than a stale field, because `evaluate()` reads `installed` on **every** selection change. The corruption is not confined to the moment of the race: it sits there for the life of the screen, and the next `toggleClass` decides signer and version against the app the *previous* archive belonged to. Two files picked in a row, one tick of a checkbox, and a correctly signed restore is refused as `SIGNER_MISMATCH`.

`supported` is deliberately left ungated: it is a property of the privilege state, not of the file being read.

Both pick buttons are disabled while a read is in flight too, but that only narrows the window — `header == null` is true for the whole of a load, so without the gate the empty-state prompt and the spinner above it were drawn together. The ViewModel is what makes the race unreachable.

## The CodeRabbit review, audited finding by finding

Its four findings were re-checked against the code rather than against its own "✅ Addressed in commit X" annotations, which are fingerprint matches on a changed line, not a re-verification. **One was live.**

- **Three were already not live**, each for a different reason than CodeRabbit's note claimed, and each confirmed against the tree — including the `.part` sweep (§ *Known, accepted* below).
- **One was real and is fixed in §8.** It was posted as an *outside-diff-range* comment inside a review **body**, so it never became a review thread and is invisible to any thread-only listing — worth recording, because "all threads resolved" would have read as "all findings addressed".
- **One proposed fix was rejected on the merits.** Making the launch-URI latch a `rememberSaveable` would re-introduce the process-death drop that `87c3d5fb` removed. A URI-keyed latch on the ViewModel is the version that is behaviour-identical today *and* stays correct if `onNewIntent` is ever added; it is not a defect today, so it is not in this PR.

The re-review of that fix then found a fifth, **against the cancel itself** — the cooperative-cancellation hole in §8. It was audited the same way rather than taken on trust, found reachable, and fixed with the generation guard; the test for it is mutation-verified below.

The re-review of *that* found a **sixth**, against the generation guard: the `installed` write was ordered before its own check, so the guard was decorative on the one field it could not otherwise cover. Confirmed, fixed by reordering, and mutation-verified (§8). The comment sitting on those lines had claimed the write was one "no generation check can undo" — false, and retracted rather than reworded. Three rounds, each finding a real defect in the previous round's fix, is the argument for auditing every one of these against the code instead of against the annotation — and for not merging on the first green poll after a push.

The `.part` finding was declined with a release-history proof rather than a code argument: `PartialArchiveLedger` was introduced in `299fc471` (2026-08-11), the newest release of any kind is `v1.94.1-dev-12` (2026-08-09), and `gh api …/compare/v1.94.1-dev-12...299fc471` returns `ahead 86, behind 0` — not contained, with no later release existing. No shipped build has ever written a ledger entry at all, so the sweep it asks for can never match. Proved with `compare` rather than `git tag --contains`, which is untrustworthy on this shallow clone.

## Wider than the ask, and why

- **All three restore outcomes go in the dialog, not just the success.** A failure was equally invisible, and two containers for one decision is how the five sentences `RestoreOutcome` documents drift into two shapes.
- **No auto-dismiss on the restore dialog**, unlike the backup sheet's 3 s success. That one has nothing left to say; this one tells the user to go and open the app to check it works, and may be carrying warnings under it.

## Verification

- `:app:testFossDebugUnitTest :app:lintFossDebug --rerun-tasks` — **BUILD SUCCESSFUL**, **1514 tests, 0 failures, 0 errors, 0 skipped** across 109 suites, counts parsed from `build/test-results/**/*.xml` with ElementTree. Re-run on the head carrying all three of §8's commits. Lint: 0 Fatal, 0 Error, 0 Warning, 5 pre-existing hints.
- **Lint run locally on both flavours**, not just the one CI builds: `lintFossDebug` and `lintStoreRelease` both `BUILD SUCCESSFUL` with **0 Fatal, 0 Error, 0 Warning** — 5 informational `VectorPath` hits in `res/drawable/`, all pre-existing brand art already downgraded in `app/lint.xml`, none in a file this branch touches. Worth doing because the `store` flavour is on no test classpath and CI does not lint it; note also that `checkTestSources` contributes nothing to a *release* variant, since AGP only builds test lint components for the debug test build type.
- `lintFossDebug` matters here: `warningsAsErrors` + `checkTestSources` are on, which is what makes the deleted `restore_back` string mandatory rather than tidy.
- **+22 tests.** `JobSheetTargetsTest` (14) covers the handoff; `MainViewModelTest` (8) covers what a tap does to state, plus the launch-URI latch that was untestable while it was a `rememberSaveable`.
- **§8's three tests pin the inversion, not the call count.** Mutation-verified: removing the cancel fails the first with `expected:<com.example.other> but was:<com.example.game>` — the first archive's package where the second's belongs, which is the defect itself. Removing the generation guard fails the second with `expected null, but was:<Known(reason=FILE_UNREADABLE)>` — the dead read's error on the live file's screen. Restoring the `installed` write to its old position fails the third with `expected null, but was:<SIGNER_MISMATCH>`, and nothing else. The third asserts after a `toggleClass` rather than straight after the two opens, deliberately: the second read runs its own `evaluate()` before the first one resumes, so the state in between looks correct with or without the bug — only the next selection change re-reads the corrupted field, which is also the shape of the bug on a device. All three needed a source fake that can *suspend*, because an instant one always finishes two reads in launch order and the bug is a read that started earlier finishing later; the failing one additionally fails from inside `withContext(NonCancellable)`, the only deterministic way on the JVM to model blocking I/O that ignores the cancel. An ordinary suspension point there throws `CancellationException` on resume, and the test would pass against the very bug it exists to catch.
- **The two §6 contracts are mutation-verified, not assumed.** Reverting `clear` to a value compare reddens three tests; reverting delivery to a buffered payload reddens the other two. A green test that would also be green against the bug is not coverage, and the test this replaced was exactly that.
- Sections 1–3 still have no new tests, for the reason stated before: those files are Compose or Android-framework I/O, and this project has no Robolectric, no `koin-test` and no `work-testing`.

## Device-tested

Confirmed on a physical device by the maintainer: **the backup sheet, the restore sheet, and the notification taps — all working.** That covers §2, §3, §4 and the §5 handoff on real hardware, which is the part no JVM test in this repo can reach.

Still unconfirmed, and listed so nothing reads as verified that wasn't:

- **The archive landing in `Downloads/Thor`** on a below-29 device (the legacy path, where `mkdirs` now actually has to create the folder). The API 29+ MediaStore path is the one a modern device exercises.
- **The two §6 edge paths.** Swipe Thor out of Recents while a backup runs, tap the notification, then check Thor is still **in** Recents afterwards. And: open a `.thorbak`, enable "Don't keep activities", background and return — the restore sheet should come back. Both are fixes for states that need to be induced deliberately, so ordinary use passing does not exercise them.
- The shim route, on a device carrying a persisted back stack that names it.
- **Known, accepted:** a `.part` orphan left in Downloads *root* by an earlier build will no longer be swept, because the sweep now looks in `Downloads/Thor`. No user can have one — the ledger that records them is itself unreleased (proof under *The CodeRabbit review* above).
- **The §8 race itself**, either half. It needs two picks overlapping a slow read, which is a JVM-test shape, not a hand-test one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup and restore progress now remains available after dismissing the sheet, with notifications providing ongoing updates.
  * Tapping an active backup or restore notification reopens its progress screen.
  * Restore is presented in a global bottom sheet, including support for opening archive files directly.
  * Backup and restore screens now provide clearer progress, background-processing guidance, outcomes, and retry options.
  * Partial backup support is clearly identified as forthcoming.
* **Bug Fixes**
  * Downloads and exported media now consistently use the `Downloads/Thor` folder.
  * Replacing an archive while it is loading no longer allows outdated results to overwrite the current selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->