### PR TITLE
feat(settings): eight doors, and a second pane on wide windows

### DIFF
--- a/app/src/androidTest/java/com/valhalla/thor/presentation/settings/SettingsSwitchRowTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/presentation/settings/SettingsSwitchRowTest.kt
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.percentOffset
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.valhalla.thor.R
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * What [SettingsSwitchRow] promises the twelve settings that use it.
+ *
+ * Two of those promises were being broken at once, in opposite directions, and neither was visible
+ * from reading a call site. The row announced itself as a *button* — `clickable`, no state — while
+ * the `Switch` beside it had its semantics cleared so the setting would not be offered twice, so
+ * between them nothing carried on or off and a screen reader user could change any toggle in
+ * Settings without ever hearing what it was set to. Meanwhile the Usage Access and Notification
+ * Access handlers both read the row as reporting "the state I am now in" and guarded on the
+ * permission still being missing, which made both rows dead once granted.
+ *
+ * So: the row is one control, it says which control it is, it says what it is set to, and it
+ * reports the value the user asked for rather than the one already in force.
+ */
+@RunWith(AndroidJUnit4::class)
+class SettingsSwitchRowTest {
+
+    @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+    private val title = "Auto freeze"
+    private val subtitle = "Freeze apps on a schedule"
+
+    private var reported = mutableListOf<Boolean>()
+
+    private fun setRow(checked: Boolean, enabled: Boolean = true) = rule.setContent {
+        SettingsSwitchRow(
+            icon = R.drawable.frozen,
+            title = title,
+            subtitle = subtitle,
+            checked = checked,
+            enabled = enabled,
+            onCheckedChange = { reported += it }
+        )
+    }
+
+    private val hasSwitchRole = SemanticsMatcher.expectValue(
+        SemanticsProperties.Role,
+        Role.Switch
+    )
+
+    /**
+     * The row is a switch and it is on — the two facts the old markup lost between the `clickable`
+     * that had no state and the `clearAndSetSemantics` that threw the state away.
+     */
+    @Test fun theRowAnnouncesItselfAsASwitchAndSaysWhatItIsSetTo() {
+        setRow(checked = true)
+
+        rule.onNodeWithText(title).assert(hasSwitchRole).assertIsOn()
+        rule.onNodeWithText(subtitle).assertIsOn()
+    }
+
+    /** And off, so that "on" above is a reading rather than a constant. */
+    @Test fun anUncheckedRowSaysOff() {
+        setRow(checked = false)
+
+        rule.onNodeWithText(title).assert(hasSwitchRole).assertIsOff()
+    }
+
+    /**
+     * The setting is offered once.
+     *
+     * The `Switch` used to carry its own toggle semantics, which is why it was silenced by hand; a
+     * null handler is what silences it now, and this is the assertion that the substitution held.
+     * Two toggleable nodes means a screen reader walks past the same setting twice and reads the
+     * title on only one of them.
+     */
+    @Test fun thereIsExactlyOneControlToFind() {
+        setRow(checked = true)
+
+        assertEquals(
+            1,
+            rule.onAllNodes(isToggleable()).fetchSemanticsNodes().size
+        )
+    }
+
+    /**
+     * The finding, as an assertion: a checked row reports **false**.
+     *
+     * `onCheckedChange` carries the value the user is asking for, not the one already in force.
+     * Usage Access and Notification Access both read it the other way and guarded on the permission
+     * being absent, so switching either of them off called the handler and the handler returned —
+     * the switch snapped back and nothing opened. Any implementation that reports the current value
+     * makes that guard look correct again.
+     */
+    @Test fun tappingACheckedRowAsksForFalse() {
+        setRow(checked = true)
+
+        rule.onNodeWithText(title).performClick()
+
+        assertEquals(listOf(false), reported)
+    }
+
+    /** The other direction, for completeness — an unchecked row asks for true. */
+    @Test fun tappingAnUncheckedRowAsksForTrue() {
+        setRow(checked = false)
+
+        rule.onNodeWithText(title).performClick()
+
+        assertEquals(listOf(true), reported)
+    }
+
+    /**
+     * A tap that lands on the switch itself still counts once.
+     *
+     * The `Switch` takes a null handler so the row owns the gesture, which also stops the Switch
+     * consuming the pointer — the tap falls through to the row. Give the Switch a handler again and
+     * this is the test that fails, because the setting toggles twice from one tap: once in the
+     * Switch, once in the row underneath it.
+     */
+    @Test fun aTapOnTheSwitchItselfTogglesOnce() {
+        setRow(checked = false)
+
+        rule.onNodeWithText(title).performTouchInput {
+            click(percentOffset(0.92f, 0.5f))
+        }
+        rule.waitForIdle()
+
+        assertEquals(listOf(true), reported)
+    }
+
+    /** A disabled row is inert and says so, rather than looking live and swallowing the tap. */
+    @Test fun aDisabledRowReportsNothing() {
+        setRow(checked = false, enabled = false)
+
+        rule.onNodeWithText(title).assertIsNotEnabled()
+        rule.onNodeWithText(title).performClick()
+
+        assertEquals(emptyList<Boolean>(), reported)
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/domain/model/ThemeMode.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ThemeMode.kt
@@ -3,14 +3,14 @@
 
 package com.valhalla.thor.domain.model
 
+/**
+ * No `label()` here. It used to return "Light"/"Dark"/"System" as Kotlin string literals — a domain
+ * enum, which has no Android dependencies by design and therefore no access to resources, answering
+ * a question only the UI asks, in English, on all five locales. The labels now live beside the other
+ * settings enums' labels in `SettingsCatalog.kt` as `ThemeMode.labelRes`.
+ */
 enum class ThemeMode {
     LIGHT,
     DARK,
-    SYSTEM;
-
-    fun label(): String = when (this) {
-        LIGHT -> "Light"
-        DARK -> "Dark"
-        SYSTEM -> "System"
-    }
+    SYSTEM
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -87,7 +87,12 @@ import com.valhalla.asgard.navigation.AsgardNavItem
 import com.valhalla.asgard.navigation.AsgardNavigationBar
 import com.valhalla.asgard.navigation.AsgardNavigationRail
 import com.valhalla.thor.presentation.permission.PermissionManagerScreen
+import com.valhalla.thor.presentation.settings.SettingsCategory
+import com.valhalla.thor.presentation.settings.SettingsCategoryScreen
+import com.valhalla.thor.presentation.settings.SettingsDetailPlaceholder
+import com.valhalla.thor.presentation.settings.SettingsRowId
 import com.valhalla.thor.presentation.settings.SettingsScreen
+import com.valhalla.thor.presentation.settings.SettingsViewModel
 import com.valhalla.thor.presentation.backup.AppBackupSheet
 import com.valhalla.thor.presentation.backup.ArchiveRestoreSheet
 import com.valhalla.thor.presentation.extension.ExtensionBrowseScreen
@@ -137,6 +142,13 @@ fun MainScreen(
     homeViewModel: HomeViewModel = koinViewModel(),
     appListViewModel: AppListViewModel = koinViewModel(),
     freezerViewModel: FreezerViewModel = koinViewModel(),
+    // Hoisted here rather than resolved inside the two settings entries, and this is load-bearing
+    // rather than tidiness. Each nav entry is wrapped in rememberViewModelStoreNavEntryDecorator
+    // below, so it owns a ViewModelStore: a koinViewModel<SettingsViewModel>() default on both the
+    // index and a category screen resolves to *two* instances. That is two privilege probes — which
+    // can spawn `su` — and two divergent copies of the PackageManager-backed any-file-opener state,
+    // one of which is showing on the index while the other is the one the switch writes to.
+    settingsViewModel: SettingsViewModel = koinViewModel(),
     onExit: () -> Unit,
 ) {
     val state by mainViewModel.uiState.collectAsStateWithLifecycle()
@@ -240,8 +252,14 @@ fun MainScreen(
         }
     }
 
+    // A settings category keeps the bar, unlike every other non-root route. Those are focused tasks
+    // you finish and leave (a permission editor, an extension browser); a settings category is one
+    // tap deep in a hierarchy that is only two deep, and taking the nav bar away for it would make
+    // "Appearance → Apps tab" a two-tap trip through an animation. It also keeps the bottom inset
+    // identical between the index and a category, which is what lets both use the same padding.
     val showBottomBar = currentBackStack.lastOrNull()?.let {
-        it == ThorRoute.Home || it == ThorRoute.Apps || it == ThorRoute.Freezer || it == ThorRoute.Settings
+        it == ThorRoute.Home || it == ThorRoute.Apps || it == ThorRoute.Freezer ||
+                it == ThorRoute.Settings || it is ThorRoute.SettingsCategory
     } ?: true
 
     // System Back Press Handler: 
@@ -515,13 +533,80 @@ fun MainScreen(
                     )
                 }
 
-                entry<ThorRoute.Settings> {
-                    SettingsScreen(
-                        onNavigateToExtensionManager = {
-                            settingsBackStack.add(ThorRoute.ExtensionManager)
-                        },
-                        onOpenRestore = { mainViewModel.openRestoreSheet() }
+                entry<ThorRoute.Settings>(
+                    metadata = ListDetailSceneStrategy.listPane(
+                        detailPlaceholder = { SettingsDetailPlaceholder() }
                     )
+                ) {
+                    SettingsScreen(
+                        viewModel = settingsViewModel,
+                        // Gated on the pane directive, never on isWideScreen — the two are in scope
+                        // four lines apart above and the comment there exists because this mistake
+                        // has been made once already. On a 600-839 dp window isWideScreen is true
+                        // while maxHorizontalPartitions is still 1, so the index would mark a row as
+                        // selected while occupying the whole window and showing none of it.
+                        selectedCategory = if (hasDetailPane) {
+                            (settingsBackStack.lastOrNull() as? ThorRoute.SettingsCategory)
+                                ?.let { SettingsCategory.fromId(it.id) }
+                        } else {
+                            null
+                        },
+                        onOpenCategory = { category, focus ->
+                            val route = ThorRoute.SettingsCategory(category.id, focus?.name)
+                            // Replace, don't stack. Picking a second category is ordinary use of a
+                            // two-pane layout — the list stays put and the right-hand side changes —
+                            // and stacking would make Back walk every category visited on the way in
+                            // before it reaches the index. The hierarchy is two deep by design
+                            // (Option C's depth limit); a settings back stack four entries tall means
+                            // the index is no longer one Back away, which is the property the split
+                            // was for.
+                            if (settingsBackStack.lastOrNull() is ThorRoute.SettingsCategory) {
+                                settingsBackStack[settingsBackStack.lastIndex] = route
+                            } else {
+                                settingsBackStack.add(route)
+                            }
+                        }
+                    )
+                }
+
+                entry<ThorRoute.SettingsCategory>(
+                    metadata = ListDetailSceneStrategy.detailPane()
+                ) { route ->
+                    val popSelf = {
+                        if (settingsBackStack.size > 1) {
+                            settingsBackStack.removeLastOrNull()
+                        }
+                        Unit
+                    }
+                    // Resolved here rather than in the route, because a route holds data and this is
+                    // a question only the current build can answer. A persisted back stack outlives
+                    // an app update (see ThorRoute.SettingsCategory), so `id` can name a category
+                    // this build merged away — null, and the entry shows nothing and pops itself,
+                    // which lands the user on the index rather than on a blank screen.
+                    //
+                    // Unqualified `SettingsCategory` is the settings *enum*; the route of the same
+                    // name is nested in ThorRoute and is spelled with that prefix everywhere here.
+                    val category = remember(route.id) { SettingsCategory.fromId(route.id) }
+                    if (category == null) {
+                        LaunchedEffect(route) { popSelf() }
+                    } else {
+                        SettingsCategoryScreen(
+                            category = category,
+                            // Same tolerance for the same reason: a row renamed between the save and
+                            // the restore is simply no focus, not a crash and not a wrong row.
+                            focus = remember(route.focus) {
+                                route.focus?.let { name ->
+                                    SettingsRowId.entries.firstOrNull { it.name == name }
+                                }
+                            },
+                            viewModel = settingsViewModel,
+                            onBack = popSelf,
+                            onOpenRestore = { mainViewModel.openRestoreSheet() },
+                            onNavigateToExtensionManager = {
+                                settingsBackStack.add(ThorRoute.ExtensionManager)
+                            }
+                        )
+                    }
                 }
 
                 // A shim, and the only thing left of the restore *route*. Restore is a sheet now

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -560,11 +560,19 @@ fun MainScreen(
                             // (Option C's depth limit); a settings back stack four entries tall means
                             // the index is no longer one Back away, which is the property the split
                             // was for.
-                            if (settingsBackStack.lastOrNull() is ThorRoute.SettingsCategory) {
-                                settingsBackStack[settingsBackStack.lastIndex] = route
-                            } else {
-                                settingsBackStack.add(route)
+                            //
+                            // Everything above the index goes, not merely a SettingsCategory sitting
+                            // on top. Extensions pushes ExtensionManager, which is *also* a detail
+                            // pane, so the index stays visible beside it — the user can pick a second
+                            // category at a moment when the top of the stack is not a category, and a
+                            // guard that only recognised SettingsCategory appended instead. Truncating
+                            // to the index is the only spelling of "replace" that holds for every
+                            // route a category can open. Index 0 is ThorRoute.Settings by
+                            // construction (rememberNavBackStack above), so size 1 *is* the index.
+                            while (settingsBackStack.size > 1) {
+                                settingsBackStack.removeAt(settingsBackStack.lastIndex)
                             }
+                            settingsBackStack.add(route)
                         }
                     )
                 }

--- a/app/src/main/java/com/valhalla/thor/presentation/navigation/ThorRoute.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/navigation/ThorRoute.kt
@@ -21,6 +21,28 @@ sealed interface ThorRoute : NavKey {
     @Serializable
     data object Settings : ThorRoute
 
+    /**
+     * One of the eight settings categories, opened from the index.
+     *
+     * Deliberately **one parameterised route rather than eight `data object`s.**
+     * [androidx.navigation3.runtime.rememberNavBackStack] persists the stack for task restoration,
+     * and that stack outlives an app update: a user backgrounded on `SettingsCategory("freezer")`
+     * can come back to a build where Freezer settings were renamed, merged, or removed. With eight
+     * objects the restore is a `Class.forName` on a type this build no longer has, which takes the
+     * *whole* back stack down, not just that entry. With an id string, an unknown category is a
+     * `fromId` returning null and one entry popping itself.
+     *
+     * @param id [com.valhalla.thor.presentation.settings.SettingsCategory.id]. A string, not the
+     *   ordinal: an ordinal survives the deserialize and then resolves to a *different* category the
+     *   first time that enum is reordered, which is worse than failing.
+     * @param focus the `name` of a [com.valhalla.thor.presentation.settings.SettingsRowId] to scroll
+     *   to and light up, set when the user arrived from a search result rather than by tapping the
+     *   category. Same reasoning as [id] for why it is a string; an unresolvable one is simply no
+     *   focus.
+     */
+    @Serializable
+    data class SettingsCategory(val id: String, val focus: String? = null) : ThorRoute
+
     @Serializable
     data class PermissionManager(val packageName: String, val appName: String) : ThorRoute
 

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCatalog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCatalog.kt
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import com.valhalla.thor.R
+import com.valhalla.thor.domain.model.AnimationIntensity
+import com.valhalla.thor.domain.model.AppGridDensity
+import com.valhalla.thor.domain.model.PrivilegeMode
+import com.valhalla.thor.domain.model.ThemeMode
+import com.valhalla.thor.util.AppLanguage
+
+/**
+ * The eight doors, and every row behind them.
+ *
+ * This file exists so that the *shape* of Settings is data rather than layout. Before it, one
+ * `Column(verticalScroll)` held 29 entries under 10 hand-written section headers, and two of the
+ * last three rows were added with a `koinInject` in the middle of the layout — there was no gate a
+ * new setting had to pass, which is why the screen grew to 1275 lines. Now a new setting is an entry
+ * in [SettingsRowId] with a category, and [SettingsCategoryScreen]'s exhaustive `when` refuses to
+ * compile until it is drawn somewhere.
+ *
+ * The index's length is fixed at eight; the number of settings is not. That is the whole point.
+ */
+enum class SettingsCategory(
+    /**
+     * The stable id carried in [com.valhalla.thor.presentation.navigation.ThorRoute.SettingsCategory].
+     *
+     * A string, not the enum's `name` or `ordinal`, and deliberately not the enum itself. A back
+     * stack is persisted for task restoration and survives an app update, so a restored stack can
+     * name a category this build no longer has. An unknown id resolves to null and the entry pops
+     * itself; an ordinal would silently resolve to *a different category* the day this enum is
+     * reordered.
+     */
+    val id: String,
+    @StringRes val title: Int,
+    @DrawableRes val icon: Int,
+) {
+    APPEARANCE("appearance", R.string.settings_category_appearance, R.drawable.theme_panel),
+    HOME("home", R.string.settings_category_home, R.drawable.home),
+    FREEZER("freezer", R.string.freezer, R.drawable.frozen),
+    INSTALLING("installing", R.string.settings_category_installing, R.drawable.apk_install),
+    SECURITY("security", R.string.settings_category_security, R.drawable.round_key),
+    BACKUP("backup", R.string.backup_and_restore, R.drawable.settings_backup_restore),
+    EXTENSIONS("extensions", R.string.extensions, R.drawable.round_extension),
+    ABOUT("about", R.string.settings_category_about, R.drawable.thor_mono);
+
+    companion object {
+        /** @return null for an id no build understands — see [id]. */
+        fun fromId(id: String): SettingsCategory? = entries.firstOrNull { it.id == id }
+    }
+}
+
+/**
+ * One entry per navigable row, in the order it is drawn inside its category.
+ *
+ * [title] and [keywords] are what search matches on. [keywords] is the row's *default* subtitle:
+ * several rows swap their subtitle at runtime (the language row names the current language, the two
+ * permission rows say granted or needed, five Freezer rows say "requires privilege" when there is
+ * none), and indexing whichever sentence happens to be showing would make a row findable on one
+ * device and not another. The static one is the one that describes the setting.
+ */
+enum class SettingsRowId(
+    val category: SettingsCategory,
+    @StringRes val title: Int,
+    @StringRes val keywords: Int,
+) {
+    // ── Appearance ──────────────────────────────────────────────────────────────────────────────
+    THEME(SettingsCategory.APPEARANCE, R.string.theme, R.string.theme_desc),
+    GRID_DENSITY(SettingsCategory.APPEARANCE, R.string.grid_density, R.string.grid_density_desc),
+    ANIMATION_INTENSITY(
+        SettingsCategory.APPEARANCE,
+        R.string.animation_intensity,
+        R.string.animation_intensity_desc,
+    ),
+    AMOLED(SettingsCategory.APPEARANCE, R.string.amoled_mode, R.string.amoled_desc),
+    DYNAMIC_COLORS(
+        SettingsCategory.APPEARANCE,
+        R.string.dynamic_colors,
+        R.string.dynamic_colors_desc,
+    ),
+    APP_LANGUAGE(SettingsCategory.APPEARANCE, R.string.app_language, R.string.app_language_desc),
+
+    // ── Home screen ─────────────────────────────────────────────────────────────────────────────
+    DEFAULT_TAB(SettingsCategory.HOME, R.string.default_tab, R.string.default_tab_desc),
+    SHOW_REINSTALL_CARD(
+        SettingsCategory.HOME,
+        R.string.show_reinstall_card,
+        R.string.show_reinstall_card_desc,
+    ),
+    SHOW_INSTALLER_TILE(
+        SettingsCategory.HOME,
+        R.string.show_installer_tile,
+        R.string.show_installer_tile_desc,
+    ),
+    SHOW_EXTENSIONS_TILE(
+        SettingsCategory.HOME,
+        R.string.show_extensions_tile,
+        R.string.show_extensions_tile_desc,
+    ),
+
+    // ── Freezer ─────────────────────────────────────────────────────────────────────────────────
+    AUTO_FREEZE(SettingsCategory.FREEZER, R.string.auto_freeze, R.string.auto_freeze_desc),
+    SUSPEND_INSTEAD_OF_FREEZE(
+        SettingsCategory.FREEZER,
+        R.string.suspend_instead_of_freeze,
+        R.string.suspend_instead_of_freeze_desc,
+    ),
+    SKIP_ROUTINE_FREEZE_CONFIRMATION(
+        SettingsCategory.FREEZER,
+        R.string.skip_routine_freeze_confirmation,
+        R.string.skip_routine_freeze_confirmation_desc,
+    ),
+    ADD_FREEZER_TO_LAUNCHER(
+        SettingsCategory.FREEZER,
+        R.string.add_freezer_to_launcher,
+        R.string.add_freezer_to_launcher_desc,
+    ),
+    UNFREEZE_ALL(
+        SettingsCategory.FREEZER,
+        R.string.unfreeze_all_apps,
+        R.string.unfreeze_all_apps_desc,
+    ),
+
+    // ── Installing & sharing ────────────────────────────────────────────────────────────────────
+    AUTO_REINSTALL(SettingsCategory.INSTALLING, R.string.auto_reinstall, R.string.auto_reinstall_desc),
+    ANY_FILE_OPENER(
+        SettingsCategory.INSTALLING,
+        R.string.any_file_opener,
+        R.string.any_file_opener_desc,
+    ),
+
+    // ── Security ────────────────────────────────────────────────────────────────────────────────
+    BIOMETRIC_LOCK(SettingsCategory.SECURITY, R.string.biometric_lock, R.string.biometric_lock_desc),
+    USAGE_ACCESS(
+        SettingsCategory.SECURITY,
+        R.string.usage_access,
+        R.string.usage_access_needed_subtitle,
+    ),
+    NOTIFICATION_ACCESS(
+        SettingsCategory.SECURITY,
+        R.string.notification_access,
+        R.string.notification_access_needed_subtitle,
+    ),
+
+    // ── Backup & restore ────────────────────────────────────────────────────────────────────────
+    RESTORE(SettingsCategory.BACKUP, R.string.restore_title, R.string.restore_settings_desc),
+    PASSPHRASE(
+        SettingsCategory.BACKUP,
+        R.string.passphrase_settings_title,
+        R.string.passphrase_settings_desc,
+    ),
+
+    // ── Extensions ──────────────────────────────────────────────────────────────────────────────
+    MANAGE_EXTENSIONS(
+        SettingsCategory.EXTENSIONS,
+        R.string.manage_extensions,
+        R.string.manage_extensions_desc,
+    ),
+
+    // ── About & support ─────────────────────────────────────────────────────────────────────────
+    SUPPORT_DEVELOPER(
+        SettingsCategory.ABOUT,
+        R.string.support_developer,
+        R.string.support_developer_desc,
+    ),
+    VERSION(SettingsCategory.ABOUT, R.string.version, R.string.release_candidate),
+    LINKS(SettingsCategory.ABOUT, R.string.github, R.string.source_code);
+
+    companion object {
+        /**
+         * Grouped once, eagerly, rather than filtered per category on every composition.
+         *
+         * `entries.groupBy` preserves declaration order inside each group, which is what makes the
+         * enum's own layout the source of truth for the order rows are drawn in.
+         */
+        private val byCategory: Map<SettingsCategory, List<SettingsRowId>> =
+            entries.groupBy { it.category }
+
+        fun rowsIn(category: SettingsCategory): List<SettingsRowId> =
+            byCategory[category].orEmpty()
+    }
+}
+
+// ── Enum labels ─────────────────────────────────────────────────────────────────────────────────
+//
+// Every closed-set setting's user-facing names, in one place, on the presentation side.
+//
+// [ThemeMode] used to carry its own `label()` returning "Light"/"Dark"/"System" as Kotlin string
+// literals — a domain enum answering a question only the UI asks, in English, on all five locales,
+// for the setting users change most. The privilege picker was worse: it rendered `mode.name`, so the
+// segmented control read ROOT / SHIZUKU / DHIZUKU while `install_mode_root` and its two siblings had
+// existed for the installer sheet all along.
+
+@get:StringRes
+internal val ThemeMode.labelRes: Int
+    get() = when (this) {
+        ThemeMode.LIGHT -> R.string.theme_light
+        ThemeMode.DARK -> R.string.theme_dark
+        ThemeMode.SYSTEM -> R.string.theme_system
+    }
+
+@get:StringRes
+internal val AppGridDensity.labelRes: Int
+    get() = when (this) {
+        AppGridDensity.COMPACT -> R.string.grid_density_compact
+        AppGridDensity.DEFAULT -> R.string.grid_density_default
+        AppGridDensity.LARGE -> R.string.grid_density_large
+    }
+
+@get:StringRes
+internal val AnimationIntensity.labelRes: Int
+    get() = when (this) {
+        AnimationIntensity.LOW -> R.string.animation_intensity_low
+        AnimationIntensity.MEDIUM -> R.string.animation_intensity_medium
+        AnimationIntensity.HIGH -> R.string.animation_intensity_high
+    }
+
+@get:StringRes
+internal val PrivilegeMode.labelRes: Int
+    get() = when (this) {
+        PrivilegeMode.ROOT -> R.string.install_mode_root
+        PrivilegeMode.SHIZUKU -> R.string.install_mode_shizuku
+        PrivilegeMode.DHIZUKU -> R.string.install_mode_dhizuku
+        // Never drawn: the engine picker only lists modes that probed available.
+        PrivilegeMode.NONE -> R.string.settings_engine_none
+    }
+
+@DrawableRes
+internal fun PrivilegeMode.iconRes(): Int = when (this) {
+    PrivilegeMode.ROOT -> R.drawable.magisk_icon
+    PrivilegeMode.SHIZUKU -> R.drawable.shizuku
+    PrivilegeMode.DHIZUKU -> R.drawable.dhizuku
+    PrivilegeMode.NONE -> R.drawable.shield
+}
+
+/**
+ * The label for each entry, the only Android-side half of [AppLanguage].
+ *
+ * Split out so the tag list and the label list cannot drift apart: they used to be two hand-written
+ * `when`/`listOf` blocks — one in the row, one in the picker sheet — and a language added to one but
+ * not the other showed up as a row reading "System default" over a checkmark next to its own name.
+ */
+@get:StringRes
+internal val AppLanguage.labelRes: Int
+    get() = when (this) {
+        AppLanguage.SystemDefault -> R.string.system_default
+        AppLanguage.English -> R.string.english
+        AppLanguage.Chinese -> R.string.chinese
+        AppLanguage.French -> R.string.french
+        AppLanguage.Spanish -> R.string.spanish
+        AppLanguage.Arabic -> R.string.arabic
+    }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
@@ -527,10 +527,13 @@ fun SettingsCategoryScreen(
                         highlighted = lit,
                         onCheckedChange = {
                             // This op can't be toggled in-app; deep-link to system settings.
-                            if (!usageGranted) {
-                                runCatching {
-                                    context.startActivity(usageAccessManager.usageAccessIntent())
-                                }
+                            // Unconditionally, in both directions: the screen that grants usage
+                            // access is the same screen that revokes it. Acting only on the
+                            // off→on tap left the row dead once granted — the switch bounced
+                            // back and nothing happened, with no way in-app to reach the
+                            // revoke toggle the row is a picture of.
+                            runCatching {
+                                context.startActivity(usageAccessManager.usageAccessIntent())
                             }
                         }
                     )
@@ -553,18 +556,19 @@ fun SettingsCategoryScreen(
                         checked = notificationsGranted,
                         highlighted = lit,
                         onCheckedChange = {
-                            if (!notificationsGranted) {
+                            if (!notificationsGranted && requestNotificationPermission != null) {
                                 // 33+: only the system dialog can grant this. Thor never self-grants
                                 // it even when it holds root/Shizuku — the dialog grants the
                                 // identical capability, and Dhizuku cannot self-grant at all.
-                                // 28-32: there is no runtime permission to request, so the only
-                                // lever is the app-level toggle; deep-link to it.
-                                if (requestNotificationPermission != null) {
-                                    requestNotificationPermission()
-                                } else {
-                                    runCatching {
-                                        context.startActivity(appNotificationSettingsIntent(context))
-                                    }
+                                requestNotificationPermission()
+                            } else {
+                                // 28-32 there is no runtime permission to request, and on 33+ there
+                                // is no dialog that *withdraws* one — requesting again while granted
+                                // returns granted without showing anything. Either way the app-level
+                                // toggle is the only lever, so the on→off tap deep-links to it
+                                // instead of doing nothing and letting the switch snap back.
+                                runCatching {
+                                    context.startActivity(appNotificationSettingsIntent(context))
                                 }
                             }
                         }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
@@ -1,0 +1,875 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.valhalla.asgard.components.ConnectedButtonGroupItem
+import com.valhalla.thor.R
+import com.valhalla.thor.data.manager.UsageAccessManager
+import com.valhalla.thor.domain.model.AnimationIntensity
+import com.valhalla.thor.domain.model.AppGridDensity
+import com.valhalla.thor.domain.model.DefaultTab
+import com.valhalla.thor.domain.model.FreezerMode
+import com.valhalla.thor.domain.model.ThemeMode
+import com.valhalla.thor.domain.usecase.ObserveInterruptedRestoreUseCase
+import com.valhalla.thor.presentation.main.toDestination
+import com.valhalla.thor.presentation.utils.ObserveAsEvents
+import com.valhalla.thor.util.AppLanguage
+import com.valhalla.thor.util.displayedLanguage
+import kotlinx.coroutines.delay
+import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
+
+/** How long a row search sent the user to stays lit before settling back to an ordinary row. */
+private const val FOCUS_HIGHLIGHT_MILLIS = 2_600L
+
+/**
+ * One of the eight doors, opened.
+ *
+ * Every setting Thor has is drawn from exactly one branch of the `when` in here, over
+ * [SettingsRowId]. That is the gate the old screen never had: a row registered in the catalogue with
+ * no renderer is a non-exhaustive `when` on an enum subject, which Kotlin has rejected outright since
+ * 1.7 — so "I added the setting but forgot to draw it" fails the **build**, not a device walk.
+ *
+ * The `when` covers all twenty-five rows rather than only this category's, because it is one function
+ * serving eight screens. Moving a row between categories is therefore a one-line change to
+ * [SettingsRowId] and nothing else.
+ *
+ * @param focus the row search matched, or null. It is scrolled to and lit for
+ *   [FOCUS_HIGHLIGHT_MILLIS]; a search that lands you on a screen of six near-identical rows and
+ *   leaves you to find the seventh yourself has only moved the problem.
+ */
+@Composable
+fun SettingsCategoryScreen(
+    category: SettingsCategory,
+    focus: SettingsRowId?,
+    onBack: () -> Unit,
+    onOpenRestore: () -> Unit,
+    onNavigateToExtensionManager: () -> Unit,
+    viewModel: SettingsViewModel = koinViewModel()
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val prefs = state.prefs
+    val hasPrivilege = state.isRootAvailable || state.isShizukuAvailable || state.isDhizukuAvailable
+    val context = LocalContext.current
+
+    var showLanguageSheet by remember { mutableStateOf(false) }
+    var showUnfreezeConfirmation by remember { mutableStateOf(false) }
+    var showSupportSheet by remember { mutableStateOf(false) }
+    var showPassphrase by remember { mutableStateOf(false) }
+
+    // The any-file switch is backed by PackageManager, not DataStore, so nothing pushes a change at
+    // us: `pm enable`, a ROM app manager, or a wipe of Thor's component state all move it silently.
+    // Re-read on every resume but the first, which the VM's init already covered.
+    var firstResume by rememberSaveable { mutableStateOf(true) }
+    LifecycleResumeEffect(Unit) {
+        if (firstResume) firstResume = false else viewModel.refreshAnyFileOpener()
+        onPauseOrDispose { }
+    }
+
+    // Collected here and not on the index, because every action that can raise one lives behind a
+    // door: the biometric refusal, the dropped language write, the unfreeze-all result. On a phone
+    // the index is not composed while a category is open, so a collector there would be the wrong
+    // half of the section.
+    ObserveAsEvents(viewModel.events) { event ->
+        android.widget.Toast.makeText(
+            context,
+            event.asString(context),
+            android.widget.Toast.LENGTH_SHORT
+        ).show()
+    }
+
+    val shownLanguage = displayedLanguage(
+        persistedTag = prefs.language,
+        appliedTag = LocalConfiguration.current.locales
+            .takeIf { !it.isEmpty }?.get(0)?.toLanguageTag()
+    )
+
+    val versionName = remember(context) {
+        runCatching {
+            context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "—"
+        }.getOrDefault("—")
+    }
+
+    // Permission state, hoisted rather than composed only for the Security category. Both reads are
+    // local AppOps/NotificationManager calls and the observer is one lifecycle listener, which is
+    // cheaper than the conditional composition it would take to skip them — and a conditional
+    // `remember` here would be keyed on a parameter, which is exactly the shape that breaks the day
+    // something recomposes this screen with a different category.
+    val usageAccessManager = koinInject<UsageAccessManager>()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var usageGranted by remember { mutableStateOf(usageAccessManager.isGranted()) }
+    var notificationsGranted by remember {
+        mutableStateOf(NotificationManagerCompat.from(context).areNotificationsEnabled())
+    }
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                usageGranted = usageAccessManager.isGranted()
+                notificationsGranted =
+                    NotificationManagerCompat.from(context).areNotificationsEnabled()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // Registering the launcher inside the version check is safe: SDK_INT is constant for the
+    // process, so the conditional group is stable across recompositions. It also keeps every
+    // POST_NOTIFICATIONS reference inside the check, which is what lint's InlinedApi wants.
+    val requestNotificationPermission: (() -> Unit)? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val activity = remember(context) { context.findActivity() }
+            val notificationPermissionLauncher = rememberLauncherForActivityResult(
+                ActivityResultContracts.RequestPermission()
+            ) { _ ->
+                // Re-read instead of trusting `granted`. The switch reflects
+                // areNotificationsEnabled(), which is also false when the permission is held but the
+                // user muted the app's notifications; trusting `granted` flipped the switch on and
+                // the next ON_RESUME flipped it back off.
+                val enabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
+                notificationsGranted = enabled
+                // RequestPermission returns immediately without showing a dialog once the user has
+                // denied twice, which would leave this row a permanent dead end.
+                // shouldShowRequestPermissionRationale distinguishes that (and the "granted but
+                // muted" case, both false) from a plain first denial (true, where re-tapping the row
+                // still shows the dialog). Where the dialog can no longer help, deep-link to system
+                // settings like the usage-access row above. Thor never self-grants this.
+                val canAskAgain = activity?.let {
+                    ActivityCompat.shouldShowRequestPermissionRationale(
+                        it,
+                        Manifest.permission.POST_NOTIFICATIONS
+                    )
+                } ?: false
+                if (!enabled && !canAskAgain) {
+                    runCatching { context.startActivity(appNotificationSettingsIntent(context)) }
+                }
+            }
+            val request = {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+            request
+        } else {
+            null
+        }
+
+    if (showUnfreezeConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showUnfreezeConfirmation = false },
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.warning),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error
+                )
+            },
+            title = { Text(stringResource(R.string.unfreeze_all_confirmation_title)) },
+            text = { Text(stringResource(R.string.unfreeze_all_confirmation_desc)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.unfreezeAll()
+                        showUnfreezeConfirmation = false
+                    }
+                ) {
+                    Text(stringResource(R.string.proceed))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showUnfreezeConfirmation = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    val rows = remember(category) { SettingsRowId.rowsIn(category) }
+    val listState = rememberLazyListState()
+
+    // Held in state rather than read straight off the parameter, so the highlight can be released
+    // without popping the route: `focus` is part of the back stack entry and survives as long as the
+    // screen does. A row that stays lit forever stops meaning "this is the one you searched for".
+    var highlighted by remember(focus) { mutableStateOf(focus) }
+    LaunchedEffect(focus, rows) {
+        val target = focus ?: return@LaunchedEffect
+        val index = rows.indexOf(target)
+        if (index >= 0) listState.animateScrollToItem(index)
+        delay(FOCUS_HIGHLIGHT_MILLIS)
+        highlighted = null
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        SettingsTopBar(title = stringResource(category.title), onBack = onBack)
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 120.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(rows, key = { it.name }) { row ->
+                val lit = highlighted == row
+                // The gate. Every SettingsRowId has to be drawn somewhere in here or this stops
+                // compiling — see the KDoc on this file's composable.
+                when (row) {
+                    // ── Appearance ──────────────────────────────────────────────────────────────
+                    SettingsRowId.THEME -> SettingsPickerRow(
+                        icon = R.drawable.theme_panel,
+                        title = stringResource(R.string.theme),
+                        subtitle = stringResource(R.string.theme_desc),
+                        items = ThemeMode.entries.map {
+                            ConnectedButtonGroupItem.Label(stringResource(it.labelRes))
+                        },
+                        selectedIndex = ThemeMode.entries.indexOf(prefs.themeMode),
+                        onItemSelected = { viewModel.setThemeMode(ThemeMode.entries[it]) },
+                        highlighted = lit
+                    )
+
+                    SettingsRowId.GRID_DENSITY -> SettingsPickerRow(
+                        icon = R.drawable.grid_view,
+                        title = stringResource(R.string.grid_density),
+                        subtitle = stringResource(R.string.grid_density_desc),
+                        items = AppGridDensity.entries.map {
+                            ConnectedButtonGroupItem.Label(stringResource(it.labelRes))
+                        },
+                        selectedIndex = AppGridDensity.entries.indexOf(prefs.appGridDensity),
+                        onItemSelected = { viewModel.setAppGridDensity(AppGridDensity.entries[it]) },
+                        highlighted = lit
+                    )
+
+                    // Was its own top-level section, whose all-caps header repeated the title of the
+                    // single row underneath it. As one row in Appearance, it says its name once.
+                    SettingsRowId.ANIMATION_INTENSITY -> SettingsPickerRow(
+                        icon = R.drawable.bolt,
+                        title = stringResource(R.string.animation_intensity),
+                        subtitle = stringResource(R.string.animation_intensity_desc),
+                        items = AnimationIntensity.entries.map {
+                            ConnectedButtonGroupItem.Label(stringResource(it.labelRes))
+                        },
+                        selectedIndex = AnimationIntensity.entries.indexOf(prefs.animationIntensity),
+                        onItemSelected = {
+                            viewModel.setAnimationIntensity(AnimationIntensity.entries[it])
+                        },
+                        highlighted = lit
+                    )
+
+                    SettingsRowId.AMOLED -> SettingsSwitchRow(
+                        icon = R.drawable.theme_panel,
+                        title = stringResource(R.string.amoled_mode),
+                        subtitle = stringResource(R.string.amoled_desc),
+                        checked = prefs.useAmoled,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setAmoledMode(it) }
+                    )
+
+                    SettingsRowId.DYNAMIC_COLORS -> SettingsSwitchRow(
+                        icon = R.drawable.shield_with_heart,
+                        title = stringResource(R.string.dynamic_colors),
+                        subtitle = stringResource(R.string.dynamic_colors_desc),
+                        checked = prefs.useDynamicColor,
+                        enabled = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setDynamicColor(it) }
+                    )
+
+                    // Subtitle is the value, not the description: which language Thor is speaking is
+                    // the one thing you cannot read off this screen if it is speaking the wrong one.
+                    // Search still finds the row by its description — see SettingsRowId.keywords.
+                    SettingsRowId.APP_LANGUAGE -> SettingsClickRow(
+                        icon = R.drawable.settings_backup_restore,
+                        title = stringResource(R.string.app_language),
+                        subtitle = stringResource(shownLanguage.labelRes),
+                        showChevron = true,
+                        highlighted = lit,
+                        onClick = { showLanguageSheet = true }
+                    )
+
+                    // ── Home screen ─────────────────────────────────────────────────────────────
+                    // Icons, not labels, and the nav bar's own glyphs: four equal slots across a
+                    // phone leave roughly 34 dp of text apiece, which turns "App List" into two
+                    // characters and its longer translations into fewer. The tab name still travels
+                    // — as each button's content description, which is what a screen reader
+                    // announces either way.
+                    SettingsRowId.DEFAULT_TAB -> SettingsPickerRow(
+                        icon = R.drawable.home,
+                        title = stringResource(R.string.default_tab),
+                        subtitle = stringResource(R.string.default_tab_desc),
+                        items = DefaultTab.entries.map { tab ->
+                            val destination = tab.toDestination()
+                            ConnectedButtonGroupItem.Icon(
+                                icon = ImageVector.vectorResource(destination.selectedIcon),
+                                contentDescription = stringResource(destination.label)
+                            )
+                        },
+                        selectedIndex = DefaultTab.entries.indexOf(prefs.defaultTab),
+                        onItemSelected = { viewModel.setDefaultTab(DefaultTab.entries[it]) },
+                        highlighted = lit
+                    )
+
+                    SettingsRowId.SHOW_REINSTALL_CARD -> SettingsSwitchRow(
+                        icon = R.drawable.apk_install,
+                        title = stringResource(R.string.show_reinstall_card),
+                        subtitle = stringResource(R.string.show_reinstall_card_desc),
+                        checked = prefs.showReinstallAllCard,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setReinstallAllCardVisibility(it) }
+                    )
+
+                    SettingsRowId.SHOW_INSTALLER_TILE -> SettingsSwitchRow(
+                        icon = R.drawable.apk_install,
+                        title = stringResource(R.string.show_installer_tile),
+                        subtitle = stringResource(R.string.show_installer_tile_desc),
+                        checked = prefs.showInstallerTile,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setInstallerTileVisibility(it) }
+                    )
+
+                    SettingsRowId.SHOW_EXTENSIONS_TILE -> SettingsSwitchRow(
+                        icon = R.drawable.round_extension,
+                        title = stringResource(R.string.show_extensions_tile),
+                        subtitle = stringResource(R.string.show_extensions_tile_desc),
+                        checked = prefs.showExtensionsTile,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setExtensionsTileVisibility(it) }
+                    )
+
+                    // ── Freezer ─────────────────────────────────────────────────────────────────
+                    SettingsRowId.AUTO_FREEZE -> SettingsSwitchRow(
+                        icon = R.drawable.frozen,
+                        title = stringResource(R.string.auto_freeze),
+                        subtitle = privilegeAwareSubtitle(hasPrivilege, R.string.auto_freeze_desc),
+                        checked = prefs.autoFreezeEnabled,
+                        enabled = hasPrivilege,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setAutoFreezeEnabled(it) }
+                    )
+
+                    SettingsRowId.SUSPEND_INSTEAD_OF_FREEZE -> SettingsSwitchRow(
+                        icon = R.drawable.frozen,
+                        title = stringResource(R.string.suspend_instead_of_freeze),
+                        subtitle = privilegeAwareSubtitle(
+                            hasPrivilege,
+                            R.string.suspend_instead_of_freeze_desc
+                        ),
+                        checked = prefs.freezerMode == FreezerMode.SUSPEND,
+                        enabled = hasPrivilege,
+                        highlighted = lit,
+                        onCheckedChange = {
+                            viewModel.setFreezerMode(
+                                if (it) FreezerMode.SUSPEND else FreezerMode.FREEZE
+                            )
+                        }
+                    )
+
+                    SettingsRowId.SKIP_ROUTINE_FREEZE_CONFIRMATION -> SettingsSwitchRow(
+                        icon = R.drawable.danger,
+                        title = stringResource(R.string.skip_routine_freeze_confirmation),
+                        subtitle = privilegeAwareSubtitle(
+                            hasPrivilege,
+                            R.string.skip_routine_freeze_confirmation_desc
+                        ),
+                        checked = prefs.skipRoutineFreezeConfirmation,
+                        enabled = hasPrivilege,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setSkipRoutineFreezeConfirmation(it) }
+                    )
+
+                    SettingsRowId.ADD_FREEZER_TO_LAUNCHER -> SettingsSwitchRow(
+                        icon = R.drawable.frozen,
+                        title = stringResource(R.string.add_freezer_to_launcher),
+                        subtitle = privilegeAwareSubtitle(
+                            hasPrivilege,
+                            R.string.add_freezer_to_launcher_desc
+                        ),
+                        checked = prefs.addFreezerToLauncher,
+                        enabled = hasPrivilege,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setAddFreezerToLauncher(it) }
+                    )
+
+                    // The one row in Settings that *does* something the moment you confirm it, and
+                    // it used to look exactly like App Language — same container, same chevron-less
+                    // click row. Error colours and no chevron: this leads nowhere, it acts.
+                    SettingsRowId.UNFREEZE_ALL -> SettingsClickRow(
+                        icon = R.drawable.unfreeze,
+                        title = stringResource(R.string.unfreeze_all_apps),
+                        subtitle = privilegeAwareSubtitle(
+                            hasPrivilege,
+                            R.string.unfreeze_all_apps_desc
+                        ),
+                        enabled = hasPrivilege,
+                        destructive = true,
+                        highlighted = lit,
+                        onClick = { showUnfreezeConfirmation = true }
+                    )
+
+                    // ── Installing & sharing ────────────────────────────────────────────────────
+                    SettingsRowId.AUTO_REINSTALL -> SettingsSwitchRow(
+                        icon = R.drawable.settings_backup_restore,
+                        title = stringResource(R.string.auto_reinstall),
+                        subtitle = stringResource(R.string.auto_reinstall_desc),
+                        checked = prefs.autoReinstallEnabled,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setAutoReinstallEnabled(it) }
+                    )
+
+                    // Reads its state from `uiState`, not `prefs`: this switch is backed by
+                    // PackageManager component state rather than DataStore. See AnyFileOpenerController.
+                    SettingsRowId.ANY_FILE_OPENER -> SettingsSwitchRow(
+                        icon = R.drawable.apk_install,
+                        title = stringResource(R.string.any_file_opener),
+                        subtitle = stringResource(R.string.any_file_opener_desc),
+                        checked = state.anyFileOpenerEnabled,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setAnyFileOpenerEnabled(it) }
+                    )
+
+                    // ── Security ────────────────────────────────────────────────────────────────
+                    // Deliberately left enabled when the device cannot authenticate. A disabled row
+                    // swallows the tap (`clickable(enabled = false)`), so a user whose device has
+                    // nothing enrolled got a greyed-out switch and silence — the subtitle was the
+                    // only clue, and it is a line of body text under a control that no longer
+                    // responds. Tappable, the refusal in `setBiometricLock` can answer with a toast
+                    // that names what is missing. `checked` stays bound to the preference, so a
+                    // refused tap settles straight back.
+                    SettingsRowId.BIOMETRIC_LOCK -> SettingsSwitchRow(
+                        icon = R.drawable.round_key,
+                        title = stringResource(R.string.biometric_lock),
+                        subtitle = if (state.canUseBiometric) {
+                            stringResource(R.string.biometric_lock_desc)
+                        } else {
+                            stringResource(R.string.biometric_not_available)
+                        },
+                        checked = prefs.biometricLockEnabled,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setBiometricLock(it) }
+                    )
+
+                    SettingsRowId.USAGE_ACCESS -> SettingsSwitchRow(
+                        icon = R.drawable.shield,
+                        title = stringResource(R.string.usage_access),
+                        subtitle = if (usageGranted) {
+                            stringResource(R.string.usage_access_granted_subtitle)
+                        } else {
+                            stringResource(R.string.usage_access_needed_subtitle)
+                        },
+                        checked = usageGranted,
+                        highlighted = lit,
+                        onCheckedChange = {
+                            // This op can't be toggled in-app; deep-link to system settings.
+                            if (!usageGranted) {
+                                runCatching {
+                                    context.startActivity(usageAccessManager.usageAccessIntent())
+                                }
+                            }
+                        }
+                    )
+
+                    // The row itself is unconditional, because what it reports —
+                    // areNotificationsEnabled(), the exact thing BulkResultNotifier checks — is
+                    // meaningful and user-toggleable all the way down to minSdk 28. Only the *way*
+                    // it is granted differs: a runtime permission on 33+, an app-level toggle in
+                    // system settings below that. Gating the whole row on 33 left users on 28-32
+                    // with silently dropped bulk-result notifications and nothing in-app explaining
+                    // why.
+                    SettingsRowId.NOTIFICATION_ACCESS -> SettingsSwitchRow(
+                        icon = R.drawable.frozen,
+                        title = stringResource(R.string.notification_access),
+                        subtitle = if (notificationsGranted) {
+                            stringResource(R.string.notification_access_granted_subtitle)
+                        } else {
+                            stringResource(R.string.notification_access_needed_subtitle)
+                        },
+                        checked = notificationsGranted,
+                        highlighted = lit,
+                        onCheckedChange = {
+                            if (!notificationsGranted) {
+                                // 33+: only the system dialog can grant this. Thor never self-grants
+                                // it even when it holds root/Shizuku — the dialog grants the
+                                // identical capability, and Dhizuku cannot self-grant at all.
+                                // 28-32: there is no runtime permission to request, so the only
+                                // lever is the app-level toggle; deep-link to it.
+                                if (requestNotificationPermission != null) {
+                                    requestNotificationPermission()
+                                } else {
+                                    runCatching {
+                                        context.startActivity(appNotificationSettingsIntent(context))
+                                    }
+                                }
+                            }
+                        }
+                    )
+
+                    // ── Backup & restore ────────────────────────────────────────────────────────
+                    SettingsRowId.RESTORE -> Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        // The same notice the index carries, kept beside the row that acts on it.
+                        // Collected in this branch rather than at the top of the screen so the
+                        // breadcrumb observer and its WorkManager watcher only run on the one
+                        // category that can do anything about them.
+                        val observeInterrupted = koinInject<ObserveInterruptedRestoreUseCase>()
+                        val interrupted by remember(observeInterrupted) { observeInterrupted() }
+                            .collectAsStateWithLifecycle(initialValue = null)
+                        // Not dismissible here on purpose: the row beneath it leads to the sheet that
+                        // can clear it, and a dismiss in two places is two chances to lose the notice.
+                        interrupted?.let { crumb ->
+                            Text(
+                                text = stringResource(R.string.restore_interrupted, crumb.appLabel),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.padding(horizontal = 8.dp)
+                            )
+                        }
+                        SettingsClickRow(
+                            icon = R.drawable.settings_backup_restore,
+                            title = stringResource(R.string.restore_title),
+                            subtitle = stringResource(R.string.restore_settings_desc),
+                            showChevron = true,
+                            highlighted = lit,
+                            onClick = onOpenRestore
+                        )
+                    }
+
+                    // §5.4. The only place "remember it on this device" — offered as a checkbox in
+                    // the backup sheet — can be undone, and the only place a stored passphrase can be
+                    // replaced without making a backup to do it.
+                    SettingsRowId.PASSPHRASE -> SettingsClickRow(
+                        icon = R.drawable.round_key,
+                        title = stringResource(R.string.passphrase_settings_title),
+                        subtitle = stringResource(R.string.passphrase_settings_desc),
+                        showChevron = true,
+                        highlighted = lit,
+                        onClick = { showPassphrase = true }
+                    )
+
+                    // ── Extensions ──────────────────────────────────────────────────────────────
+                    // Entry into the manager itself is further gated by a one-time
+                    // liability-consent sheet (see ExtensionManagerScreen).
+                    SettingsRowId.MANAGE_EXTENSIONS -> SettingsClickRow(
+                        icon = R.drawable.round_extension,
+                        title = stringResource(R.string.manage_extensions),
+                        subtitle = stringResource(R.string.manage_extensions_desc),
+                        showChevron = true,
+                        highlighted = lit,
+                        onClick = onNavigateToExtensionManager
+                    )
+
+                    // ── About & support ─────────────────────────────────────────────────────────
+                    SettingsRowId.SUPPORT_DEVELOPER -> SettingsClickRow(
+                        icon = R.drawable.shield_with_heart,
+                        title = stringResource(R.string.support_developer),
+                        subtitle = stringResource(R.string.support_developer_desc),
+                        showChevron = true,
+                        highlighted = lit,
+                        onClick = { showSupportSheet = true }
+                    )
+
+                    SettingsRowId.VERSION -> VersionRow(versionName = versionName)
+
+                    SettingsRowId.LINKS -> Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        AboutTile(
+                            title = stringResource(R.string.github),
+                            subtitle = stringResource(R.string.source_code),
+                            icon = R.drawable.brand_github,
+                            modifier = Modifier.weight(1f),
+                            onClick = {
+                                context.startActivity(
+                                    Intent(
+                                        Intent.ACTION_VIEW,
+                                        "https://github.com/trinadhthatakula/Thor".toUri()
+                                    )
+                                )
+                            }
+                        )
+                        AboutTile(
+                            title = stringResource(R.string.telegram),
+                            subtitle = stringResource(R.string.community),
+                            icon = R.drawable.brand_telegram,
+                            modifier = Modifier.weight(1f),
+                            onClick = {
+                                context.startActivity(
+                                    Intent(Intent.ACTION_VIEW, "https://t.me/thorAppDev".toUri())
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showLanguageSheet) {
+        LanguageBottomSheet(
+            // The same value the row shows, for the same reason: a checkmark against Français on a
+            // screen rendering English is the identical lie in a smaller font.
+            selectedLanguage = shownLanguage,
+            onLanguageSelected = { language ->
+                viewModel.setLanguage(language.tag)
+                showLanguageSheet = false
+            },
+            onDismiss = { showLanguageSheet = false }
+        )
+    }
+
+    if (showSupportSheet) {
+        SupportDeveloperHelper(onDismiss = { showSupportSheet = false })
+    }
+
+    if (showPassphrase) {
+        PassphraseSettingsSheet(onDismiss = { showPassphrase = false })
+    }
+}
+
+/**
+ * The Freezer's five rows all say the same thing when Thor holds no privilege, and it is not their
+ * own description.
+ */
+@Composable
+private fun privilegeAwareSubtitle(hasPrivilege: Boolean, @StringRes descriptionRes: Int): String =
+    if (hasPrivilege) stringResource(descriptionRes)
+    else stringResource(R.string.privilege_required_warning)
+
+@Composable
+private fun VersionRow(versionName: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
+            SettingsIconBox(R.drawable.thor_mono)
+            Spacer(Modifier.width(16.dp))
+            Column {
+                Text(
+                    stringResource(R.string.version),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    stringResource(R.string.release_candidate),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+        Spacer(Modifier.width(8.dp))
+        Box(
+            modifier = Modifier
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f))
+                .padding(horizontal = 12.dp, vertical = 4.dp)
+        ) {
+            Text(
+                versionName,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
+
+@Composable
+private fun AboutTile(
+    title: String,
+    subtitle: String,
+    icon: Int,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .clickable { onClick() }
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.secondaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(icon),
+                contentDescription = null,
+                modifier = Modifier.size(28.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+        Column {
+            Text(
+                title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                subtitle,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                letterSpacing = 1.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LanguageBottomSheet(
+    selectedLanguage: AppLanguage,
+    onLanguageSelected: (AppLanguage) -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Expanded, SheetValue.Hidden)
+        ),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 48.dp)
+                .padding(horizontal = 24.dp)
+        ) {
+            Text(
+                stringResource(R.string.select_language),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+
+            AppLanguage.PICKER_ORDER.forEach { language ->
+                val isSelected = selectedLanguage == language
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(
+                            if (isSelected) MaterialTheme.colorScheme.primaryContainer
+                            else Color.Transparent
+                        )
+                        .clickable { onLanguageSelected(language) }
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(language.labelRes),
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                        color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
+                        else MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The system's per-app notification settings screen — the only place a user can undo a permanent
+ * POST_NOTIFICATIONS denial or re-enable app-wide notifications.
+ */
+private fun appNotificationSettingsIntent(context: Context): Intent =
+    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+
+/**
+ * Unwrap [LocalContext] to the hosting Activity. Compose hands out a ContextWrapper in some hosts,
+ * and `shouldShowRequestPermissionRationale` needs the real Activity.
+ */
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsComponents.kt
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings
+
+import androidx.annotation.DrawableRes
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.valhalla.asgard.components.ConnectedButtonGroup
+import com.valhalla.asgard.components.ConnectedButtonGroupItem
+import com.valhalla.thor.R
+
+/**
+ * The row vocabulary shared by the settings index and the eight category screens.
+ *
+ * Pulled out of `SettingsScreen` when that screen split in two, so the index and a category cannot
+ * drift into two slightly different-looking rows. Everything here is `internal`: these are Thor's
+ * settings rows, not a general component set — Asgard owns that role, and its `AsgardSettingRow`
+ * does not forward `subtitleMaxLines` to the `AsgardListRow` underneath it, which is the one thing
+ * these rows exist to get right.
+ *
+ * ## Two lines of subtitle, and no marquee
+ *
+ * Every subtitle here is `maxLines = 2`. The previous switch row was `maxLines = 1` with an opt-in
+ * `basicMarquee` that started on a tap *on the subtitle text* — a nested clickable inside a row
+ * whose whole surface already toggles the switch, so the gesture that revealed the description was
+ * a tap that looked exactly like the one that changed the setting. Nine call sites opted in; the
+ * other rows just truncated. Two lines fit every description Thor ships, in all five locales, so
+ * the scrolling text had nothing left to reveal.
+ */
+
+/** The tinted circle that carries a row's glyph. */
+@Composable
+internal fun SettingsIconBox(
+    @DrawableRes icon: Int,
+    modifier: Modifier = Modifier,
+    /** Error colours, for a row that *does* something destructive rather than storing a preference. */
+    destructive: Boolean = false,
+) {
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(
+                if (destructive) MaterialTheme.colorScheme.errorContainer
+                else MaterialTheme.colorScheme.secondaryContainer
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = painterResource(icon),
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = if (destructive) MaterialTheme.colorScheme.onErrorContainer
+            else MaterialTheme.colorScheme.primary
+        )
+    }
+}
+
+/**
+ * The container colour every row draws on, lifted while the row is the one search sent you to.
+ *
+ * Animated rather than switched, because the highlight is released a couple of seconds after
+ * arrival (see `SettingsCategoryScreen`) and a colour that simply vanishes reads as a glitch.
+ */
+@Composable
+private fun rowContainerColor(highlighted: Boolean) = animateColorAsState(
+    targetValue = if (highlighted) MaterialTheme.colorScheme.secondaryContainer
+    else MaterialTheme.colorScheme.surfaceContainerLow,
+    label = "settingsRowContainer"
+).value
+
+/** A row that opens something, or does something. */
+@Composable
+internal fun SettingsClickRow(
+    @DrawableRes icon: Int,
+    title: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    highlighted: Boolean = false,
+    destructive: Boolean = false,
+    /** The `›` affordance. On for a row that navigates, off for one that acts in place. */
+    showChevron: Boolean = false,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .background(rowContainerColor(highlighted))
+            .clickable(enabled = enabled) { onClick() }
+            .alpha(if (enabled) 1f else 0.5f)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SettingsIconBox(icon, destructive = destructive)
+        Spacer(Modifier.width(16.dp))
+        Column(Modifier.weight(1f)) {
+            RowTitle(title)
+            RowSubtitle(subtitle)
+        }
+        if (showChevron) {
+            Spacer(Modifier.width(8.dp))
+            Icon(
+                painter = painterResource(R.drawable.chevron_right),
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/** A row that stores a boolean. */
+@Composable
+internal fun SettingsSwitchRow(
+    @DrawableRes icon: Int,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    highlighted: Boolean = false,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .background(rowContainerColor(highlighted))
+            .clickable(enabled = enabled) { onCheckedChange(!checked) }
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
+            SettingsIconBox(icon)
+            Spacer(Modifier.width(16.dp))
+            Column {
+                RowTitle(title)
+                RowSubtitle(subtitle)
+            }
+        }
+        Spacer(Modifier.width(8.dp))
+        // The row is the tap target; the Switch is a picture of the state. Left to itself the
+        // Switch also announces itself as a separate toggle, so a screen reader offers the same
+        // setting twice and reads the title only on one of them.
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled,
+            modifier = Modifier.clearAndSetSemantics { }
+        )
+    }
+}
+
+/**
+ * A row whose value is a short closed set: title and description above, a segmented control below.
+ *
+ * The shape Theme and Grid Density already had, extracted so that the five places using it stop
+ * being five hand-written copies — one of which had drifted into duplicating its own section header
+ * as the header *above* itself.
+ */
+@Composable
+internal fun SettingsPickerRow(
+    @DrawableRes icon: Int,
+    title: String,
+    subtitle: String,
+    items: List<ConnectedButtonGroupItem>,
+    selectedIndex: Int,
+    onItemSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    highlighted: Boolean = false,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .background(rowContainerColor(highlighted))
+            .padding(16.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            SettingsIconBox(icon)
+            Spacer(Modifier.width(16.dp))
+            Column {
+                RowTitle(title)
+                RowSubtitle(subtitle)
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        ConnectedButtonGroup(
+            items = items,
+            selectedIndex = selectedIndex,
+            onItemSelected = onItemSelected,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+/** One line, always. A wrapped title stops the row scanning as a list. */
+@Composable
+private fun RowTitle(title: String) {
+    Text(
+        title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Bold,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+/** Two lines. See this file's header for why that number and not one. */
+@Composable
+private fun RowSubtitle(subtitle: String) {
+    Text(
+        subtitle,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+/**
+ * A category screen's top bar.
+ *
+ * The settings root has none — it carries a display-size "Settings" heading instead — so this is
+ * the first back affordance in the section. An arrow rather than the `round_close` the extension
+ * screens use: those are modal-feeling destinations reached from one place, a category is a step
+ * into a hierarchy you walk back out of.
+ */
+@Composable
+internal fun SettingsTopBar(title: String, onBack: () -> Unit, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(horizontal = 8.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                painter = painterResource(R.drawable.arrow_back),
+                contentDescription = stringResource(R.string.cd_back),
+                tint = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsComponents.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -31,7 +32,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -158,7 +159,17 @@ internal fun SettingsSwitchRow(
             .fillMaxWidth()
             .clip(RoundedCornerShape(24.dp))
             .background(rowContainerColor(highlighted))
-            .clickable(enabled = enabled) { onCheckedChange(!checked) }
+            // `toggleable`, not `clickable`: the row is the whole control, so it has to carry the
+            // control's semantics. Under `clickable` it announced as a button with no state at all
+            // — the Switch beside it had its own semantics cleared to stop the setting being
+            // offered twice, so between them nothing said on or off, and a screen reader user could
+            // change the setting but never hear what it was set to.
+            .toggleable(
+                value = checked,
+                enabled = enabled,
+                role = Role.Switch,
+                onValueChange = onCheckedChange
+            )
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
@@ -172,14 +183,15 @@ internal fun SettingsSwitchRow(
             }
         }
         Spacer(Modifier.width(8.dp))
-        // The row is the tap target; the Switch is a picture of the state. Left to itself the
-        // Switch also announces itself as a separate toggle, so a screen reader offers the same
-        // setting twice and reads the title only on one of them.
+        // The row is the tap target; the Switch is a picture of the state. A null handler is what
+        // says so — Material3 only applies its own toggleable semantics when one is present, so
+        // this contributes no second announcement of the same setting and needs no
+        // `clearAndSetSemantics` to suppress one. It also stops consuming the pointer, which is
+        // what lets a tap landing on the thumb reach the row's toggleable above.
         Switch(
             checked = checked,
-            onCheckedChange = onCheckedChange,
-            enabled = enabled,
-            modifier = Modifier.clearAndSetSemantics { }
+            onCheckedChange = null,
+            enabled = enabled
         )
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsScreen.kt
@@ -3,19 +3,7 @@
 
 package com.valhalla.thor.presentation.settings
 
-import android.Manifest
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
-import android.content.Intent
-import android.os.Build
-import android.provider.Settings
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.StringRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.basicMarquee
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,23 +14,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
-import androidx.compose.material3.Switch
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,136 +31,109 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.app.ActivityCompat
-import androidx.core.app.NotificationManagerCompat
-import androidx.core.net.toUri
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LifecycleResumeEffect
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.valhalla.asgard.components.ConnectedButtonGroupItem
 import com.valhalla.thor.R
-import com.valhalla.thor.data.manager.UsageAccessManager
-import com.valhalla.thor.domain.model.AnimationIntensity
-import com.valhalla.thor.domain.model.AppGridDensity
-import com.valhalla.thor.domain.model.DefaultTab
 import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.PrivilegeMode
-import com.valhalla.thor.domain.model.ThemeMode
 import com.valhalla.thor.domain.usecase.ObserveInterruptedRestoreUseCase
 import com.valhalla.thor.presentation.main.toDestination
-import com.valhalla.thor.presentation.utils.ObserveAsEvents
-import com.valhalla.thor.util.AppLanguage
 import com.valhalla.thor.util.displayedLanguage
-import com.valhalla.asgard.components.ConnectedButtonGroup
-import com.valhalla.asgard.components.ConnectedButtonGroupItem
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * The settings index: eight doors, a search field, and the state that decides which door to open.
+ *
+ * This screen used to *be* Settings — one `Column(verticalScroll)` roughly 3000 dp tall holding 29
+ * entries under ten hand-written section headers, growing by a section every feature. The index's
+ * length is now fixed at eight and the number of settings is not; a new setting is an entry in
+ * [SettingsRowId], and [SettingsCategoryScreen]'s exhaustive `when` will not compile until something
+ * draws it.
+ *
+ * @param onOpenCategory push a category. The second argument is the row search matched, or null for
+ *   an ordinary tap on a category row — see [SettingsCategoryScreen] for what it does with it.
+ * @param selectedCategory the category showing in the detail pane beside this one, so its row can be
+ *   marked as the active one. Null on a phone, where this screen and a category are never on screen
+ *   together and a persistent highlight would only be a row that looks stuck. `MainScreen` decides
+ *   which case applies from the pane directive, not from a width breakpoint.
+ */
 @Composable
 fun SettingsScreen(
-    onNavigateToExtensionManager: () -> Unit,
-    // Not defaulted, so the one call site has to supply it. A default would leave a Restore row that
-    // does nothing, and nothing would fail to compile.
-    //
-    // `onOpen`, not `onNavigateTo`: restore is a bottom sheet hosted by `MainScreen` over whatever
-    // section is showing. Nothing is pushed and this screen stays composed underneath.
-    onOpenRestore: () -> Unit,
+    onOpenCategory: (SettingsCategory, SettingsRowId?) -> Unit,
+    selectedCategory: SettingsCategory? = null,
     viewModel: SettingsViewModel = koinViewModel()
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val prefs = state.prefs
     val hasPrivilege = state.isRootAvailable || state.isShizukuAvailable || state.isDhizukuAvailable
     val context = LocalContext.current
-    var showLanguageSheet by remember { mutableStateOf(false) }
-    var showUnfreezeConfirmation by remember { mutableStateOf(false) }
-    var showSupportSheet by remember { mutableStateOf(false) }
-
-    // The any-file switch is backed by PackageManager, not DataStore, so nothing pushes a change at
-    // us: `pm enable`, a ROM app manager, or a wipe of Thor's component state all move it silently.
-    // Re-read on every resume but the first, which the VM's init already covered.
-    var firstResume by rememberSaveable { mutableStateOf(true) }
-    LifecycleResumeEffect(Unit) {
-        if (firstResume) firstResume = false else viewModel.refreshAnyFileOpener()
-        onPauseOrDispose { }
-    }
-
-    // The language the row and the picker's checkmark are allowed to name.
-    //
-    // `LocalConfiguration.current` is the Configuration this composition is being drawn with —
-    // `AndroidCompositionLocals` seeds it from `view.context.resources.configuration`, and that
-    // context is the Activity, whose base `AppLocale.wrap` overrode. So this is not what Thor
-    // believes it applied; it is what the screen is rendering in, read back off the screen. If the
-    // override ever fails to take, this reports the locale the user is actually looking at and the
-    // row says so, which is precisely what the old `when (prefs.language)` could not do — it read
-    // the persisted preference and therefore confirmed every change, applied or not.
-    //
-    // Recomposition is automatic on both paths: a locale change recreates the activity (the
-    // platform's on 33+, `AppLocale.recreateOnChange` below it), which rebuilds this composition
-    // with the new Configuration.
-    val shownLanguage = displayedLanguage(
-        persistedTag = prefs.language,
-        appliedTag = LocalConfiguration.current.locales
-            .takeIf { !it.isEmpty }?.get(0)?.toLanguageTag()
-    )
-
-    ObserveAsEvents(viewModel.events) { event ->
-        android.widget.Toast.makeText(
-            context,
-            event.asString(context),
-            android.widget.Toast.LENGTH_SHORT
-        ).show()
-    }
-
-    if (showUnfreezeConfirmation) {
-        AlertDialog(
-            onDismissRequest = { showUnfreezeConfirmation = false },
-            icon = {
-                Icon(
-                    painter = painterResource(R.drawable.warning),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.error
-                )
-            },
-            title = { Text(stringResource(R.string.unfreeze_all_confirmation_title)) },
-            text = { Text(stringResource(R.string.unfreeze_all_confirmation_desc)) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        viewModel.unfreezeAll()
-                        showUnfreezeConfirmation = false
-                    }
-                ) {
-                    Text(stringResource(R.string.proceed))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showUnfreezeConfirmation = false }) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
-        )
-    }
 
     val versionName = remember(context) {
         runCatching {
             context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "—"
         }.getOrDefault("—")
     }
+
+    // §8.5's notice, now at the index rather than inside the Backup card.
+    //
+    // It was under `if (hasPrivilege)`, which is the one condition under which the person who most
+    // needs it cannot see it: a restore is interrupted precisely when something went wrong, and a
+    // Shizuku service that died between the write and the reboot takes the notice down with it. The
+    // door below stays privilege-gated — an unprivileged user cannot finish the restore — but the
+    // statement that their app's data may be half-written is a fact, not an offer.
+    //
+    // The use case, not `ArchiveBreadcrumbStore.observe()` directly: the breadcrumb is written at the
+    // start of the destructive phase, and the restore sheet is hosted by `MainScreen` over whatever
+    // section is showing, so a raw observe() would render "did not finish" beneath a progress bar
+    // reporting normal progress. The use case holds the notice back while a restore for that app is
+    // live, and still takes it down the moment "Got it" clears the breadcrumb.
+    val observeInterrupted = koinInject<ObserveInterruptedRestoreUseCase>()
+    val interrupted by remember(observeInterrupted) { observeInterrupted() }
+        .collectAsStateWithLifecycle(initialValue = null)
+
+    // The language the Appearance summary is allowed to name.
+    //
+    // `LocalConfiguration.current` is the Configuration this composition is being drawn with, so
+    // this is not what Thor believes it applied; it is what the screen is rendering in, read back
+    // off the screen. See `displayedLanguage`.
+    val shownLanguage = displayedLanguage(
+        persistedTag = prefs.language,
+        appliedTag = LocalConfiguration.current.locales
+            .takeIf { !it.isEmpty }?.get(0)?.toLanguageTag()
+    )
+
+    val availableModes = buildList {
+        if (state.isRootAvailable) add(PrivilegeMode.ROOT)
+        if (state.isShizukuAvailable) add(PrivilegeMode.SHIZUKU)
+        if (state.isDhizukuAvailable) add(PrivilegeMode.DHIZUKU)
+    }
+
+    // Backup and Extensions are privileged surfaces: there is no unprivileged path to another app's
+    // data, and the extension manager is a third-party code host. An unprivileged user offered
+    // either would reach a screen whose only content is a refusal.
+    //
+    // Backup has one exception, and it is the reason the notice above is not gated: a breadcrumb can
+    // outlive the privilege that wrote it. Hiding the door while showing the notice would leave a
+    // statement of damage with nothing to act on.
+    val visibleCategories = SettingsCategory.entries.filter { category ->
+        when (category) {
+            SettingsCategory.BACKUP -> hasPrivilege || interrupted != null
+            SettingsCategory.EXTENSIONS -> hasPrivilege
+            else -> true
+        }
+    }
+
+    var query by rememberSaveable { mutableStateOf("") }
 
     Column(
         modifier = Modifier
@@ -189,8 +143,6 @@ fun SettingsScreen(
             .padding(horizontal = 24.dp)
             .padding(top = 64.dp, bottom = 120.dp)
     ) {
-
-        // Header Section
         Text(
             text = stringResource(R.string.settings),
             style = MaterialTheme.typography.displayMedium,
@@ -204,762 +156,111 @@ fun SettingsScreen(
             letterSpacing = 2.sp
         )
 
-        Spacer(Modifier.height(48.dp))
+        Spacer(Modifier.height(24.dp))
 
-        // ── GENERAL ─────────────────────────────────────────────────────────
-        SettingsSectionLabel(stringResource(R.string.general))
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(32.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                .padding(8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            // Default tab. Shaped like the Theme row in APPEARANCE — a titled row with a segmented
-            // control underneath — rather than a picker sheet, because four options fit.
-            Column(modifier = Modifier.padding(16.dp)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconBox(R.drawable.home)
-                    Spacer(Modifier.width(16.dp))
-                    Column {
-                        Text(
-                            stringResource(R.string.default_tab),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            stringResource(R.string.default_tab_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            shape = RoundedCornerShape(24.dp),
+            placeholder = { Text(stringResource(R.string.settings_search_hint)) },
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(R.drawable.round_search),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            },
+            trailingIcon = {
+                if (query.isNotEmpty()) {
+                    IconButton(onClick = { query = "" }) {
+                        Icon(
+                            painter = painterResource(R.drawable.round_close),
+                            contentDescription = stringResource(R.string.cd_settings_search_clear),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
-                Spacer(Modifier.height(16.dp))
-                // Icons, not labels, and the nav bar's own glyphs: four equal slots across a phone
-                // leave roughly 34 dp of text apiece, which turns "App List" into two characters and
-                // its longer translations into fewer. The tab name still travels — as each button's
-                // content description, which is what a screen reader announces either way.
-                ConnectedButtonGroup(
-                    items = DefaultTab.entries.map { tab ->
-                        val destination = tab.toDestination()
-                        ConnectedButtonGroupItem.Icon(
-                            icon = ImageVector.vectorResource(destination.selectedIcon),
-                            contentDescription = stringResource(destination.label)
-                        )
-                    },
-                    selectedIndex = DefaultTab.entries.indexOf(prefs.defaultTab),
-                    onItemSelected = { viewModel.setDefaultTab(DefaultTab.entries[it]) },
-                    modifier = Modifier.fillMaxWidth()
-                )
             }
+        )
 
-            SettingsSwitchRow(
-                icon = R.drawable.apk_install,
-                title = stringResource(R.string.show_reinstall_card),
-                subtitle = stringResource(R.string.show_reinstall_card_desc),
-                checked = prefs.showReinstallAllCard,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setReinstallAllCardVisibility(it) }
-            )
+        Spacer(Modifier.height(16.dp))
 
-            SettingsSwitchRow(
-                icon = R.drawable.apk_install,
-                title = stringResource(R.string.show_installer_tile),
-                subtitle = stringResource(R.string.show_installer_tile_desc),
-                checked = prefs.showInstallerTile,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setInstallerTileVisibility(it) }
-            )
-
-            // Reads its state from `uiState`, not `prefs`: this switch is backed by PackageManager
-            // component state rather than DataStore. See AnyFileOpenerController.
-            SettingsSwitchRow(
-                icon = R.drawable.apk_install,
-                title = stringResource(R.string.any_file_opener),
-                subtitle = stringResource(R.string.any_file_opener_desc),
-                checked = state.anyFileOpenerEnabled,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setAnyFileOpenerEnabled(it) }
-            )
-
-            SettingsSwitchRow(
-                icon = R.drawable.round_extension,
-                title = stringResource(R.string.show_extensions_tile),
-                subtitle = stringResource(R.string.show_extensions_tile_desc),
-                checked = prefs.showExtensionsTile,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setExtensionsTileVisibility(it) }
-            )
-
-            SettingsSwitchRow(
-                icon = R.drawable.settings_backup_restore,
-                title = stringResource(R.string.auto_reinstall),
-                subtitle = stringResource(R.string.auto_reinstall_desc),
-                checked = prefs.autoReinstallEnabled,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setAutoReinstallEnabled(it) }
-            )
-        }
-
-        Spacer(Modifier.height(32.dp))
-
-        // ── APPEARANCE ──────────────────────────────────────────────────────
-        SettingsSectionLabel(stringResource(R.string.appearance))
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(32.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                .padding(8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            // Theme Row
-            Column(modifier = Modifier.padding(16.dp)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconBox(R.drawable.theme_panel)
-                    Spacer(Modifier.width(16.dp))
-                    Column {
-                        Text(
-                            stringResource(R.string.theme),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            stringResource(R.string.theme_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-                Spacer(Modifier.height(16.dp))
-                ConnectedButtonGroup(
-                    items = ThemeMode.entries.map { ConnectedButtonGroupItem.Label(it.label()) },
-                    selectedIndex = ThemeMode.entries.indexOf(prefs.themeMode),
-                    onItemSelected = { viewModel.setThemeMode(ThemeMode.entries[it]) },
-                    modifier = Modifier.fillMaxWidth()
+        interrupted?.let { crumb ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.warning),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.onErrorContainer
                 )
-            }
-
-            // Grid density. Same titled-row-plus-segmented-control shape as Theme above it, and it
-            // lives here rather than in GENERAL because it changes how the app looks, not what it
-            // does. One control for every grid Thor draws — the Apps tab, the Freezer, and the two
-            // pickers in the Freezer's sheets — because a per-screen density is a setting the user
-            // has to find four times.
-            Column(modifier = Modifier.padding(16.dp)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconBox(R.drawable.grid_view)
-                    Spacer(Modifier.width(16.dp))
-                    Column {
-                        Text(
-                            stringResource(R.string.grid_density),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            stringResource(R.string.grid_density_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-                Spacer(Modifier.height(16.dp))
-                ConnectedButtonGroup(
-                    items = AppGridDensity.entries.map {
-                        val label = when (it) {
-                            AppGridDensity.COMPACT -> stringResource(R.string.grid_density_compact)
-                            AppGridDensity.DEFAULT -> stringResource(R.string.grid_density_default)
-                            AppGridDensity.LARGE -> stringResource(R.string.grid_density_large)
-                        }
-                        ConnectedButtonGroupItem.Label(label)
-                    },
-                    selectedIndex = AppGridDensity.entries.indexOf(prefs.appGridDensity),
-                    onItemSelected = { viewModel.setAppGridDensity(AppGridDensity.entries[it]) },
-                    modifier = Modifier.fillMaxWidth()
+                Spacer(Modifier.size(12.dp))
+                Text(
+                    text = stringResource(R.string.restore_interrupted, crumb.appLabel),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer
                 )
-            }
-
-            SettingsSwitchRow(
-                icon = R.drawable.theme_panel,
-                title = stringResource(R.string.amoled_mode),
-                subtitle = stringResource(R.string.amoled_desc),
-                checked = prefs.useAmoled,
-                onCheckedChange = { viewModel.setAmoledMode(it) }
-            )
-
-            SettingsSwitchRow(
-                icon = R.drawable.shield_with_heart,
-                title = stringResource(R.string.dynamic_colors),
-                subtitle = stringResource(R.string.dynamic_colors_desc),
-                checked = prefs.useDynamicColor,
-                enabled = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S,
-                onCheckedChange = { viewModel.setDynamicColor(it) }
-            )
-
-            SettingsClickRow(
-                icon = R.drawable.settings_backup_restore,
-                title = stringResource(R.string.app_language),
-                subtitle = stringResource(shownLanguage.labelRes),
-                onClick = { showLanguageSheet = true }
-            )
-        }
-
-        Spacer(Modifier.height(32.dp))
-
-        // ── ANIMATION INTENSITY ─────────────────────────────────────────────
-        SettingsSectionLabel(stringResource(R.string.animation_intensity))
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(32.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                .padding(16.dp)
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                IconBox(R.drawable.bolt)
-                Spacer(Modifier.width(16.dp))
-                Column {
-                    Text(
-                        stringResource(R.string.animation_intensity),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        stringResource(R.string.animation_intensity_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
             }
             Spacer(Modifier.height(16.dp))
-            ConnectedButtonGroup(
-                items = AnimationIntensity.entries.map {
-                    val label = when (it) {
-                        AnimationIntensity.LOW -> stringResource(R.string.animation_intensity_low)
-                        AnimationIntensity.MEDIUM -> stringResource(R.string.animation_intensity_medium)
-                        AnimationIntensity.HIGH -> stringResource(R.string.animation_intensity_high)
-                    }
-                    ConnectedButtonGroupItem.Label(label)
-                },
-                selectedIndex = AnimationIntensity.entries.indexOf(prefs.animationIntensity),
-                onItemSelected = { viewModel.setAnimationIntensity(AnimationIntensity.entries[it]) },
-                modifier = Modifier.fillMaxWidth()
-            )
         }
 
-        Spacer(Modifier.height(32.dp))
-
-        // ── SECURITY ────────────────────────────────────────────────────────
-        SettingsSectionLabel(stringResource(R.string.security))
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(32.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                .padding(8.dp)
-        ) {
-            // Deliberately left enabled when the device cannot authenticate. A disabled row
-            // swallows the tap (`clickable(enabled = false)`), so a user whose device has nothing
-            // enrolled got a greyed-out switch and silence — the subtitle was the only clue, and it
-            // is a line of body text under a control that no longer responds. Tappable, the refusal
-            // in `setBiometricLock` can answer with a toast that names what is missing. `checked`
-            // stays bound to the preference, so a refused tap settles straight back.
-            SettingsSwitchRow(
-                icon = R.drawable.round_key,
-                title = stringResource(R.string.biometric_lock),
-                subtitle = if (state.canUseBiometric) {
-                    stringResource(R.string.biometric_lock_desc)
-                } else {
-                    stringResource(R.string.biometric_not_available)
-                },
-                checked = prefs.biometricLockEnabled,
-                onCheckedChange = { viewModel.setBiometricLock(it) }
-            )
-        }
-
-        Spacer(Modifier.height(32.dp))
-
-        // ── PERMISSIONS ─────────────────────────────────────────────────────
-        SettingsSectionLabel(stringResource(R.string.permissions))
-
-        val usageAccessManager = koinInject<UsageAccessManager>()
-        val lifecycleOwner = LocalLifecycleOwner.current
-        var usageGranted by remember { mutableStateOf(usageAccessManager.isGranted()) }
-        var notificationsGranted by remember {
-            mutableStateOf(NotificationManagerCompat.from(context).areNotificationsEnabled())
-        }
-        DisposableEffect(lifecycleOwner) {
-            val observer = LifecycleEventObserver { _, event ->
-                if (event == Lifecycle.Event.ON_RESUME) {
-                    usageGranted = usageAccessManager.isGranted()
-                    notificationsGranted =
-                        NotificationManagerCompat.from(context).areNotificationsEnabled()
-                }
-            }
-            lifecycleOwner.lifecycle.addObserver(observer)
-            onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(32.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                .padding(8.dp)
-        ) {
-            SettingsSwitchRow(
-                icon = R.drawable.shield,
-                title = stringResource(R.string.usage_access),
-                subtitle = if (usageGranted) {
-                    stringResource(R.string.usage_access_granted_subtitle)
-                } else {
-                    stringResource(R.string.usage_access_needed_subtitle)
-                },
-                checked = usageGranted,
-                onCheckedChange = {
-                    // This op can't be toggled in-app; deep-link to system settings.
-                    if (!usageGranted) {
-                        runCatching { context.startActivity(usageAccessManager.usageAccessIntent()) }
-                    }
-                }
-            )
-            // The row itself is unconditional, because what it reports —
-            // areNotificationsEnabled(), the exact thing BulkResultNotifier checks — is
-            // meaningful and user-toggleable all the way down to minSdk 28. Only the *way* it is
-            // granted differs: a runtime permission on 33+, an app-level toggle in system
-            // settings below that. Gating the whole row on 33 left users on 28-32 with silently
-            // dropped bulk-result notifications and nothing in-app explaining why.
+        if (query.isBlank()) {
+            // The engine picker, unconditional where it used to need two engines to appear.
             //
-            // Registering the launcher inside the version check is safe: SDK_INT is constant for
-            // the process, so the conditional group is stable across recompositions. It also
-            // keeps every POST_NOTIFICATIONS reference inside the check, which is what lint's
-            // InlinedApi wants.
-            val requestNotificationPermission: (() -> Unit)? =
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    val activity = remember(context) { context.findActivity() }
-                    val notificationPermissionLauncher = rememberLauncherForActivityResult(
-                        ActivityResultContracts.RequestPermission()
-                    ) { _ ->
-                        // Re-read instead of trusting `granted`. The switch reflects
-                        // areNotificationsEnabled(), which is also false when the permission is
-                        // held but the user muted the app's notifications; trusting `granted`
-                        // flipped the switch on and the next ON_RESUME flipped it back off.
-                        val enabled =
-                            NotificationManagerCompat.from(context).areNotificationsEnabled()
-                        notificationsGranted = enabled
-                        // RequestPermission returns immediately without showing a dialog once
-                        // the user has denied twice, which would leave this row a permanent
-                        // dead end. shouldShowRequestPermissionRationale distinguishes that
-                        // (and the "granted but muted" case, both false) from a plain first
-                        // denial (true, where re-tapping the row still shows the dialog).
-                        // Where the dialog can no longer help, deep-link to system settings
-                        // like the usage-access row above. Thor never self-grants this.
-                        val canAskAgain = activity?.let {
-                            ActivityCompat.shouldShowRequestPermissionRationale(
-                                it,
-                                Manifest.permission.POST_NOTIFICATIONS
-                            )
-                        } ?: false
-                        if (!enabled && !canAskAgain) {
-                            runCatching {
-                                context.startActivity(appNotificationSettingsIntent(context))
-                            }
-                        }
-                    }
-                    val request = {
-                        notificationPermissionLauncher.launch(
-                            Manifest.permission.POST_NOTIFICATIONS
-                        )
-                    }
-                    request
-                } else {
-                    null
-                }
-
-            SettingsSwitchRow(
-                icon = R.drawable.frozen,
-                title = stringResource(R.string.notification_access),
-                subtitle = if (notificationsGranted) {
-                    stringResource(R.string.notification_access_granted_subtitle)
-                } else {
-                    stringResource(R.string.notification_access_needed_subtitle)
-                },
-                checked = notificationsGranted,
-                onCheckedChange = {
-                    if (!notificationsGranted) {
-                        // 33+: only the system dialog can grant this. Thor never self-grants it
-                        // even when it holds root/Shizuku — the dialog grants the identical
-                        // capability, and Dhizuku cannot self-grant at all.
-                        // 28-32: there is no runtime permission to request, so the only lever
-                        // is the app-level toggle; deep-link to it, as the usage-access row does.
-                        if (requestNotificationPermission != null) {
-                            requestNotificationPermission()
-                        } else {
-                            runCatching {
-                                context.startActivity(appNotificationSettingsIntent(context))
-                            }
-                        }
-                    }
-                }
-            )
-        }
-
-        Spacer(Modifier.height(32.dp))
-
-        // ── FREEZER ─────────────────────────────────────────────────────────
-        SettingsSectionLabel(stringResource(R.string.freezer))
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(32.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                .padding(8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            SettingsSwitchRow(
-                icon = R.drawable.frozen,
-                title = stringResource(R.string.auto_freeze),
-                subtitle = if (hasPrivilege) stringResource(R.string.auto_freeze_desc) else stringResource(
-                    R.string.privilege_required_warning
-                ),
-                checked = prefs.autoFreezeEnabled,
-                enabled = hasPrivilege,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setAutoFreezeEnabled(it) }
-            )
-
-            SettingsSwitchRow(
-                icon = R.drawable.frozen,
-                title = stringResource(R.string.suspend_instead_of_freeze),
-                subtitle = if (hasPrivilege) stringResource(R.string.suspend_instead_of_freeze_desc) else stringResource(
-                    R.string.privilege_required_warning
-                ),
-                checked = prefs.freezerMode == FreezerMode.SUSPEND,
-                enabled = hasPrivilege,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setFreezerMode(if (it) FreezerMode.SUSPEND else FreezerMode.FREEZE) }
-            )
-
-            SettingsClickRow(
-                icon = R.drawable.unfreeze,
-                title = stringResource(R.string.unfreeze_all_apps),
-                subtitle = if (hasPrivilege) stringResource(R.string.unfreeze_all_apps_desc) else stringResource(
-                    R.string.privilege_required_warning
-                ),
-                enabled = hasPrivilege,
-                onClick = { showUnfreezeConfirmation = true }
-            )
-
-            SettingsSwitchRow(
-                icon = R.drawable.danger,
-                title = stringResource(R.string.skip_routine_freeze_confirmation),
-                subtitle = if (hasPrivilege) stringResource(R.string.skip_routine_freeze_confirmation_desc) else stringResource(
-                    R.string.privilege_required_warning
-                ),
-                checked = prefs.skipRoutineFreezeConfirmation,
-                enabled = hasPrivilege,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setSkipRoutineFreezeConfirmation(it) }
-            )
-
-            SettingsSwitchRow(
-                icon = R.drawable.frozen,
-                title = stringResource(R.string.add_freezer_to_launcher),
-                subtitle = if (hasPrivilege) stringResource(R.string.add_freezer_to_launcher_desc) else stringResource(
-                    R.string.privilege_required_warning
-                ),
-                checked = prefs.addFreezerToLauncher,
-                enabled = hasPrivilege,
-                enableMarqueeOnClick = true,
-                onCheckedChange = { viewModel.setAddFreezerToLauncher(it) }
-            )
-        }
-
-        // ── BACKUP & RESTORE ────────────────────────────────────────────────
-        // Root/Shizuku/Dhizuku only: there is no unprivileged path to another app's data, so an
-        // unprivileged user offered this would reach a screen whose only content is a refusal.
-        if (hasPrivilege) {
-            Spacer(Modifier.height(32.dp))
-
-            SettingsSectionLabel(stringResource(R.string.backup_and_restore))
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(32.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                    .padding(8.dp)
-            ) {
-                // §8.5's notice, where a user who is not looking for it will still see it. Injected
-                // here rather than threaded through SettingsViewModel: it is one flow that no other
-                // part of Settings needs, and putting it in the view model that owns every preference
-                // would make a backup concern part of that class's surface.
-                //
-                // The use case, not `ArchiveBreadcrumbStore.observe()` directly. A live observation of
-                // the raw breadcrumb is *wrong* on this surface: the breadcrumb is written at the start
-                // of the destructive phase, and the restore sheet is hosted by `MainScreen` over
-                // whatever section is showing — so this row stays composed, on every window size,
-                // underneath the restore it describes, and a raw observe() would render "did not finish
-                // … restore it again" beneath a progress bar reporting normal progress. The use case
-                // holds the notice back while a restore for that app is live, and still takes it down
-                // the moment "Got it" in the sheet clears the breadcrumb. Both of its inputs read off
-                // the main thread.
-                //
-                // This was true of the old restore *screen* only in theory and by a different argument
-                // (a detail pane beside a composed list pane, which is not the layout it got). Being a
-                // sheet is what makes the overlap unconditional.
-                val observeInterrupted = koinInject<ObserveInterruptedRestoreUseCase>()
-                val interrupted by remember(observeInterrupted) { observeInterrupted() }
-                    .collectAsStateWithLifecycle(initialValue = null)
-                // Not dismissible here on purpose: the row beneath it leads to the screen that can
-                // clear it, and a dismiss in two places is two chances to lose the notice.
-                interrupted?.let { crumb ->
-                    Text(
-                        text = stringResource(R.string.restore_interrupted, crumb.appLabel),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
-                    )
-                }
-                SettingsClickRow(
-                    icon = R.drawable.settings_backup_restore,
-                    title = stringResource(R.string.restore_title),
-                    subtitle = stringResource(R.string.restore_settings_desc),
-                    onClick = onOpenRestore
-                )
-
-                // §5.4. The only place "remember it on this device" — offered as a checkbox in the
-                // backup sheet — can be undone, and the only place a stored passphrase can be replaced
-                // without making a backup to do it.
-                var showPassphrase by remember { mutableStateOf(false) }
-
-                SettingsClickRow(
-                    icon = R.drawable.round_key,
-                    title = stringResource(R.string.passphrase_settings_title),
-                    subtitle = stringResource(R.string.passphrase_settings_desc),
-                    onClick = { showPassphrase = true }
-                )
-
-                // Hosted at its row, which is the exception in this composable and not the
-                // convention. The three other overlays here — the unfreeze-all AlertDialog, the
-                // language sheet and the support sheet — all sit at the screen root with only their
-                // trigger down among the rows: the dialog before this scrolling Column opens, the two
-                // sheets after it closes. This one is the first that keeps its state and its host
-                // beside the row they belong to.
-                //
-                // (Written without line numbers on purpose. The first draft of this comment cited
-                // three, and editing the comment itself moved one of them — and asserted a shared
-                // "after the Column closes" that was only ever true of two of the three.)
-                //
-                // Still correct where it is: a ModalBottomSheet draws in its own window over the
-                // whole screen no matter where it is composed, so being inside this Column costs it
-                // nothing.
-                if (showPassphrase) {
-                    PassphraseSettingsSheet(onDismiss = { showPassphrase = false })
-                }
-            }
-        }
-
-        // ── EXTENSIONS ──────────────────────────────────────────────────────
-        // Power-user surface: shown only when an elevated privilege (Root / Shizuku / Dhizuku) is
-        // available, so normal users aren't offered it. Entry into the manager itself is further
-        // gated by a one-time liability-consent sheet (see ExtensionManagerScreen).
-        if (hasPrivilege) {
-            Spacer(Modifier.height(32.dp))
-
-            SettingsSectionLabel(stringResource(R.string.extensions))
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(32.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                    .padding(8.dp)
-            ) {
-                SettingsClickRow(
-                    icon = R.drawable.round_extension,
-                    title = stringResource(R.string.manage_extensions),
-                    subtitle = stringResource(R.string.manage_extensions_desc),
-                    onClick = onNavigateToExtensionManager
-                )
-            }
-        }
-
-        Spacer(Modifier.height(32.dp))
-
-        // ── WORK MODE ───────────────────────────────────────────────────────
-        val availableModes = buildList {
-            if (state.isRootAvailable) add(PrivilegeMode.ROOT)
-            if (state.isShizukuAvailable) add(PrivilegeMode.SHIZUKU)
-            if (state.isDhizukuAvailable) add(PrivilegeMode.DHIZUKU)
-        }
-
-        if (availableModes.size > 1) {
-            SettingsSectionLabel(stringResource(R.string.work_mode))
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(32.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                    .padding(16.dp)
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    val activeMode = prefs.preferredPrivilegeMode ?: availableModes.first()
-                    val icon = when (activeMode) {
-                        PrivilegeMode.ROOT -> R.drawable.magisk_icon
-                        PrivilegeMode.SHIZUKU -> R.drawable.shizuku
-                        PrivilegeMode.DHIZUKU -> R.drawable.dhizuku
-                        // Unreachable here: WORK MODE only renders when a real privilege mode is available.
-                        PrivilegeMode.NONE -> R.drawable.shield
-                    }
-                    IconBox(icon)
-                    Spacer(Modifier.width(16.dp))
-                    Column {
-                        Text(
-                            stringResource(R.string.active_engine),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            stringResource(R.string.active_engine_desc),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-                Spacer(Modifier.height(16.dp))
-                ConnectedButtonGroup(
-                    items = availableModes.map { mode ->
-                        ConnectedButtonGroupItem.Label(mode.name)
+            // `availableModes.size > 1` hid the one line that answers "how is Thor doing this?" from
+            // every single-engine device — which is most of them. A one-button group is not a choice,
+            // but it is an answer, and the icon beside it names the engine at a glance.
+            if (availableModes.isNotEmpty()) {
+                val activeMode = prefs.preferredPrivilegeMode?.takeIf { it in availableModes }
+                    ?: availableModes.first()
+                SettingsPickerRow(
+                    icon = activeMode.iconRes(),
+                    title = stringResource(R.string.active_engine),
+                    subtitle = stringResource(R.string.active_engine_desc),
+                    items = availableModes.map {
+                        ConnectedButtonGroupItem.Label(stringResource(it.labelRes))
                     },
-                    selectedIndex = availableModes.indexOf(
-                        prefs.preferredPrivilegeMode ?: availableModes.first()
-                    ),
-                    onItemSelected = { viewModel.setPrivilegeMode(availableModes[it]) },
-                    modifier = Modifier.fillMaxWidth()
+                    selectedIndex = availableModes.indexOf(activeMode),
+                    onItemSelected = { viewModel.setPrivilegeMode(availableModes[it]) }
                 )
+                Spacer(Modifier.height(16.dp))
             }
-            Spacer(Modifier.height(32.dp))
-        }
 
-        // ── ABOUT ───────────────────────────────────────────────────────────
-        SettingsSectionLabel(stringResource(R.string.about))
-
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            SettingsClickRow(
-                icon = R.drawable.shield_with_heart,
-                title = stringResource(R.string.support_developer),
-                subtitle = stringResource(R.string.support_developer_desc),
-                onClick = { showSupportSheet = true }
-            )
-            // Version Tile
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(32.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                    .padding(20.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    IconBox(R.drawable.thor_mono)
-                    Spacer(Modifier.width(16.dp))
-                    Column {
-                        Text(
-                            stringResource(R.string.version),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            stringResource(R.string.release_candidate),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-                Box(
-                    modifier = Modifier
-                        .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.1f))
-                        .padding(horizontal = 12.dp, vertical = 4.dp)
-                ) {
-                    Text(
-                        versionName,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                visibleCategories.forEach { category ->
+                    SettingsClickRow(
+                        icon = category.icon,
+                        title = stringResource(category.title),
+                        subtitle = categorySummary(
+                            category = category,
+                            state = state,
+                            hasPrivilege = hasPrivilege,
+                            shownLanguageLabel = stringResource(shownLanguage.labelRes),
+                            versionName = versionName,
+                            restoreInterrupted = interrupted != null
+                        ),
+                        showChevron = true,
+                        highlighted = selectedCategory == category,
+                        onClick = { onOpenCategory(category, null) }
                     )
                 }
             }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                AboutTile(
-                    title = stringResource(R.string.github),
-                    subtitle = stringResource(R.string.source_code),
-                    icon = R.drawable.brand_github,
-                    modifier = Modifier.weight(1f),
-                    onClick = {
-                        context.startActivity(
-                            Intent(
-                                Intent.ACTION_VIEW,
-                                "https://github.com/trinadhthatakula/Thor".toUri()
-                            )
-                        )
-                    }
-                )
-                AboutTile(
-                    title = stringResource(R.string.telegram),
-                    subtitle = stringResource(R.string.community),
-                    icon = R.drawable.brand_telegram,
-                    modifier = Modifier.weight(1f),
-                    onClick = {
-                        context.startActivity(
-                            Intent(
-                                Intent.ACTION_VIEW,
-                                "https://t.me/thorAppDev".toUri()
-                            )
-                        )
-                    }
-                )
-            }
+        } else {
+            SettingsSearchResults(
+                query = query,
+                visibleCategories = visibleCategories,
+                onOpenRow = { row -> onOpenCategory(row.category, row) }
+            )
         }
 
-        // Technical Stats Footer
         Spacer(Modifier.height(48.dp))
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -989,287 +290,167 @@ fun SettingsScreen(
                 letterSpacing = 4.sp
             )
         }
-
-        Spacer(Modifier.height(32.dp))
-    }
-
-    if (showLanguageSheet) {
-        LanguageBottomSheet(
-            // The same value the row shows, for the same reason: a checkmark against Français on a
-            // screen rendering English is the identical lie in a smaller font.
-            selectedLanguage = shownLanguage,
-            onLanguageSelected = { language ->
-                viewModel.setLanguage(language.tag)
-                showLanguageSheet = false
-            },
-            onDismiss = { showLanguageSheet = false }
-        )
-    }
-
-    if (showSupportSheet) {
-        SupportDeveloperHelper(
-            onDismiss = { showSupportSheet = false }
-        )
     }
 }
 
 /**
- * The label for each entry, the only Android-side half of [AppLanguage].
+ * What each door says about the room behind it.
  *
- * Split out so the tag list and the label list cannot drift apart: they used to be two hand-written
- * `when`/`listOf` blocks — one in the row, one in this sheet — and a language added to one but not
- * the other showed up as a row reading "System default" over a checkmark next to its own name.
+ * The point of the index is that eight rows replace 29, and eight rows that only say their own name
+ * would make that a straight loss: the user would have to open a category to find out whether the
+ * thing they came for is already on. Each summary names the state that is worth crossing a screen
+ * boundary to learn.
+ *
+ * Deliberately short of exhaustive — Appearance has six settings and reports three. The line is a
+ * reason to tap, not a substitute for tapping.
  */
-private val AppLanguage.labelRes: Int
-    @StringRes get() = when (this) {
-        AppLanguage.SystemDefault -> R.string.system_default
-        AppLanguage.English -> R.string.english
-        AppLanguage.Chinese -> R.string.chinese
-        AppLanguage.French -> R.string.french
-        AppLanguage.Spanish -> R.string.spanish
-        AppLanguage.Arabic -> R.string.arabic
-    }
-
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun LanguageBottomSheet(
-    selectedLanguage: AppLanguage,
-    onLanguageSelected: (AppLanguage) -> Unit,
-    onDismiss: () -> Unit
-) {
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = rememberBottomSheetState(
-            initialValue = SheetValue.Hidden,
-            enabledValues = setOf(
-                SheetValue.Expanded, SheetValue.Hidden
-            )
-        ),
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 48.dp)
-                .padding(horizontal = 24.dp)
-        ) {
-            Text(
-                stringResource(R.string.select_language),
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(bottom = 24.dp)
-            )
+private fun categorySummary(
+    category: SettingsCategory,
+    state: SettingsViewModel.SettingsUiState,
+    hasPrivilege: Boolean,
+    shownLanguageLabel: String,
+    versionName: String,
+    restoreInterrupted: Boolean,
+): String {
+    val prefs = state.prefs
+    val parts: List<String> = when (category) {
+        SettingsCategory.APPEARANCE -> listOf(
+            stringResource(prefs.themeMode.labelRes),
+            stringResource(prefs.appGridDensity.labelRes),
+            shownLanguageLabel
+        )
 
-            AppLanguage.PICKER_ORDER.forEach { language ->
-                val isSelected = selectedLanguage == language
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(16.dp))
-                        .background(
-                            if (isSelected) MaterialTheme.colorScheme.primaryContainer
-                            else Color.Transparent
-                        )
-                        .clickable { onLanguageSelected(language) }
-                        .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = stringResource(language.labelRes),
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                        color = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
-                        else MaterialTheme.colorScheme.onSurface
+        SettingsCategory.HOME -> listOf(
+            stringResource(
+                R.string.settings_summary_opens_on,
+                stringResource(prefs.defaultTab.toDestination().label)
+            )
+        )
+
+        SettingsCategory.FREEZER -> if (!hasPrivilege) {
+            listOf(stringResource(R.string.settings_summary_unprivileged))
+        } else {
+            buildList {
+                add(
+                    stringResource(
+                        if (prefs.autoFreezeEnabled) R.string.settings_summary_auto_freeze_on
+                        else R.string.settings_summary_auto_freeze_off
                     )
+                )
+                if (prefs.freezerMode == FreezerMode.SUSPEND) {
+                    add(stringResource(R.string.settings_summary_suspend_mode))
                 }
             }
         }
+
+        SettingsCategory.INSTALLING -> listOf(
+            stringResource(
+                if (prefs.autoReinstallEnabled) R.string.settings_summary_auto_reinstall_on
+                else R.string.settings_summary_auto_reinstall_off
+            )
+        )
+
+        SettingsCategory.SECURITY -> listOf(
+            stringResource(
+                if (prefs.biometricLockEnabled) R.string.settings_summary_app_lock_on
+                else R.string.settings_summary_app_lock_off
+            )
+        )
+
+        SettingsCategory.BACKUP -> listOf(
+            stringResource(
+                if (restoreInterrupted) R.string.settings_summary_restore_interrupted
+                else R.string.settings_summary_backup
+            )
+        )
+
+        SettingsCategory.EXTENSIONS -> listOf(stringResource(R.string.manage_extensions_desc))
+
+        SettingsCategory.ABOUT -> listOf(versionName)
     }
+    return parts.joinToString(" · ")
 }
 
+/**
+ * Search, over the catalogue rather than over the screen.
+ *
+ * Matching is on [SettingsRowId.title] and [SettingsRowId.keywords], both static. Several rows swap
+ * their subtitle at runtime — the language row names the current language, the permission rows say
+ * granted or needed, the Freezer rows say "requires privilege" when there is none — and indexing
+ * whichever sentence happens to be showing would make a row findable on one device and not another.
+ *
+ * Rows in a hidden category are not offered, because tapping one would push a door the index itself
+ * has decided not to show.
+ */
 @Composable
-private fun SettingsClickRow(
-    icon: Int,
-    title: String,
-    subtitle: String,
-    enabled: Boolean = true,
-    onClick: () -> Unit
+private fun SettingsSearchResults(
+    query: String,
+    visibleCategories: List<SettingsCategory>,
+    onOpenRow: (SettingsRowId) -> Unit,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(24.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f))
-            .clickable(enabled = enabled) { onClick() }
-            .alpha(if (enabled) 1f else 0.5f)
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        IconBox(icon)
-        Spacer(Modifier.width(16.dp))
-        Column {
-            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Text(
-                subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+    val matches = visibleCategories
+        .flatMap { SettingsRowId.rowsIn(it) }
+        .map { row -> Triple(row, stringResource(row.title), stringResource(row.keywords)) }
+        .filter { (_, title, keywords) ->
+            title.contains(query, ignoreCase = true) || keywords.contains(query, ignoreCase = true)
+        }
+
+    if (matches.isEmpty()) {
+        Text(
+            text = stringResource(R.string.settings_search_no_results, query),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(vertical = 24.dp)
+        )
+        return
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        matches.forEach { (row, title, _) ->
+            SettingsClickRow(
+                icon = row.category.icon,
+                title = title,
+                subtitle = stringResource(
+                    R.string.settings_search_result_in,
+                    stringResource(row.category.title)
+                ),
+                showChevron = true,
+                onClick = { onOpenRow(row) }
             )
         }
     }
 }
 
+/**
+ * What the detail pane shows on a wide window before a category has been picked.
+ *
+ * Public because `MainScreen` hands it to `ListDetailSceneStrategy.listPane` as the placeholder, and
+ * it belongs beside the screen it stands in for rather than among the navigation wiring.
+ */
 @Composable
-private fun SettingsSectionLabel(label: String) {
-    Text(
-        text = label,
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.primary,
-        fontWeight = FontWeight.Bold,
-        modifier = Modifier.padding(start = 8.dp, bottom = 12.dp),
-        letterSpacing = 2.sp
-    )
-}
-
-@Composable
-private fun IconBox(icon: Int) {
-    Box(
+fun SettingsDetailPlaceholder() {
+    Column(
         modifier = Modifier
-            .size(40.dp)
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.secondaryContainer),
-        contentAlignment = Alignment.Center
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
         Icon(
-            painter = painterResource(icon),
+            painter = painterResource(R.drawable.thor_mono),
             contentDescription = null,
-            modifier = Modifier.size(20.dp),
-            tint = MaterialTheme.colorScheme.primary
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
         )
-    }
-}
-
-@Composable
-private fun SettingsSwitchRow(
-    icon: Int,
-    title: String,
-    subtitle: String,
-    checked: Boolean,
-    enabled: Boolean = true,
-    enableMarqueeOnClick: Boolean = false,
-    onCheckedChange: (Boolean) -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(24.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f))
-            .clickable(enabled = enabled) { onCheckedChange(!checked) }
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
-            IconBox(icon)
-            Spacer(Modifier.width(16.dp))
-            Column {
-                Text(
-                    title,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                var startMarquee by remember { mutableStateOf(false) }
-                val textModifier = if (enableMarqueeOnClick && startMarquee) {
-                    Modifier.basicMarquee()
-                } else {
-                    Modifier
-                }
-                Text(
-                    subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = if (enableMarqueeOnClick && startMarquee) TextOverflow.Clip else TextOverflow.Ellipsis,
-                    modifier = textModifier.then(
-                        if (enableMarqueeOnClick && enabled) {
-                            Modifier.clickable { startMarquee = !startMarquee }
-                        } else {
-                            Modifier
-                        }
-                    )
-                )
-            }
-        }
-        Switch(checked = checked, onCheckedChange = onCheckedChange, enabled = enabled)
-    }
-}
-
-/**
- * The system's per-app notification settings screen — the only place a user can undo a
- * permanent POST_NOTIFICATIONS denial or re-enable app-wide notifications.
- */
-private fun appNotificationSettingsIntent(context: Context): Intent =
-    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
-        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-
-/**
- * Unwrap [LocalContext] to the hosting Activity. Compose hands out a ContextWrapper in some
- * hosts, and `shouldShowRequestPermissionRationale` needs the real Activity.
- */
-private tailrec fun Context.findActivity(): Activity? = when (this) {
-    is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> null
-}
-
-@Composable
-private fun AboutTile(
-    title: String,
-    subtitle: String,
-    icon: Int,
-    modifier: Modifier = Modifier,
-    onClick: () -> Unit
-) {
-    Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(32.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerLow)
-            .clickable { onClick() }
-            .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(RoundedCornerShape(16.dp))
-                .background(MaterialTheme.colorScheme.secondaryContainer),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                painter = painterResource(icon),
-                contentDescription = null,
-                modifier = Modifier.size(28.dp),
-                tint = MaterialTheme.colorScheme.primary
-            )
-        }
-        Column {
-            Text(
-                title,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                subtitle,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                letterSpacing = 1.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.settings_select_category),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }

--- a/app/src/main/res/drawable/arrow_back.xml
+++ b/app/src/main/res/drawable/arrow_back.xml
@@ -1,0 +1,19 @@
+<!--
+  ~ SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+<!--
+  autoMirrored, because this one points somewhere. Thor ships an Arabic locale, and a back arrow
+  that keeps pointing left in RTL points *forward*.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/app/src/main/res/drawable/chevron_right.xml
+++ b/app/src/main/res/drawable/chevron_right.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+<!-- autoMirrored for the same reason as arrow_back: "there is more this way" flips in RTL. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z" />
+</vector>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -10,7 +10,6 @@
     <string name="settings">الإعدادات</string>
     <string name="settings_desc">صفحة الإعدادات لتغيير إعدادات التطبيق</string>
     <string name="config_engine_v">محرك التكوين • إصدار %1$s</string>
-    <string name="general">عام</string>
     <string name="show_reinstall_card">إظهار بطاقة إعادة التثبيت</string>
     <string name="show_reinstall_card_desc">إظهار تذكير إصلاح المتجر على الشاشة الرئيسية</string>
     <string name="show_installer_tile">إظهار مربع المثبِّت</string>
@@ -22,21 +21,17 @@
     <string name="show_extensions_tile_desc">إظهار الإضافات على الشاشة الرئيسية</string>
     <string name="default_tab">علامة التبويب الافتراضية</string>
     <string name="default_tab_desc">الشاشة التي يفتحها Thor عند التشغيل</string>
-    <string name="appearance">المظهر</string>
     <string name="theme">المظهر</string>
     <string name="theme_desc">نمط الواجهة المرئية</string>
     <string name="amoled_mode">وضع AMOLED</string>
     <string name="amoled_desc">خلفية سوداء نقية</string>
     <string name="dynamic_colors">ألوان ديناميكية</string>
     <string name="dynamic_colors_desc">تكامل Material You</string>
-    <string name="security">الأمان</string>
     <string name="biometric_lock">قفل القياسات الحيوية</string>
     <string name="biometric_lock_desc">يتطلب المصادقة عند التشغيل</string>
     <string name="biometric_not_available">المقاييس الحيوية غير مسجلة أو غير متوفرة</string>
-    <string name="work_mode">وضع العمل</string>
     <string name="active_engine">المحرك النشط</string>
     <string name="active_engine_desc">التبديل بين الموفرين المتاحين</string>
-    <string name="about">حول</string>
     <string name="version">الإصدار</string>
     <string name="release_candidate">نسخة مرشحة</string>
     <string name="source_code">كود المصدر</string>
@@ -571,7 +566,6 @@
     <string name="failed_to_load_permissions">فشل تحميل الأذونات</string>
     <string name="permission_status_updated">تم تحديث حالة الإذن</string>
     <string name="failed_to_modify_permission">فشل تعديل الإذن</string>
-    <string name="permissions">الأذونات</string>
     <string name="usage_access">الوصول إلى بيانات الاستخدام</string>
     <string name="usage_access_granted_subtitle">تم المنح — يتيح فرز التطبيقات حسب الحجم</string>
     <string name="usage_access_needed_subtitle">مطلوب لقراءة أحجام التطبيقات للفرز حسب الحجم</string>
@@ -691,5 +685,34 @@
     <string name="export_list_failed">تعذّر حفظ القائمة</string>
     <string name="clear_all_caches_requires_usage_access">لا يستطيع Shizuku مسح ذاكرة التخزين المؤقت لكل التطبيقات بدون إذن الوصول إلى الاستخدام. يجب إخبار Android بعدد البايتات المطلوب تحريرها، وهذا الإذن وحده هو ما يمكنه قياس حجم ذاكرة التخزين المؤقت. امنح Thor إذن الوصول إلى الاستخدام من الإعدادات ثم أعد المحاولة.</string>
     <string name="clear_all_caches_unsupported_dhizuku">لا يستطيع Dhizuku مسح ذاكرة التخزين المؤقت. ليست لديه صدفة (shell) لتشغيل أداة تقليص ذاكرة التخزين المؤقت في Android، ولا تتضمن واجهة مالك الجهاز أي بديل لها. بدّل إلى وضع Root أو Shizuku.</string>
+
+    <!-- شاشة الإعدادات المقسّمة إلى فئات — راجع values/strings_settings.xml -->
+    <string name="settings_category_appearance">المظهر</string>
+    <string name="settings_category_home">الشاشة الرئيسية</string>
+    <string name="settings_category_installing">التثبيت والمشاركة</string>
+    <string name="settings_category_security">الأمان</string>
+    <string name="settings_category_about">حول التطبيق والدعم</string>
+    <string name="settings_search_hint">ابحث في الإعدادات…</string>
+    <string name="settings_search_no_results">لا يوجد إعداد يطابق ”%1$s“.</string>
+    <string name="settings_search_result_in">في %1$s</string>
+    <string name="cd_settings_search_clear">مسح البحث</string>
+    <string name="cd_back">رجوع</string>
+    <string name="settings_select_category">اختر فئة لعرض إعداداتها</string>
+    <string name="settings_engine_none">لا يوجد</string>
+    <string name="app_language_desc">لغة شاشات Thor نفسها</string>
+    <string name="theme_light">فاتح</string>
+    <string name="theme_dark">داكن</string>
+    <string name="theme_system">النظام</string>
+    <string name="settings_summary_opens_on">يفتح على %1$s</string>
+    <string name="settings_summary_auto_freeze_on">التجميد التلقائي مفعّل</string>
+    <string name="settings_summary_auto_freeze_off">التجميد التلقائي معطّل</string>
+    <string name="settings_summary_suspend_mode">وضع التعليق</string>
+    <string name="settings_summary_auto_reinstall_on">إعادة التثبيت التلقائية مفعّلة</string>
+    <string name="settings_summary_auto_reinstall_off">إعادة التثبيت التلقائية معطّلة</string>
+    <string name="settings_summary_app_lock_on">قفل التطبيق مفعّل</string>
+    <string name="settings_summary_app_lock_off">قفل التطبيق معطّل</string>
+    <string name="settings_summary_restore_interrupted">لم تكتمل إحدى عمليات الاستعادة</string>
+    <string name="settings_summary_backup">استعادة أرشيف أو تغيير عبارة المرور</string>
+    <string name="settings_summary_unprivileged">يتطلب Root أو Shizuku أو Dhizuku</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -10,7 +10,6 @@
     <string name="settings">Ajustes</string>
     <string name="settings_desc">Página de ajustes para cambiar las opciones de la aplicación</string>
     <string name="config_engine_v">Motor de configuración • v%1$s</string>
-    <string name="general">GENERAL</string>
     <string name="show_reinstall_card">Mostrar tarjeta de reinstalación</string>
     <string name="show_reinstall_card_desc">Mostrar recordatorio de Fix Store en la pantalla de inicio</string>
     <string name="show_installer_tile">Mostrar mosaico del instalador</string>
@@ -22,21 +21,17 @@
     <string name="show_extensions_tile_desc">Mostrar Extensiones en la pantalla de inicio</string>
     <string name="default_tab">Pestaña predeterminada</string>
     <string name="default_tab_desc">La pantalla que abre Thor al iniciarse</string>
-    <string name="appearance">APARIENCIA</string>
     <string name="theme">Tema</string>
     <string name="theme_desc">Estilo de interfaz visual</string>
     <string name="amoled_mode">Modo AMOLED</string>
     <string name="amoled_desc">Fondo negro puro</string>
     <string name="dynamic_colors">Colores dinámicos</string>
     <string name="dynamic_colors_desc">Integración con Material You</string>
-    <string name="security">SEGURIDAD</string>
     <string name="biometric_lock">Bloqueo biométrico</string>
     <string name="biometric_lock_desc">Requerir autenticación al iniciar</string>
     <string name="biometric_not_available">Biometría no registrada o disponible</string>
-    <string name="work_mode">MODO DE TRABAJO</string>
     <string name="active_engine">Motor activo</string>
     <string name="active_engine_desc">Cambiar entre proveedores disponibles</string>
-    <string name="about">ACERCA DE</string>
     <string name="version">Versión</string>
     <string name="release_candidate">Versión candidata</string>
     <string name="source_code">CÓDIGO FUENTE</string>
@@ -533,7 +528,6 @@
     <string name="failed_to_load_permissions">Error al cargar los permisos</string>
     <string name="permission_status_updated">Estado de permiso actualizado</string>
     <string name="failed_to_modify_permission">Error al modificar el permiso</string>
-    <string name="permissions">PERMISOS</string>
     <string name="usage_access">Acceso de uso</string>
     <string name="usage_access_granted_subtitle">Concedido — permite ordenar por tamaño de app</string>
     <string name="usage_access_needed_subtitle">Necesario para leer el tamaño de las apps al ordenar por tamaño</string>
@@ -640,5 +634,34 @@
     <string name="export_list_failed">No se pudo guardar la lista</string>
     <string name="clear_all_caches_requires_usage_access">Shizuku no puede borrar la caché de todas las apps sin acceso de uso. Hay que indicarle a Android cuántos bytes debe liberar, y solo ese permiso puede medir cuánta caché hay. Concede a Thor el acceso de uso en Ajustes e inténtalo de nuevo.</string>
     <string name="clear_all_caches_unsupported_dhizuku">Dhizuku no puede borrar cachés. No tiene una shell en la que ejecutar la limpieza de caché de Android, y la API de propietario del dispositivo no ofrece nada equivalente. Cambia a Root o a Shizuku.</string>
+
+    <!-- Pantalla de ajustes por categorías — véase values/strings_settings.xml -->
+    <string name="settings_category_appearance">Apariencia</string>
+    <string name="settings_category_home">Pantalla de inicio</string>
+    <string name="settings_category_installing">Instalación y uso compartido</string>
+    <string name="settings_category_security">Seguridad</string>
+    <string name="settings_category_about">Acerca de y apoyo</string>
+    <string name="settings_search_hint">Buscar en los ajustes…</string>
+    <string name="settings_search_no_results">Ningún ajuste coincide con «%1$s».</string>
+    <string name="settings_search_result_in">en %1$s</string>
+    <string name="cd_settings_search_clear">Borrar la búsqueda</string>
+    <string name="cd_back">Atrás</string>
+    <string name="settings_select_category">Elige una categoría para ver sus ajustes</string>
+    <string name="settings_engine_none">Ninguno</string>
+    <string name="app_language_desc">El idioma de las pantallas de Thor</string>
+    <string name="theme_light">Claro</string>
+    <string name="theme_dark">Oscuro</string>
+    <string name="theme_system">Sistema</string>
+    <string name="settings_summary_opens_on">Se abre en %1$s</string>
+    <string name="settings_summary_auto_freeze_on">Congelación automática activada</string>
+    <string name="settings_summary_auto_freeze_off">Congelación automática desactivada</string>
+    <string name="settings_summary_suspend_mode">Modo de suspensión</string>
+    <string name="settings_summary_auto_reinstall_on">Reinstalación automática activada</string>
+    <string name="settings_summary_auto_reinstall_off">Reinstalación automática desactivada</string>
+    <string name="settings_summary_app_lock_on">Bloqueo activado</string>
+    <string name="settings_summary_app_lock_off">Bloqueo desactivado</string>
+    <string name="settings_summary_restore_interrupted">Una restauración no terminó</string>
+    <string name="settings_summary_backup">Restaurar un archivo o cambiar la frase de contraseña</string>
+    <string name="settings_summary_unprivileged">Requiere Root, Shizuku o Dhizuku</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -10,7 +10,6 @@
     <string name="settings">Paramètres</string>
     <string name="settings_desc">Page de paramètres pour modifier les options de l\'application</string>
     <string name="config_engine_v">Moteur de configuration • v%1$s</string>
-    <string name="general">GÉNÉRAL</string>
     <string name="show_reinstall_card">Afficher la carte de réinstallation</string>
     <string name="show_reinstall_card_desc">Afficher le rappel Fix Store sur l\'écran d\'accueil</string>
     <string name="show_installer_tile">Afficher la tuile d\'installation</string>
@@ -22,21 +21,17 @@
     <string name="show_extensions_tile_desc">Afficher les extensions sur l\'écran d\'accueil</string>
     <string name="default_tab">Onglet par défaut</string>
     <string name="default_tab_desc">L\'écran que Thor ouvre au lancement</string>
-    <string name="appearance">APPARENCE</string>
     <string name="theme">Thème</string>
     <string name="theme_desc">Style d\'interface visuelle</string>
     <string name="amoled_mode">Mode AMOLED</string>
     <string name="amoled_desc">Arrière-plan noir pur</string>
     <string name="dynamic_colors">Couleurs dynamiques</string>
     <string name="dynamic_colors_desc">Intégration Material You</string>
-    <string name="security">SÉCURITÉ</string>
     <string name="biometric_lock">Verrouillage biométrique</string>
     <string name="biometric_lock_desc">Exiger une authentification au lancement</string>
     <string name="biometric_not_available">Biométrie non enregistrée ou indisponible</string>
-    <string name="work_mode">MODE DE TRAVAIL</string>
     <string name="active_engine">Moteur actif</string>
     <string name="active_engine_desc">Passer d\'un fournisseur à l\'autre</string>
-    <string name="about">À PROPOS</string>
     <string name="version">Version</string>
     <string name="release_candidate">Version candidate</string>
     <string name="source_code">CODE SOURCE</string>
@@ -533,7 +528,6 @@
     <string name="failed_to_load_permissions">Échec du chargement des autorisations</string>
     <string name="permission_status_updated">Statut de l\'autorisation mis à jour</string>
     <string name="failed_to_modify_permission">Échec de la modification de l\'autorisation</string>
-    <string name="permissions">AUTORISATIONS</string>
     <string name="usage_access">Accès aux données d\'utilisation</string>
     <string name="usage_access_granted_subtitle">Accordé — permet le tri par taille d\'application</string>
     <string name="usage_access_needed_subtitle">Nécessaire pour lire la taille des applications pour le tri par Taille</string>
@@ -640,5 +634,34 @@
     <string name="export_list_failed">Impossible d\'enregistrer la liste</string>
     <string name="clear_all_caches_requires_usage_access">Shizuku ne peut pas vider le cache de toutes les applications sans l\'accès aux données d\'utilisation. Android doit savoir combien d\'octets libérer, et seule cette autorisation permet de mesurer la taille du cache. Accordez l\'accès aux données d\'utilisation à Thor dans les Paramètres, puis réessayez.</string>
     <string name="clear_all_caches_unsupported_dhizuku">Dhizuku ne peut pas vider les caches. Il n\'a pas de shell pour exécuter le nettoyage de cache d\'Android, et l\'API propriétaire de l\'appareil n\'offre aucun équivalent. Passez en mode Root ou Shizuku.</string>
+
+    <!-- Écran de paramètres par catégories — voir values/strings_settings.xml -->
+    <string name="settings_category_appearance">Apparence</string>
+    <string name="settings_category_home">Écran d\'accueil</string>
+    <string name="settings_category_installing">Installation et partage</string>
+    <string name="settings_category_security">Sécurité</string>
+    <string name="settings_category_about">À propos et soutien</string>
+    <string name="settings_search_hint">Rechercher dans les paramètres…</string>
+    <string name="settings_search_no_results">Aucun paramètre ne correspond à « %1$s ».</string>
+    <string name="settings_search_result_in">dans %1$s</string>
+    <string name="cd_settings_search_clear">Effacer la recherche</string>
+    <string name="cd_back">Retour</string>
+    <string name="settings_select_category">Choisissez une catégorie pour voir ses paramètres</string>
+    <string name="settings_engine_none">Aucun</string>
+    <string name="app_language_desc">La langue des écrans de Thor</string>
+    <string name="theme_light">Clair</string>
+    <string name="theme_dark">Sombre</string>
+    <string name="theme_system">Système</string>
+    <string name="settings_summary_opens_on">Ouvre sur %1$s</string>
+    <string name="settings_summary_auto_freeze_on">Gel automatique activé</string>
+    <string name="settings_summary_auto_freeze_off">Gel automatique désactivé</string>
+    <string name="settings_summary_suspend_mode">Mode suspension</string>
+    <string name="settings_summary_auto_reinstall_on">Réinstallation automatique activée</string>
+    <string name="settings_summary_auto_reinstall_off">Réinstallation automatique désactivée</string>
+    <string name="settings_summary_app_lock_on">Verrouillage activé</string>
+    <string name="settings_summary_app_lock_off">Verrouillage désactivé</string>
+    <string name="settings_summary_restore_interrupted">Une restauration ne s\'est pas terminée</string>
+    <string name="settings_summary_backup">Restaurer une archive ou changer la phrase secrète</string>
+    <string name="settings_summary_unprivileged">Nécessite Root, Shizuku ou Dhizuku</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -9,7 +9,6 @@
     <string name="settings">设置</string>
     <string name="settings_desc">设置页面以更改应用设置</string>
     <string name="config_engine_v">配置引擎 • v%1$s</string>
-    <string name="general">通用</string>
     <string name="show_reinstall_card">显示重新安装卡片</string>
     <string name="show_reinstall_card_desc">在主屏幕上显示修复商店提醒</string>
     <string name="show_installer_tile">显示安装器磁贴</string>
@@ -21,21 +20,17 @@
     <string name="show_extensions_tile_desc">在主屏幕上显示扩展</string>
     <string name="default_tab">默认标签页</string>
     <string name="default_tab_desc">Thor 启动时打开的页面</string>
-    <string name="appearance">外观</string>
     <string name="theme">主题</string>
     <string name="theme_desc">视觉界面风格</string>
     <string name="amoled_mode">AMOLED 模式</string>
     <string name="amoled_desc">纯黑背景</string>
     <string name="dynamic_colors">动态色彩</string>
     <string name="dynamic_colors_desc">Material You 集成</string>
-    <string name="security">安全</string>
     <string name="biometric_lock">生物识别锁定</string>
     <string name="biometric_lock_desc">启动时需要验证</string>
     <string name="biometric_not_available">生物识别未注册或不可用</string>
-    <string name="work_mode">工作模式</string>
     <string name="active_engine">活动引擎</string>
     <string name="active_engine_desc">在可用提供者之间切换</string>
-    <string name="about">关于</string>
     <string name="version">版本</string>
     <string name="release_candidate">发布候选版</string>
     <string name="source_code">源代码</string>
@@ -524,7 +519,6 @@
     <string name="failed_to_load_permissions">加载权限失败</string>
     <string name="permission_status_updated">权限状态已更新</string>
     <string name="failed_to_modify_permission">修改权限失败</string>
-    <string name="permissions">权限</string>
     <string name="usage_access">使用情况访问权限</string>
     <string name="usage_access_granted_subtitle">已授予 — 启用应用大小排序</string>
     <string name="usage_access_needed_subtitle">读取应用大小以进行按大小排序所需</string>
@@ -628,5 +622,34 @@
     <string name="export_list_failed">无法保存列表</string>
     <string name="clear_all_caches_requires_usage_access">没有「使用情况访问权限」，Shizuku 无法清除所有应用的缓存。必须告诉 Android 需要释放多少字节，而只有该权限才能测量缓存的大小。请在系统设置中授予 Thor 使用情况访问权限后重试。</string>
     <string name="clear_all_caches_unsupported_dhizuku">Dhizuku 无法清除缓存。它没有可用于执行 Android 缓存清理的 shell，设备所有者 API 也没有对应的接口。请切换到 Root 或 Shizuku 模式。</string>
+
+    <!-- 分类式设置页面 — 参见 values/strings_settings.xml -->
+    <string name="settings_category_appearance">外观</string>
+    <string name="settings_category_home">主屏幕</string>
+    <string name="settings_category_installing">安装与分享</string>
+    <string name="settings_category_security">安全</string>
+    <string name="settings_category_about">关于与支持</string>
+    <string name="settings_search_hint">搜索设置…</string>
+    <string name="settings_search_no_results">没有与“%1$s”匹配的设置。</string>
+    <string name="settings_search_result_in">位于 %1$s</string>
+    <string name="cd_settings_search_clear">清除搜索</string>
+    <string name="cd_back">返回</string>
+    <string name="settings_select_category">选择一个类别以查看其设置</string>
+    <string name="settings_engine_none">无</string>
+    <string name="app_language_desc">Thor 自身界面使用的语言</string>
+    <string name="theme_light">浅色</string>
+    <string name="theme_dark">深色</string>
+    <string name="theme_system">跟随系统</string>
+    <string name="settings_summary_opens_on">启动时打开%1$s</string>
+    <string name="settings_summary_auto_freeze_on">自动冻结已开启</string>
+    <string name="settings_summary_auto_freeze_off">自动冻结已关闭</string>
+    <string name="settings_summary_suspend_mode">暂停模式</string>
+    <string name="settings_summary_auto_reinstall_on">自动重新安装已开启</string>
+    <string name="settings_summary_auto_reinstall_off">自动重新安装已关闭</string>
+    <string name="settings_summary_app_lock_on">应用锁已开启</string>
+    <string name="settings_summary_app_lock_off">应用锁已关闭</string>
+    <string name="settings_summary_restore_interrupted">有一次恢复未完成</string>
+    <string name="settings_summary_backup">恢复存档，或更改密码短语</string>
+    <string name="settings_summary_unprivileged">需要 Root、Shizuku 或 Dhizuku</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,13 @@
     <string name="settings">Settings</string>
     <string name="settings_desc">Settings Page to change app settings</string>
     <string name="config_engine_v">Configuration Engine • v%1$s</string>
-    <string name="general">GENERAL</string>
+    <!--
+      The SCREAMING CASE section labels that used to head the ten groups of the one-column settings
+      screen — general, appearance, security, work_mode, about, permissions — are gone with it.
+      Settings is eight category rows now, titled in Title Case in strings_settings.xml; the
+      remaining sections whose names survived (freezer, extensions, backup_and_restore) are reused
+      as those titles rather than duplicated.
+    -->
     <string name="show_reinstall_card">Show Reinstall Card</string>
     <string name="show_reinstall_card_desc">Show Fix Store reminder on home screen</string>
     <string name="show_installer_tile">Show Installer Tile</string>
@@ -25,21 +31,17 @@
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Default Tab</string>
     <string name="default_tab_desc">The screen Thor opens on at launch</string>
-    <string name="appearance">APPEARANCE</string>
     <string name="theme">Theme</string>
     <string name="theme_desc">Visual interface style</string>
     <string name="amoled_mode">AMOLED Mode</string>
     <string name="amoled_desc">Pure black background</string>
     <string name="dynamic_colors">Dynamic Colors</string>
     <string name="dynamic_colors_desc">Material You integration</string>
-    <string name="security">SECURITY</string>
     <string name="biometric_lock">Biometric Lock</string>
     <string name="biometric_lock_desc">Require auth on launch</string>
     <string name="biometric_not_available">Biometrics not enrolled or available</string>
-    <string name="work_mode">WORK MODE</string>
     <string name="active_engine">Active Engine</string>
     <string name="active_engine_desc">Switch between available providers</string>
-    <string name="about">ABOUT</string>
     <string name="version">Version</string>
     <string name="release_candidate">Release candidate</string>
     <string name="source_code">SOURCE CODE</string>
@@ -276,7 +278,9 @@
     <string name="failed_to_modify_permission">Failed to modify permission</string>
 
     <!-- Usage Access / Size sort -->
-    <string name="permissions">PERMISSIONS</string>
+    <!-- `permissions` (the PERMISSIONS section header) removed with the one-column settings screen;
+         those two rows are in the Security category now. -->
+
     <string name="usage_access">Usage Access</string>
     <string name="usage_access_granted_subtitle">Granted — enables app-size sorting</string>
     <string name="usage_access_needed_subtitle">Needed to read app sizes for the Size sort</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+<resources>
+
+    <!-- ── The eight categories ──────────────────────────────────────────────────────────────
+         Title Case, unlike the SCREAMING CASE section labels they replace: these are screen
+         titles and index rows now, not the small all-caps rubric above a group. `freezer`,
+         `extensions` and `backup_and_restore` are already Title Case and are reused as they are. -->
+    <string name="settings_category_appearance">Appearance</string>
+    <string name="settings_category_home">Home screen</string>
+    <string name="settings_category_installing">Installing &amp; sharing</string>
+    <string name="settings_category_security">Security</string>
+    <string name="settings_category_about">About &amp; support</string>
+
+    <!-- ── Index chrome ──────────────────────────────────────────────────────────────────── -->
+    <string name="settings_search_hint">Search settings…</string>
+    <string name="settings_search_no_results">Nothing in Settings matches “%1$s”.</string>
+    <string name="settings_search_result_in">in %1$s</string>
+    <string name="cd_settings_search_clear">Clear search</string>
+    <string name="cd_back">Back</string>
+
+    <!--
+      The empty right-hand pane on a tablet or an unfolded foldable, before a category is picked.
+      Never shown on a phone, where the index occupies the whole window and opening a category
+      replaces it.
+    -->
+    <string name="settings_select_category">Pick a category to see its settings</string>
+
+    <!--
+      The privilege picker's label for PrivilegeMode.NONE. Present for exhaustiveness only — the
+      picker is built from the engines that probed available, so NONE is never one of its buttons.
+      Worth a real string rather than an empty one: if it ever does render, "None" is a state a
+      user can act on and `mode.name` is not.
+    -->
+    <string name="settings_engine_none">None</string>
+
+    <!--
+      The language row's description. It had none: the row's subtitle was the *current language*,
+      which is the value, not what the setting does — so the row was the one entry in Settings that
+      could not say what it was for, and search had nothing static to index it by.
+    -->
+    <string name="app_language_desc">The language Thor\'s own screens use</string>
+
+    <!--
+      Theme option labels. These were `ThemeMode.label()` returning hardcoded "Light"/"Dark"/
+      "System" from a domain enum — English in all five locales, on the setting users flip most.
+    -->
+    <string name="theme_light">Light</string>
+    <string name="theme_dark">Dark</string>
+    <string name="theme_system">System</string>
+
+    <!-- ── Index summary lines ───────────────────────────────────────────────────────────────
+         Each index row carries a line describing the state behind it, so that the door does not
+         have to be opened to see what is through it. Joined with a middle dot by the caller. -->
+    <string name="settings_summary_opens_on">Opens on %1$s</string>
+    <string name="settings_summary_auto_freeze_on">Auto-freeze on</string>
+    <string name="settings_summary_auto_freeze_off">Auto-freeze off</string>
+    <string name="settings_summary_suspend_mode">Suspend mode</string>
+    <string name="settings_summary_auto_reinstall_on">Auto-reinstall on</string>
+    <string name="settings_summary_auto_reinstall_off">Auto-reinstall off</string>
+    <string name="settings_summary_app_lock_on">App lock on</string>
+    <string name="settings_summary_app_lock_off">App lock off</string>
+    <string name="settings_summary_restore_interrupted">A restore did not finish</string>
+    <string name="settings_summary_backup">Restore an archive, or change the passphrase</string>
+    <string name="settings_summary_unprivileged">Needs root, Shizuku or Dhizuku</string>
+
+</resources>

--- a/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsCatalogTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsCatalogTest.kt
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings
+
+import com.valhalla.thor.presentation.navigation.ThorRoute
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The invariants of the eight doors that the compiler does not already enforce.
+ *
+ * Most of the split's safety is a build gate rather than a test: `SettingsCategoryScreen`'s single
+ * `when (row)` is exhaustive over [SettingsRowId], so a setting added to the catalogue and never
+ * drawn is a compile error. That gate runs in one direction only — it proves every *row* reaches a
+ * branch, and says nothing about whether every *category* reaches a row, whether two categories
+ * claim the same route id, or whether a row survives the round trip through
+ * [ThorRoute.SettingsCategory]. Those are the three ways this file can be wrong while still
+ * compiling, and they are what is asserted here.
+ *
+ * What this cannot reach, stated plainly: nothing here renders anything. That the index draws all
+ * eight categories, that the detail pane resolves against the same scene key as the list pane, and
+ * that a focused row is actually scrolled to are Compose behaviour with no JVM seam — a mismatched
+ * scene key produces a silently blank pane that neither this test nor lint can see.
+ */
+class SettingsCatalogTest {
+
+    /**
+     * Every door opens onto something.
+     *
+     * The exhaustive `when` cannot catch this: it fails when a row has no branch, not when a
+     * category has no rows. Moving the last row out of a category — which is a one-line edit inside
+     * [SettingsRowId] and looks like a reordering — leaves a full-width row on the index, with an
+     * icon and a summary line, that opens an empty scrolling list.
+     */
+    @Test
+    fun everyCategoryHasAtLeastOneRow() {
+        for (category in SettingsCategory.entries) {
+            assertTrue(
+                "$category is drawn on the index but has no rows behind it",
+                SettingsRowId.rowsIn(category).isNotEmpty()
+            )
+        }
+    }
+
+    /**
+     * Each row belongs to exactly one category, and the eight lists together are the whole enum.
+     *
+     * `groupBy` gives this for free today. It is pinned because the grouping is a cache — the KDoc
+     * on `byCategory` invites replacing it — and a filter written by hand can drop a row or repeat
+     * one, which shows up as a setting that exists, compiles, has a branch, and is on no screen.
+     */
+    @Test
+    fun theEightCategoriesPartitionEveryRow() {
+        val drawn = SettingsCategory.entries.flatMap { SettingsRowId.rowsIn(it) }
+        assertEquals(
+            "a row is drawn twice or not at all",
+            SettingsRowId.entries.size,
+            drawn.size
+        )
+        assertEquals("a row is drawn under two categories", drawn.size, drawn.distinct().size)
+        assertEquals(SettingsRowId.entries.toSet(), drawn.toSet())
+    }
+
+    /**
+     * A category's rows come out in the order they were declared.
+     *
+     * The enum's own layout is the source of truth for the order settings appear in — there is no
+     * separate ordering field to keep in step, which is deliberate — so an implementation of
+     * [SettingsRowId.rowsIn] that sorts, or that groups into an unordered map, silently reshuffles
+     * every category the day it lands.
+     */
+    @Test
+    fun rowsComeOutInDeclarationOrder() {
+        for (category in SettingsCategory.entries) {
+            assertEquals(
+                "$category rows are out of declaration order",
+                SettingsRowId.entries.filter { it.category == category },
+                SettingsRowId.rowsIn(category)
+            )
+        }
+    }
+
+    /**
+     * No two categories answer to the same route id.
+     *
+     * [SettingsCategory.fromId] takes the *first* match, so a duplicated id does not throw or fail
+     * to compile — it makes one category permanently unreachable, and its index row opens the other
+     * one's settings. Copy-pasting an entry is the obvious way in.
+     */
+    @Test
+    fun categoryIdsAreUniqueAndNotBlank() {
+        val ids = SettingsCategory.entries.map { it.id }
+        assertEquals("two categories share a route id", ids.size, ids.distinct().size)
+        for (id in ids) {
+            assertTrue("a category has a blank route id", id.isNotBlank())
+            assertEquals("a route id carries whitespace: '$id'", id.trim(), id)
+        }
+    }
+
+    /** Every category is reachable by the id it publishes. */
+    @Test
+    fun everyCategoryRoundTripsThroughItsId() {
+        for (category in SettingsCategory.entries) {
+            assertEquals(category, SettingsCategory.fromId(category.id))
+        }
+    }
+
+    /**
+     * An id no build understands resolves to null rather than to a neighbour.
+     *
+     * This is the restored-back-stack path, and the reason the route carries a string instead of an
+     * ordinal: `rememberNavBackStack` is persisted for task restoration and survives an app update,
+     * so a stack saved by yesterday's build can name a category today's build removed or renamed.
+     * Null is what makes the entry pop itself; an ordinal would resolve, quietly, to whichever
+     * category now sits at that position.
+     */
+    @Test
+    fun anUnknownIdResolvesToNothing() {
+        assertNull(SettingsCategory.fromId("privacy"))
+        assertNull(SettingsCategory.fromId(""))
+        assertNull(SettingsCategory.fromId("APPEARANCE"))
+        assertNull(SettingsCategory.fromId(" about "))
+    }
+
+    /**
+     * The focus argument survives the trip out to the route and back.
+     *
+     * Search results and the interrupted-restore banner deep-link to a single row by putting
+     * `SettingsRowId.name` into [ThorRoute.SettingsCategory.focus]; `MainScreen` reads it back with
+     * a name lookup over `entries`. The two halves are written in different files and neither
+     * mentions the other, so this pins the contract between them — including that the row named
+     * really does live in the category the same route asks for, which is what makes the scroll
+     * find it.
+     */
+    @Test
+    fun everyRowRoundTripsThroughTheRouteAsAFocusTarget() {
+        for (row in SettingsRowId.entries) {
+            val route = ThorRoute.SettingsCategory(row.category.id, row.name)
+            val category = SettingsCategory.fromId(route.id)
+            assertEquals(row.category, category)
+
+            val focused = route.focus?.let { name ->
+                SettingsRowId.entries.firstOrNull { it.name == name }
+            }
+            assertEquals(row, focused)
+            assertNotNull(category)
+            assertTrue(
+                "${row.name} is focusable but is not drawn in ${row.category}",
+                SettingsRowId.rowsIn(category!!).contains(row)
+            )
+        }
+    }
+
+    /**
+     * A focus name from an older build is dropped, and the category still opens.
+     *
+     * The same persistence that can name a missing category can name a missing row. Failing to
+     * resolve the focus must cost the highlight and nothing else — the route's id half is still
+     * good, so refusing to open the category here would turn a cosmetic staleness into a screen the
+     * user cannot reach.
+     */
+    @Test
+    fun anUnknownFocusNameDoesNotTakeTheCategoryWithIt() {
+        val route = ThorRoute.SettingsCategory(SettingsCategory.ABOUT.id, "TELEMETRY")
+        assertEquals(SettingsCategory.ABOUT, SettingsCategory.fromId(route.id))
+        assertNull(SettingsRowId.entries.firstOrNull { it.name == route.focus })
+    }
+
+    /** Opening a category with no row in mind is the ordinary case, and carries no focus. */
+    @Test
+    fun aCategoryOpenedFromTheIndexHasNoFocus() {
+        assertNull(ThorRoute.SettingsCategory(SettingsCategory.FREEZER.id).focus)
+    }
+}


### PR DESCRIPTION
Settings was one `Column(verticalScroll)` holding 29 rows under 10 hand-written section headers — 1275 lines, and the last two rows had been added with a `koinInject` in the middle of the layout. This is options **C** and **D** from the previews, plus the two-line subtitles.

## What changed

**C — eight doors.** `SettingsCatalog.kt` declares eight categories and, per row, which category it belongs to. `SettingsCategoryScreen`'s single `when (row)` is exhaustive over `SettingsRowId`, so **a setting added to the catalogue and never drawn is a compile error**. That is the gate the old screen never had. The index is fixed at eight entries; the number of settings is not.

Depth stops at two. The index has a search field matching titles and static descriptions, deep-linking to the row and briefly highlighting it on arrival — so categories are a way to browse, not a maze to memorise. Each index row carries a summary line derived from live state.

**D — two panes.** On a wide window the category opens *beside* the index via `ListDetailSceneStrategy`, and the index shows which one is open. Opening a second category **replaces** rather than stacks, so Back means "leave Settings" on a tablet and "go up" on a phone without either needing to know which it is.

**Two-line subtitles.** Asgard's row already supported it; the descriptions were clipped at one line, which is why several were written as fragments that stop before the useful half.

## Three things that were wrong, not merely long

- **The route carries a string id**, not the enum and not its ordinal. `rememberNavBackStack` is persisted for task restoration and survives an app update, so a restored stack can name a category this build no longer has. Unknown id → null → the entry pops itself. An ordinal would have silently opened a *different* category the day the enum was reordered.
- **`ThemeMode.label()` returned `"Light"`/`"Dark"`/`"System"` as Kotlin literals** — a domain enum answering a question only the UI asks, in English, on all five locales, for the setting users change most. Deleted; every closed-set label now has a string resource. The privilege picker was worse: it rendered `mode.name`, so the segmented control read `ROOT / SHIZUKU / DHIZUKU` while `install_mode_root` and its two siblings had existed for the installer sheet all along.
- **`ANIMATION_INTENSITY`** had a section header duplicating its own row title; it is now an ordinary Appearance row. **`UNFREEZE_ALL`** is marked destructive and drops its chevron — it is an action, not a door.

## Review fixes (`3bf14f45`)

CodeRabbit found three, all real:

- **Back stack leak.** `ExtensionManager` is *itself* a `detailPane`, so on a wide window the index stays visible beside it — the user can pick a second category while the top of the stack is not a `SettingsCategory`, and the replace-guard fell through to `add`. Now truncates to the index.
- **Two dead switch rows.** Usage Access and Notification Access both guarded on the permission being *absent*, so once granted the switch bounced back and nothing opened. Both deep-link in either direction now.
- **The row was unreadable to a screen reader.** `clickable` + a `Switch` with cleared semantics meant nothing carried the on/off state. Now `toggleable(role = Role.Switch)` with a null handler on the Switch.

## Verification

| Gate | Result |
|---|---|
| `:app:compileFossDebugKotlin` + `:app:compileStoreDebugKotlin` | ✅ both flavours |
| `:app:lintFossDebug` | ✅ **0 errors, 0 warnings** (from 33 errors) |
| `:app:testFossDebugUnitTest --rerun-tasks` | ✅ **1523 tests, 0 failures** — counts parsed from `test-results/**/*.xml` |
| `:app:connectedFossDebugAndroidTest` (`SettingsSwitchRowTest`) | ✅ **7 tests, 0 failures** — Pixel 10 Pro Fold AVD, API 37 |
| Hand-driven on the same fold, 851 dp and 411 dp | ✅ see below |

`SettingsCatalogTest` (9 unit tests) pins what the exhaustive `when` cannot: no empty categories, no duplicate route ids, declaration order preserved, every row round-tripping through the route as a focus target. `SettingsSwitchRowTest` (7 instrumented) pins the role, the state, the single-control invariant and the report-the-requested-value contract that the two dead rows depended on.

**Device-checked by hand** (details in the thread): two panes populate correctly at 851 dp with the index row highlighted; the placeholder renders before a selection and is correctly absent at 411 dp; the search deep-link scrolls to the row and lights it; and both review fixes were reproduced broken and then confirmed fixed on hardware — including toggling a *granted* Usage Access, which now opens the system revoke screen.

## Please read before merging

- **The 27 new strings' fr / es / ar / zh-rCN translations are machine-quality and want a native reader.** They are here so `MissingTranslation` stays a real gate rather than a `lint.xml` override — not because I can vouch for the register. Arabic especially, and the two-pane layout is new so an RTL pass is worth doing.
- **One emulator, one API level (37), `foss` only.** No physical-device pass; `store` is compile-verified only.
- **Six strings were deleted** from five files: `general`, `appearance`, `security`, `work_mode`, `about`, `permissions` — orphaned when the section headers went, and flagged `UnusedResources`. If anything outside `:app` reads them, that is a lint blind spot I did not check.
- The bottom nav bar **stays visible** on a category screen, unlike every other non-root route. Deliberate: a category is one tap deep in a two-deep hierarchy, and it keeps the bottom inset identical between index and category. Say the word if it should hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
