### PR TITLE
feat(permissions,jobs): grant what privilege already allows, ask for notifications when a job needs them, and stop a failed export destroying the old file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,9 @@ Thor is built using modern Android development practices. Please read the archit
 * **Root Operations**: [Odin](https://github.com/trinadhthatakula/Odin), an in-house Kotlin fork of
   libsu, consumed as `com.trinadhthatakula:odin` from Maven Central.
 * **Hidden API Bypass**: Custom internal `:bypass` module.
+* **Background Work**: WorkManager, but only for two operations — see
+  [docs/workers/README.md](docs/workers/README.md) for which ones, what the job seam requires of a new
+  job kind, and why every bulk action is a plain coroutine instead.
 
 ### Useful Build Commands
 * **Assemble Debug APK (FOSS)**: `./gradlew assembleFossDebug`

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,8 +44,10 @@
         tools:ignore="ProtectedPermissions" />
     <!-- Bulk-freeze results from the QS tile and launcher shortcuts, neither of which has a
          usable foreground surface: a Toast is dropped by checkCanEnqueueToast and, even when
-         enqueued, draws under the shade (layer 7 vs 17). Requested normally from Settings;
-         never self-granted. Inert below API 33. -->
+         enqueued, draws under the shade (layer 7 vs 17). Requested from Settings, from a job that
+         starts without it, or — for a user who has already handed Thor root or Shizuku — taken
+         silently by SelfPermissionGranter, since privilege is the stronger form of the same answer.
+         Inert below API 33, where an app-wide mute is the only state and no `pm` verb reaches it. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- WorkManager's own manifest declares the base FOREGROUND_SERVICE permission but leaves the
          type to the app. Without the type permission AND the type attribute below, setForeground()

--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -15,6 +15,7 @@ import com.rosan.dhizuku.api.Dhizuku
 import com.valhalla.bypass.Bypass
 import com.valhalla.thor.core.ThorShellConfig
 import com.valhalla.thor.data.backup.ArchiveOrphanSweeper
+import com.valhalla.thor.data.permission.SelfPermissionGranter
 import com.valhalla.thor.data.service.AutoFreezeManager
 import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper
 import com.valhalla.thor.domain.repository.PreferenceRepository
@@ -189,6 +190,17 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
     private val archiveOrphanSweeper: ArchiveOrphanSweeper by inject()
 
     /**
+     * Resolved here because a Koin `@Single` nobody injects is never constructed, so its observer
+     * would never start — the same reason [autoFreezeManager] is resolved eagerly.
+     *
+     * Constructing it resolves `PrivilegeStateProvider`, which brings the first privilege probe
+     * forward from "when the first ViewModel is built" to `onCreate`. That is milliseconds on the
+     * path this app already takes (`MainScreen` composes immediately) and the probe launches into
+     * `PrivilegeManager`'s own scope rather than blocking here.
+     */
+    private val selfPermissionGranter: SelfPermissionGranter by inject()
+
+    /**
      * The sweep's dispatcher, injected rather than hardcoded even here.
      *
      * [appScope] runs on `Dispatchers.Main.immediate`, and the sweeper blocks on whoever calls it —
@@ -250,6 +262,11 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
         }
 
         autoFreezeManager.startObserving()
+
+        // After the Dhizuku init above, not before: that call is what lets the Dhizuku rung of the
+        // privilege probe answer truthfully on a first run, and this observer acts on the probe's
+        // result. Nothing here blocks — it launches a collector and returns.
+        selfPermissionGranter.startObserving()
 
         appScope.launch {
             runCatching {

--- a/app/src/main/java/com/valhalla/thor/data/permission/SelfPermissionGranter.kt
+++ b/app/src/main/java/com/valhalla/thor/data/permission/SelfPermissionGranter.kt
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.permission
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.PermissionInfo
+import android.os.Build
+import com.valhalla.thor.domain.model.DeclaredPermission
+import com.valhalla.thor.domain.model.SelfGrantPlan
+import com.valhalla.thor.domain.model.SelfPermission
+import com.valhalla.thor.domain.model.SelfPermissionDeclaration
+import com.valhalla.thor.domain.model.planSelfGrant
+import com.valhalla.thor.domain.repository.PrivilegeStateProvider
+import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
+
+/**
+ * Grants Thor **its own** declared runtime permissions through whichever privilege gateway is live,
+ * so that a user who has already handed Thor root or Shizuku is not asked again for permissions that
+ * privilege can simply take.
+ *
+ * The rule — which permissions, and why not the others — is [planSelfGrant]; this class only asks the
+ * device the questions that rule needs and issues the commands it returns. That split is what makes
+ * the decision testable on the JVM: `PackageManager` is abstract, `:app` carries no mocking library
+ * by policy, and a rule written inline here would be a rule no test can reach.
+ *
+ * ### Scope
+ *
+ * **Thor's own package, and nothing else.** [SystemRepository.grantPermission] takes a package name
+ * and every call below passes `context.packageName`. The general-purpose per-app grant UI is
+ * `PermissionManagerScreen`, which is user-driven and untouched by this.
+ *
+ * ⚠️ **This is a deliberate reversal of Thor's previous policy**, which was that Thor never
+ * self-grants — stated on the manifest's `POST_NOTIFICATIONS` declaration and beside the
+ * `GET_INSTALLED_APPS` launcher in `AppListScreen`, both now updated to say what actually happens.
+ * The owner's call, and the reasoning is that an ungranted permission cannot be told apart from a
+ * refused one, so a privileged user was being asked for something they had already answered in a
+ * stronger form. It follows that this must never run without a live gateway: see [startObserving].
+ *
+ * ### What it deliberately does not do
+ *
+ * Nothing here knows a permission by name, including `POST_NOTIFICATIONS`. That matters because a
+ * name-specific rung is where this class would rot — Thor's manifest is the input, so a permission
+ * added to it later is covered with no edit here.
+ *
+ * ⚠️ It follows that **granting `POST_NOTIFICATIONS` is not the same as notifications working.**
+ * `NotificationManagerCompat.areNotificationsEnabled()` is also false when the user has muted Thor
+ * app-wide, and below API 33 the permission does not exist at all while the mute still does — no
+ * `pm` verb and no app-op reaches that state, only Settings. The screen-level request path
+ * (`rememberNotificationPermissionRequest`) re-reads the real answer and deep-links when it has to,
+ * which is why this class does not try to special-case it.
+ *
+ * Modelled on [com.valhalla.thor.data.manager.UsageAccessManager]: latch only after a run that
+ * actually finished, always re-verify rather than trust the command's exit code, and never throw at
+ * the caller.
+ */
+@Single
+class SelfPermissionGranter(
+    private val context: Context,
+    private val packageManager: PackageManager,
+    private val systemRepository: SystemRepository,
+    private val privilegeStateProvider: PrivilegeStateProvider,
+    // Backs a process-lifetime scope rather than one call, so this chooses where every self-grant
+    // sweep lives for the life of the process — the same reason AutoFreezeManager injects its two.
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private var observationJob: Job? = null
+
+    /**
+     * Latched only after a run that both attempted everything and had nothing left to attempt.
+     *
+     * `@Volatile` for publication, matching `UsageAccessManager.autoGrantAttempted`; the only caller
+     * is the single collector below, so there is no mutual exclusion to arrange.
+     */
+    @Volatile
+    private var completed = false
+
+    /**
+     * Start watching for a privilege gateway to become available, and self-grant when one does.
+     *
+     * Driven off [PrivilegeStateProvider.state] rather than a one-shot call at startup because the
+     * event this reacts to is usually *later* than process start: a first-run user authorises Shizuku
+     * or answers the `su` prompt while Thor is already open, and on a cold start the first probe has
+     * not landed yet either. The collector stays subscribed, so a privilege gained minutes in is
+     * still seen, and [maybeAutoGrant]'s latch makes every subsequent emission free.
+     *
+     * `hasAnyPrivilege` is the gate and it is not decoration: with no gateway, every `pm grant` below
+     * fails, so running unprivileged would spend a package-manager sweep per privilege state change
+     * to issue commands that cannot work.
+     *
+     * Called from `ThorApplication.onCreate`, beside `AutoFreezeManager.startObserving()`, for the
+     * same reason that one is: a Koin `@Single` nobody resolves is never constructed, so an observer
+     * that is only wired in its own initialiser never runs. Idempotent, so a second call is a no-op
+     * rather than a second collector.
+     */
+    @Synchronized
+    fun startObserving() {
+        if (observationJob != null) return
+        observationJob = scope.launch {
+            privilegeStateProvider.state.collect { state ->
+                if (state.isReady && state.hasAnyPrivilege) maybeAutoGrant()
+            }
+        }
+    }
+
+    /** Stop watching. Present for symmetry with [startObserving]; nothing in the app calls it yet. */
+    @Synchronized
+    fun stopObserving() {
+        observationJob?.cancel()
+        observationJob = null
+    }
+
+    /**
+     * One best-effort sweep per process, latched only once there is genuinely nothing left to do.
+     *
+     * Three things have to be true before the latch closes: the plan had no unanswered probe, every
+     * command was issued, and every issued command verified. A run that fails any of them leaves the
+     * latch open so the next privilege state change tries again — a gateway that is up but not yet
+     * usable (Shizuku bound, permission not yet returned) is the ordinary case here, not an
+     * exceptional one.
+     */
+    suspend fun maybeAutoGrant() {
+        if (completed) return
+        val outcome = tryGrantViaPrivilege()
+        if (outcome.isComplete) completed = true
+    }
+
+    /**
+     * Ask the device, issue the grants [planSelfGrant] returns, and verify each one.
+     *
+     * Verification is a re-read and not the command's exit code, because the two disagree in both
+     * directions: `pm grant` exits 0 on some ROMs while the permission stays ungranted, and a
+     * gateway can report failure for a grant that landed. `checkSelfPermission` asks the same
+     * authority the rest of the app asks.
+     *
+     * Never throws. A failure here means a permission the user can still grant by hand, which is a
+     * strictly better outcome than taking down whatever called this.
+     */
+    suspend fun tryGrantViaPrivilege(): SelfGrantOutcome {
+        val plan = runCatching { plan() }.getOrElse { throwable ->
+            if (throwable is CancellationException) throw throwable
+            Logger.e("SelfPermissions", "Could not read Thor's own permissions", throwable)
+            // Not a verdict about anything — the sweep never happened, so it must be repeatable.
+            return SelfGrantOutcome(granted = emptyList(), refused = emptyList(), isComplete = false)
+        }
+
+        if (plan.toGrant.isEmpty()) {
+            return SelfGrantOutcome(
+                granted = emptyList(),
+                refused = emptyList(),
+                isComplete = !plan.hasUnanswered,
+            )
+        }
+
+        val granted = mutableListOf<String>()
+        val refused = mutableListOf<String>()
+        for (permission in plan.toGrant) {
+            val result = systemRepository.grantPermission(context.packageName, permission)
+            if (isHeld(permission)) {
+                granted += permission
+            } else {
+                refused += permission
+                Logger.w(
+                    "SelfPermissions",
+                    "Self-grant of $permission did not take" +
+                            (result.exceptionOrNull()?.let { ": ${it.message}" } ?: "")
+                )
+            }
+        }
+
+        if (granted.isNotEmpty()) {
+            Logger.d("SelfPermissions", "Self-granted ${granted.size}: ${granted.joinToString()}")
+        }
+
+        return SelfGrantOutcome(
+            granted = granted,
+            refused = refused,
+            isComplete = refused.isEmpty() && !plan.hasUnanswered,
+        )
+    }
+
+    /**
+     * Thor's own declared permissions, each folded into what [planSelfGrant] needs to classify it.
+     *
+     * `requestedPermissions` is the manifest's list **as this build of Android parsed it**, which is
+     * doing more work than it looks: a `uses-permission` carrying a `maxSdkVersion` the running OS
+     * has passed is dropped at parse time and never appears here, so Thor's API-28-only
+     * `WRITE_EXTERNAL_STORAGE` needs no special case — on API 29+ there is nothing to skip.
+     */
+    @Suppress("DEPRECATION")
+    private fun plan(): SelfGrantPlan {
+        val flags = PackageManager.GET_PERMISSIONS
+        val packageInfo: PackageInfo =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getPackageInfo(
+                    context.packageName,
+                    PackageManager.PackageInfoFlags.of(flags.toLong())
+                )
+            } else {
+                packageManager.getPackageInfo(context.packageName, flags)
+            }
+
+        val declared = packageInfo.requestedPermissions ?: emptyArray()
+        return planSelfGrant(
+            declared.map { name ->
+                SelfPermission(
+                    name = name,
+                    declaration = declarationOf(name),
+                    isGranted = isHeld(name),
+                )
+            }
+        )
+    }
+
+    /**
+     * What the running OS says about [name].
+     *
+     * Deliberately uncached, unlike `InstalledAppsPermissionChecker`, which caches the same lookup.
+     * That class answers on the app-list scan path and is asked constantly; this one runs a handful
+     * of times per process at most, so a cache would buy nothing and would have to reproduce that
+     * class's careful rule about which answers may be remembered.
+     */
+    @Suppress("DEPRECATION")
+    private fun declarationOf(name: String): SelfPermissionDeclaration {
+        val info = try {
+            packageManager.getPermissionInfo(name, 0)
+        } catch (_: PackageManager.NameNotFoundException) {
+            return SelfPermissionDeclaration.Undefined
+        } catch (throwable: Throwable) {
+            if (throwable is CancellationException) throw throwable
+            // A failed question rather than an answer about the device; see the KDoc on
+            // SelfPermissionDeclaration.Unknown for what that costs and why it is worth it.
+            Logger.w("SelfPermissions", "Could not classify $name: ${throwable.message}")
+            return SelfPermissionDeclaration.Unknown
+        }
+        return SelfPermissionDeclaration.Declared(
+            DeclaredPermission(
+                isDangerous = (info.protectionLevel and PermissionInfo.PROTECTION_MASK_BASE) ==
+                        PermissionInfo.PROTECTION_DANGEROUS,
+                group = info.group,
+            )
+        )
+    }
+
+    private fun isHeld(name: String): Boolean =
+        context.checkSelfPermission(name) == PackageManager.PERMISSION_GRANTED
+}
+
+/**
+ * What one self-grant sweep achieved.
+ *
+ * [isComplete] is **not** `refused.isEmpty()`. A sweep that granted nothing because a probe failed
+ * has an empty [refused] too, and treating that as done is what would latch the feature off for the
+ * life of the process; the flag is computed where both facts are in hand.
+ */
+data class SelfGrantOutcome(
+    val granted: List<String>,
+    val refused: List<String>,
+    val isComplete: Boolean,
+)

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppBundleFileStoreImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppBundleFileStoreImpl.kt
@@ -3,9 +3,12 @@
 
 package com.valhalla.thor.data.repository
 
+import android.content.ContentResolver
 import android.content.Context
+import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.provider.DocumentsContract
 import android.provider.MediaStore
 import androidx.annotation.RequiresApi
 import androidx.core.content.FileProvider
@@ -15,6 +18,9 @@ import androidx.documentfile.provider.DocumentFile
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.repository.AppBundleFileStore
+import com.valhalla.thor.domain.repository.ArchiveDestination
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -22,9 +28,12 @@ import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+
+private const val TAG = "AppBundleFileStore"
 
 /**
  * The subdirectory of public Downloads that every write Thor makes lands in.
@@ -59,27 +68,21 @@ class AppBundleFileStoreImpl(
     // injected IO dispatcher so callers can invoke them from any context without risking an ANR.
     override suspend fun writeToDownloads(file: File, mime: String): String =
         withContext(ioDispatcher) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) writeToDownloadsMediaStore(file, mime)
-            else writeToDownloadsLegacy(file)
+            val destination = (
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) openInDownloads(file, mime)
+                else openInLegacyDownloads(file)
+                ) ?: throw IOException("Could not create file")
+            destination.write(file)
+            context.getString(R.string.export_dest_downloads)
         }
 
     override suspend fun writeToTree(file: File, treeUriStr: String, mime: String): String =
         withContext(ioDispatcher) {
             val treeUri = treeUriStr.toUri()
             val tree = DocumentFile.fromTreeUri(context, treeUri) ?: throw IOException("Invalid folder")
-            tree.findFile(file.name)?.delete() // overwrite
-            val doc = tree.createFile(mime, file.name) ?: throw IOException("Could not create file")
-            try {
-                context.contentResolver.openOutputStream(doc.uri)?.use { out ->
-                    file.inputStream().use { it.copyCancellableTo(out) }
-                } ?: throw IOException("openOutputStream failed")
-            } catch (e: Exception) {
-                // CancellationException is an Exception, so a cancelled export lands here too and
-                // that is the point: the half-written document is deleted before the throw
-                // propagates. Rethrowing unchanged keeps the cancellation a cancellation.
-                doc.delete() // don't leave a partial/corrupted file behind
-                throw e
-            }
+            val destination = openInTree(treeUri, tree, file.name, mime)
+                ?: throw IOException("Could not create file")
+            destination.write(file)
             tree.name ?: context.getString(R.string.export_dest_selected)
         }
 
@@ -114,64 +117,269 @@ class AppBundleFileStoreImpl(
             File(dir, fileName).apply { writeText(content) }
         }
 
-    @RequiresApi(Build.VERSION_CODES.Q)
-    private suspend fun writeToDownloadsMediaStore(source: File, mime: String): String {
-        val resolver = context.contentResolver
-        val relativePath = "${Environment.DIRECTORY_DOWNLOADS}/$THOR_DOWNLOADS_SUBDIR/"
-        // MediaStore.insert appends " (1)" instead of overwriting, so delete any same-named
-        // entry first. RELATIVE_PATH must match exactly, including the trailing slash.
-        val selection =
-            "${MediaStore.Downloads.DISPLAY_NAME} = ? AND ${MediaStore.Downloads.RELATIVE_PATH} = ?"
-        val selectionArgs = arrayOf(source.name, relativePath)
+    /**
+     * Copy [source] into this destination and settle it exactly once.
+     *
+     * The calling shape [BaseDestination] documents — `try { … publish() } finally { discard() }` —
+     * where the trailing `discard()` is a no-op after any settle and the cleanup after a throw. A
+     * `CancellationException` is an `Exception`, so a cancelled export lands in that `finally` too and
+     * the partial goes with it; nothing is caught, so the cancellation stays a cancellation.
+     *
+     * A false [ArchiveDestination.publish] becomes an [IOException] because that is what every caller
+     * up the chain already handles: `writeStaged` maps a throw to a worded failure, and there is no
+     * "wrote the bytes but could not name them" outcome for it to report.
+     */
+    private suspend fun ArchiveDestination.write(source: File) {
+        var published = false
         try {
-            resolver.delete(MediaStore.Downloads.EXTERNAL_CONTENT_URI, selection, selectionArgs)
-        } catch (_: Exception) { /* best-effort overwrite; fall through to insert */ }
-        val values = contentValuesOf(
-            MediaStore.Downloads.DISPLAY_NAME to source.name,
-            MediaStore.Downloads.MIME_TYPE to mime,
-            MediaStore.Downloads.RELATIVE_PATH to relativePath,
-            MediaStore.Downloads.IS_PENDING to 1
-        )
-        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
-            ?: throw IOException("MediaStore insert failed")
-        try {
-            resolver.openOutputStream(uri)?.use { out ->
-                source.inputStream().use { it.copyCancellableTo(out) }
-            } ?: throw IOException("openOutputStream failed")
-            values.clear()
-            values.put(MediaStore.Downloads.IS_PENDING, 0)
-            resolver.update(uri, values, null, null)
-        } catch (e: Exception) {
-            // Cancellation included — see writeToTree. An IS_PENDING entry that is never cleared
-            // is invisible to other apps and never collected, so leaving one behind on cancel
-            // would be a permanent phantom row in the user's Downloads.
-            resolver.delete(uri, null, null) // don't leave a dangling pending entry
-            throw e
+            source.inputStream().use { it.copyCancellableTo(output) }
+            published = publish()
+        } finally {
+            discard()
         }
-        return context.getString(R.string.export_dest_downloads)
+        if (!published) throw IOException("Could not publish ${source.name}")
     }
 
-    private suspend fun writeToDownloadsLegacy(source: File): String {
+    /**
+     * SAF, any API: write `<name>.part`, then rename it over the file being replaced.
+     *
+     * The order is the whole point. This used to delete the existing file **before** creating the new
+     * document, so every byte of a multi-gigabyte copy was a window in which the user had neither the
+     * old export nor the new one — and a `Worker` widens that window from "a rare foreground cancel"
+     * to routine (foreground-service time cap, Task Manager Stop, low-memory kill, and WorkManager's
+     * free re-run of an interrupted worker). Now the replace is a delete plus a rename with every byte
+     * already on disk.
+     *
+     * A provider that cannot rename is refused **before** anything is deleted. That matches
+     * [AppArchiveStoreImpl]'s answer for the same provider — a rename that publishes nothing is a
+     * failure, not a reason to fall back to a copy — because a fallback that copies into the final name
+     * after deleting the old file re-creates exactly the window this function exists to close.
+     *
+     * `onSettled = {}`: [PartialArchiveLedger] exists so the launch sweep can delete a `.thorbak.part`
+     * an archive left behind, and export partials are deliberately not in it. A killed export leaves
+     * `<name>.part` in the user's folder — visible, obviously incomplete, and never mistaken for a
+     * finished export, which is the trade this reordering buys.
+     */
+    private fun openInTree(
+        treeUri: Uri,
+        tree: DocumentFile,
+        fileName: String,
+        mime: String,
+    ): ArchiveDestination? {
+        val resolver = context.contentResolver
+        val parent = DocumentsContract.buildDocumentUriUsingTree(
+            treeUri,
+            DocumentsContract.getTreeDocumentId(treeUri),
+        )
+        val partUri = DocumentsContract.createDocument(
+            resolver,
+            parent,
+            mime,
+            partialName(fileName),
+        ) ?: return null
+        if (renameKnownUnsupported(resolver, partUri)) {
+            Logger.e(TAG, "the provider for $treeUri cannot rename, so it can never publish a partial")
+            DocumentsContract.deleteDocument(resolver, partUri)
+            return null
+        }
+        val stream = resolver.openOutputStream(partUri) ?: run {
+            DocumentsContract.deleteDocument(resolver, partUri)
+            return null
+        }
+        return object : BaseDestination(stream, onSettled = {}) {
+            override fun onPublish(): Boolean {
+                // Now, with the bytes written: a rename onto a name the folder still holds would be
+                // de-duplicated or refused, so the file being replaced goes first — and it goes at the
+                // last possible moment rather than the first.
+                tree.findFile(fileName)?.delete()
+                return DocumentsContract.renameDocument(resolver, partUri, fileName) != null
+            }
+
+            override fun onDiscard() {
+                DocumentsContract.deleteDocument(resolver, partUri)
+            }
+        }
+    }
+
+    /**
+     * True only when the provider **said** it cannot rename.
+     *
+     * Deliberately not "supportsRename": an unreadable or absent flags column answers "unknown", and
+     * unknown proceeds. Refusing on unknown would turn an exotic provider that renames perfectly well
+     * into an export that cannot be written at all, which is a worse regression than the one this
+     * guard prevents — and on unknown the publish still fails safely, having lost only the file it was
+     * asked to overwrite, which is what today's code loses unconditionally at the *start*.
+     */
+    private fun renameKnownUnsupported(resolver: ContentResolver, docUri: Uri): Boolean = try {
+        resolver.query(
+            docUri,
+            arrayOf(DocumentsContract.Document.COLUMN_FLAGS),
+            null,
+            null,
+            null,
+        )?.use { cursor ->
+            // `isNull` before `getInt`, because `getInt` on a null column answers 0 — indistinguishable
+            // from "the provider supports nothing", which is exactly the wrong way to read silence.
+            cursor.moveToFirst() && !cursor.isNull(0) &&
+                (cursor.getInt(0) and DocumentsContract.Document.FLAG_SUPPORTS_RENAME) == 0
+        } == true
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Logger.e(TAG, "could not read the document flags; assuming the provider can rename", e)
+        false
+    }
+
+    /**
+     * Q+ Downloads: write a pending row, then clear the pending flag once every byte has landed.
+     *
+     * `IS_PENDING` is MediaStore's own settle-once, so no partial name is needed — a pending row is
+     * invisible to other apps. What was wrong was the *replace*: the same-named row was deleted before
+     * the insert, so the whole copy ran with the old export already gone.
+     *
+     * The row being replaced is resolved to an `_ID` **before** the insert, and deleted by that id.
+     * Re-running the original `DISPLAY_NAME = ? AND RELATIVE_PATH = ?` delete after the insert would
+     * match the row just written — it carries that display name in that folder — and so would delete
+     * the export it had only just finished.
+     */
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun openInDownloads(source: File, mime: String): ArchiveDestination? {
+        val resolver = context.contentResolver
+        val relativePath = "${Environment.DIRECTORY_DOWNLOADS}/$THOR_DOWNLOADS_SUBDIR/"
+        // RELATIVE_PATH must match exactly, including the trailing slash.
+        val replacedIds = idsAt(resolver, source.name, relativePath)
+        val uri = resolver.insert(
+            MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+            contentValuesOf(
+                MediaStore.Downloads.DISPLAY_NAME to source.name,
+                MediaStore.Downloads.MIME_TYPE to mime,
+                MediaStore.Downloads.RELATIVE_PATH to relativePath,
+                MediaStore.Downloads.IS_PENDING to 1,
+            ),
+        ) ?: return null
+        val stream = resolver.openOutputStream(uri) ?: run {
+            resolver.delete(uri, null, null)
+            return null
+        }
+        return object : BaseDestination(stream, onSettled = {}) {
+            override fun onPublish(): Boolean {
+                // Clearing IS_PENDING first is what makes the bytes real, and it is the one step that
+                // must not be traded for a tidier name: a crash between here and the delete below
+                // leaves the user with two complete files, where the other order would leave them with
+                // neither the old file nor a visible new one.
+                val cleared = resolver.update(
+                    uri,
+                    contentValuesOf(MediaStore.Downloads.IS_PENDING to 0),
+                    null,
+                    null,
+                ) == 1
+                if (!cleared) return false
+                replacedIds.forEach { id ->
+                    resolver.delete(
+                        MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                        "${MediaStore.Downloads._ID} = ?",
+                        arrayOf(id.toString()),
+                    )
+                }
+                // MediaStore de-duplicates a colliding display name at insert, so while the old row
+                // still existed this one may have become `Foo (1).apk`. With it gone, ask for the name
+                // the user was promised — but do not fail the export over it: the bytes are already
+                // published and complete, and a wrong word beats a lost file.
+                val assigned = displayNameOf(resolver, uri)
+                if (assigned != null && assigned != source.name) {
+                    runCatching {
+                        resolver.update(
+                            uri,
+                            contentValuesOf(MediaStore.Downloads.DISPLAY_NAME to source.name),
+                            null,
+                            null,
+                        )
+                    }.onFailure {
+                        Logger.w(TAG, "exported as $assigned, not ${source.name}: $it")
+                    }
+                }
+                return true
+            }
+
+            override fun onDiscard() {
+                // An IS_PENDING row that is never cleared is invisible to other apps and never
+                // collected, so leaving one behind would be a permanent phantom in Downloads.
+                resolver.delete(uri, null, null)
+            }
+        }
+    }
+
+    /** The ids of every row already carrying [displayName] in [relativePath]. */
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun idsAt(
+        resolver: ContentResolver,
+        displayName: String,
+        relativePath: String,
+    ): List<Long> = try {
+        resolver.query(
+            MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+            arrayOf(MediaStore.Downloads._ID),
+            "${MediaStore.Downloads.DISPLAY_NAME} = ? AND ${MediaStore.Downloads.RELATIVE_PATH} = ?",
+            arrayOf(displayName, relativePath),
+            null,
+        )?.use { cursor ->
+            buildList { while (cursor.moveToNext()) add(cursor.getLong(0)) }
+        }.orEmpty()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        // Best-effort replace: an unreadable query leaves the old row in place, so the export lands
+        // beside it under a de-duplicated name. A visible duplicate, not a lost file.
+        Logger.e(TAG, "could not look up the row being replaced", e)
+        emptyList()
+    }
+
+    /**
+     * Null when the provider will not say; the caller then leaves the assigned name alone.
+     *
+     * `MediaColumns.DISPLAY_NAME`, not `Downloads.DISPLAY_NAME` — the same string, from a class that has
+     * existed since API 1, so this helper needs no API gate of its own.
+     */
+    private fun displayNameOf(resolver: ContentResolver, uri: Uri): String? = try {
+        resolver.query(
+            uri,
+            arrayOf(MediaStore.MediaColumns.DISPLAY_NAME),
+            null,
+            null,
+            null,
+        )?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Logger.e(TAG, "could not read the display name MediaStore assigned", e)
+        null
+    }
+
+    /**
+     * API 28 Downloads: write `<name>.part`, then `renameTo` over the file being replaced.
+     *
+     * `rename(2)` within one volume is atomic and overwrites, so this is the one backend that needs no
+     * delete at all — and it is where the old code was worst. It wrote straight into the final name, so
+     * a cancelled or killed export left a **truncated `.apk` under the right name**: the one failure
+     * shape a user cannot tell from a good export.
+     */
+    private fun openInLegacyDownloads(source: File): ArchiveDestination? {
         @Suppress("DEPRECATION")
         val dir = File(
             Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
-            THOR_DOWNLOADS_SUBDIR
+            THOR_DOWNLOADS_SUBDIR,
         )
-        if (!dir.exists()) dir.mkdirs()
-        val dest = File(dir, source.name)
-        try {
-            source.inputStream().use { input ->
-                dest.outputStream().use { output -> input.copyCancellableTo(output) }
+        if (!dir.isDirectory && !dir.mkdirs()) return null
+        val partial = File(dir, partialName(source.name))
+        val published = File(dir, source.name)
+        val stream = FileOutputStream(partial)
+        return object : BaseDestination(stream, onSettled = {}) {
+            override fun onPublish(): Boolean = partial.renameTo(published)
+
+            override fun onDiscard() {
+                partial.delete()
             }
-        } catch (e: Exception) {
-            // The SAF and MediaStore paths have always cleaned up after themselves; this one had
-            // nothing to clean up because `File.copyTo` could not be interrupted. Now that it can,
-            // a cancelled export would otherwise leave a truncated .apk sitting in Downloads under
-            // the right name — the one failure shape a user cannot tell from a good export.
-            dest.delete()
-            throw e
         }
-        return context.getString(R.string.export_dest_downloads)
     }
 
     /**

--- a/app/src/main/java/com/valhalla/thor/domain/model/SelfPermissions.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/SelfPermissions.kt
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+/**
+ * What the running OS says about one permission **Thor's own manifest declares**.
+ *
+ * Three states and not two, for the same reason [installedAppsPermissionState] needs
+ * [DeclaredPermission] to be nullable: "this OS has never heard of it" is an authoritative answer
+ * about the device, and "the package manager would not tell us" is not an answer at all. Folding the
+ * second into the first is what would make [planSelfGrant] latch a permission off forever on the
+ * strength of one unlucky binder call.
+ */
+sealed interface SelfPermissionDeclaration {
+
+    /**
+     * `getPermissionInfo` threw `NameNotFoundException` — the definitive "not on this build".
+     *
+     * The common case, not an edge one. Thor's manifest declares `POST_NOTIFICATIONS`, which does not
+     * exist below API 33, and `com.android.permission.GET_INSTALLED_APPS`, which exists only on the
+     * Chinese-market ROMs [GET_INSTALLED_APPS_PERMISSION] documents. Thor's supported range starts at
+     * API 28, so both of those are ordinary devices.
+     */
+    data object Undefined : SelfPermissionDeclaration
+
+    /**
+     * The question failed for some reason other than "no such permission".
+     *
+     * A failed question, not a verdict about the device — and treated as such: it costs this run its
+     * latch rather than being remembered. Same rule, and the same reasoning, as the uncached branch
+     * in `InstalledAppsPermissionChecker.declaredPermission`.
+     */
+    data object Unknown : SelfPermissionDeclaration
+
+    /** The OS defines it, and described it. */
+    data class Declared(val permission: DeclaredPermission) : SelfPermissionDeclaration
+}
+
+/** One permission out of Thor's own `requestedPermissions`, as the running device describes it. */
+data class SelfPermission(
+    val name: String,
+    val declaration: SelfPermissionDeclaration,
+    val isGranted: Boolean,
+)
+
+/**
+ * What a privileged self-grant should do this run.
+ *
+ * [toGrant] is what to issue `pm grant` for. [hasUnanswered] is the reason this is a data class and
+ * not a `List<String>`: a run that could not classify everything has to be repeatable, and the
+ * *absence* of a permission from [toGrant] does not say which of the four reasons put it there.
+ */
+data class SelfGrantPlan(
+    /** The permissions worth a `pm grant`, in the manifest's declaration order. */
+    val toGrant: List<String>,
+    /**
+     * True when at least one permission came back [SelfPermissionDeclaration.Unknown].
+     *
+     * The caller must not latch its once-per-process guard on such a run. Without this, a package
+     * manager that hiccupped on the one probe that mattered would disable the whole feature for the
+     * life of the process and report success while doing it.
+     */
+    val hasUnanswered: Boolean,
+)
+
+/**
+ * Which of Thor's own declared permissions a privileged `pm grant` could actually change.
+ *
+ * **The device is asked, and no name is hardcoded.** Thor's manifest is the input, so a permission
+ * added to it later is covered without a second edit here — the failure mode of a hand-kept list is
+ * that the list and the manifest agree on the day they are written and never again. It also means
+ * the answer is honest per device rather than per build: on a Pixel this returns
+ * `POST_NOTIFICATIONS` alone, on HyperOS it returns that and
+ * [GET_INSTALLED_APPS_PERMISSION], and on API 28 it returns neither of them.
+ *
+ * The three rejections all exist because `pm grant` *fails* on them, and a privileged command issued
+ * once per attempt per permission is not free — it is a round trip through the root shell or the
+ * Shizuku binder, on a path that runs while the user is waiting for the app list:
+ *
+ * 1. **Not defined on this build** ([SelfPermissionDeclaration.Undefined]).
+ *    `PackageManagerShellCommand.runGrantRevokePermission` resolves the name first and answers
+ *    `Unknown permission: …`. Nothing to grant, and nothing a retry could improve.
+ * 2. **Defined but not `dangerous`.** `grantRuntimePermission` throws
+ *    `SecurityException("… is not a changeable permission type")` for anything that is not a runtime
+ *    permission. Two of Thor's declarations are exactly this and both are already handled properly
+ *    elsewhere: `PACKAGE_USAGE_STATS` is `signature|privileged|appop`, whose *app-op* half
+ *    `UsageAccessManager` sets through `appops` rather than `pm`, and `REQUEST_INSTALL_PACKAGES` is an
+ *    app-op the user toggles under "Install unknown apps". Sending either to `pm grant` would be a
+ *    guaranteed failure wearing the shape of a real attempt.
+ * 3. **Already held.** Re-granting is a no-op that still costs the round trip.
+ *
+ * A [SelfPermissionDeclaration.Unknown] is not a rejection: it is left out of [toGrant] *and*
+ * recorded in [SelfGrantPlan.hasUnanswered], so the run can be repeated.
+ *
+ * Pure, because everything above is a decision and none of it is a binder call. `PackageManager` is
+ * abstract and `:app` has no mocking library by policy, so a rule that lives in the data layer is a
+ * rule no test can reach — the same split `installedAppsPermissionState` and [runtimeGroupFor] make.
+ *
+ * ⚠️ **This overrides a decision the user may have made deliberately.** A permission is in
+ * [toGrant] precisely because it is ungranted, and Thor cannot tell "never asked" from "denied on
+ * purpose". That is the owner's explicit call for privileged users — the point of granting Thor
+ * root or Shizuku is not to keep being asked — and it is why the grant runs *only* once a privilege
+ * gateway is live, and why nothing here touches another package's permissions.
+ */
+fun planSelfGrant(permissions: List<SelfPermission>): SelfGrantPlan {
+    val toGrant = mutableListOf<String>()
+    var hasUnanswered = false
+
+    for (permission in permissions) {
+        when (val declaration = permission.declaration) {
+            SelfPermissionDeclaration.Unknown -> hasUnanswered = true
+            SelfPermissionDeclaration.Undefined -> Unit
+            is SelfPermissionDeclaration.Declared -> {
+                if (declaration.permission.isDangerous && !permission.isGranted) {
+                    toGrant += permission.name
+                }
+            }
+        }
+    }
+
+    return SelfGrantPlan(toGrant = toGrant, hasUnanswered = hasUnanswered)
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
@@ -131,9 +131,12 @@ fun AppListScreen(
         }
     }
 
-    // com.android.permission.GET_INSTALLED_APPS — an ordinary runtime permission, so an ordinary
-    // RequestPermission contract. No privilege path: Thor never self-grants the permission that
-    // decides how much of the device it is allowed to see.
+    // com.android.permission.GET_INSTALLED_APPS — an ordinary runtime permission on the ROMs that
+    // define it, so an ordinary RequestPermission contract. This is the route for an unprivileged
+    // user: a user who has already granted root or Shizuku will normally never reach it, because
+    // SelfPermissionGranter takes every declared runtime permission as soon as a gateway is live —
+    // asking someone to approve in a weaker form what they have already approved in a stronger one
+    // is the ask this dialog exists to avoid, not to repeat.
     //
     // The result boolean is deliberately ignored and the truth re-read instead, the same way the
     // notification row does it in SettingsScreen. This permission is three-state on the ROMs that

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
@@ -53,6 +53,7 @@ import com.valhalla.thor.domain.model.DataClassSize
 import com.valhalla.thor.domain.model.SizeLabelKind
 import com.valhalla.thor.domain.model.labelKind
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.presentation.common.RequestNotificationsWhenJobStarts
 import com.valhalla.thor.presentation.settings.PassphraseError
 import com.valhalla.thor.presentation.settings.passphraseErrorText
 import kotlinx.coroutines.delay
@@ -111,6 +112,11 @@ fun AppBackupSheet(packageName: String, appLabel: String, onDismiss: () -> Unit)
     val context = LocalContext.current
 
     LaunchedEffect(packageName) { viewModel.start(packageName, appLabel) }
+
+    // "Back up in the background" is the point of the worker, and the notification is the only thing
+    // that comes back once this sheet is gone — so the permission is asked for when the job is
+    // accepted, not when the sheet opens.
+    RequestNotificationsWhenJobStarts(jobActive = state.running || state.queued)
 
     var passphrase by remember { mutableStateOf("") }
     var confirmation by remember { mutableStateOf("") }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
@@ -47,6 +47,7 @@ import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.ArchiveRestoreRefusal
 import com.valhalla.thor.domain.model.ArchiveRestoreWarning
 import com.valhalla.thor.domain.model.DataClassSize
+import com.valhalla.thor.presentation.common.RequestNotificationsWhenJobStarts
 import java.text.DateFormat
 import java.util.Date
 import org.koin.androidx.compose.koinViewModel
@@ -141,6 +142,11 @@ internal fun ArchiveRestoreSheet(uriString: String?, onDismiss: () -> Unit) {
     var passphrase by remember(uriString) { mutableStateOf("") }
 
     LaunchedEffect(uriString) { uriString?.let(viewModel::open) }
+
+    // A restore that runs with notifications off is worse off than a backup: it rewrites an app's
+    // data, and the only report that it finished — or failed partway — is the one this permission
+    // gates. Asked on the transition, so a refused or replaced enqueue never prompts.
+    RequestNotificationsWhenJobStarts(jobActive = state.running || state.queued)
 
     val picker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         // No takePersistableUriPermission: OpenDocument's grant lasts for this task, which is all the

--- a/app/src/main/java/com/valhalla/thor/presentation/common/NotificationPermission.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/common/NotificationPermission.kt
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.common
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.valhalla.thor.util.Logger
+
+/**
+ * Whether Thor can post a notification right now, and the one or two routes to changing that.
+ *
+ * Returned by [rememberNotificationPermissionRequest]; a fresh instance is produced whenever
+ * [isEnabled] changes, so it is a value and not a controller.
+ */
+@Immutable
+class NotificationPermissionRequest internal constructor(
+    /**
+     * `NotificationManagerCompat.areNotificationsEnabled()` — the exact question `ThorJobNotifications`
+     * and `BulkResultNotifier` ask before posting, and therefore the only one worth reporting.
+     *
+     * ⚠️ **This is not "the permission is held".** It is also false when the user has muted Thor
+     * app-wide, which is a different state with a different fix, and below API 33 it is the *only*
+     * state — there is no `POST_NOTIFICATIONS` to hold. Anything that renders this must not say
+     * "permission denied".
+     */
+    val isEnabled: Boolean,
+    private val requester: (() -> Unit)?,
+    private val openSettings: () -> Unit,
+    private val deepLinkWhenBlocked: Boolean,
+) {
+
+    /**
+     * Whether a system dialog exists to be shown at all — API 33+, and nothing else.
+     *
+     * The system decides separately whether it will actually *draw* that dialog: after two denials
+     * `RequestPermission` returns immediately having shown nothing. That is not visible from here, and
+     * [request] is written so that it does not need to be.
+     */
+    val canRequest: Boolean get() = requester != null
+
+    /**
+     * Ask, by whatever route this device has — and on a device with no dialog, only if the caller said
+     * a trip to Settings is warranted.
+     *
+     * A no-op when notifications are already enabled: on API 33+ requesting a held permission returns
+     * granted without drawing anything, so calling this on a whim would be silent but pointless, and
+     * below 33 it would send a user who has no problem into Settings.
+     *
+     * Below API 33 there is no dialog at all, so this is *either* the deep link or nothing. That is
+     * the same fork `deepLinkWhenBlocked` answers on 33+ after a hard denial, and it answers it the
+     * same way: an ask Thor raised on the user's behalf stays silent rather than launching a Settings
+     * screen nobody asked for. A caller that wants the deep link unconditionally — the Settings row,
+     * where the user just tapped — has [openNotificationSettings] and does not go through here.
+     */
+    fun request() {
+        if (isEnabled) return
+        val requester = requester
+        when {
+            requester != null -> requester()
+            deepLinkWhenBlocked -> openSettings()
+        }
+    }
+
+    /**
+     * The per-app notification settings screen.
+     *
+     * The only lever below API 33, and the only one left on 33+ once the user has denied twice or
+     * muted the app. Also the only way *back off* — there is no dialog that withdraws a granted
+     * permission.
+     */
+    fun openNotificationSettings() = openSettings()
+}
+
+/**
+ * The one place that knows how Thor asks for permission to post a notification.
+ *
+ * Extracted from the Settings → Notification access row, which had all of this inline, because a
+ * second caller arrived: a job that starts while notifications are off runs with no visible progress
+ * and no result — `ThorJobNotifications.update` and `postResult` both open with
+ * `if (!areNotificationsEnabled()) return`, so a backup silently has no surface at all. Three
+ * hand-written copies of a permission flow is how one of them ends up missing the
+ * `shouldShowRequestPermissionRationale` branch and nagging a user forever.
+ *
+ * [isEnabled] is re-read on every `ON_RESUME`, because none of the ways it can change come back
+ * through the launcher callback: a grant made in system Settings, an app-wide mute, and (on a ROM
+ * that allows it) a revocation while Thor is backgrounded are all invisible until we look again.
+ *
+ * @param deepLinkWhenBlocked what [NotificationPermissionRequest.request] does when there is no dialog
+ *   to draw — either because the user has denied twice on API 33+, or because the device is below 33
+ *   and the permission does not exist. `true` where the **user** asked — the Settings row, where doing
+ *   nothing would leave a dead switch that snaps back. `false` where **Thor** raised it on the user's
+ *   behalf, such as a job starting: throwing someone out to a Settings screen they did not ask for,
+ *   every time they run a backup, is worse than the missing notification. With it false, a re-request
+ *   after a hard denial is a silent no-op, which is the throttle — no per-process latch is needed
+ *   for it.
+ */
+@Composable
+fun rememberNotificationPermissionRequest(
+    deepLinkWhenBlocked: Boolean,
+): NotificationPermissionRequest {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    var isEnabled by remember(context) {
+        mutableStateOf(NotificationManagerCompat.from(context).areNotificationsEnabled())
+    }
+    DisposableEffect(lifecycleOwner, context) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                isEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // runCatching because ACTION_APP_NOTIFICATION_SETTINGS is not resolvable on every ROM, and a
+    // missing Settings screen must not take down the screen that offered the link. Logged rather than
+    // swallowed silently: on such a ROM there is no route left at all, which is worth knowing when a
+    // user reports that the switch does nothing.
+    val openSettings: () -> Unit = remember(context) {
+        {
+            runCatching { context.startActivity(appNotificationSettingsIntent(context)) }
+                .onFailure { throwable ->
+                    Logger.w("Notifications", "No app notification settings screen: $throwable")
+                }
+        }
+    }
+
+    // Registering the launcher inside the version check is safe: SDK_INT is constant for the process,
+    // so the conditional group is stable across recompositions. It also keeps every POST_NOTIFICATIONS
+    // reference inside the check, which is what lint's InlinedApi wants.
+    val requester: (() -> Unit)? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val activity = remember(context) { context.findActivity() }
+            val launcher = rememberLauncherForActivityResult(
+                ActivityResultContracts.RequestPermission()
+            ) { _ ->
+                // Re-read instead of trusting `granted`. What callers act on is
+                // areNotificationsEnabled(), which is also false when the permission is held but the
+                // user muted the app — trusting `granted` flipped the Settings switch on and the next
+                // ON_RESUME flipped it back off.
+                val enabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
+                isEnabled = enabled
+                // RequestPermission returns immediately without showing a dialog once the user has
+                // denied twice, which would otherwise leave the caller with nothing to offer.
+                // shouldShowRequestPermissionRationale distinguishes that (and the "granted but
+                // muted" case, both false) from a plain first denial (true, where asking again still
+                // shows the dialog). Only the caller knows whether the user invited this, so whether
+                // a dead end is worth a trip to Settings is theirs to decide.
+                if (deepLinkWhenBlocked && !enabled) {
+                    val canAskAgain = activity?.let {
+                        ActivityCompat.shouldShowRequestPermissionRationale(
+                            it,
+                            Manifest.permission.POST_NOTIFICATIONS
+                        )
+                    } ?: false
+                    if (!canAskAgain) openSettings()
+                }
+            }
+            remember(launcher) { { launcher.launch(Manifest.permission.POST_NOTIFICATIONS) } }
+        } else {
+            null
+        }
+
+    return remember(isEnabled, requester, openSettings, deepLinkWhenBlocked) {
+        NotificationPermissionRequest(
+            isEnabled = isEnabled,
+            requester = requester,
+            openSettings = openSettings,
+            deepLinkWhenBlocked = deepLinkWhenBlocked,
+        )
+    }
+}
+
+/**
+ * Ask for the notification permission at the moment a background job starts without it.
+ *
+ * Draws nothing. It exists because a WorkManager job is the one case where Thor's *only* surface is a
+ * notification: `ThorJobNotifications.update` and `postResult` both return early when notifications
+ * are off, so a backup or restore started in that state runs invisibly, finishes invisibly, and — if
+ * the sheet was dismissed — reports nothing at all. Every job sheet wants exactly this, so it is one
+ * composable rather than a block copied per sheet.
+ *
+ * @param jobActive whether a job is running **or queued**. Queued counts: `APPEND_OR_REPLACE` puts
+ *   work behind a live job, and that job posts no progress either. Keyed on the transition, so the
+ *   ask follows the job actually being accepted rather than the button being pressed — an enqueue
+ *   that is refused or replaced never reaches here.
+ *
+ * `deepLinkWhenBlocked = false` throughout: Thor raised this, not the user. After a hard denial the
+ * request is a silent no-op, which is the whole throttle — a user who has said no twice runs their
+ * backups without notifications rather than being thrown out to a Settings screen every time.
+ */
+@Composable
+fun RequestNotificationsWhenJobStarts(jobActive: Boolean) {
+    val notifications = rememberNotificationPermissionRequest(deepLinkWhenBlocked = false)
+    LaunchedEffect(jobActive) {
+        if (jobActive && !notifications.isEnabled) notifications.request()
+    }
+}
+
+/** Thor's own entry in system Settings → Apps → Notifications. */
+private fun appNotificationSettingsIntent(context: Context): Intent =
+    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+
+/**
+ * Unwrap [LocalContext] to the hosting Activity. Compose hands out a ContextWrapper in some hosts,
+ * and `shouldShowRequestPermissionRationale` needs the real Activity.
+ */
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
@@ -3,15 +3,8 @@
 
 package com.valhalla.thor.presentation.settings
 
-import android.Manifest
-import android.app.Activity
-import android.content.Context
-import android.content.ContextWrapper
 import android.content.Intent
 import android.os.Build
-import android.provider.Settings
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -62,8 +55,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.app.ActivityCompat
-import androidx.core.app.NotificationManagerCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -79,6 +70,7 @@ import com.valhalla.thor.domain.model.DefaultTab
 import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.ThemeMode
 import com.valhalla.thor.domain.usecase.ObserveInterruptedRestoreUseCase
+import com.valhalla.thor.presentation.common.rememberNotificationPermissionRequest
 import com.valhalla.thor.presentation.main.toDestination
 import com.valhalla.thor.presentation.utils.ObserveAsEvents
 import com.valhalla.thor.util.AppLanguage
@@ -166,59 +158,21 @@ fun SettingsCategoryScreen(
     val usageAccessManager = koinInject<UsageAccessManager>()
     val lifecycleOwner = LocalLifecycleOwner.current
     var usageGranted by remember { mutableStateOf(usageAccessManager.isGranted()) }
-    var notificationsGranted by remember {
-        mutableStateOf(NotificationManagerCompat.from(context).areNotificationsEnabled())
-    }
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 usageGranted = usageAccessManager.isGranted()
-                notificationsGranted =
-                    NotificationManagerCompat.from(context).areNotificationsEnabled()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    // Registering the launcher inside the version check is safe: SDK_INT is constant for the
-    // process, so the conditional group is stable across recompositions. It also keeps every
-    // POST_NOTIFICATIONS reference inside the check, which is what lint's InlinedApi wants.
-    val requestNotificationPermission: (() -> Unit)? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val activity = remember(context) { context.findActivity() }
-            val notificationPermissionLauncher = rememberLauncherForActivityResult(
-                ActivityResultContracts.RequestPermission()
-            ) { _ ->
-                // Re-read instead of trusting `granted`. The switch reflects
-                // areNotificationsEnabled(), which is also false when the permission is held but the
-                // user muted the app's notifications; trusting `granted` flipped the switch on and
-                // the next ON_RESUME flipped it back off.
-                val enabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
-                notificationsGranted = enabled
-                // RequestPermission returns immediately without showing a dialog once the user has
-                // denied twice, which would leave this row a permanent dead end.
-                // shouldShowRequestPermissionRationale distinguishes that (and the "granted but
-                // muted" case, both false) from a plain first denial (true, where re-tapping the row
-                // still shows the dialog). Where the dialog can no longer help, deep-link to system
-                // settings like the usage-access row above. Thor never self-grants this.
-                val canAskAgain = activity?.let {
-                    ActivityCompat.shouldShowRequestPermissionRationale(
-                        it,
-                        Manifest.permission.POST_NOTIFICATIONS
-                    )
-                } ?: false
-                if (!enabled && !canAskAgain) {
-                    runCatching { context.startActivity(appNotificationSettingsIntent(context)) }
-                }
-            }
-            val request = {
-                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-            }
-            request
-        } else {
-            null
-        }
+    // The whole flow — the launcher, the re-read that must not trust `granted`, the resume observer,
+    // and the two-denials dead end — now lives in one composable shared with the job sheets, which is
+    // the second caller it was extracted for. `deepLinkWhenBlocked = true` because the user tapped
+    // this row: doing nothing here would leave a switch that snaps back with no explanation.
+    val notifications = rememberNotificationPermissionRequest(deepLinkWhenBlocked = true)
 
     if (showUnfreezeConfirmation) {
         AlertDialog(
@@ -548,28 +502,28 @@ fun SettingsCategoryScreen(
                     SettingsRowId.NOTIFICATION_ACCESS -> SettingsSwitchRow(
                         icon = R.drawable.frozen,
                         title = stringResource(R.string.notification_access),
-                        subtitle = if (notificationsGranted) {
+                        subtitle = if (notifications.isEnabled) {
                             stringResource(R.string.notification_access_granted_subtitle)
                         } else {
                             stringResource(R.string.notification_access_needed_subtitle)
                         },
-                        checked = notificationsGranted,
+                        checked = notifications.isEnabled,
                         highlighted = lit,
                         onCheckedChange = {
-                            if (!notificationsGranted && requestNotificationPermission != null) {
-                                // 33+: only the system dialog can grant this. Thor never self-grants
-                                // it even when it holds root/Shizuku — the dialog grants the
-                                // identical capability, and Dhizuku cannot self-grant at all.
-                                requestNotificationPermission()
+                            if (!notifications.isEnabled && notifications.canRequest) {
+                                // 33+: the system dialog. A privileged user will usually never see
+                                // this row switched off — `SelfPermissionGranter` grants
+                                // POST_NOTIFICATIONS as soon as root or Shizuku is live — but the
+                                // dialog is still the route for everyone else, and for a privileged
+                                // user who has muted Thor app-wide, which no `pm grant` can undo.
+                                notifications.request()
                             } else {
                                 // 28-32 there is no runtime permission to request, and on 33+ there
                                 // is no dialog that *withdraws* one — requesting again while granted
                                 // returns granted without showing anything. Either way the app-level
                                 // toggle is the only lever, so the on→off tap deep-links to it
                                 // instead of doing nothing and letting the switch snap back.
-                                runCatching {
-                                    context.startActivity(appNotificationSettingsIntent(context))
-                                }
+                                notifications.openNotificationSettings()
                             }
                         }
                     )
@@ -858,22 +812,4 @@ private fun LanguageBottomSheet(
             }
         }
     }
-}
-
-/**
- * The system's per-app notification settings screen — the only place a user can undo a permanent
- * POST_NOTIFICATIONS denial or re-enable app-wide notifications.
- */
-private fun appNotificationSettingsIntent(context: Context): Intent =
-    Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
-        .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-
-/**
- * Unwrap [LocalContext] to the hosting Activity. Compose hands out a ContextWrapper in some hosts,
- * and `shouldShowRequestPermissionRationale` needs the real Activity.
- */
-private tailrec fun Context.findActivity(): Activity? = when (this) {
-    is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> null
 }

--- a/app/src/test/java/com/valhalla/thor/domain/model/SelfPermissionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/SelfPermissionsTest.kt
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Which of Thor's own declared permissions a privileged self-grant may issue `pm grant` for.
+ *
+ * Every rejection [planSelfGrant] makes is a command that would have *failed*, and each failure mode
+ * is a different one, which is why they are pinned separately: an undefined permission answers
+ * `Unknown permission`, a non-runtime one throws `not a changeable permission type`, and an
+ * already-held one succeeds while changing nothing. All three cost a round trip through the root
+ * shell or the Shizuku binder, on a path that runs while the user is waiting for the app list.
+ *
+ * The device is asked and no name is hardcoded in the production rule, so the interesting cases here
+ * are whole devices rather than single permissions: the same Thor manifest yields one grant on a
+ * Pixel, two on HyperOS and none on API 28. Pure for the usual reason — `PackageManager` is abstract
+ * and `:app` has no mocking library by policy — so "a HyperOS device on Android 13" is nothing more
+ * exotic here than a list of [SelfPermission].
+ */
+class SelfPermissionsTest {
+
+    // Thor's own manifest, by name. Spelled out rather than read from android.Manifest so that a
+    // reader can see which of Thor's declarations each case is actually about.
+    private val postNotifications = "android.permission.POST_NOTIFICATIONS"
+    private val internet = "android.permission.INTERNET"
+    private val queryAllPackages = "android.permission.QUERY_ALL_PACKAGES"
+    private val packageUsageStats = "android.permission.PACKAGE_USAGE_STATS"
+    private val requestInstallPackages = "android.permission.REQUEST_INSTALL_PACKAGES"
+
+    /** Defined by this OS, `dangerous`, and therefore requestable — the only grantable shape. */
+    private fun runtime(name: String, granted: Boolean = false) = SelfPermission(
+        name = name,
+        declaration = SelfPermissionDeclaration.Declared(
+            DeclaredPermission(isDangerous = true, group = null)
+        ),
+        isGranted = granted,
+    )
+
+    /** Defined, but at a protection level `pm grant` refuses: normal, signature, appop, privileged. */
+    private fun installTime(name: String, granted: Boolean = false) = SelfPermission(
+        name = name,
+        declaration = SelfPermissionDeclaration.Declared(
+            DeclaredPermission(isDangerous = false, group = null)
+        ),
+        isGranted = granted,
+    )
+
+    /** `getPermissionInfo` threw `NameNotFoundException`: this build has never heard of it. */
+    private fun undefined(name: String) = SelfPermission(
+        name = name,
+        declaration = SelfPermissionDeclaration.Undefined,
+        isGranted = false,
+    )
+
+    /** The package manager would not answer — a failed question, not a verdict about the device. */
+    private fun unanswered(name: String) = SelfPermission(
+        name = name,
+        declaration = SelfPermissionDeclaration.Unknown,
+        isGranted = false,
+    )
+
+    @Test
+    fun onAPixelOnlyPostNotificationsIsGrantable() {
+        // The ordinary device, and the case the owner actually asked for. GET_INSTALLED_APPS is a
+        // Chinese-market permission no AOSP build defines, and the four AOSP declarations below are
+        // all install-time, so exactly one command is worth issuing.
+        val plan = planSelfGrant(
+            listOf(
+                installTime(internet),
+                installTime(queryAllPackages),
+                undefined(GET_INSTALLED_APPS_PERMISSION),
+                installTime(packageUsageStats),
+                runtime(postNotifications),
+            )
+        )
+        assertEquals(listOf(postNotifications), plan.toGrant)
+        // Nothing was left unclassified, so this run may latch and never sweep again.
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun onAChineseRomBothRuntimePermissionsAreGrantable() {
+        // MIUI/HyperOS, ColorOS, OriginOS, MagicOS: GET_INSTALLED_APPS is defined *and* dangerous
+        // there, which is the whole reason the rule asks the device instead of carrying a list.
+        val plan = planSelfGrant(
+            listOf(
+                installTime(internet),
+                runtime(GET_INSTALLED_APPS_PERMISSION),
+                runtime(postNotifications),
+            )
+        )
+        assertEquals(listOf(GET_INSTALLED_APPS_PERMISSION, postNotifications), plan.toGrant)
+    }
+
+    @Test
+    fun onApi28NothingIsGrantable() {
+        // Thor's minSdk. POST_NOTIFICATIONS does not exist until API 33 and GET_INSTALLED_APPS is
+        // absent from AOSP entirely, so the manifest declares both and the device defines neither.
+        // An empty plan still counts as complete: there is nothing here a retry would find.
+        val plan = planSelfGrant(
+            listOf(
+                installTime(internet),
+                undefined(GET_INSTALLED_APPS_PERMISSION),
+                undefined(postNotifications),
+            )
+        )
+        assertTrue(plan.toGrant.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun anUngrantedInstallTimePermissionIsStillSkipped() {
+        // Ungranted is not the same as grantable. `grantRuntimePermission` throws
+        // SecurityException("... is not a changeable permission type") for anything that is not a
+        // runtime permission, and both of these are Thor's real cases: PACKAGE_USAGE_STATS is
+        // signature|privileged|appop, whose app-op half UsageAccessManager sets through `appops`,
+        // and REQUEST_INSTALL_PACKAGES is an app-op the user toggles under "Install unknown apps".
+        val plan = planSelfGrant(
+            listOf(
+                installTime(packageUsageStats),
+                installTime(requestInstallPackages),
+            )
+        )
+        assertTrue(plan.toGrant.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun anAlreadyHeldRuntimePermissionIsSkipped() {
+        // Re-granting succeeds and changes nothing, so it is a privileged round trip bought for no
+        // effect — on every privilege state change, since the latch only closes on a complete run.
+        val plan = planSelfGrant(listOf(runtime(postNotifications, granted = true)))
+        assertTrue(plan.toGrant.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun aPermissionTheDeviceWouldNotClassifyKeepsTheRunRepeatable() {
+        // The distinction the three-state declaration exists for. Both an undefined permission and an
+        // unanswered one are left out of `toGrant`, so the *plans* are indistinguishable — but only
+        // the undefined one is an answer. Reporting no unanswered probe here would let the caller
+        // latch its once-per-process guard on a package manager that simply hiccupped, disabling the
+        // whole feature for the life of the process and calling it success.
+        val plan = planSelfGrant(listOf(unanswered(postNotifications)))
+        assertTrue(plan.toGrant.isEmpty())
+        assertTrue(plan.hasUnanswered)
+    }
+
+    @Test
+    fun oneUnansweredProbeDoesNotHoldBackTheGrantsThatAreKnown() {
+        // Partial knowledge is still worth acting on: the user gets the permission that could be
+        // classified now, and the flag brings the sweep back for the one that could not. Failing
+        // closed on the whole plan would mean one flaky lookup costs a grant that was ready.
+        val plan = planSelfGrant(
+            listOf(
+                unanswered(GET_INSTALLED_APPS_PERMISSION),
+                runtime(postNotifications),
+            )
+        )
+        assertEquals(listOf(postNotifications), plan.toGrant)
+        assertTrue(plan.hasUnanswered)
+    }
+
+    @Test
+    fun theManifestsDeclarationOrderIsPreserved() {
+        // The grants are issued in this order, one privileged command at a time, and the notification
+        // permission is the one the user is most likely to be waiting on — a plan that reordered
+        // could put it behind a permission whose gateway call hangs.
+        val plan = planSelfGrant(
+            listOf(
+                runtime(postNotifications),
+                runtime(GET_INSTALLED_APPS_PERMISSION),
+            )
+        )
+        assertEquals(listOf(postNotifications, GET_INSTALLED_APPS_PERMISSION), plan.toGrant)
+    }
+
+    @Test
+    fun aManifestWithNoPermissionsPlansNothingAndIsComplete() {
+        // `requestedPermissions` is nullable on the platform side and arrives here as an empty list.
+        // Complete rather than repeatable: there is no question left open.
+        val plan = planSelfGrant(emptyList())
+        assertTrue(plan.toGrant.isEmpty())
+        assertFalse(plan.hasUnanswered)
+    }
+}

--- a/docs/workers/README.md
+++ b/docs/workers/README.md
@@ -378,7 +378,7 @@ and proving them is device-only.
 |---|---|
 | `THOR_SWEEP_CHAIN` has no producers | The whole sweep half of the seam is dead code awaiting the bulk-actions work. |
 | The cross-chain `su` argument | Two chains let a sweep run beside a restore, which the KDoc's own FIFO-session reasoning argues against. Unresolved. |
-| Notifications gate silently | A job runs and shows **nothing** when notifications are off; on API 28–32 there is no surface at all. |
+| Notifications gate silently — **narrowed, not closed** | `update` and `postResult` still return early when notifications are off, so a job in that state has no surface. Two things now make that state unlikely rather than fixable: `SelfPermissionGranter` takes `POST_NOTIFICATIONS` as soon as root or Shizuku is live, and `RequestNotificationsWhenJobStarts` asks when a job is accepted without it (both sheets). Neither reaches an **app-wide mute**, which is the only off state below API 33 and no `pm` verb or app-op can undo — only Settings. So a muted user on 28–32 still gets a silent job, by design. |
 | `getStopReason()` unread | A system-killed FGS is reported to the user as an ordinary cancel. |
 | Four stale comments | They claim the enqueue is not awaited. It is. |
 | `ArchiveRestoreRequest` carries no `Data`-schema KDoc | Its twin does; the rule is enforced by that one comment. |

--- a/docs/workers/README.md
+++ b/docs/workers/README.md
@@ -1,0 +1,396 @@
+# 🧵 Workers — what Thor runs through WorkManager
+
+Which of Thor's operations are WorkManager jobs, which are not, and what the difference costs.
+
+**Read this if** you are adding a background job, wondering why a bulk action is *not* one, or
+debugging a job that never showed up. For the branch/release side of the repo see
+[`branching-and-releases.md`](../branching-and-releases.md); for deferred work see
+[`follow-ups/README.md`](../follow-ups/README.md).
+
+**Last verified:** 2026-08-13 (UTC) against branch `feat/job-seam-generalise` @ `ba65dc16`. Dates here
+are UTC, matching the GitHub timestamps they can be checked against. Every line number below was
+opened, not grepped for; if you move code, move the anchor.
+
+---
+
+## The answer, in four lines
+
+**Two operations use WorkManager.** Back up **one** app to an encrypted `.thorbak`, and restore
+**one** app from one. Both are single-app, both are archive work, and both go onto the same unique
+chain, so they serialise and never run at once.
+
+Everything else Thor does in the background — including the **multi-app export that shares the word
+"backup"**, and every bulk freeze, unfreeze, force-stop, cache clear and reinstall — is a coroutine on
+a process-lifetime scope or a `viewModelScope`. See [What is *not* on WorkManager](#what-is-not-on-workmanager-and-why).
+
+---
+
+## The two jobs
+
+| | `ARCHIVE_BACKUP` | `ARCHIVE_RESTORE` |
+|---|---|---|
+| `ThorJobKind.id` | `archive-backup` | `archive-restore` |
+| Worker | `ArchiveBackupWorker` — `AppArchiveWorker.kt:61` | `ArchiveRestoreWorker` — `AppArchiveWorker.kt:236` |
+| Unique chain | `THOR_JOB_CHAIN` = `"thor.job.chain"` | same chain |
+| Started by | `ThorJobLauncher.startBackup` (`:64`), from `AppBackupViewModel:361` | `ThorJobLauncher.startRestore` (`:102`), from `ArchiveRestoreViewModel:751` |
+| Work tag | `thor.job.archive-backup.<pkg>` | `thor.job.archive-restore.<pkg>` |
+| Input `Data` | `thor.backup.package` (String), `thor.backup.classes` (String[]), `thor.backup.bundle` (Boolean), `thor.backup.salt` (Base64 String) | `thor.restore.uri`, `thor.restore.package` (String), `thor.restore.classes` (String[]), `thor.restore.obb` (Boolean) |
+| Output on success | bare `Result.success()` — no data | `Result.success(workDataOf(JOB_WARNINGS_KEY to …))`, a String[] |
+| Output on failure | `JOB_ERROR_KEY` = `"thor.job.error"`, one sentence | same |
+| Runs foreground | yes (`dataSync`) | yes (`dataSync`) |
+
+**How a user gets there.** Backup: the app-info surfaces open the backup sheet, plus a second host —
+`MainViewModel.BackupSheetState` (`MainViewModel.kt:205`), which is *only* ever opened by a
+notification tap. Restore: the Settings → Restore row, or a notification tap routed through
+`JobSheetLaunchActivity` (`AndroidManifest.xml:391`, `exported="false"`, `noHistory="true"`).
+
+### The `Data` contract, and the one rule that is only half written down
+
+`androidx.work.Data` accepts a small set of types. In Thor that is **String, Boolean and
+`Array<String>`** — a `Set` or an enum passed to `workDataOf` throws **at enqueue time, in
+production**. `ArchiveBackupRequest.toMap()` states this in its KDoc (`ArchiveBackupRequest.kt:47-54`);
+`ArchiveRestoreRequest.toMap()` (`ArchiveRestoreRequest.kt:40`) is the identical shape, serialised the
+same way at `ThorJobLauncher.kt:116`, and **says nothing**. Half the enqueued payloads in the app are
+covered by that comment and half are not.
+
+`fromMap` returns `null` for anything it cannot turn into a runnable job, and the worker converts that
+into `Result.failure()` with a reason — never `Result.retry()`, which would re-read the same unusable
+map forever. Unknown `DataClass` ids are *dropped* rather than fatal, so a job enqueued by a newer
+build and run after a downgrade still backs up what it can.
+
+### What is deliberately not in `Data`
+
+No passphrase, no derived key. Input `Data` is written to WorkManager's own SQLite database, so a key
+there would be on disk in the clear until the job is pruned. The key is derived in the foreground
+(PBKDF2, 210 000 iterations, on `default`) and handed to `ArchiveKeyHolder` in **process memory** under
+the request's id.
+
+The KDF **salt** *is* in `Data`, on purpose: it is published in `thorbak.json` where every reader needs
+it, and its job is to make one reused passphrase produce a different key per archive.
+
+The restore side also deliberately omits `installFirst` and the header. The worker re-reads the header
+from the URI and re-runs `evaluateArchiveRestoreGate` **at the moment it runs** — a gate decision
+persisted at enqueue time describes an app that may have been installed, removed or updated while the
+job waited its turn.
+
+---
+
+## ⚠️ Being on WorkManager here does **not** mean durable
+
+Both workers open by taking their AES key out of process memory, and both fail immediately if it is
+gone:
+
+- `AppArchiveWorker.kt:128-130` — *"this backup's key is no longer in memory — start it again"*
+- `AppArchiveWorker.kt:282-283` — the same for restore
+
+So a reboot or an OOM kill does **not** resume the job. WorkManager re-runs the worker, and the worker
+refuses. That is the intended design (`§9.2`), not a gap to close — but it means "it's a Worker, so it
+survives" is false here, and anyone reasoning about a new job kind should decide explicitly which side
+of that line it sits on.
+
+**What WorkManager actually buys Thor is four things:**
+
+1. A `dataSync` **foreground service**, so a multi-gigabyte capture is not frozen mid-write.
+2. A **Cancel action in the shade** via `WorkManager.createCancelPendingIntent`, needing no receiver
+   of Thor's own — and it cancels the *work*, not just the row.
+3. A persisted `WorkInfo.State` a **reopened sheet can reattach to** after a rotation or a trip away
+   from the app.
+4. A **serialising chain** that holds peak disk to one job however many backups the user starts.
+
+Nothing on that list is retry-on-reboot, and none of the four workers' inputs asks for it: neither
+request sets `Constraints`, `setExpedited`, `setInitialDelay` or `setBackoffCriteria`.
+
+> One consequence of no `setExpedited`: WorkManager never calls `getForegroundInfoAsync()` for this
+> work — it does that only for expedited `WorkSpec`s. `getForegroundInfo()` is still on the deadline
+> path, because `ThorJobWorker.doWork` opens with `setForeground(getForegroundInfo())`.
+
+---
+
+## The seam every job goes through
+
+All of it lives in `app/src/main/java/com/valhalla/thor/data/backup/job/`.
+
+| Class | Job |
+|---|---|
+| `ThorJobWorker` | `abstract … : CoroutineWorker`. Owns the foreground notification, progress throttling, one failure policy, and the `finally` that cleans up. `doWork()` and `getForegroundInfo()` are **`final`**. |
+| `ThorJobLauncher` | `@Single(binds = [ArchiveJobLauncher::class])`. Derives the key, builds the request, and owns enqueue / status / cancel. |
+| `enqueueUniqueJob(context, chainName, work, onAbandoned)` | Top-level `internal suspend fun` (`ThorJobLauncher.kt:240`) — the one enqueue expression in the app, extracted so the next launcher shares it rather than copying it. |
+| `JobRegistry` | In-memory progress channel, used **instead of** `ListenableWorker.setProgress` (which has zero call sites anywhere in `app/src`). |
+| `ThorJobNotifications` | `@Single`. Owns the shade rows, the ids, the channel and the cancel action. |
+| `ArchiveKeyHolder`, `JobSheetTargets` | The two process-memory side channels: key material and notification tap targets. |
+| `ThorJobWatcher` | Split off `ArchiveJobLauncher` so a screen can watch a job without being able to start one. |
+
+### Adding a new job kind
+
+1. Append to `ThorJobKind` (`ThorJob.kt:67`). **Append only — never insert or reorder** (see below).
+2. Subclass `ThorJobWorker` and implement the four abstract members: `kind`, `initialLabel`,
+   `sheetTarget`, `runJob()`.
+3. Override the two `open` members if you need them: `runsForeground` (default `true`,
+   `ThorJobWorker.kt:80`) and `onJobFinished()` (`:227` — non-suspend, on the cancellation path, and
+   **must not throw**).
+4. Annotate the class `@KoinWorker`.
+5. Add an arm to `ThorJobNotifications.titleFor` (`:203`) and `iconFor` (`:221`). Both are `when`s with
+   **no `else`**, so a new kind is a compile error until someone has worded it. That is the mechanism,
+   not an inconvenience.
+6. Call `enqueueUniqueJob(...)` from a launcher with the right chain name.
+
+Useful helpers a subclass already has: `noteResult(message)` (`:203`), `retargetSheet(target)` (`:238`),
+`fail(reason)` (`:258`), `publish(progress)` (`:280`).
+
+> ⚠️ **`ThorJobKind` is append-only for a concrete reason.** `notificationId = BASE_NOTIFICATION_ID +
+> kind.ordinal`, and that same number is the `PendingIntent` **request code** for the row's tap target.
+> Inserting a kind renumbers every kind after it and hands a live notification another job's request
+> code. `jobKindFromId` is immune (it matches on `id`); the id arithmetic is not.
+
+### The two chains
+
+| Name | Value | For | Producers today |
+|---|---|---|---|
+| `THOR_JOB_CHAIN` | `"thor.job.chain"` | anything that **moves bytes** | 2 (`startBackup`, `startRestore`) |
+| `THOR_SWEEP_CHAIN` | `"thor.sweep.chain"` | privilege **sweeps** — bulk freeze, unfreeze, force-stop, cache clear, reinstall | **0** |
+
+`THOR_SWEEP_CHAIN` exists, is documented at length (`ThorJob.kt:23-40`), and is asserted about by three
+tests — and **nothing enqueues onto it**. It is the landing pad for the bulk-actions work, not a live
+code path. Same for `ThorJobStage.ACTING`, `runsForeground = false`, and `ThorJobLauncher.cancel`.
+
+The split exists because the disk argument for serialising byte-movers does not reach a sweep: a
+freeze writes no bytes, so queueing a five-second sweep behind an hour-long backup buys nothing.
+
+> ⚠️ **One argument in that KDoc does not survive the split, and the doc should not launder it.**
+> `ThorJob.kt:36-38` says sweeps must serialise among themselves partly because *"Odin's root channel is
+> one long-lived FIFO `su` session, so two 'concurrent' root sweeps interleave into that single session
+> anyway."* That reasoning is chain-agnostic — it applies just as well to a sweep running beside a
+> restore, which is exactly what two chains newly permit, and `ARCHIVE_RESTORE` is a privileged-shell
+> path too (`RestoreAppArchiveUseCase` runs `extractInto` through `AppDataArchiveGateway`). Treat the
+> cross-chain case as **not yet argued**, and settle it before the first sweep is enqueued.
+
+### `ExistingWorkPolicy.APPEND_OR_REPLACE`, precisely
+
+One call site: `ThorJobLauncher.kt:253-259`. Read from work-runtime 2.11.2's `EnqueueRunnable`:
+
+- Any chain leaf **live** (ENQUEUED / RUNNING / BLOCKED / SUCCEEDED) ⇒ the newcomer is appended as a
+  **dependent** and enters BLOCKED. It waits.
+- Any leaf **FAILED or CANCELLED** ⇒ every `WorkSpec` carrying that name is **deleted**, and the new
+  request becomes a fresh chain root. This is the anti-wedging escape hatch, and the reason the policy
+  is not plain `APPEND`.
+
+**It never pre-empts.** And a failing prerequisite cancels its dependents, which is the ugly path worth
+knowing: a failed backup cancels the restore queued behind it, `doWork` is **never invoked**, so no
+notification is ever posted and the UI sees `Failed(reason = null)`.
+
+### The enqueue is awaited
+
+`enqueueUniqueJob` calls `operation.awaitSuccess()` (`ThorJobLauncher.kt:261`). This matters: a
+`WorkSpec` insert that fails, a corrupt WorkManager database or a rejected executor task all arrive as
+a *failed* `Operation`, and catching only what is thrown synchronously catches argument validation and
+nothing else. Without the wait, the launcher returned an id for a row that does not exist, and the
+screen sat on a progress bar forever with no timeout anywhere.
+
+If the caller's coroutine is cancelled mid-wait, the work is already WorkManager's, so the key is
+**not** released — but `whenFailed` keeps watching the future for the one outcome that means no worker
+will run (`ThorJobLauncher.kt:274-276`, `:335`).
+
+> 🕳️ **Four comments in the tree still say the opposite** — *"`ThorJobLauncher` does not await
+> `enqueue()`"* — at `AppBackupViewModel.kt:432`, `ArchiveRestoreViewModel.kt:882`,
+> `AppBackupViewModelTest.kt:739` and `ArchiveRestoreViewModelTest.kt:1453`. They pre-date the awaited
+> `Operation`. Do not quote them as fact.
+
+---
+
+## Progress and notifications
+
+`ThorJobProgress(stage, label, completed, total)`. `completed`/`total` are **unit-agnostic** — bytes for
+a streaming restore, class indices for a backup. `total == 0` means *unknown*, `percent` is null, and
+the UI shows an **indeterminate** bar. Never render an unknown total as 0%.
+
+`ThorJobStage` has **eight** values: `PREPARING`, `MEASURING`, `CAPTURING`, `WRITING`, `INSTALLING`,
+`RESTORING`, `ACTING`, `FINISHING`. `ThorJobStatus` has **six**: `Gone`, `Pending`, `Running`,
+`Succeeded(warnings)`, `Cancelled`, `Failed(reason?)`. `Gone` is the *ordinary* answer for an old id —
+WorkManager prunes finished work — not an error.
+
+| Thing | Value | Where |
+|---|---|---|
+| Channel | `"thor.jobs"`, `IMPORTANCE_LOW` | `ThorJobNotifications.CHANNEL_ID` |
+| Ongoing row id | `1100 + kind.ordinal` | `BASE_NOTIFICATION_ID` |
+| Outcome row id | `1200 + kind.ordinal` | `BASE_RESULT_NOTIFICATION_ID` |
+| Outcome row lifetime | 10 s (`setTimeoutAfter`) | `TIMEOUT_MS` |
+| Progress throttle | at most one update/second, or on a stage change | `NOTIFICATION_INTERVAL_MS`, `ThorJobWorker.kt:25` |
+| Message cap | 512 chars, ellipsised | `MAX_JOB_MESSAGE_CHARS`, `ThorJobWorker.kt:298` |
+
+`BulkResultNotifier` owns id 1001 and request code 0 — a separate channel on purpose, so silencing bulk
+results does not silence jobs.
+
+Two ids per kind, not one, because `ThorJobWorker`'s `finally` cancels the *ongoing* id on every
+terminal path; an outcome posted under the same id would be cancelled microseconds after being posted.
+
+**Why `postResult` exists at all:** WorkManager **discards a cancelled worker's `Result`** —
+`WorkerWrapper` records CANCELLED and drops the output `Data`. So a sweep stopped at 7 of 20 cannot
+report that count through `Result.success(...)`. Posting from the worker's own `finally` is the only
+route those counts survive by, and that is what `noteResult` is for.
+
+### ⚠️ The notification gate — a real hole today
+
+`ThorJobNotifications.update` (`:110`) and `postResult` (`:145`) both open with:
+
+```kotlin
+if (!notificationManager.areNotificationsEnabled()) return
+```
+
+That is a cheap guard, not a `POST_NOTIFICATIONS` gate — and it is worth being exact about what the
+user is left with:
+
+- On **API 28–32** a job whose notifications are blocked has **no user-visible surface at all**. No
+  indication it is running, and no way to stop it short of force-stopping Thor.
+- On **API 33+** the system's Task Manager row exists, but it renders the app and a **Stop** button —
+  not a notification's actions, so the cancel `PendingIntent` never reaches it. Its Stop force-stops the
+  process, which runs **none** of `ThorJobWorker`'s `finally`: no registry clear, no key drop, no
+  notification cancel. A restore is covered by §8.5's breadcrumb; a backup relies on the launch sweep.
+
+`areNotificationsEnabled()` is also false when the permission *is* held but notifications are off
+app-wide, so granting `POST_NOTIFICATIONS` is necessary and not always sufficient.
+
+A revocation racing a `notify()` call is caught (`SecurityException`) so a lost shade row never fails a
+backup.
+
+---
+
+## What is *not* on WorkManager, and why
+
+Not one of these is a `ListenableWorker`. They are coroutines, on three different lifetimes.
+
+| Operation | Where it runs | Anchor |
+|---|---|---|
+| **Multi-app export** ("backup all") | process-lifetime `@Single` scope | `BackupRunner.kt:58`, scope `:63` |
+| **Bulk freeze / unfreeze engine** | process-lifetime `@Single` scope, 5-wide fan-out, 30 s deadline | `BulkFreezeRunner.kt:73`, scope `:84` |
+| Bulk reinstall, uninstall, force-stop, cache clear, share, suspend, unsuspend | `viewModelScope` | `MainViewModel.performLoggedMultiAction`, `AppListViewModel`'s bulk branch |
+| Counted freeze from the Freezer buttons | `viewModelScope` — **bypasses `BulkFreezeRunner`** | `MainViewModel.performCountedFreeze` |
+| Auto-freeze | own scopes | `AutoFreezeManager.kt:49-50` |
+| Dynamic shortcuts | own scope | `FreezerShortcutManager.kt:52` |
+| QS tile + freezer launcher | own scopes | `FreezerTileService.kt:107`, `FreezerLaunchActivity.kt:49` |
+| Launch-time sweeps | app scope | `ThorApplication.kt:204` |
+| Privilege probing | own scope | `PrivilegeManager.kt:57` |
+| Archive key expiry | own scope, 1 h timer | `ArchiveKeyHolder.kt:50` |
+| Install / auto-reinstall broadcasts | `goAsync()` | `AutoReinstallReceiver.kt:40`, `InstallReceiver.kt:34` |
+| Extension + freezer bridge IPC | `runBlocking` with a timeout | `ExtensionOpsProvider.kt`, `FreezerBridgeProvider.kt` |
+
+`BackupRunner`'s **non**-adoption is deliberate and argued in its own KDoc (`BackupRunner.kt:47`) — read
+that before "fixing" it.
+
+**`MultiAppAction` has exactly ten members**: `ReInstall`, `Uninstall`, `Freeze`, `UnFreeze`, `Share`,
+`Backup`, `Kill`, `ClearCache`, `Suspend`, `UnSuspend`. There is **no** bulk clear-data and **no** bulk
+background-restrict; a `ClearData` variant existed, was reachable from nothing, and was removed (see the
+comment at `MultiAppAction.kt:22-29` before proposing it again). Sizing a migration from an older list
+will over-count.
+
+**Nothing outside `:app` contributes a worker.** `settings.gradle.kts` includes only `:app`, `:bypass`
+and `:vm-runtime`; neither of the latter two mentions `androidx.work`; and the three in-house AARs
+(`odin`, `asgard`, `thor-extension-api`) carry zero `androidx.work` classes, zero `androidx.work`
+manifest entries and no declared components at all. Extensions reach Thor only through the synchronous
+`ExtensionOpsProvider`, so no extension can enqueue work.
+
+**No `AlarmManager`, `JobScheduler`, `JobIntentService`, `GlobalScope` or Thor-owned foreground
+`Service`** in Thor's own code. (Thor *does* end up using JobScheduler — see the next section.)
+
+> 🪤 **Naming traps.** `BulkFreezeWorkerTest` is not a WorkManager test, and the "worker" inside
+> `BulkFreezeRunner` is a coroutine. `BootReceiver` is inert. Grep for `CoroutineWorker` /
+> `ListenableWorker`, not for the word *worker*.
+
+---
+
+## What adopting WorkManager cost
+
+Verifiable, and currently invisible from the build file:
+
+- **Three permissions Thor never wrote** ship in the APK. `work-runtime-2.11.2.aar`'s own manifest
+  declares `WAKE_LOCK`, `ACCESS_NETWORK_STATE`, `FOREGROUND_SERVICE` and `RECEIVE_BOOT_COMPLETED`; Thor
+  declares only the last of those itself. All three extras are in the merged manifest.
+- **A Play Console Foreground Service declaration** for `FOREGROUND_SERVICE_DATA_SYNC` now stands
+  between the repo and a `store` release. That overlay lives in `main`
+  (`AndroidManifest.xml:416-419`), so it ships in **both** flavours; `follow-ups/README.md:234` (row 23)
+  already records it as one of two things blocking a `store` release.
+- **Thor ships `androidx.work.impl.background.systemjob.SystemJobService`** (merged manifest `:463-468`),
+  so the app *does* use JobScheduler — via WorkManager. The "no JobScheduler" claim above is true of
+  Thor's own code and false as a statement about the shipped app.
+- On `targetSdk = 37` the system can **time-cap a long `dataSync` FGS**. Thor renders that as a plain
+  `Cancelled`, because `WorkInfo.getStopReason()` is read **nowhere** in `app/src`.
+
+### Initialisation
+
+Koin's `workManagerFactory()` (`ThorApplication.kt:227`) — which performs `WorkManager.initialize()` —
+installs a `DelegatingWorkerFactory`. There is no `Configuration.Provider`. The manifest
+`tools:node="remove"`s `androidx.startup`'s `WorkManagerInitializer` (`AndroidManifest.xml:424-433`) so
+there is exactly one initializer; the merged manifest confirms it took effect (`InitializationProvider`
+lists only `EmojiCompat`, `ProcessLifecycle` and `ProfileInstaller`).
+
+> ⚠️ **One process, and the seam depends on it.** The merged manifest contains exactly one
+> `android:process` attribute — `:root` on `ThorRootService`. `ArchiveKeyHolder`, `JobRegistry` and
+> `JobSheetTargets` are process-memory singletons, so the whole seam works only because the worker runs
+> in the **same process** as the ViewModel reading them. Give any of these components an
+> `android:process` and three side channels break silently.
+
+---
+
+## Inspecting a job on a device
+
+Everything from `beginUniqueWork` inward is verified by reading, not by tests — so on-device inspection
+is the only ground truth. WorkManager ships a diagnostics receiver, exported, gated on
+`android.permission.DUMP` (merged manifest `:484-493`), which `adb shell` holds:
+
+```bash
+# debug build; drop the .debug suffix for a release build
+adb shell am broadcast -a androidx.work.diagnostics.REQUEST_DIAGNOSTICS \
+  -n com.valhalla.thor.debug/androidx.work.impl.diagnostics.DiagnosticsReceiver
+adb logcat -s WM-DiagnosticsWrkr
+```
+
+That dumps the queued, running and recently-completed `WorkSpec`s — chain names, tags, states.
+
+---
+
+## Test coverage — the honest position
+
+**64 JVM tests across six files**, and **not one file in `app/src/test` or `app/src/androidTest`
+imports `androidx.work`**:
+
+| File | `@Test`s |
+|---|---|
+| `data/backup/job/AppArchiveWorkerTest.kt` | 21 |
+| `data/backup/job/JobSheetTargetsTest.kt` | 14 |
+| `domain/model/ThorJobTest.kt` | 10 |
+| `data/backup/job/ArchiveKeyHolderTest.kt` | 8 |
+| `data/backup/job/JobRegistryTest.kt` | 6 |
+| `data/backup/job/EnqueueFailureWatchTest.kt` | 5 |
+
+There is no `work-testing`, no Robolectric and no mockk on the classpath. What those 64 cover is the
+seam's constants, its holders, and the top-level sentence builders that were deliberately hoisted out of
+the workers so a JVM test could reach them (`wrongKeyReason`, `restoreFailureReason`, `obbNotice`,
+`refusalReason`, `boundedForJobData`, `whenFailed`). What they do **not** cover is every chain-behaviour
+claim in this document — those are read from WorkManager's source and confirmed against its bytecode,
+and proving them is device-only.
+
+`app/src/androidTest` contains zero `WorkManager`/`Worker` hits of any kind.
+
+---
+
+## Known gaps
+
+| Gap | Detail |
+|---|---|
+| `THOR_SWEEP_CHAIN` has no producers | The whole sweep half of the seam is dead code awaiting the bulk-actions work. |
+| The cross-chain `su` argument | Two chains let a sweep run beside a restore, which the KDoc's own FIFO-session reasoning argues against. Unresolved. |
+| Notifications gate silently | A job runs and shows **nothing** when notifications are off; on API 28–32 there is no surface at all. |
+| `getStopReason()` unread | A system-killed FGS is reported to the user as an ordinary cancel. |
+| Four stale comments | They claim the enqueue is not awaited. It is. |
+| `ArchiveRestoreRequest` carries no `Data`-schema KDoc | Its twin does; the rule is enforced by that one comment. |
+| Everything past `beginUniqueWork` is desk-verified | No `work-testing`, no instrumented coverage. |
+
+---
+
+## Related
+
+- [`follow-ups/README.md`](../follow-ups/README.md) — row 23 carries the seam's one-line summary and the
+  `store`-release blocker.
+- [`../../CLAUDE.md`](../../CLAUDE.md) — module layout, gateways, DI rules.
+- `ThorJob.kt` and `ThorJobWorker.kt` KDocs are the primary source for chain policy and the
+  no-`Result.retry()` rule. Where this document and a KDoc disagree, check the code: seven comments in
+  this subsystem were found stale on 2026-08-13.


### PR DESCRIPTION
Four commits that were finished but never pushed. Folding them into 1942 so they ship with the
release rather than waiting for 1943.

## `feat(permissions)` — stop asking a privileged user to approve what they already have

Once Thor has root, Shizuku or Dhizuku it can grant its own declared runtime permissions, so
prompting for them is asking permission to do something it can already do. `SelfPermissions` is the
flavour-agnostic model of what is declared and what is held; `SelfPermissionGranter` does the
granting through the active gateway. `SettingsCategoryScreen` loses its hand-rolled copy of the same
logic.

`isEnabled` is `areNotificationsEnabled()` — the exact question the notifier itself asks — rather
than a permission check, because those two answers diverge when the user turns notifications off in
system settings without revoking the permission.

Covered by `SelfPermissionsTest` (9 tests, all passing).

## `feat(jobs)` — ask for notifications when a job starts without them

A backup or restore that runs without `POST_NOTIFICATIONS` produces no progress notification and
looks like nothing happened. The ask is now made at the moment a job starts, from the sheet that
started it (`AppBackupSheet`, `ArchiveRestoreSheet`, `AppListScreen`).

## `fix(export)` — stop deleting the old export before the new one exists

Exporting over an existing file deleted the old one first, so a failed or interrupted export left
the user with neither. Each backend now stages its bytes and settles exactly once, reusing the
already-tested `BaseDestination`: SAF writes `<name>.part` and renames over the replaced file at
publish; MediaStore resolves the replaced row's `_ID` **before** the insert, because MediaStore
de-duplicates a colliding `DISPLAY_NAME` at insert time rather than replacing; legacy Downloads
renames within one volume.

Accepted, and stated rather than hidden: an export killed mid-write leaves `<name>.part` in the
destination folder instead of a truncated file under the real name. Nothing sweeps it —
`isSweepableOrphanName` is fed only from the partial-archive ledger, which an export does not use.

This is commit 1 of the export/WorkManager sequence and stands alone. Commits 2–7 (moving export
onto WorkManager with a background button) are **not** in this PR and are not ready.

## `docs(workers)`

`docs/workers/README.md` records which two operations actually run on WorkManager and what the other
twelve are, because the naming misleads in both directions. It states four gaps rather than hiding
them, including that `THOR_SWEEP_CHAIN` currently has zero producers.

## Verification

- `:app:compileFossDebugKotlin` + `:app:compileStoreDebugKotlin` — BUILD SUCCESSFUL.
- `:app:testFossDebugUnitTest --rerun-tasks` — 1548 tests, 0 failures, 0 errors, 0 skipped, 112
  classes; counts parsed from `test-results/**/*.xml`.
- **Desk-verified, not device-tested.** The two permission commits in particular touch the
  privileged gateways and the notification prompt, neither of which a JVM test can reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic permission granting when supported by root or Shizuku access.
  * Improved notification-permission requests for backup and restore jobs.
  * Added clearer notification settings recovery when prompts are unavailable.

* **Bug Fixes**
  * Downloads and exports now publish files only after successful completion, preventing incomplete outputs.

* **Documentation**
  * Expanded WorkManager and job behavior documentation.
  * Clarified permission and notification handling across supported Android versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->