### PR TITLE
fix(bulk): make the batch actions honest, and make the job seam able to host them

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/backup/BackupRunner.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/BackupRunner.kt
@@ -38,10 +38,21 @@ import java.io.IOException
  *
  * The point of the @Single is the scope: exporting 200 apps outlives the sheet that started it,
  * the ViewModel behind that sheet and often the Activity behind *that*. A process-lifetime
- * [SupervisorJob] scope survives all three **without a foreground service** — Thor declares no
- * `FOREGROUND_SERVICE` permission, and a `dataSync` FSU is mandatory-typed on API 34+, time-capped
- * on 35+ and comes with a whole new class of start-not-allowed crashes. This is the same shape
+ * [SupervisorJob] scope survives all three **without a foreground service**, which is the same shape
  * `BulkFreezeRunner` already uses for exactly this problem.
+ *
+ * The reason given here used to be that Thor declares no `FOREGROUND_SERVICE` permission. **That is
+ * false, and was false when it was written.** The merged manifest carries the base permission from
+ * `work-runtime`'s own manifest, Thor declares `FOREGROUND_SERVICE_DATA_SYNC` explicitly, and it
+ * overlays `androidx.work.impl.foreground.SystemForegroundService` with `android:foregroundServiceType`
+ * `dataSync` — because the archive job seam next door runs as a foreground service and would throw
+ * `MissingForegroundServiceTypeException` without it.
+ *
+ * What survives is the rest of the argument, which never needed that claim: a `dataSync` FSU is
+ * mandatory-typed on API 34+, time-capped on 35+, and cannot be started from the background on 31+
+ * without risking `ForegroundServiceStartNotAllowedException`. A process-lifetime scope has none of
+ * those failure modes. It also does not have the FSU's wakelock or process priority — the trade this
+ * class makes, and the reason an archive capture makes the opposite one.
  */
 @Single
 class BackupRunner(

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/AppArchiveWorker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/AppArchiveWorker.kt
@@ -70,9 +70,26 @@ internal class ArchiveBackupWorker(
     private val systemRepository: SystemRepository,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
     sheetTargets: JobSheetTargets,
-) : ThorJobWorker(appContext, params, notifications, registry, keys, sheetTargets) {
+) : ThorJobWorker(appContext, params, notifications, registry, sheetTargets) {
 
     override val kind = ThorJobKind.ARCHIVE_BACKUP
+
+    /**
+     * Drop the derived key on every path `doWork` can reach.
+     *
+     * Was the base class's job while [ArchiveKeyHolder] was a constructor parameter of it; it is this
+     * worker's now, because holding key material is a property of archive jobs and not of Thor's jobs.
+     * The guarantees it rested on are unchanged — the base calls this from its `finally`, so it still
+     * covers cancellation and any throw that fires before [runJob]'s own `take`, and it is still a
+     * no-op afterwards (`ConcurrentHashMap.remove` on an absent key).
+     *
+     * The window it does **not** cover is unchanged too: a job cancelled between
+     * [ArchiveKeyHolder.put] and WorkManager starting `doWork` never reaches any `finally`, so nothing
+     * here runs. That branch is closed by [ArchiveKeyHolder]'s own expiry.
+     */
+    override fun onJobFinished() {
+        keys.drop(id.toString())
+    }
 
     /**
      * The package name, not the label.
@@ -234,9 +251,14 @@ internal class ArchiveRestoreWorker(
     private val installedFacts: ReadInstalledAppFactsUseCase,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
     sheetTargets: JobSheetTargets,
-) : ThorJobWorker(appContext, params, notifications, registry, keys, sheetTargets) {
+) : ThorJobWorker(appContext, params, notifications, registry, sheetTargets) {
 
     override val kind = ThorJobKind.ARCHIVE_RESTORE
+
+    /** Same contract and same uncovered window as [ArchiveBackupWorker.onJobFinished]. */
+    override fun onJobFinished() {
+        keys.drop(id.toString())
+    }
 
     override val initialLabel: String
         get() = inputData.getString(RESTORE_PACKAGE_KEY).orEmpty()

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobLauncher.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobLauncher.kt
@@ -11,6 +11,7 @@ import androidx.work.Operation
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.workDataOf
+import com.google.common.util.concurrent.ListenableFuture
 import com.valhalla.thor.data.backup.AppArchiveCipher
 import com.valhalla.thor.domain.model.ArchiveBackupRequest
 import com.valhalla.thor.domain.model.ArchiveRestoreRequest
@@ -231,9 +232,10 @@ class ThorJobLauncher(
  *
  * @param chainName the unique work name — `THOR_JOB_CHAIN` for anything that moves bytes,
  *   `THOR_SWEEP_CHAIN` for a privilege sweep. See their docs for why that split exists.
- * @param onAbandoned run only when the request will never execute. **Not** run when the *wait* is
- *   cancelled: the work is with WorkManager by then and is going to run, so releasing anything it
- *   depends on would fail a live job.
+ * @param onAbandoned run only when the request will never execute, and at most once. Not run *because*
+ *   the wait was cancelled — the work is with WorkManager by then and is going to run, so releasing
+ *   anything it depends on would fail a live job. It is still run if the enqueue then fails, which can
+ *   happen after the caller has stopped waiting; see the cancellation branch.
  */
 internal suspend fun enqueueUniqueJob(
     context: Context,
@@ -262,6 +264,16 @@ internal suspend fun enqueueUniqueJob(
         // Only the *wait* was cancelled; the work is already with WorkManager and the worker that will
         // take this job's key is real. Dropping it here would fail that job for the one reason it must
         // never fail for.
+        //
+        // But "nobody is waiting" is not "nothing can still go wrong": the enqueue resolves on
+        // WorkManager's own executor, so it can fail *after* this frame is gone, and then no worker ever
+        // runs and neither `catch` below is there to see it. The future outlives the coroutine, so keep
+        // watching it for that one outcome. Without this the key sits in the holder until its own
+        // hour-long expiry (see [ArchiveKeyHolder.KEY_LIFETIME_MS]) with nothing left that could consume
+        // it — bounded and self-clearing, but an hour of held key material for a job that does not exist.
+        operation.result.whenFailed { cause ->
+            abandon("enqueue failed after the wait was cancelled", cause)
+        }
         throw e
     } catch (e: Exception) {
         abandon("enqueue failed", e)
@@ -302,4 +314,39 @@ private suspend fun Operation.awaitSuccess(): Operation.State.SUCCESS {
             Executor { it.run() },
         )
     }
+}
+
+/**
+ * Run [handle] if this future has already failed or fails later — once, and never on success.
+ *
+ * The counterpart to [awaitSuccess] for a caller that has stopped waiting. A `ListenableFuture` runs each
+ * listener at most once and runs it immediately if it is already done, so both the "failed while nobody
+ * was looking" and "failed before we registered" orders are covered without a guard flag here.
+ *
+ * **Only a genuine failure counts.** An [ExecutionException] is WorkManager saying the enqueue did not
+ * land, and its `cause` is the reason. A cancelled future or an interrupted listener says nothing about
+ * whether the `WorkSpec` was written, so this stays silent for those and lets the key expire on its own
+ * timer: releasing a key a live worker still needs is the worse of the two failures.
+ *
+ * `internal` rather than private to this file, unlike [awaitSuccess], because it is the only part of the
+ * cancellation path a JVM test can reach — [enqueueUniqueJob] itself needs `WorkManager.getInstance`, and
+ * there is no `work-testing` or Robolectric on this project's test classpath.
+ */
+internal fun ListenableFuture<*>.whenFailed(handle: (Throwable) -> Unit) {
+    addListener(
+        {
+            // Nothing may be thrown from here: the executor below runs this on whichever thread completed
+            // the future, which is WorkManager's, and it is not expecting our exceptions.
+            val cause = try {
+                get()
+                null
+            } catch (e: ExecutionException) {
+                e.cause ?: e
+            } catch (_: Exception) {
+                null
+            }
+            if (cause != null) handle(cause)
+        },
+        Executor { it.run() },
+    )
 }

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobLauncher.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobLauncher.kt
@@ -5,6 +5,7 @@ package com.valhalla.thor.data.backup.job
 
 import android.content.Context
 import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.Operation
 import androidx.work.WorkInfo
@@ -79,13 +80,7 @@ class ThorJobLauncher(
         // Before enqueue, not after: the worker can start the instant enqueue returns, and a worker
         // that starts before its key is in the holder fails for the one reason it must never fail for.
         keys.put(work.id.toString(), key)
-        return enqueue(work.id) {
-            WorkManager.getInstance(context).beginUniqueWork(
-                THOR_JOB_CHAIN,
-                ExistingWorkPolicy.APPEND_OR_REPLACE,
-                work,
-            ).enqueue()
-        }
+        return enqueueUniqueJob(context, THOR_JOB_CHAIN, work, ::abandonKey)
     }
 
     /**
@@ -122,13 +117,7 @@ class ThorJobLauncher(
             .build()
 
         keys.put(work.id.toString(), key)
-        return enqueue(work.id) {
-            WorkManager.getInstance(context).beginUniqueWork(
-                THOR_JOB_CHAIN,
-                ExistingWorkPolicy.APPEND_OR_REPLACE,
-                work,
-            ).enqueue()
-        }
+        return enqueueUniqueJob(context, THOR_JOB_CHAIN, work, ::abandonKey)
     }
 
     /**
@@ -207,46 +196,75 @@ class ThorJobLauncher(
     }
 
     /**
-     * Enqueue, **wait for WorkManager to say it worked**, and hand back the id — or drop the key and
-     * hand back null.
+     * The cleanup [enqueueUniqueJob] performs when a request never made it into the database.
      *
-     * The wait is the point. `WorkContinuation.enqueue()` does its real work on WorkManager's task
-     * executor and reports the result on the returned [Operation]; catching only what is thrown
-     * synchronously catches argument validation and nothing else. A `WorkSpec` insert that fails, a
-     * corrupt WorkManager database, an internal executor that rejects the task — all of those arrive
-     * as a failed [Operation] and used to be invisible here, so this returned an id for a row that
-     * does not exist.
-     *
-     * What that cost downstream is worth naming, because no consumer can fix it: `getWorkInfoByIdFlow`
-     * emits null forever for an id with no row, [status] maps null to [ThorJobStatus.Gone], and both
-     * watchers correctly treat a first-and-only `Gone` as "not started yet" rather than as terminal.
-     * The screen then sits on a progress bar for a job that will never exist, with no timeout
-     * anywhere. This is the one hole underneath that rule, and it is created here.
+     * Key material must not sit in memory for a job that will never run. A sweep launcher passes
+     * something else here, or nothing at all — which is why the generic function takes it as a
+     * parameter rather than knowing about keys.
      */
-    private suspend fun enqueue(id: UUID, block: () -> Operation): UUID? {
-        val operation = try {
-            block()
-        } catch (e: Exception) {
-            return abandon(id, "enqueue was refused", e)
-        }
-        return try {
-            operation.awaitSuccess()
-            id
-        } catch (e: CancellationException) {
-            // Only the *wait* was cancelled; the work is already with WorkManager and the worker that
-            // will take this key is real. Dropping it here would fail that job for the one reason it
-            // must never fail for.
-            throw e
-        } catch (e: Exception) {
-            abandon(id, "enqueue failed", e)
-        }
+    private fun abandonKey(id: UUID) {
+        keys.drop(id.toString())
+    }
+}
+
+/**
+ * Enqueue one request on a unique chain, **wait for WorkManager to say it worked**, and hand back the
+ * id — or run [onAbandoned] and hand back null.
+ *
+ * The wait is the point. `WorkContinuation.enqueue()` does its real work on WorkManager's task
+ * executor and reports the result on the returned [Operation]; catching only what is thrown
+ * synchronously catches argument validation and nothing else. A `WorkSpec` insert that fails, a
+ * corrupt WorkManager database, an internal executor that rejects the task — all of those arrive as a
+ * failed [Operation] and were once invisible here, so this returned an id for a row that does not
+ * exist.
+ *
+ * What that cost downstream is worth naming, because no consumer can fix it: `getWorkInfoByIdFlow`
+ * emits null forever for an id with no row, [ThorJobLauncher.status] maps null to
+ * [ThorJobStatus.Gone], and both watchers correctly treat a first-and-only `Gone` as "not started
+ * yet" rather than as terminal. The screen then sits on a progress bar for a job that will never
+ * exist, with no timeout anywhere. This is the one hole underneath that rule, and it is created here.
+ *
+ * **Top-level and `internal` so the next launcher shares this and not a copy of it.** It was a private
+ * method on [ThorJobLauncher] while archives were the only jobs; the awaited-[Operation] handling
+ * above is the part a second launcher would reimplement badly, and the only thing that actually
+ * differed between the two archive call sites was the chain name.
+ *
+ * @param chainName the unique work name — `THOR_JOB_CHAIN` for anything that moves bytes,
+ *   `THOR_SWEEP_CHAIN` for a privilege sweep. See their docs for why that split exists.
+ * @param onAbandoned run only when the request will never execute. **Not** run when the *wait* is
+ *   cancelled: the work is with WorkManager by then and is going to run, so releasing anything it
+ *   depends on would fail a live job.
+ */
+internal suspend fun enqueueUniqueJob(
+    context: Context,
+    chainName: String,
+    work: OneTimeWorkRequest,
+    onAbandoned: (UUID) -> Unit = {},
+): UUID? {
+    val id = work.id
+    fun abandon(what: String, cause: Throwable): UUID? {
+        Logger.e(TAG, "$what on $chainName", cause)
+        onAbandoned(id)
+        return null
     }
 
-    /** Key material must not sit in memory for a job that will never run. */
-    private fun abandon(id: UUID, what: String, cause: Throwable): UUID? {
-        Logger.e(TAG, what, cause)
-        keys.drop(id.toString())
-        return null
+    val operation = try {
+        WorkManager.getInstance(context)
+            .beginUniqueWork(chainName, ExistingWorkPolicy.APPEND_OR_REPLACE, work)
+            .enqueue()
+    } catch (e: Exception) {
+        return abandon("enqueue was refused", e)
+    }
+    return try {
+        operation.awaitSuccess()
+        id
+    } catch (e: CancellationException) {
+        // Only the *wait* was cancelled; the work is already with WorkManager and the worker that will
+        // take this job's key is real. Dropping it here would fail that job for the one reason it must
+        // never fail for.
+        throw e
+    } catch (e: Exception) {
+        abandon("enqueue failed", e)
     }
 }
 

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobNotifications.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobNotifications.kt
@@ -119,6 +119,51 @@ class ThorJobNotifications(private val context: Context) {
     }
 
     /**
+     * Leave a one-line outcome in the shade after a job ends.
+     *
+     * The gap this closes is that the ongoing row is the *only* surface a background job has, and
+     * [ThorJobWorker]'s `finally` removes it. A job that finished while Thor was not on screen
+     * therefore reported to nobody: `ThorJobStatus.Succeeded` is observed by a live ViewModel and by
+     * nothing else, so the shade simply went quiet and the user is left to guess.
+     *
+     * It matters most on the path that has no other reporter at all. **WorkManager discards a
+     * cancelled worker's `Result`** — `WorkerWrapper` records CANCELLED and drops the output `Data` —
+     * so a sweep stopped halfway cannot report "7 of 20 done" through `Result.success(...)`. Calling
+     * this before returning is the one way those counts survive.
+     *
+     * Transient and quiet by construction: [TIMEOUT_MS] so a stale outcome does not sit in the shade
+     * for a day, `setAutoCancel` so a tap clears it, and the same IMPORTANCE_LOW channel as the
+     * progress row, so it neither makes a sound nor peeks. It reuses that channel rather than
+     * `BulkResultNotifier`'s deliberately — a user who silenced *"Background jobs"* has said they do
+     * not want to hear about jobs, and routing the ending around that switch would be a way of
+     * ignoring them.
+     *
+     * Guarded exactly like [update]: this can be called from a `finally`, where an uncaught
+     * [SecurityException] from a permission revoked mid-job would replace the job's real outcome.
+     */
+    fun postResult(kind: ThorJobKind, message: String) {
+        if (!notificationManager.areNotificationsEnabled()) return
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(iconFor(kind))
+            .setContentTitle(message)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true)
+            .setSilent(true)
+            .setTimeoutAfter(TIMEOUT_MS)
+            // The same target as the progress row: whatever sheet this kind of job belongs to. By the
+            // time a user taps it, `JobSheetTargets` has been cleared for the finished job — so this
+            // opens the app rather than that sheet. Acceptable, and better than no target at all.
+            .setContentIntent(contentIntents.getValue(kind))
+            .build()
+        try {
+            notificationManager.notify(resultNotificationId(kind), notification)
+        } catch (e: SecurityException) {
+            Logger.e(TAG, "${kind.id}: result notify() denied after revocation", e)
+        }
+    }
+
+    /**
      * Cancel the notification for [kind].
      *
      * On the happy path WorkManager cancels the id it owns via setForeground when the job finishes.
@@ -131,8 +176,7 @@ class ThorJobNotifications(private val context: Context) {
 
     private fun build(kind: ThorJobKind, progress: ThorJobProgress, jobId: UUID) =
         NotificationCompat.Builder(context, CHANNEL_ID).apply {
-            // BulkResultNotifier uses R.drawable.frozen; no ic_thor_notification exists in this build.
-            setSmallIcon(R.drawable.frozen)
+            setSmallIcon(iconFor(kind))
             setContentTitle(context.getString(titleFor(kind)))
             setContentText(progress.label)
             setOngoing(true)
@@ -162,14 +206,46 @@ class ThorJobNotifications(private val context: Context) {
     }
 
     /**
+     * The shade's small icon, per kind.
+     *
+     * Both archive kinds get `settings_backup_restore`, which is what that Material symbol is for.
+     * This used to be `R.drawable.frozen` for every job — a snowflake, borrowed from
+     * `BulkResultNotifier` where it means *frozen app*, sitting on top of a backup. It was never a
+     * deliberate choice: the comment beside it said only that no dedicated icon existed.
+     *
+     * `thor_mono` is not a candidate despite being the obvious one. It is the adaptive icon's
+     * monochrome layer at 200dp, drawn with the safe-zone padding that format requires; scaled into a
+     * 24dp status bar slot it renders as a speck. A notification small icon has to be a 24dp asset
+     * drawn for 24dp.
+     */
+    private fun iconFor(kind: ThorJobKind) = when (kind) {
+        ThorJobKind.ARCHIVE_BACKUP, ThorJobKind.ARCHIVE_RESTORE -> R.drawable.settings_backup_restore
+    }
+
+    /**
      * One id per [ThorJobKind], which means two jobs of the same kind would share a notification.
      *
-     * Safe only because `THOR_JOB_CHAIN` carries no target: every archive job is appended to one
-     * chain, so at most one runs at a time. The day someone puts the target into the unique name to
-     * get parallelism — `jobTag(kind, target)` already exists and is the obvious source — this
+     * Safe because of an invariant that spans this file and `ThorJob.kt`: **each kind belongs to
+     * exactly one unique work name, and each of those chains is serial.** Archive kinds are appended
+     * to `THOR_JOB_CHAIN`, sweep kinds to `THOR_SWEEP_CHAIN`; two chains means an archive and a sweep
+     * can now run at once, but they are different kinds and so hold different ids. Two jobs of the
+     * *same* kind still cannot overlap, because they are on the same chain.
+     *
+     * What breaks it is putting one kind on both chains, or putting the target into a unique name to
+     * get parallelism — `jobTag(kind, target)` already exists and is the obvious source. Either
      * silently collapses two jobs onto one row, and the first to finish cancels the second's.
      */
     private fun notificationId(kind: ThorJobKind) = BASE_NOTIFICATION_ID + kind.ordinal
+
+    /**
+     * The id of the transient outcome row, kept in a second block so it cannot collide with the
+     * ongoing row it outlives.
+     *
+     * It has to be a different id: [ThorJobWorker]'s `finally` calls [cancel] for the ongoing
+     * notification on every terminal path, so an outcome posted under the same id would be cancelled
+     * within microseconds of being posted — by the very cleanup that is supposed to follow it.
+     */
+    private fun resultNotificationId(kind: ThorJobKind) = BASE_RESULT_NOTIFICATION_ID + kind.ordinal
 
     private fun ensureChannel() {
         notificationManager.createNotificationChannel(
@@ -186,5 +262,14 @@ class ThorJobNotifications(private val context: Context) {
 
         /** `BulkResultNotifier` owns 1001. */
         const val BASE_NOTIFICATION_ID = 1100
+
+        /**
+         * The outcome rows. 100 ids of headroom above [BASE_NOTIFICATION_ID], so the two blocks
+         * cannot meet until [ThorJobKind] has a hundred entries.
+         */
+        const val BASE_RESULT_NOTIFICATION_ID = 1200
+
+        /** How long an outcome row stays before the system removes it. `BulkResultNotifier`'s figure. */
+        private const val TIMEOUT_MS = 10_000L
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobWorker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobWorker.kt
@@ -29,18 +29,32 @@ private const val NOTIFICATION_INTERVAL_MS = 1_000L
  * failure policy.
  *
  * Deliberately knows nothing about archives — exports and bulk actions are meant to move onto this.
+ * Anything a single kind of job needs on the way out goes in that subclass's [onJobFinished], not in
+ * this constructor; [ArchiveKeyHolder] used to be a parameter here and was the one thing keeping this
+ * class from being reusable at all.
  *
- * **No subclass may return `Result.retry()`.** Archive jobs hold their key in process memory
- * ([ArchiveKeyHolder]), so a retry after process death runs without a key and cannot succeed; and a
- * partially written destination is discarded on the way out, so there is nothing for a retry to
- * resume. Process death ends a run.
+ * **No subclass may return `Result.retry()`, and a subclass must be safe to re-run regardless.**
+ *
+ * Those are two separate rules and the second is the one that is easy to miss. WorkManager re-runs a
+ * worker whose process was killed mid-run **whatever it returned** — the ban on `retry()` only stops
+ * Thor from *asking* for a re-run, it does not stop one happening. So every subclass has to be
+ * idempotent: re-running it must not do damage that running it once would not.
+ *
+ * Archive jobs satisfy both. They hold their key in process memory ([ArchiveKeyHolder]), so a re-run
+ * after process death has no key and fails before touching anything; and a partially written
+ * destination is discarded on the way out, so there is nothing to resume and nothing left behind.
+ *
+ * A sweep has to earn it per operation. `pm install -r` and a cache clear are naturally idempotent —
+ * doing them twice is doing them once. An uninstall and a force-stop are not: the second pass acts on
+ * a selection whose members may no longer be in the state that made them eligible, and reports a
+ * failure for work the first pass completed. A sweep of those must record what it has already done
+ * where a re-run can read it, or not be put on this seam.
  */
 abstract class ThorJobWorker(
     appContext: Context,
     params: WorkerParameters,
     private val notifications: ThorJobNotifications,
     private val registry: JobRegistry,
-    private val keyHolder: ArchiveKeyHolder,
     private val sheetTargets: JobSheetTargets,
 ) : CoroutineWorker(appContext, params) {
 
@@ -48,6 +62,22 @@ abstract class ThorJobWorker(
 
     /** Shown before the job knows anything about sizes. */
     protected abstract val initialLabel: String
+
+    /**
+     * Whether this job runs as a foreground service.
+     *
+     * True for anything that moves bytes: a multi-gigabyte capture that the system freezes halfway is
+     * a corrupt archive, and the FGS is what buys it the wakelock and the process priority to finish.
+     *
+     * False is for short privilege sweeps, and it costs them nothing they need. The progress
+     * notification is **not** the foreground service — [ThorJobNotifications.update] posts through
+     * `NotificationManagerCompat.notify`, so a `runsForeground = false` job still gets its shade row,
+     * its progress bar and its cancel action. What it gives up is the priority and the wakelock, which
+     * a sweep that finishes in seconds does not need, in exchange for not spending Thor's one
+     * `dataSync` slot and not risking `ForegroundServiceStartNotAllowedException` on API 31+ for work
+     * that is over before the exception would have mattered.
+     */
+    protected open val runsForeground: Boolean = true
 
     /**
      * Which sheet this job's notification reopens, or null if its input `Data` did not carry enough to
@@ -60,6 +90,9 @@ abstract class ThorJobWorker(
     // Throttle state — one ThorJobWorker instance per WorkManager execution, so fields are safe.
     private var lastNotifyMs = 0L
     private var lastNotifyStage: ThorJobStage? = null
+
+    /** Set by [noteResult]; posted by [doWork]'s `finally`. Same single-instance argument as above. */
+    private var resultNotice: String? = null
 
     final override suspend fun getForegroundInfo(): ForegroundInfo =
         notifications.foregroundInfo(
@@ -80,12 +113,24 @@ abstract class ThorJobWorker(
             // catch degrades that non-cancellation failure to running without a foreground
             // notification rather than failing the whole job. CancellationException is rethrown
             // explicitly so it is not swallowed by the inner catch(Exception).
-            try {
-                setForeground(getForegroundInfo())
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Logger.e(TAG, "${kind.id}: continuing without a foreground notification", e)
+            //
+            // A runsForeground = false job skips this and nothing else: its first publish() posts the
+            // same row through NotificationManagerCompat. The degraded path this catch produces is
+            // exactly what such a job runs in deliberately, which is the evidence that the path works.
+            if (runsForeground) {
+                try {
+                    setForeground(getForegroundInfo())
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.e(TAG, "${kind.id}: continuing without a foreground notification", e)
+                }
+            } else {
+                // Post the row here rather than waiting for the subclass's first publish(). Otherwise
+                // a job has no user-visible surface for however long its own setup takes, which is a
+                // contract a subclass can forget; setForeground gives foreground jobs this for free
+                // and a non-foreground one should not be worse off for a reason nobody can see.
+                publish(ThorJobProgress(ThorJobStage.PREPARING, initialLabel))
             }
 
             runJob()
@@ -107,23 +152,25 @@ abstract class ThorJobWorker(
             // outcome, so dropping in-memory progress loses nothing and bounds the map.
             registry.clear(id)
             //
-            // keyHolder: drop() ensures key material is not held beyond this job's lifetime. It
-            // covers cancellation and any throw that fires before the concrete worker's own take().
-            // If take() already ran, drop() is a no-op (ConcurrentHashMap.remove on an absent key).
-            // The path where the job is cancelled between put() and WorkManager starting doWork()
-            // cannot be covered here: doWork never runs, so neither does this finally.
-            // ThorJobLauncher.cancel would drop the key first and close that window, but **nothing
-            // calls it today** — the only user-facing cancel is the notification's action, built from
-            // WorkManager.createCancelPendingIntent, which goes straight to WorkManager. So both the
-            // pre-start cancel and a chain cancel (WorkManager cancels the dependents of a failed
-            // prerequisite) reach neither this finally nor the launcher, and are covered by
-            // ArchiveKeyHolder's own expiry.
-            keyHolder.drop(id.toString())
+            // onJobFinished: whatever this kind of job has to release. Runs on every path doWork can
+            // reach, and before the two cleanups below so a subclass cannot observe a half-torn-down
+            // job. Guarded, because this is a `finally`: an override that throws would otherwise skip
+            // the notification cancel below and leave an ongoing row for a job that is over — a
+            // permanent, undismissable one, since setOngoing(true) means the user cannot swipe it away.
+            // Losing one subclass's cleanup is recoverable; losing the base's is not.
+            runCatching { onJobFinished() }
+                .onFailure { Logger.e(TAG, "${kind.id}: onJobFinished threw", it) }
             //
             // notification: always runs; idempotent. On the happy path WorkManager already cancelled
             // the id it owns via setForeground — this is a no-op there and the actual cleanup on
             // both the setForeground-failed path and the cancellation-during-setForeground path.
             notifications.cancel(kind)
+            //
+            // outcome: after the cancel above, so the ongoing row is gone before the outcome replaces
+            // it rather than the two overlapping for a frame. They hold different ids, so this is
+            // ordering for the user's benefit and not a correctness requirement. Nothing is posted
+            // unless the job called noteResult — see it for why archives currently do not.
+            resultNotice?.let { notifications.postResult(kind, it) }
             //
             // sheetTarget: keyed on this job's id, so a successor that has already published keeps
             // its own target even when the two describe the same work and compare equal. Called
@@ -134,6 +181,50 @@ abstract class ThorJobWorker(
             sheetTargets.clear(kind, id)
         }
     }
+
+    /**
+     * Ask for a one-line outcome to be left in the shade when this job ends.
+     *
+     * Recorded rather than posted, so that it survives the one path where a job cannot report through
+     * its `Result` at all: **WorkManager discards a cancelled worker's `Result`.** A sweep that is
+     * stopped after 7 of 20 apps has no way to return that count — but [doWork]'s `finally` runs on the
+     * cancellation path, so a notice set before returning is still posted. Call it and then return;
+     * do not try to post from a cancellation handler.
+     *
+     * The last call wins. A job that notes progress and then fails ends up reporting the failure,
+     * which is the right way round.
+     *
+     * **Archive jobs deliberately do not call this yet.** Both have a sheet that reports every outcome
+     * in detail, including the warning list a plain sentence would flatten, and adding a second
+     * reporter to the paths a user *is* watching is a change to backup behaviour that belongs in its
+     * own pass rather than in a refactor. The mechanism is here because a sweep needs it and because
+     * the reason it has to work this way is only obvious while looking at `finally`.
+     */
+    protected fun noteResult(message: String) {
+        // Capped with the `Data` helper even though this never becomes `Data` — it is the cap Thor
+        // already has for "one sentence about a job", and a notification title assembled from a shell
+        // error is the same unbounded input on a different path. Read the name as the size, not as the
+        // destination.
+        resultNotice = message.boundedForJobData()
+    }
+
+    /**
+     * Release whatever this *kind* of job holds. Called from [doWork]'s `finally`, on every path.
+     *
+     * This is where [ArchiveKeyHolder] went when it came out of the constructor. The base class has no
+     * business knowing that some jobs hold key material and others hold nothing; it only has to
+     * guarantee the call happens, which the `finally` does.
+     *
+     * Not `suspend`, on purpose. It runs on a cancellation path, where a suspending call would either
+     * throw `CancellationException` immediately or need `NonCancellable` around it — and cleanup that
+     * can be interrupted is not cleanup. Anything that genuinely must suspend belongs in the
+     * subclass's own `finally` inside `runJob`, where `withContext(NonCancellable)` is already the
+     * shape the archive workers use.
+     *
+     * **Must not throw.** It is called inside a `finally`; the base guards the call so a throw cannot
+     * strand the notification, but the override's own work would be abandoned partway.
+     */
+    protected open fun onJobFinished() {}
 
     /**
      * Republish this job's sheet target after learning something better than its input `Data` carried.
@@ -151,8 +242,9 @@ abstract class ThorJobWorker(
     /**
      * `Result.failure` carrying a sentence, never `Result.retry`.
      *
-     * A retry re-runs in a process where [ArchiveKeyHolder.take] returns null, so it cannot succeed —
-     * and it would report the failure long after the moment the user was watching.
+     * A retry reports the failure long after the moment the user was watching, which is true of every
+     * job on this seam. For an archive job it also cannot succeed: the re-run is a fresh process, and
+     * [ArchiveKeyHolder.take] returns null there.
      *
      * Lives here rather than at file level in the workers because `ListenableWorker.Result` is a
      * nested type: a top-level helper would have to name it fully qualified at every call site, and

--- a/app/src/main/java/com/valhalla/thor/domain/model/MultiAppAction.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/MultiAppAction.kt
@@ -16,7 +16,15 @@ sealed interface MultiAppAction {
     data class Kill(val appList: List<AppInfo>) : MultiAppAction
 
     data class ClearCache(val appList: List<AppInfo>) : MultiAppAction
-    data class ClearData(val appList: List<AppInfo>) : MultiAppAction
     data class Suspend(val appList: List<AppInfo>) : MultiAppAction
     data class UnSuspend(val appList: List<AppInfo>) : MultiAppAction
+
+    // There is deliberately no `ClearData` here. One existed, with a handler in MainViewModel, a
+    // "this cannot be undone" confirmation in AffirmationDialog and translated batch copy in five
+    // locales — and no button anywhere in the app ever constructed it. Nothing was reachable; the
+    // three pieces only made it look reachable, which is worse than absent, because a plan drawn up
+    // from this file would have sized it as an existing feature to migrate rather than as a
+    // destructive one to design. Single-app clear data is a real feature and unaffected: see
+    // [AppClickAction.ClearData]. If bulk clear data is wanted, it wants a deliberate design pass
+    // for the irreversible-over-N-apps case, not the resurrection of this stub.
 }

--- a/app/src/main/java/com/valhalla/thor/domain/model/ThorJob.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ThorJob.kt
@@ -4,7 +4,7 @@
 package com.valhalla.thor.domain.model
 
 /**
- * The one unique work name every archive job shares.
+ * The one unique work name every job that **moves bytes** shares: archives today, exports next.
  *
  * Deliberately does **not** name the target. With `ExistingWorkPolicy.APPEND_OR_REPLACE` this makes
  * runs *serialise*, which is what holds peak disk at one storage class however many backups the user
@@ -12,8 +12,32 @@ package com.valhalla.thor.domain.model
  *
  * `APPEND_OR_REPLACE` rather than `APPEND` because the chain must not be wedged by a job that failed
  * or was cancelled — replace is the escape hatch that keeps the queue usable.
+ *
+ * **The argument above is about disk, so it does not reach a privilege sweep.** A freeze, a suspend, a
+ * force-stop and an uninstall write no bytes; putting them on this name would queue a five-second
+ * sweep behind an hour-long backup for a reason that does not apply to it. They use
+ * [THOR_SWEEP_CHAIN] instead.
  */
 const val THOR_JOB_CHAIN = "thor.job.chain"
+
+/**
+ * The unique work name every **privilege sweep** shares — bulk freeze, unfreeze, force-stop, cache
+ * clear, reinstall.
+ *
+ * Separate from [THOR_JOB_CHAIN] so a sweep is not queued behind a multi-gigabyte capture, and so a
+ * capture is not delayed by a queue of sweeps. Same `APPEND_OR_REPLACE` policy, for the same
+ * anti-wedging reason.
+ *
+ * Sweeps still serialise *among themselves*, and not on disk grounds:
+ *
+ * - Two sweeps over overlapping selections race on the same packages. A freeze landing between
+ *   another sweep's `getApplicationInfo` and its `setAppDisabled` is a decision made on state that
+ *   has already changed.
+ * - Odin's root channel is one long-lived FIFO `su` session, so two "concurrent" root sweeps
+ *   interleave into that single session anyway. The parallelism would be a fiction bought at the
+ *   price of the race above.
+ */
+const val THOR_SWEEP_CHAIN = "thor.sweep.chain"
 
 /** Set on a failed job's output `Data` so the UI can say what went wrong instead of "failed". */
 const val JOB_ERROR_KEY = "thor.job.error"
@@ -33,6 +57,12 @@ const val JOB_WARNINGS_KEY = "thor.job.warnings"
  *
  * Two for now. Exports and bulk actions are meant to join them — that is why nothing in this file or
  * in `ThorJobWorker` mentions archives.
+ *
+ * **Append only. Never insert or reorder.** `ThorJobNotifications` derives a notification id from
+ * `BASE_NOTIFICATION_ID + ordinal`, and that same number is the `PendingIntent` request code for the
+ * row's tap target. Inserting a kind renumbers every kind after it, which hands a live notification
+ * the request code of a different job. [jobKindFromId] is deliberately immune to this — the tap extra
+ * travels as [id], not as an ordinal — but the id arithmetic is not.
  */
 enum class ThorJobKind(val id: String) {
     ARCHIVE_BACKUP("archive-backup"),
@@ -58,6 +88,16 @@ enum class ThorJobStage {
     WRITING,
     INSTALLING,
     RESTORING,
+
+    /**
+     * A sweep working through its selection — freezing, clearing, force-stopping.
+     *
+     * One stage for the whole loop rather than one per operation, because a sweep's interesting
+     * quantity is *which app of how many*, and that is [ThorJobProgress.label] and its counts. The
+     * stage exists to distinguish the loop from [PREPARING] and [FINISHING] on either side of it; the
+     * operation is already in the notification title.
+     */
+    ACTING,
     FINISHING,
 }
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/ArchiveJobLauncher.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/ArchiveJobLauncher.kt
@@ -32,6 +32,19 @@ sealed interface ThorJobStatus {
      * paths, and a UI that keys "did it fail?" off a non-null reason reports those as nothing at all.
      */
     data class Failed(val reason: String?) : ThorJobStatus
+
+    /**
+     * **Carries nothing, and cannot be made to.** The obvious want for a bulk sweep is
+     * `Cancelled(done, total)` — "stopped after 7 of 20" is the only useful thing to say about a
+     * stopped batch. It is not reachable from here: WorkManager's `WorkerWrapper` records CANCELLED
+     * and discards the worker's returned `Result`, so there is no output `Data` on this state to read
+     * counts out of. A worker that carefully assembled them would be handing them to something that
+     * throws them away.
+     *
+     * The route that works is `ThorJobWorker.noteResult`, which posts from the worker's own `finally`
+     * and so runs on the cancellation path. Partial counts are reported *beside* this status, never
+     * through it.
+     */
     data object Cancelled : ThorJobStatus
 
     /** No such job — WorkManager prunes finished work, so this is the normal answer for an old id. */
@@ -39,13 +52,39 @@ sealed interface ThorJobStatus {
 }
 
 /**
+ * Watch a Thor job. Says nothing about what kind of job it is or how it was started.
+ *
+ * Split out of [ArchiveJobLauncher] because *watching* is the half with no archive in it: both members
+ * take a [UUID] or a [ThorJobKind] and neither mentions a passphrase, a salt or a request. A bulk
+ * sweep launcher implements this and its own `start…`, and every screen that only needs to follow a
+ * job — a progress row, a reattach after rotation — depends on this rather than on a launcher whose
+ * other half it cannot use.
+ *
+ * A port for the same reason [ArchiveJobLauncher] is: the implementation calls
+ * `WorkManager.getInstance(context)`, which would put every consumer beyond the reach of a JVM test.
+ */
+interface ThorJobWatcher {
+
+    fun status(jobId: UUID): Flow<ThorJobStatus>
+
+    /**
+     * The id of an unfinished job for this kind and target, or null.
+     *
+     * How a screen reattaches after a rotation and how a second tap is refused. Backed by
+     * `jobTag(kind, target)`, since a chain name carries no target.
+     */
+    fun runningJobFor(kind: ThorJobKind, target: String): Flow<UUID?>
+}
+
+/**
  * Start an archive job and watch it.
  *
  * A port because the implementation calls `WorkManager.getInstance(context)`, which would put every
  * consumer beyond the reach of a JVM test — the same reason `AppShortcutController` exists next to
- * `FreezerShortcutManager`. The whole surface is "enqueue this, and tell me how it goes".
+ * `FreezerShortcutManager`. The whole surface is "enqueue this, and tell me how it goes"; the second
+ * half of that sentence is [ThorJobWatcher] and is not archive-specific.
  */
-interface ArchiveJobLauncher {
+interface ArchiveJobLauncher : ThorJobWatcher {
 
     /** @param passphrase not cleared here; the caller owns it. @return the job id, or null if it could not be enqueued. */
     suspend fun startBackup(request: ArchiveBackupRequest, passphrase: CharArray): UUID?
@@ -65,14 +104,4 @@ interface ArchiveJobLauncher {
         salt: ByteArray,
         iterations: Int,
     ): UUID?
-
-    fun status(jobId: UUID): Flow<ThorJobStatus>
-
-    /**
-     * The id of an unfinished job for this kind and target, or null.
-     *
-     * How a screen reattaches after a rotation and how a second tap is refused. Backed by
-     * `jobTag(kind, target)`, since every job shares one chain name.
-     */
-    fun runningJobFor(kind: ThorJobKind, target: String): Flow<UUID?>
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -10,6 +10,8 @@ import com.valhalla.thor.domain.model.APP_LIST_MIME
 import com.valhalla.thor.domain.model.AppGridDensity
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
+import com.valhalla.thor.domain.model.BulkOp
+import com.valhalla.thor.domain.model.BulkResult
 import com.valhalla.thor.domain.model.FilterType
 import com.valhalla.thor.domain.model.FreezeTier
 import com.valhalla.thor.domain.model.InstalledAppsPermission
@@ -40,6 +42,7 @@ import com.valhalla.thor.presentation.freezer.FreezerPrompt
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.util.UiTextException
+import com.valhalla.thor.util.bulkResultMessage
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -158,6 +161,22 @@ class AppListViewModel(
     private var refreshIndicatorJob: Job? = null
     private var permissionIndexJob: Job? = null
     private var permissionRefreshJob: Job? = null
+
+    /**
+     * The one list export in flight, save or share.
+     *
+     * Both destinations are guarded by the same handle on purpose: they are one feature with two
+     * endings, and the share half stages through a directory that is wiped on entry
+     * (`AppBundleFileStoreImpl.stageText`). Two overlapping runs therefore do not merely write the
+     * same file twice — the second one can delete the first one's staged file after the Uri for it
+     * has already been handed out.
+     *
+     * A duplicate tap is dropped rather than reported. The work is a `buildString` and one write,
+     * so the window is a few frames wide; a toast saying "already exporting" would appear and
+     * disappear faster than it could be read, and would be the only message on this screen that
+     * describes Thor's internals rather than the user's apps.
+     */
+    private var listExportJob: Job? = null
     private val _rawState = MutableStateFlow(AppListUiState())
 
     // One-off UI feedback (toasts, freezer prompt). A buffered Channel fires each event exactly
@@ -675,43 +694,50 @@ class AppListViewModel(
                     }
                     _events.send(
                         AppListEvent.ShowMessage(
-                            if (failures == 0) {
-                                UiText.PluralsResource(
-                                    R.plurals.tile_freeze_success,
-                                    action.appList.size
+                            bulkResultMessage(
+                                BulkResult(
+                                    op = BulkOp.FREEZE,
+                                    total = action.appList.size,
+                                    succeeded = succeededPackages.size,
+                                    failed = failures,
                                 )
-                            } else {
-                                UiText.StringResource(
-                                    R.string.tile_freeze_partial_failure,
-                                    succeededPackages.size,
-                                    action.appList.size,
-                                    failures
-                                )
-                            }
+                            )
                         )
                     )
                 }
 
                 is MultiAppAction.UnFreeze -> {
-                    val packageNames = action.appList.map { it.packageName }.toSet()
-                    action.appList.forEach {
-                        manageAppUseCase.setAppDisabled(it.packageName, false)
+                    // Only the packages that actually came back successful, for both halves of the
+                    // report. This used to discard every `setAppDisabled` result, mark the whole
+                    // selection `enabled = true` and then send an unconditional success plural for
+                    // `appList.size` — so a batch where nothing was unfrozen said "Unfroze 12 apps"
+                    // and drew twelve thawed rows to match. The freeze branch above always counted
+                    // properly; only this direction did not.
+                    val succeededPackages = mutableSetOf<String>()
+                    action.appList.forEach { app ->
+                        if (manageAppUseCase.setAppDisabled(app.packageName, false).isSuccess) {
+                            succeededPackages.add(app.packageName)
+                        }
                     }
                     _rawState.update { state ->
                         state.copy(
                             allUserApps = state.allUserApps.map {
-                                if (it.packageName in packageNames) it.copy(enabled = true) else it
+                                if (it.packageName in succeededPackages) it.copy(enabled = true) else it
                             },
                             allSystemApps = state.allSystemApps.map {
-                                if (it.packageName in packageNames) it.copy(enabled = true) else it
+                                if (it.packageName in succeededPackages) it.copy(enabled = true) else it
                             }
                         )
                     }
                     _events.send(
                         AppListEvent.ShowMessage(
-                            UiText.PluralsResource(
-                                R.plurals.unfrozen_count_success,
-                                action.appList.size
+                            bulkResultMessage(
+                                BulkResult(
+                                    op = BulkOp.UNFREEZE,
+                                    total = action.appList.size,
+                                    succeeded = succeededPackages.size,
+                                    failed = action.appList.size - succeededPackages.size,
+                                )
                             )
                         )
                     )
@@ -833,7 +859,8 @@ class AppListViewModel(
             }
             return
         }
-        viewModelScope.launch {
+        if (listExportJob?.isActive == true) return
+        listExportJob = viewModelScope.launch {
             exportAppListUseCase(apps)
                 .onSuccess {
                     _events.send(
@@ -862,7 +889,8 @@ class AppListViewModel(
             }
             return
         }
-        viewModelScope.launch {
+        if (listExportJob?.isActive == true) return
+        listExportJob = viewModelScope.launch {
             exportAppListUseCase.shareUri(apps)
                 .onSuccess { _events.send(AppListEvent.ShareList(it, APP_LIST_MIME)) }
                 .onFailure { e ->

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -708,24 +708,55 @@ class AppListViewModel(
 
                 is MultiAppAction.UnFreeze -> {
                     // Only the packages that actually came back successful, for both halves of the
-                    // report. This used to discard every `setAppDisabled` result, mark the whole
-                    // selection `enabled = true` and then send an unconditional success plural for
+                    // report. This used to discard every result, mark the whole selection
+                    // `enabled = true` and then send an unconditional success plural for
                     // `appList.size` — so a batch where nothing was unfrozen said "Unfroze 12 apps"
                     // and drew twelve thawed rows to match. The freeze branch above always counted
                     // properly; only this direction did not.
+                    //
+                    // `forceUnfreeze`, not `setAppDisabled(_, false)` and not
+                    // `restoreApp(_, app.enabled, app.isSuspended)`:
+                    //
+                    //  - `setAppDisabled` clears one of the two dimensions a frozen app can be
+                    //    frozen in. An app suspended from any other surface — the Freezer's suspend
+                    //    mode, `MainViewModel.performCountedFreeze(useSuspend = true)`, the QS tile,
+                    //    an extension — comes back still suspended, and the report above now says so
+                    //    *precisely*: it counts the enable that succeeded while the user still can't
+                    //    open the app.
+                    //  - `restoreApp` reads the flags, and the flags here are stale by construction.
+                    //    `isSuspended` is patched in exactly one place in this ViewModel
+                    //    ([toggleFreezerMembership]) and never on a bulk path, so it only moves on a
+                    //    full rescan. A snapshot that still calls a just-suspended app active makes
+                    //    `restorePlanFor` plan nothing, and `restoreApp` then returns success having
+                    //    made zero privileged calls — the same lie this branch was just fixed to stop
+                    //    telling, re-entering through the choice of API. FreezerViewModel documents
+                    //    this trap twice for the same reason.
+                    //
+                    // `forceUnfreeze` asks unconditionally, which is what its KDoc is for ("bulk
+                    // 'unfreeze all' when per-app state isn't known"). The cost is one redundant
+                    // unsuspend per already-active app; root and Shizuku answer that from the flag
+                    // alone and Dhizuku pays one `pm unsuspend`. A redundant call is the cheaper of
+                    // the two mistakes.
                     val succeededPackages = mutableSetOf<String>()
                     action.appList.forEach { app ->
-                        if (manageAppUseCase.setAppDisabled(app.packageName, false).isSuccess) {
+                        if (manageAppUseCase.forceUnfreeze(app.packageName).isSuccess) {
                             succeededPackages.add(app.packageName)
                         }
                     }
                     _rawState.update { state ->
+                        // Both dimensions, because forceUnfreeze cleared both. Patching only
+                        // `enabled` would leave a thawed app drawn as suspended until the next
+                        // rescan, and would leave the next unfreeze reading that stale flag.
                         state.copy(
                             allUserApps = state.allUserApps.map {
-                                if (it.packageName in succeededPackages) it.copy(enabled = true) else it
+                                if (it.packageName in succeededPackages) {
+                                    it.copy(enabled = true, isSuspended = false)
+                                } else it
                             },
                             allSystemApps = state.allSystemApps.map {
-                                if (it.packageName in succeededPackages) it.copy(enabled = true) else it
+                                if (it.packageName in succeededPackages) {
+                                    it.copy(enabled = true, isSuspended = false)
+                                } else it
                             }
                         )
                     }

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -926,7 +926,10 @@ class MainViewModel(
                             }
                         }
 
-                        if (stopRequested) {
+                        // `processed <`, not `stopRequested` alone — see the same gate at the end of
+                        // [performLoggedMultiAction] for why. A Stop tapped while the last
+                        // `shareAppUseCase` runs would otherwise report "Stopped: 20 of 20".
+                        if (processed < action.appList.size) {
                             addLog(UiText.StringResource(R.string.log_stopped, processed, action.appList.size))
                         }
                         if (uris.isNotEmpty()) {
@@ -982,8 +985,24 @@ class MainViewModel(
                     if (useSuspend) manageAppUseCase.setAppSuspended(app.packageName, true)
                     else manageAppUseCase.setAppDisabled(app.packageName, true)
                 } else {
-                    // State-aware restore: clears suspend AND disable, incl. mixed state.
-                    manageAppUseCase.restoreApp(app.packageName, app.enabled, app.isSuspended)
+                    // `forceUnfreeze`, not the state-aware `restoreApp(_, app.enabled,
+                    // app.isSuspended)` this used to call. Both clear suspend AND disable; the
+                    // difference is that `restoreApp` decides which halves to attempt from the flags,
+                    // and on this path the flags are stale by construction.
+                    //
+                    // Nothing patches `isSuspended` on an app list after a bulk freeze — not this
+                    // function (it updates only the logger counters and never refreshes the lists on
+                    // completion), not `AppListViewModel`'s bulk branch, not the QS tile. So the
+                    // freeze-then-unfreeze round trip that is the *primary* way suspend mode gets
+                    // used — `useSuspend = true` above, then Unfreeze over the same selection —
+                    // hands `restorePlanFor` a snapshot that still calls every app active. It plans
+                    // nothing, returns `Result.success`, and this loop counts a success for each app
+                    // while all of them are still suspended: "Unfroze 12" over 12 paused apps.
+                    //
+                    // FreezerViewModel already documents this trap twice and answers it the same way.
+                    // The cost is one redundant unsuspend per already-active app, which root and
+                    // Shizuku answer from the flag alone.
+                    manageAppUseCase.forceUnfreeze(app.packageName)
                 }
                 processed++
                 if (result.isFailure) failed++
@@ -1153,7 +1172,15 @@ class MainViewModel(
             }
         }
 
-        if (stopRequested) {
+        // `processed <`, not `stopRequested` alone. The flag is checked between apps, so a Stop
+        // tapped while the *last* app's call is in flight sets it after the loop has already run
+        // every app — and reporting on the flag then says "Stopped: 20 of 20", a stop that skipped
+        // nothing, which reads as though something was lost. The count is the only thing that knows
+        // whether the loop broke early.
+        //
+        // Six bulk actions come through here (kill, clear cache, uninstall, reinstall, suspend,
+        // unsuspend) and the share branch keeps its own copy of this loop; both now gate the same way.
+        if (processed < apps.size) {
             addLog(UiText.StringResource(R.string.log_stopped, processed, apps.size))
         }
         finishLogger()

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -826,7 +826,19 @@ class MainViewModel(
                     UiText.StringResource(R.string.log_killing_batch),
                     action.appList
                 ) {
-                    manageAppUseCase.forceStop(it.packageName)
+                    // Thor is in its own app list, so "select all -> Kill" is two taps and the
+                    // batch would reach the process running it. Force-stopping that process does
+                    // not stop the batch cleanly — it takes the ViewModel, the logger and the
+                    // remaining apps with it, and the user is left with a partly-killed selection
+                    // and no report of where it stopped. `fixStoreCandidates` already excludes
+                    // Thor from its computed target list for the same reason; this is the same
+                    // exclusion on a list the user assembled by hand, so it is reported rather
+                    // than filtered silently.
+                    if (it.packageName == BuildConfig.APPLICATION_ID) {
+                        Result.failure(UiTextException(UiText.StringResource(R.string.error_self_skipped)))
+                    } else {
+                        manageAppUseCase.forceStop(it.packageName)
+                    }
                 }
 
                 // Root-only, like every per-package clear. The freed byte counts are discarded here
@@ -845,7 +857,10 @@ class MainViewModel(
                     UiText.StringResource(R.string.log_uninstalling_batch),
                     action.appList
                 ) { appInfo ->
-                    if (appInfo.freezeTier == FreezeTier.BLOCKED) {
+                    if (appInfo.packageName == BuildConfig.APPLICATION_ID) {
+                        // Same reasoning as the Kill branch, with a worse ending: this one succeeds.
+                        Result.failure(UiTextException(UiText.StringResource(R.string.error_self_skipped)))
+                    } else if (appInfo.freezeTier == FreezeTier.BLOCKED) {
                         Result.failure(UiTextException(UiText.StringResource(R.string.error_unsafe_skipped)))
                     } else {
                         val result = manageAppUseCase.uninstallApp(appInfo.packageName)
@@ -870,22 +885,32 @@ class MainViewModel(
                     manageAppUseCase.setAppSuspended(it.packageName, false)
                 }
 
-                is MultiAppAction.ClearData -> performLoggedMultiAction(
-                    UiText.StringResource(R.string.log_clearing_data_batch),
-                    action.appList
-                ) {
-                    manageAppUseCase.clearAppData(it.packageName)
-                }
-
                 is MultiAppAction.Share -> {
                     viewModelScope.launch {
-                        startLogger(UiText.StringResource(R.string.log_sharing_batch))
+                        // `canStop` and the break below are what every other batch has had since
+                        // `performLoggedMultiAction` grew them. This loop is hand-rolled — it
+                        // collects Uris rather than counting successes, which is why it never went
+                        // through the shared helper — and the Stop button was simply never wired
+                        // to it. Preparing 50 installer bundles is the slowest batch Thor has, so
+                        // it was the one batch most likely to be stopped and the only one that
+                        // could not be.
+                        startLogger(
+                            UiText.StringResource(R.string.log_sharing_batch),
+                            canStop = action.appList.size > 1
+                        )
                         val uris = mutableListOf<android.net.Uri>()
+                        var processed = 0
 
                         withContext(ioDispatcher) {
-                            action.appList.forEachIndexed { index, app ->
+                            for ((index, app) in action.appList.withIndex()) {
+                                // Between apps, never during one — same contract as
+                                // `performLoggedMultiAction`. Whatever is already staged is still
+                                // shared; stopping declines to prepare the rest, it does not
+                                // discard the work already done.
+                                if (stopRequested) break
                                 addLog(UiText.StringResource(R.string.log_batch_preparing, index + 1, action.appList.size, app.appName ?: ""))
                                 val result = shareAppUseCase(app)
+                                processed++
                                 if (result.isSuccess) {
                                     uris.add(result.getOrThrow())
                                     addLog(UiText.StringResource(R.string.log_ready))
@@ -901,6 +926,9 @@ class MainViewModel(
                             }
                         }
 
+                        if (stopRequested) {
+                            addLog(UiText.StringResource(R.string.log_stopped, processed, action.appList.size))
+                        }
                         if (uris.isNotEmpty()) {
                             dismissLogger()
                             _effect.send(MainSideEffect.ShareApps(uris))

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AffirmationDialog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AffirmationDialog.kt
@@ -165,8 +165,6 @@ fun MultiAppAffirmationDialog(
 
                     is MultiAppAction.Uninstall -> "Uninstall ${multiAppAction.appList.size} apps?"
 
-                    is MultiAppAction.ClearData -> "Permanently clear data for ${multiAppAction.appList.size} apps? This cannot be undone."
-
                     is MultiAppAction.Suspend -> "Suspend ${multiAppAction.appList.size} apps? This will restrict background activities."
 
                     is MultiAppAction.UnSuspend -> "Unsuspend ${multiAppAction.appList.size} apps?"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -433,7 +433,6 @@
     <string name="log_uninstalling_batch">جارٍ إلغاء تثبيت التطبيقات</string>
     <string name="log_suspending_batch">جارٍ تعليق التطبيقات</string>
     <string name="log_unsuspending_batch">جارٍ إلغاء تعليق التطبيقات</string>
-    <string name="log_clearing_data_batch">جارٍ مسح البيانات</string>
     <string name="log_sharing_batch">جارٍ مشاركة التطبيقات</string>
     <string name="log_batch_step">[%1$d/%2$d] %3$s…</string>
     <string name="log_batch_preparing">[%1$d/%2$d] جارٍ تجهيز %3$s…</string>
@@ -454,6 +453,7 @@
     <string name="filter_all">الكل</string>
     <string name="error_debuggable_app">التطبيق قابل للتصحيح (من المحتمل عدم تطابق التوقيع)</string>
     <string name="error_unsafe_skipped">تم التخطي: تطبيق النظام غير آمن / فشل فحص الأمان</string>
+    <string name="error_self_skipped">تم التخطي: لا يمكن لـ Thor تنفيذ ذلك على نفسه</string>
     <string name="error_parse_package">فشل في تحليل الحزمة.</string>
     <string name="error_downgrade_privilege">خفض الإصدار مدعوم فقط مع الوصول المميز (Root أو Shizuku أو Dhizuku).</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -399,7 +399,6 @@
     <string name="log_uninstalling_batch">Desinstalando aplicaciones</string>
     <string name="log_suspending_batch">Suspendiendo aplicaciones</string>
     <string name="log_unsuspending_batch">Reanudando aplicaciones</string>
-    <string name="log_clearing_data_batch">Limpiando datos</string>
     <string name="log_sharing_batch">Compartiendo aplicaciones</string>
     <string name="log_batch_step">[%1$d/%2$d] %3$s…</string>
     <string name="log_batch_preparing">[%1$d/%2$d] Preparando %3$s…</string>
@@ -420,6 +419,7 @@
     <string name="filter_all">Todas</string>
     <string name="error_debuggable_app">La aplicación es depurable (probablemente discrepancia de firma)</string>
     <string name="error_unsafe_skipped">Omitido: La aplicación del sistema es INSEGURA / falló la verificación de seguridad</string>
+    <string name="error_self_skipped">Omitido: Thor no puede hacerse esto a sí mismo</string>
     <string name="error_parse_package">Error al analizar el paquete.</string>
     <string name="error_downgrade_privilege">La degradación solo es compatible con acceso privilegiado (Root, Shizuku o Dhizuku).</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -399,7 +399,6 @@
     <string name="log_uninstalling_batch">Désinstallation des applications</string>
     <string name="log_suspending_batch">Suspension des applications</string>
     <string name="log_unsuspending_batch">Rétablissement des applications</string>
-    <string name="log_clearing_data_batch">Effacement des données</string>
     <string name="log_sharing_batch">Partage des applications</string>
     <string name="log_batch_step">[%1$d/%2$d] %3$s…</string>
     <string name="log_batch_preparing">[%1$d/%2$d] Préparation de %3$s…</string>
@@ -420,6 +419,7 @@
     <string name="filter_all">Tout</string>
     <string name="error_debuggable_app">L\'application est débogable (probablement une incompatibilité de signature)</string>
     <string name="error_unsafe_skipped">Ignoré : L\'application système est DANGEREUSE / échec de la vérification de sécurité</string>
+    <string name="error_self_skipped">Ignoré : Thor ne peut pas se l\'appliquer à lui-même</string>
     <string name="error_parse_package">Échec de l\'analyse du paquet.</string>
     <string name="error_downgrade_privilege">La rétrogradation n\'est prise en charge qu\'avec un accès privilégié (Root, Shizuku ou Dhizuku).</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -391,7 +391,6 @@
     <string name="log_uninstalling_batch">正在批量卸载应用</string>
     <string name="log_suspending_batch">正在批量暂停应用</string>
     <string name="log_unsuspending_batch">正在批量取消暂停应用</string>
-    <string name="log_clearing_data_batch">正在批量清除数据</string>
     <string name="log_sharing_batch">正在批量分享应用</string>
     <string name="log_batch_step">[%1$d/%2$d] %3$s…</string>
     <string name="log_batch_preparing">[%1$d/%2$d] 正在准备 %3$s…</string>
@@ -412,6 +411,7 @@
     <string name="filter_all">全部</string>
     <string name="error_debuggable_app">应用可调试（签名可能不匹配）</string>
     <string name="error_unsafe_skipped">已跳过：系统应用不安全 / 安全检查失败</string>
+    <string name="error_self_skipped">已跳过：Thor 无法对自身执行此操作</string>
     <string name="error_parse_package">解析包失败。</string>
     <string name="error_downgrade_privilege">降级仅支持特权访问（Root、Shizuku 或 Dhizuku）。</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -591,7 +591,6 @@
     <string name="log_uninstalling_batch">Uninstalling Apps</string>
     <string name="log_suspending_batch">Suspending Apps</string>
     <string name="log_unsuspending_batch">Unsuspending Apps</string>
-    <string name="log_clearing_data_batch">Clearing Data</string>
     <string name="log_sharing_batch">Sharing Apps</string>
     <string name="log_batch_step">[%1$d/%2$d] %3$s…</string>
     <string name="log_batch_preparing">[%1$d/%2$d] Preparing %3$s…</string>
@@ -612,6 +611,7 @@
     <string name="filter_all">All</string>
     <string name="error_debuggable_app">App is Debuggable (Signature mismatch likely)</string>
     <string name="error_unsafe_skipped">Skipped: System app is UNSAFE / safety check failed</string>
+    <string name="error_self_skipped">Skipped: Thor cannot do this to itself</string>
     <string name="error_parse_package">Failed to parse package.</string>
     <string name="error_downgrade_privilege">Downgrade is only supported with privileged access (Root, Shizuku, or Dhizuku).</string>
 

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -10,8 +10,15 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="job_backing_up">Backing up</string>
     <string name="job_restoring">Restoring</string>
-    <string name="job_channel_name">Backup and restore</string>
-    <string name="job_channel_description">Progress for backups and restores running in the background</string>
+    <!--
+      Named for the channel's scope, not for the feature that opened it. A user silencing this is
+      silencing every long-running job Thor reports — bulk actions are meant to join backups on it —
+      and a switch labelled "Backup and restore" would not have told them that. The channel id is
+      unchanged ("thor.jobs"), so renaming it here renames the existing switch rather than creating a
+      second one; a channel's name is updatable, its importance is not once the user has touched it.
+    -->
+    <string name="job_channel_name">Background jobs</string>
+    <string name="job_channel_description">Progress for backups, restores and bulk actions running in the background</string>
 
     <string name="action_backup">Back up</string>
     <string name="backup_unsupported">Thor cannot read another app\'s private data with the access it has right now. This needs root, or Shizuku started from root.</string>

--- a/app/src/test/java/com/valhalla/thor/data/backup/job/EnqueueFailureWatchTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/backup/job/EnqueueFailureWatchTest.kt
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.backup.job
+
+import com.google.common.util.concurrent.ListenableFuture
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * [whenFailed] — the cleanup that survives its caller.
+ *
+ * The sequence these cover: a caller stops waiting for an enqueue (its coroutine is cancelled), and the
+ * enqueue *then* fails. No worker will ever run, so the key put in [ArchiveKeyHolder] before the enqueue
+ * has nothing left that could consume it, and the frame that would have dropped it is gone.
+ *
+ * **What is pinned here and what is not.** These pin the watch's own contract — fails ⇒ release, succeeds
+ * ⇒ do not, and the argument is the *cause* rather than the wrapper. They do **not** pin that
+ * [enqueueUniqueJob]'s cancellation branch registers the watch: that call needs `WorkManager.getInstance`,
+ * and with no `work-testing` or Robolectric on this classpath there is no JVM seam for it. That half is
+ * one line, and it is verified by reading it.
+ */
+class EnqueueFailureWatchTest {
+
+    /**
+     * The five `Future` methods plus `addListener`, with the two orderings that matter: completing after a
+     * listener is registered, and registering on a future that is already done. Guava's contract is that
+     * the listener runs immediately in the second case, and a fake that forgot to do that would make the
+     * "already failed" test below pass for the wrong reason.
+     */
+    private class FakeFuture : ListenableFuture<String> {
+        private var listener: Runnable? = null
+        private var executor: Executor? = null
+        private var failure: Throwable? = null
+        private var cancelled = false
+        private var done = false
+
+        fun succeed() = complete { done = true }
+        fun fail(cause: Throwable) = complete { failure = cause; done = true }
+        fun cancelFuture() = complete { cancelled = true; done = true }
+
+        private fun complete(settle: () -> Unit) {
+            settle()
+            val pending = listener ?: return
+            (executor ?: Executor { it.run() }).execute(pending)
+        }
+
+        override fun addListener(listener: Runnable, executor: Executor) {
+            this.listener = listener
+            this.executor = executor
+            if (done) executor.execute(listener)
+        }
+
+        override fun get(): String = when {
+            cancelled -> throw CancellationException("the operation's own future was cancelled")
+            failure != null -> throw ExecutionException(failure)
+            else -> "enqueued"
+        }
+
+        override fun get(timeout: Long, unit: TimeUnit): String = get()
+        override fun isDone(): Boolean = done
+        override fun isCancelled(): Boolean = cancelled
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
+    }
+
+    private val future = FakeFuture()
+    private val released = mutableListOf<Throwable>()
+
+    @Test
+    fun `an enqueue that fails after nobody is waiting still releases what it was holding`() {
+        val reason = IllegalStateException("WorkSpec insert failed")
+        future.whenFailed { released.add(it) }
+
+        future.fail(reason)
+
+        assertEquals(1, released.size)
+        assertSame(
+            "the handler gets the cause, not the ExecutionException wrapping it — the wrapper says " +
+                "nothing about what went wrong",
+            reason,
+            released.single(),
+        )
+    }
+
+    @Test
+    fun `an enqueue that succeeds after the wait was cancelled releases nothing`() {
+        future.whenFailed { released.add(it) }
+
+        future.succeed()
+
+        assertEquals(
+            "the work is with WorkManager and its worker still needs the key; this is the case the " +
+                "cancellation branch exists to protect",
+            emptyList<Throwable>(),
+            released,
+        )
+    }
+
+    @Test
+    fun `a future that had already failed by the time the watch was registered releases immediately`() {
+        val reason = IllegalStateException("enqueue was rejected")
+        future.fail(reason)
+
+        future.whenFailed { released.add(it) }
+
+        assertSame(reason, released.singleOrNull())
+    }
+
+    @Test
+    fun `a cancelled future releases nothing, because it does not say the enqueue failed`() {
+        future.whenFailed { released.add(it) }
+
+        future.cancelFuture()
+
+        assertEquals(
+            "a cancelled future says nothing about whether the WorkSpec landed; releasing a key a live " +
+                "worker needs is the worse of the two failures, so this fails closed and lets the " +
+                "holder's own expiry deal with it",
+            emptyList<Throwable>(),
+            released,
+        )
+    }
+
+    @Test
+    fun `a get that throws is swallowed instead of thrown into the thread that completed the future`() {
+        future.whenFailed { released.add(it) }
+
+        // Distinct from the test above, which pins what was *released*: this pins that the listener body
+        // itself is exception-free. `get()` on a cancelled future throws, and that throw would otherwise
+        // travel into WorkManager's executor, which is not expecting Thor's exceptions.
+        assertNull(runCatching { future.cancelFuture() }.exceptionOrNull())
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/ThorJobTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/ThorJobTest.kt
@@ -3,6 +3,7 @@
 
 package com.valhalla.thor.domain.model
 
+import com.valhalla.thor.data.backup.job.ThorJobNotifications
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -18,6 +19,23 @@ class ThorJobTest {
         // avoid.
         assertEquals(false, THOR_JOB_CHAIN.contains("com.example"))
         assertEquals(false, ThorJobKind.entries.any { THOR_JOB_CHAIN.contains(it.id) })
+    }
+
+    @Test
+    fun `the sweep chain is a different name from the byte-mover chain`() {
+        // Two chains is the whole point: a five-second freeze sweep must not queue behind an
+        // hour-long capture. Collapsing them back to one name is a one-character mistake that would
+        // show up only as "why is Thor taking so long to freeze an app", on a device, under load.
+        assertNotEquals(THOR_JOB_CHAIN, THOR_SWEEP_CHAIN)
+    }
+
+    @Test
+    fun `the sweep chain name does not depend on the target either`() {
+        // Same reason as the byte-mover chain, minus the disk argument: sweeps serialise so two of
+        // them cannot race on the same package, and because Odin's root channel is one FIFO `su`
+        // session that would interleave them anyway.
+        assertEquals(false, THOR_SWEEP_CHAIN.contains("com.example"))
+        assertEquals(false, ThorJobKind.entries.any { THOR_SWEEP_CHAIN.contains(it.id) })
     }
 
     @Test
@@ -46,6 +64,22 @@ class ThorJobTest {
 
         assertEquals(ids.size, ids.toSet().size)
         for (a in ids) for (b in ids) if (a != b) assertEquals(false, a.startsWith(b))
+    }
+
+    @Test
+    fun `the ongoing and outcome notification id blocks cannot overlap`() {
+        // Both blocks are BASE + kind.ordinal, so they collide the moment the enum grows past the gap
+        // between them — and the symptom is that a job's outcome row is posted under the id of some
+        // *other* kind's progress row, which the other job's `finally` then cancels.
+        //
+        // Reading two `const val`s does not load ThorJobNotifications: a const is inlined at the call
+        // site, so this stays a JVM test even though the class it names needs a Context and a
+        // NotificationManager. Nothing else in that file is reachable from here.
+        assertEquals(
+            true,
+            ThorJobNotifications.BASE_RESULT_NOTIFICATION_ID - ThorJobNotifications.BASE_NOTIFICATION_ID
+                    >= ThorJobKind.entries.size,
+        )
     }
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
@@ -346,6 +346,26 @@ class FreezeAppUseCaseTest {
         assertEquals(emptyList<String>(), repository.lookups)
     }
 
+    @Test
+    fun `a state-aware restore told the app is active makes no call and still succeeds`() = runTest {
+        // The trap that decides which of these two primitives a *bulk* path may use, pinned here
+        // because it is invisible at the call site: `restoreApp` plans from the flags it is handed,
+        // so flags saying "active" plan nothing, and planning nothing reports `success`.
+        //
+        // That is correct for a single app whose flags were just read, and a lie for a batch, because
+        // no bulk path patches `isSuspended` on the list it is iterating: not
+        // `MainViewModel.performCountedFreeze` (it updates the logger counters and never refreshes
+        // the lists), not `AppListViewModel`'s bulk branch, not the QS tile. So freeze-with-suspend
+        // followed by unfreeze over the same selection hands this method a stale snapshot, and every
+        // app comes back counted as unfrozen while all of them are still suspended.
+        //
+        // Both bulk paths call `forceUnfreeze` instead, and the test above is what they get for it.
+        // If this test goes red because `restoreApp` started asking the system what the flags are,
+        // that choice is worth revisiting — this is the only reason for it.
+        assertTrue(manage.restoreApp(PKG, enabled = true, isSuspended = false).isSuccess)
+        assertEquals(emptyList<String>(), system.calls)
+    }
+
     // --- The batch paths must not report twice -----------------------------------------------
 
     @Test

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -549,15 +549,29 @@ class FakePreferenceRepository(
 // disk — so this one fails loudly rather than quietly, and a share test that reaches it reports the
 // real reason instead of a confusing null.
 
-class FakeAppBundleBuilder : AppBundleBuilder {
+class FakeAppBundleBuilder(
+    /**
+     * Run at the top of every [build], before it fails.
+     *
+     * The seam for a test that has to act *during* a batch rather than before or after it — tapping
+     * Stop, say, which a view model only observes between apps. Nothing else can reach that moment:
+     * the loop runs to completion inside one `withContext`, so a test body regains control only once
+     * every app has had its turn.
+     *
+     * Defaulted, so the tests that predate it read unchanged.
+     */
+    private val onBuild: (AppInfo) -> Unit = {},
+) : AppBundleBuilder {
     // No default values on the override — Kotlin takes them from the interface.
     override suspend fun build(
         appInfo: AppInfo,
         cacheSubDir: String,
         format: BundleFormat,
         fileName: String?
-    ): Result<File> =
-        Result.failure(UnsupportedOperationException("bundle building needs a device"))
+    ): Result<File> {
+        onBuild(appInfo)
+        return Result.failure(UnsupportedOperationException("bundle building needs a device"))
+    }
 }
 
 /**

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
@@ -5,8 +5,11 @@ package com.valhalla.thor.presentation.appList
 
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AnimationIntensity
+import com.valhalla.thor.domain.model.BulkOp
+import com.valhalla.thor.domain.model.BulkResult
 import com.valhalla.thor.domain.model.FilterType
 import com.valhalla.thor.domain.model.InstalledAppsPermission
+import com.valhalla.thor.domain.model.MultiAppAction
 import com.valhalla.thor.domain.model.PermissionIndex
 import com.valhalla.thor.domain.model.SortBy
 import com.valhalla.thor.domain.model.SortOrder
@@ -33,6 +36,7 @@ import com.valhalla.thor.presentation.FakeUsageAccessGate
 import com.valhalla.thor.presentation.MainDispatcherRule
 import com.valhalla.thor.presentation.userApp
 import com.valhalla.thor.util.UiText
+import com.valhalla.thor.util.bulkResultMessage
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -458,6 +462,101 @@ class AppListViewModelTest {
             "the watchlist entry is the only route back to a still-frozen app",
             freezer.contains("a")
         )
+    }
+
+    // --- Bulk unfreeze ----------------------------------------------------------------------
+
+    /**
+     * The bulk direction had two independent ways to report a thaw that never happened, and fixing
+     * one of them made the other one worse.
+     *
+     * It used to discard every result, mark the whole selection enabled and send an unconditional
+     * success plural. Counting properly fixed the arithmetic and left the deeper problem: with
+     * `setAppDisabled` it counted an enable that succeeded on an app that was *suspended*, so the
+     * report became precisely accurate about a call that did not unfreeze anything. Both halves have
+     * to hold at once — the right call, and only the apps it worked for.
+     */
+    @Test
+    fun `a bulk unfreeze clears both freeze dimensions for every app`() = runTest {
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+        appRepository.apps.value = listOf(
+            userApp("a", enabled = false),
+            userApp("b", enabled = true, isSuspended = true),
+        )
+        runCurrent()
+        system.calls.clear()
+
+        vm.performMultiAction(
+            MultiAppAction.UnFreeze(listOf(userApp("a", enabled = false), userApp("b", isSuspended = true)))
+        )
+        runCurrent()
+
+        // Asked for unconditionally rather than planned from the flags: `isSuspended` is patched on
+        // exactly one path in this view model and never on a bulk one, so a snapshot is the wrong
+        // thing to plan from. `b` needs the unsuspend and `a` does not; both are asked anyway.
+        assertEquals(
+            listOf(
+                "setAppSuspended:a:false", "setAppDisabled:a:false",
+                "setAppSuspended:b:false", "setAppDisabled:b:false",
+            ),
+            system.calls
+        )
+    }
+
+    @Test
+    fun `a bulk unfreeze stops the rows reading as suspended, not just as disabled`() = runTest {
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+        appRepository.apps.value = listOf(userApp("a", enabled = false, isSuspended = true))
+        runCurrent()
+
+        vm.performMultiAction(MultiAppAction.UnFreeze(listOf(userApp("a", enabled = false, isSuspended = true))))
+        runCurrent()
+
+        // Patching only `enabled` would leave a thawed app drawn as suspended until the next rescan —
+        // and would leave the *next* unfreeze reading that stale flag, which is the trap this whole
+        // section exists for.
+        val app = vm.uiState.value.allUserApps.first { it.packageName == "a" }
+        assertTrue("enabled again", app.enabled)
+        assertFalse("and not suspended", app.isSuspended)
+    }
+
+    @Test
+    fun `a bulk unfreeze counts only the apps that came back and leaves the rest frozen`() = runTest {
+        val vm = viewModel(AnimationIntensity.LOW)
+        val events = mutableListOf<AppListEvent>()
+        backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.events.collect { events += it } }
+        runCurrent()
+        appRepository.apps.value = listOf(
+            userApp("a", enabled = false),
+            userApp("b", enabled = false),
+        )
+        runCurrent()
+        events.clear()
+        // The enable is the second half of forceUnfreeze, so failing it fails the whole restore for
+        // that app while the other one succeeds — the mixed outcome the report has to survive.
+        system.failWith("setAppDisabled:b:false", IllegalStateException("no privilege"))
+
+        vm.performMultiAction(
+            MultiAppAction.UnFreeze(listOf(userApp("a", enabled = false), userApp("b", enabled = false)))
+        )
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                AppListEvent.ShowMessage(
+                    bulkResultMessage(
+                        BulkResult(op = BulkOp.UNFREEZE, total = 2, succeeded = 1, failed = 1)
+                    )
+                )
+            ),
+            events
+        )
+        // And the row for the app that stayed frozen must still say so, or the only affordance for
+        // retrying it is gone.
+        assertFalse(vm.uiState.value.allUserApps.first { it.packageName == "b" }.enabled)
+        assertTrue(vm.uiState.value.allUserApps.first { it.packageName == "a" }.enabled)
     }
 
     // --- GET_INSTALLED_APPS banner ---------------------------------------------------------

--- a/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
@@ -119,12 +119,15 @@ class MainViewModelTest {
         // on it, so a test can drive a notification tap by calling `requestOpen` on the same instance
         // the view model is watching. Defaulted so the tests that predate it read unchanged.
         sheetTargets: JobSheetTargets = JobSheetTargets(),
+        // Only the two stop-reporting tests pass one: they need to act from *inside* the share loop,
+        // which is the one moment a test body cannot otherwise reach. See FakeAppBundleBuilder.onBuild.
+        bundleBuilder: FakeAppBundleBuilder = FakeAppBundleBuilder(),
     ): MainViewModel {
         val vm = MainViewModel(
             manageAppUseCase = ManageAppUseCase(system),
             getInstalledAppsUseCase = GetInstalledAppsUseCase(appRepository),
             shareAppUseCase = ShareAppUseCase(
-                FakeAppBundleBuilder(),
+                bundleBuilder,
                 FakeAppBundleFileStore(),
                 mainDispatcherRule.dispatcher
             ),
@@ -268,9 +271,52 @@ class MainViewModelTest {
 
         // Reusing the freeze filter for unfreeze is the tempting simplification, and it would strand
         // every blocked app that is already frozen — the exact state a user needs a way out of.
-        assertEquals(listOf("setAppDisabled:com.blocked:false"), system.calls)
+        //
+        // Both dimensions, unconditionally: this app is only *disabled*, so the unsuspend is redundant
+        // and asked for anyway. See the round-trip test below for what reading the flags instead costs.
+        assertEquals(
+            listOf("setAppSuspended:com.blocked:false", "setAppDisabled:com.blocked:false"),
+            system.calls
+        )
         assertEquals(1, vm.uiState.value.freezeLoggerState.total)
     }
+
+    @Test
+    fun `apps suspended by a bulk freeze are actually unsuspended by the bulk unfreeze after it`() =
+        runTest {
+            val vm = viewModel()
+            // One selection, held across both actions — which is what the UI does, and the whole
+            // point: nothing patches `isSuspended` on these objects when the freeze suspends them, so
+            // by the second action the flags are stale and still read "active".
+            val selection = listOf(userApp("com.a"), userApp("com.b"))
+
+            vm.onMultiAppAction(MultiAppAction.Freeze(selection, useSuspend = true))
+            advanceUntilIdle()
+            assertEquals(
+                listOf("setAppSuspended:com.a:true", "setAppSuspended:com.b:true"),
+                system.calls
+            )
+            system.calls.clear()
+
+            vm.onMultiAppAction(MultiAppAction.UnFreeze(selection))
+            advanceUntilIdle()
+
+            // The regression: reading the stale flags made `restoreApp` plan nothing, return success
+            // for both apps, and report "Unfroze 2" over two apps still showing the system's "app
+            // paused" dialog. The suspend-then-unsuspend round trip is the primary way suspend mode
+            // gets used, so the failure was reachable in two taps.
+            assertEquals(
+                "the unsuspend has to be asked for, not inferred from a snapshot the freeze never patched",
+                listOf(
+                    "setAppSuspended:com.a:false", "setAppDisabled:com.a:false",
+                    "setAppSuspended:com.b:false", "setAppDisabled:com.b:false",
+                ),
+                system.calls
+            )
+            val state = vm.uiState.value.freezeLoggerState
+            assertEquals(2, state.processed)
+            assertEquals(0, state.failed)
+        }
 
     @Test
     fun `the freeze counter reports every failure and still finishes the run`() = runTest {
@@ -940,6 +986,74 @@ class MainViewModelTest {
         assertEquals(
             listOf("forceStopApp:com.a", "forceStopApp:com.b", "forceStopApp:com.c", "forceStopApp:com.d"),
             system.calls
+        )
+    }
+
+    @Test
+    fun `a stop that arrives during the last app does not report a stopped batch`() = runTest {
+        val vm = viewModel()
+        // The last app is the only one that can tell `processed < apps.size` apart from
+        // `stopRequested`: the flag is read *after* the loop, so a stop arriving while the final call
+        // is in flight sets it with every app already done.
+        system.onCall = { if (it == "forceStopApp:com.b") vm.requestStopBatch() }
+
+        vm.onMultiAppAction(MultiAppAction.Kill(listOf(userApp("com.a"), userApp("com.b"))))
+        advanceUntilIdle()
+
+        // Nothing was skipped, so nothing may say it was — "Stopped: 2 of 2" is a complete run
+        // describing itself as an interrupted one, and the user's next question is what got lost.
+        assertEquals(listOf("forceStopApp:com.a", "forceStopApp:com.b"), system.calls)
+        assertFalse(
+            "a batch that finished every app reported itself stopped",
+            vm.uiState.value.loggerState.logs.any {
+                it is UiText.StringResource && it.resId == R.string.log_stopped
+            }
+        )
+    }
+
+    @Test
+    fun `a stop that skipped apps reports how many were done`() = runTest {
+        val vm = viewModel()
+        system.onCall = { if (it == "forceStopApp:com.a") vm.requestStopBatch() }
+
+        vm.onMultiAppAction(
+            MultiAppAction.Kill(listOf(userApp("com.a"), userApp("com.b"), userApp("com.c")))
+        )
+        advanceUntilIdle()
+
+        // The other half of the gate: two apps really were skipped, and the count has to be the one
+        // the loop reached, not the size of the selection.
+        assertEquals(listOf("forceStopApp:com.a"), system.calls)
+        assertTrue(
+            vm.uiState.value.loggerState.logs.contains(
+                UiText.StringResource(R.string.log_stopped, 1, 3)
+            )
+        )
+    }
+
+    @Test
+    fun `a stop during the last shared app does not report a stopped batch either`() = runTest {
+        // The share branch keeps its own copy of the batch loop, so it needs its own pin. Driven from
+        // the bundle builder rather than the system fake because sharing never reaches the privilege
+        // layer — it stages files.
+        // Assigned after construction because the builder is a constructor argument of the thing it
+        // has to call back into.
+        var stopper: MainViewModel? = null
+        val builder = FakeAppBundleBuilder { app ->
+            if (app.packageName == "com.b") stopper?.requestStopBatch()
+        }
+        val vm = viewModel(bundleBuilder = builder)
+        stopper = vm
+
+        vm.onMultiAppAction(MultiAppAction.Share(listOf(userApp("com.a"), userApp("com.b"))))
+        advanceUntilIdle()
+
+        // Both bundles fail here (no device), so the logger stays up to be read instead of being
+        // dismissed for a share sheet — which is what makes this assertion possible at all.
+        assertFalse(
+            vm.uiState.value.loggerState.logs.any {
+                it is UiText.StringResource && it.resId == R.string.log_stopped
+            }
         )
     }
 


### PR DESCRIPTION
Phases 1 and 2 of moving Thor's bulk actions onto WorkManager. **No worker is added here** — this is
the groundwork: fix what the batch paths already get wrong, then make the job seam able to take a
job that is not an archive. The workers themselves are the next PR.

Two commits, deliberately separable.

## 1 — `fix(bulk)`: the batch actions tell the truth

Five behavioural fixes, all in paths a user reaches today.

- **Bulk unfreeze reported a result it never read.** It called `setAppDisabled` per app, discarded
  every `Result`, marked the *entire* selection `enabled = true` and sent an unconditional success
  plural for `appList.size`. A batch where nothing thawed said "Unfroze 12 apps" and drew twelve
  thawed rows to match. Results are now bound, only what succeeded is marked, and both directions
  report through `bulkResultMessage(BulkResult(...))` — the tested three-bucket helper five other
  surfaces already use. The freeze branch beside it always counted properly; it now shares that
  helper instead of hand-rolling the same buckets, and its wording is unchanged (`unresolved` is 0
  in both).
- **Bulk share was the slowest batch Thor has and the only one whose Stop button was never wired.**
  It now passes `canStop`, breaks between apps, and logs how many of how many it got through. The
  count is apps *processed*, not URIs collected, so an app that failed before the stop is not
  quietly dropped from the total.
- **Bulk Kill and Uninstall could target Thor.** Thor is in its own app list, so "select all → Kill"
  is two taps: force-stopping takes the ViewModel, the logger and the remaining apps with it, and
  the uninstall is worse because it succeeds. Both now skip the self package with a localised
  reason. `fixStoreCandidates` already excluded Thor for this reason.
- **Repeated taps on Export/Share list raced** each other through a staging directory that
  `stageText` wipes on entry. One shared job handle, because it is one directory.
- **`MultiAppAction.ClearData` is removed** — a variant, a handler, an `AffirmationDialog`
  confirmation and five locales of copy, with **no construction site anywhere in the app**. Bulk
  clear data wants a design pass, not a resurrected stub. Single-app clear data is untouched.

## 2 — `refactor(jobs)`: the seam can host a non-archive job

The seam was written for reuse and says so in three KDocs, but it could not take a second kind of
job.

- **`ArchiveKeyHolder` is out of `ThorJobWorker`'s constructor**, replaced by a `protected open
  onJobFinished()`. The base guards the call, because it runs inside a `finally`: an override that
  threw would skip the notification cancel below it and leave an ongoing row for a finished job —
  permanently, since `setOngoing(true)` means the user cannot swipe it away.
- **`runsForeground`, default true.** A sweep should not spend Thor's one `dataSync` slot or risk
  `ForegroundServiceStartNotAllowedException` for work that ends in seconds, and it loses nothing
  visible — the progress row goes through `NotificationManagerCompat`, not the FGS.
- **Two chains.** `THOR_JOB_CHAIN`'s KDoc sold serialisation on *peak disk*, which does not reach a
  freeze, a suspend or a force-stop. Sweeps get `THOR_SWEEP_CHAIN`, and still serialise among
  themselves for reasons that are theirs: overlapping selections race on the same packages, and
  Odin's root channel is one FIFO `su` session that would interleave them anyway.
- **A terminal notifier, which the seam never had.** The ongoing row is a background job's only
  surface and the `finally` removes it, so a job that finished off screen reported to nobody. It
  matters most where nothing else *can*: WorkManager records CANCELLED and **discards the worker's
  `Result`**, so a sweep stopped at 7 of 20 cannot return that count. `noteResult` is posted from
  the `finally`, the one place that still runs. `ThorJobStatus.Cancelled` now documents why it
  cannot carry counts.
- Plus: the awaited-`Operation` enqueue is a top-level function taking the chain name; `status()`
  and `runningJobFor()` move to a `ThorJobWatcher` interface; the shade icon stops being
  `R.drawable.frozen` (a snowflake meaning *frozen app*, sitting on top of every backup); the
  channel is "Background jobs"; `ThorJobKind` is marked append-only, since its ordinal is a
  notification id *and* a `PendingIntent` request code.

## Verification

**1526 unit tests green** (three new: the chain split, and that the two notification-id blocks
cannot overlap). Lint clean.

**Not device-tested, and some of it cannot be.** The chain split and the notification changes are
unobservable on the JVM — this module has no `work-testing` and no Robolectric, so every claim about
WorkManager chain behaviour here is read from its source, not observed. Worth a look on hardware:
the shade icon, the renamed channel switch (same channel id, so it renames the existing switch
rather than adding one), and Stop on a bulk share.

## Disclosed

- Archive jobs deliberately do **not** call `noteResult` yet — their sheets already report every
  outcome, including a warning list one sentence would flatten. Turning it on for backups is a
  one-line change and belongs in its own pass.
- The four `error_self_skipped` translations (es/fr/ar/zh-rCN) are mine, not a native reader's —
  same standing caveat as the 27 strings from #383.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer completion notifications for backup, restore, export, and other background jobs.
  - Added separate scheduling for privilege sweeps.
  - Added progress tracking and cancellation support for multi-app sharing.
  - Added success and failure counts for bulk freeze and unfreeze actions.

- **Bug Fixes**
  - Prevented overlapping export and share requests.
  - Thor now skips attempts to uninstall or disable itself and explains why.
  - Improved cleanup when background jobs fail or are cancelled.
  - Unfreeze results update only for successfully processed apps.

- **Documentation**
  - Improved backup and background-job notification descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->