### PR TITLE
feat(release): put the dev rung's build on internal as well as alpha

### DIFF
--- a/.github/scripts/check-notes-budget.sh
+++ b/.github/scripts/check-notes-budget.sh
@@ -38,14 +38,31 @@
 # wrapper-units is the size of the caption scaffolding the workflow wraps
 # around telegram.md. It is NOT a constant - it contains the ref name and the
 # actor - so release-rung.yml measures it per run and passes the result here
-# rather than passing its declared floor. On the ladder's own three refs:
-#   dev rung:        149 (own actor) / 152 (bot actor)
+# rather than passing its declared floor. The caption that is really SENT costs,
+# on the ladder's own three refs:
+#   dev rung:        160 (own actor) / 163 (bot actor)
 #   beta rung:       145 (own actor) / 148 (bot actor)
 #   production rung: 146 (own actor) / 149 (bot actor)
-# but a workflow_dispatch from a long branch name measures 176, because the dev
-# figure above is for a three-character ref. The 160 default here is for
-# invoking the script by hand: a conservative round number that covers all three
-# rungs from their own branches, not a claim about any particular run.
+# but a workflow_dispatch from a long branch name measures 187, because the dev
+# figure above is for a three-character ref.
+#
+# What the workflow PASSES is not that number. At gate time fastlane has not
+# written track.txt yet, so the measurement substitutes the longest label any
+# rung can emit - dev's two-track 'Closed + Internal Testing' - on every rung.
+# Pessimistic on purpose, and it means the values arriving here are 160/163 on
+# dev (exact, since that label is dev's own), 158/161 on beta and 161/164 on
+# production.
+#
+# Hence the 164 default, which exists only for invoking the script by hand: it
+# is the largest wrapper the ladder can pass, so a hand run is never LOOSER than
+# the release that follows it. It was 160 back when the longest label was
+# 'Internal Testing' and 160 was exactly what all three rungs ended up using;
+# adding the two-track label raised the gate on every rung and left that default
+# 4 units light on production - a hand-run pass for a caption the release would
+# refuse, i.e. the discovery this pre-flight exists to move earlier, moved back
+# again. test-caption-wrapper.sh pins both the table above and this default
+# against a fresh measurement, because this is the second copy of that table and
+# the first one drifted the moment the label changed.
 set -euo pipefail
 
 required=()
@@ -78,7 +95,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 version_name="${1:?usage: check-notes-budget.sh [--require <file>]... <version-name> [wrapper-units]}"
-wrapper_units="${2:-160}"
+wrapper_units="${2:-164}"
 
 TELEGRAM_CAP=1024
 PLAYSTORE_CAP=500

--- a/.github/scripts/test/test-caption-wrapper.sh
+++ b/.github/scripts/test/test-caption-wrapper.sh
@@ -104,9 +104,10 @@ def header(title, ref, actor, track, status):
 
 
 # 3 - the documented table still holds. Track labels come from the rung's own
-# destination: dev uploads to alpha, and the promote lanes name their target.
+# destination: dev uploads to alpha and mirrors onto internal, so it names both,
+# and the promote lanes name their single target.
 RUNGS = {
-    "dev": ("1-dev-publish.yml", "dev", "Closed Testing"),
+    "dev": ("1-dev-publish.yml", "dev", "Closed + Internal Testing"),
     "beta": ("2-master-promote.yml", "master", "Open Testing"),
     "production": ("3-production-promote.yml", "production", "Production"),
 }

--- a/.github/scripts/test/test-caption-wrapper.sh
+++ b/.github/scripts/test/test-caption-wrapper.sh
@@ -24,7 +24,12 @@
 #      the wrapper contains the ref name, the table's refs are the ladder's own
 #      short ones, and the whole reason the gate measures per run is that a
 #      dispatch from a long branch costs more. Pinning the cited number keeps
-#      that counter-example honest rather than leaving it as prose.
+#      that counter-example honest rather than leaving it as prose, and
+#   6. check-notes-budget.sh's copy of that table agrees, and its hand-run
+#      default is at least as large as the biggest wrapper the ladder can pass
+#      it. 1-5 pinned only release-rung.yml, so the second copy drifted the
+#      first time the numbers moved; and a default below what CI passes turns
+#      the hand-run pre-flight into a false green.
 set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 assertions=0
@@ -156,6 +161,59 @@ if cited:
         check(cited_units > ceiling,
               f"the cited long-ref figure {cited_units} is not above the per-rung table's maximum {ceiling} - "
               "the table would then read as a ceiling, which is the misreading this pins against")
+
+# 6 - check-notes-budget.sh holds a SECOND copy of that table, and the default
+# the table justifies. Nothing pinned it until now, and it drifted at the first
+# opportunity: when the track label grew to name two tracks, release-rung.yml's
+# copy was updated and this one silently kept the old numbers. The default is
+# worse than a stale comment - it is the figure a HAND run actually uses, so if
+# it sits below what the ladder passes, a hand run green-lights a caption the
+# release then refuses, which is the discovery this whole pre-flight exists to
+# move earlier.
+budget_text = (root / ".github" / "scripts" / "check-notes-budget.sh").read_text()
+
+
+def rung_inputs(fname):
+    doc = yaml.safe_load((wf_dir / fname).read_text())
+    job = next(iter((doc.get("jobs") or {}).values()))
+    return job.get("with") or {}
+
+
+budget_doc = dict(
+    (m.group(1), (int(m.group(2)), int(m.group(3))))
+    for m in re.finditer(
+        r"^#\s+(dev|beta|production) rung:\s+(\d+) \(own actor\) / (\d+) \(bot actor\)$",
+        budget_text, re.M)
+)
+check(budget_doc == documented,
+      f"check-notes-budget.sh documents {budget_doc} but release-rung.yml documents {documented} - "
+      "the two copies of the per-rung table have drifted")
+
+default_m = re.search(r'^wrapper_units="\$\{2:-(\d+)\}"$', budget_text, re.M)
+check(default_m is not None, "check-notes-budget.sh has no parseable wrapper-units default to pin")
+if default_m and placeholder:
+    default_units = int(default_m.group(1))
+    # Measured with the PLACEHOLDER label, not each rung's real one: what the
+    # gate passes is what a hand run has to match, and the gate prices every
+    # rung at the longest label because track.txt does not exist yet.
+    gate_max = max(
+        header(rung_inputs(fname)["title_prefix"], ref, actor,
+               placeholder.group(1), rung_inputs(fname)["caption_status"])
+        for fname, ref, _ in RUNGS.values()
+        for actor in ("trinadhthatakula", "github-actions[bot]")
+    )
+    check(default_units >= gate_max,
+          f"check-notes-budget.sh defaults to {default_units} units, but the ladder passes it up to "
+          f"{gate_max} - a hand run would be looser than the release that follows it")
+
+# The long-ref counter-example is cited in that header too, a third copy.
+budget_long = re.search(r"long branch name measures (\d+)", budget_text)
+check(budget_long is not None,
+      "check-notes-budget.sh no longer cites a long-ref measurement - a third copy of it moved")
+if budget_long and cited:
+    check(int(budget_long.group(1)) == int(cited.group(3)),
+          f"check-notes-budget.sh cites {budget_long.group(1)} units for a long ref, "
+          f"release-rung.yml cites {cited.group(3)}")
 
 if checked == 0:
     sys.exit("  nothing was checked - the test is vacuous")

--- a/.github/scripts/test/test-fastlane-lib.sh
+++ b/.github/scripts/test/test-fastlane-lib.sh
@@ -6,3 +6,31 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
 ruby "$repo_root/fastlane/test/test_thor_release.rb"
 echo "  ok: fastlane/lib unit tests passed"
+
+# A GitHub workflow command has to start the line, and inside a Fastfile `puts`
+# is NOT Kernel#puts: fast_file.rb defines its own, which runs the puts action
+# and prints through UI.message, which prefixes "[HH:MM:SS]: " unless
+# FASTLANE_HIDE_TIMESTAMP is set - this repo does not set it. So a bare
+# `puts "::warning..."` emits no annotation while looking exactly like it does,
+# in a build that stays green. Only an explicit receiver bypasses the override.
+fastfile="$repo_root/fastlane/Fastfile"
+bare="$(grep -nE '^[[:space:]]*puts[[:space:]]*["'"'"']::' "$fastfile" || true)"
+if [ -n "$bare" ]; then
+  echo "::error::Fastfile emits a GitHub workflow command through fastlane's puts action, which prefixes the line and voids the annotation. Use \$stdout.puts:" >&2
+  echo "$bare" >&2
+  exit 1
+fi
+echo "  ok: no workflow command in the Fastfile is emitted through fastlane's puts"
+
+# Non-vacuity: the check above passes trivially if nothing emits one at all.
+# If a future edit deliberately removes the last annotation, update this line
+# rather than deleting it, so "nothing to check" stays a decision and not a
+# silent gap.
+# [$] rather than \$ so the pattern needs no backslash escape inside single
+# quotes, which shellcheck reads as an attempted expansion (SC2016).
+emitted="$(grep -cE '([$]stdout|STDOUT|Kernel)[.]puts[[:space:]]*["'"'"']::' "$fastfile" || true)"
+if [ "$emitted" -lt 1 ]; then
+  echo "::error::the Fastfile no longer emits any GitHub workflow command with an explicit receiver, so the check above is vacuous" >&2
+  exit 1
+fi
+echo "  ok: ${emitted} workflow command(s) emitted with an explicit receiver"

--- a/.github/workflows/1-dev-publish.yml
+++ b/.github/workflows/1-dev-publish.yml
@@ -1,8 +1,12 @@
-name: 1. Dev — publish to Play alpha
+name: 1. Dev — publish to Play alpha + internal
 
 # Rung 1 of 3. This is the ONLY workflow in the repo that uploads an artifact
 # to Play. master and production promote what this uploaded; they never upload.
 # That is what gives every version code exactly one uploader.
+#
+# It lands on two tracks from that one upload: distribute_dev uploads to alpha
+# and then assigns the same release to internal (ThorRelease::MIRROR_TRACKS).
+# Two tracks, still one upload - see docs/branching-and-releases.md.
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/release-rung.yml
+++ b/.github/workflows/release-rung.yml
@@ -1,7 +1,8 @@
 name: Release rung
 
-# One workflow, three rungs. dev uploads to Play alpha; master promotes
-# alpha -> beta; production promotes beta -> production. Exactly one branch
+# One workflow, three rungs. dev uploads to Play alpha and mirrors that same
+# release onto internal; master promotes alpha -> beta; production promotes
+# beta -> production. The mirror uploads nothing, so exactly one branch
 # ever uploads an artifact, which is what makes Play's per-app (not per-track)
 # version-code uniqueness a non-issue rather than an error to handle.
 #
@@ -67,17 +68,23 @@ on:
       # the actor, counting the "\n\n" that joins it to telegram.md:
       #
       #                  trinadhthatakula   github-actions[bot]
-      #     dev                 149                152
+      #     dev                 160                163
       #     beta                145                148
       #     production          146                149
       #
-      # 152 is the maximum of those, so 160 reads like eight units of margin. It
-      # is not. That 152 is the DEV rung, whose ref is three characters, so 160
-      # tolerated an 11-character ref - and 'production' is already 10. A
-      # workflow_dispatch of the dev rung from feat/release-ladder-phase-2
-      # assembles a real wrapper of 176 against the assumed 160, and with
-      # v1.94.0's 847-unit telegram.md the true caption is 1023/1024: it passed
-      # by one unit rather than by design.
+      # dev is the long one because it is the only rung that reaches two tracks:
+      # it uploads to alpha and mirrors onto internal, so its caption says
+      # 'Closed + Internal Testing' where the others name a single track.
+      #
+      # 163 is the maximum of those, so the 160 floor is no longer even a floor
+      # on the dev rung - the measurement always wins there. Nor was it ever the
+      # margin it looked like: that maximum belongs to the rung whose ref is
+      # three characters, so 160 only ever tolerated an 11-character ref, and
+      # 'production' is already 10. A workflow_dispatch of the dev rung from
+      # feat/release-ladder-phase-2 assembles a real wrapper of 187 against the
+      # assumed 160 - and against v1.94.0's 847-unit telegram.md that is
+      # 1034/1024, a caption Telegram would refuse outright. The floor cannot see
+      # any of that; only the per-run measurement can.
       #
       # The floor stays because it costs nothing and keeps the gate no weaker
       # than it was; the per-run measurement is what makes it correct. Only an
@@ -224,22 +231,25 @@ jobs:
           # caption that would have fitted; under-estimating spends the Play
           # upload first and finds out from Telegram.
           #
-          # 'Internal Testing' is two units longer than the 'Closed Testing'
-          # the dev rung actually gets, and that is not free: a dispatch from
-          # feat/release-ladder-phase-2 measures 178 where the true caption is
-          # 1023/1024, so today's notes would be refused from a long-named
-          # branch. Deriving the label from inputs.rung instead would be exact,
-          # and is rejected on purpose - it would be a fourth place encoding
-          # which track a rung uploads to, and the comment below records that
-          # this caption already once told users the wrong track for months
-          # after a lane moved. A gate that is two units pessimistic is worth
-          # more than a mapping that can go quietly stale.
+          # That longest label is now the dev rung's own 'Closed + Internal
+          # Testing', because dev uploads to alpha and mirrors onto internal. So
+          # the substitution is EXACT on the one rung that uploads, and
+          # pessimistic by 11-15 units on the two that promote - the safe
+          # direction, and the direction that matters least, since those rungs
+          # publish an already-broadcast version code.
+          #
+          # Deriving the label from inputs.rung instead would be exact
+          # everywhere, and is rejected on purpose - it would be a fourth place
+          # encoding which track a rung uploads to, and the comment below
+          # records that this caption already once told users the wrong track for
+          # months after a lane moved. A gate that is pessimistic on the promote
+          # rungs is worth more than a mapping that can go quietly stale.
           #
           # The format string is byte-identical to the one that assembles the
           # real caption below, and test-caption-wrapper.sh pins the two
           # together - a reworded header that changed only one of them would
           # otherwise make this measurement quietly wrong.
-          HEADER=$(printf "🚀 *Thor (Valhalla) %s*\n\nBranch: %s\nAuthor: %s\nTrack: %s\nStatus: %s" "$TITLE_PREFIX" "$GITHUB_REF_NAME" "$GITHUB_ACTOR" "Internal Testing" "$CAPTION_STATUS")
+          HEADER=$(printf "🚀 *Thor (Valhalla) %s*\n\nBranch: %s\nAuthor: %s\nTrack: %s\nStatus: %s" "$TITLE_PREFIX" "$GITHUB_REF_NAME" "$GITHUB_ACTOR" "Closed + Internal Testing" "$CAPTION_STATUS")
           # + 2 for the blank line that joins the header to telegram.md.
           MEASURED=$(printf '%s' "$HEADER" | python3 -c 'import sys; print(len(sys.stdin.buffer.read().decode("utf-8").encode("utf-16-le")) // 2 + 2)')
           if [ "$MEASURED" -gt "$WRAPPER" ]; then
@@ -419,14 +429,21 @@ jobs:
           # be the literal "Internal Testing" and stayed that way after the lane moved, which nothing
           # in the repo could catch — there is no actionlint or shellcheck over .github/workflows.
           # The default arm prints whatever key it got instead of inventing a friendly name for it.
+          #
+          # The dev rung writes a '+'-joined value ("alpha+internal") because it uploads to one track
+          # and mirrors onto another, and it writes it AFTER the mirror, from what actually
+          # succeeded — so a mirror that failed reads back as plain "alpha" and is announced as
+          # exactly that. Each combination needs its own arm: the default arm would broadcast the
+          # raw key to users without an error or a warning.
           TRACK=$(cat track.txt 2>/dev/null || echo "")
           case "$TRACK" in
-            internal)   TRACK_LABEL="Internal Testing" ;;
-            alpha)      TRACK_LABEL="Closed Testing" ;;
-            beta)       TRACK_LABEL="Open Testing" ;;
-            production) TRACK_LABEL="Production" ;;
-            "")         TRACK_LABEL="unknown" ;;
-            *)          TRACK_LABEL="$TRACK" ;;
+            internal)       TRACK_LABEL="Internal Testing" ;;
+            alpha)          TRACK_LABEL="Closed Testing" ;;
+            alpha+internal) TRACK_LABEL="Closed + Internal Testing" ;;
+            beta)           TRACK_LABEL="Open Testing" ;;
+            production)     TRACK_LABEL="Production" ;;
+            "")             TRACK_LABEL="unknown" ;;
+            *)              TRACK_LABEL="$TRACK" ;;
           esac
 
           # "& GitHub" was a lie of ordering: Create GitHub Release is a later step in this job, so

--- a/.github/workflows/release-rung.yml
+++ b/.github/workflows/release-rung.yml
@@ -234,9 +234,15 @@ jobs:
           # That longest label is now the dev rung's own 'Closed + Internal
           # Testing', because dev uploads to alpha and mirrors onto internal. So
           # the substitution is EXACT on the one rung that uploads, and
-          # pessimistic by 11-15 units on the two that promote - the safe
+          # pessimistic by 13 units on beta and 15 on production - the safe
           # direction, and the direction that matters least, since those rungs
-          # publish an already-broadcast version code.
+          # publish an already-broadcast version code. (On dev it is 11 units
+          # pessimistic in one case only: a FAILED mirror, which falls back to
+          # announcing plain 'Closed Testing'.)
+          #
+          # Consequence worth carrying: this raised what the gate passes on every
+          # rung, up to 161/164 on production, so check-notes-budget.sh's
+          # hand-run default moved 160 -> 164 to stay no looser than CI.
           #
           # Deriving the label from inputs.rung instead would be exact
           # everywhere, and is rejected on purpose - it would be a fourth place

--- a/docs/branching-and-releases.md
+++ b/docs/branching-and-releases.md
@@ -28,6 +28,8 @@ list "merged" branches will happily offer it up. It is a live release lane.
                    ▼            ▼                ▼
               Play alpha    Play beta      Play production
              (closed test)  (open test)      (everyone)
+                   │
+                   └─▶ Play internal  (same release, mirrored — no second upload)
 ```
 
 ---
@@ -51,7 +53,7 @@ there is no arithmetic on the version number anywhere in the routing.
 
 | Merge | Workflow | Play | GitHub | Telegram |
 |---|---|---|---|---|
-| `<topic>` → `dev` | [`1-dev-publish.yml`](../.github/workflows/1-dev-publish.yml) | **uploads** to `alpha` (Closed testing) | pre-release `v<name>-dev-<run>` | ✅ |
+| `<topic>` → `dev` | [`1-dev-publish.yml`](../.github/workflows/1-dev-publish.yml) | **uploads** to `alpha` (Closed testing), then mirrors onto `internal` | pre-release `v<name>-dev-<run>` | ✅ |
 | `dev` → `master` | [`2-master-promote.yml`](../.github/workflows/2-master-promote.yml) | promotes `alpha` → `beta` (Open testing) | pre-release `v<name>-beta-<run>` | ❌ |
 | `master` → `production` | [`3-production-promote.yml`](../.github/workflows/3-production-promote.yml) | promotes `beta` → `production` | **release** `v<name>` (Latest) | ✅ |
 
@@ -61,10 +63,35 @@ declare. **If a rung needs to behave differently, add an input — do not fork t
 
 ### Rung 1 — `dev`
 
-Builds both flavours, uploads the `store` AAB to Play's `alpha` track, publishes a GitHub
-pre-release with the APKs attached, and broadcasts to the Telegram testers' channel.
+Builds both flavours, uploads the `store` AAB to Play's `alpha` track, **mirrors that same release
+onto `internal`**, publishes a GitHub pre-release with the APKs attached, and broadcasts to the
+Telegram testers' channel.
 
-This is the only rung that puts bytes into Play.
+This is the only rung that puts bytes into Play — the mirror moves none.
+
+#### The mirror onto `internal`
+
+One build, two test tracks, one upload. `alpha` is uploaded first and the mirror runs only after it
+succeeds, because the upload is the single step in the ladder that **cannot be repeated** (Play
+allows one upload per version code per app). The table lives in
+[`ThorRelease::MIRROR_TRACKS`](../fastlane/lib/thor_release.rb); it is deliberately *not* an entry
+in `PROMOTION_EDGES`, which exists to forbid rungs that skip a step.
+
+Three things are worth knowing before touching it:
+
+- **The obvious implementation silently does nothing.** Passing `track: 'internal'` with
+  `version_code:` and both artifact skips set writes no release and still reports success —
+  `supply` decides whether to touch a track from whether it uploaded new binaries, and with both
+  skips set that list is empty. `track_promote_to` from a track that already holds the code is the
+  path that actually assigns it. (Verified against the pinned fastlane 2.237.0.)
+- **The mirror leaves `alpha` alone.** `promote_track` copies the source release object onto another
+  track name; there is no cross-track deactivation path in 2.237.0 at all.
+- **A failed mirror does not fail the build.** The bytes are already on `alpha` and cannot be
+  uploaded again, so aborting would cost the GitHub release and the Telegram broadcast for a build
+  that did publish. It logs a `::warning::` instead, and `track.txt` is rewritten from what
+  *actually* succeeded — so the Telegram caption says "Closed Testing" rather than claiming a track
+  the build never reached. If you see that warning, assign the release to `internal` in the Play
+  Console; do not re-run the rung.
 
 ### Rung 2 — `master`
 
@@ -93,7 +120,9 @@ Version code 1940 has already been used. Try another version code.
 
 The previous design had two branches building and uploading, which meant every release was one
 mis-timed merge away from that error. The ladder removes the possibility rather than working around
-it: `dev` uploads, and the other two rungs move that same upload up a track.
+it: `dev` uploads, and every other track — `internal` by mirror, `beta` and `production` by
+promotion — is reached by *assigning that same release*, never by uploading it again. Two tracks on
+the dev rung is therefore still one upload, which is the only number this rule cares about.
 
 The invariant is enforced in three independent places, so breaking it takes three mistakes:
 
@@ -200,6 +229,7 @@ bypass. It is the one and only exception to "never push directly to `dev`".
 | Channel | Source | Notes |
 |---|---|---|
 | Play — Closed testing | `dev` rung upload | testers opted in via the Play link |
+| Play — Internal testing | `dev` rung mirror | the same release as Closed testing, assigned not re-uploaded |
 | Play — Open testing | `master` rung promotion | |
 | Play — Production | `production` rung promotion | |
 | GitHub Releases | every rung | only the production rung is not a pre-release |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,6 +26,21 @@ platform :android do
     # rather than fail.
     track = ThorRelease.validate_upload_track!(track) if upload_to_store
 
+    # Resolve the mirror table HERE rather than at the mirror call site, for the
+    # same reason that guard is here: mirror_tracks_for can raise, and by the
+    # mirror call site the Play upload has already happened. A raise there would
+    # skip Prepare Release Notes, and with it the Telegram broadcast and the
+    # GitHub release, leaving a version code live on Play that can never be
+    # re-uploaded and was never announced - the exact outcome the per-target
+    # rescue further down exists to prevent.
+    #
+    # This is depth, not a live hole: the only values reaching it are already
+    # narrowed to UPLOAD_TRACKS by the line above, MIRROR_TRACKS is frozen, and
+    # both of its guards are pinned by tests that run on every PR. It can only
+    # fire on a bad source edit - so resolve it before anything publishes, where
+    # a bad source edit costs a red build instead of a silent, unannounced one.
+    mirror_targets = upload_to_store ? ThorRelease.mirror_tracks_for(track) : []
+
     # 1. PREPARATION
     fastlane_dir = Dir.pwd
     project_root = File.expand_path("..", fastlane_dir)
@@ -148,7 +163,8 @@ platform :android do
       # upload and never before it: the upload is the one step in the whole
       # ladder that cannot be repeated, so nothing optional gets to run ahead of
       # it. A mirror that fails leaves a correct, complete release on `track`.
-      mirrored = mirror_to_additional_tracks(source: track, version_code: final_version_code)
+      mirrored = mirror_to_additional_tracks(targets: mirror_targets, source: track,
+                                             version_code: final_version_code)
 
       # Rewrite track.txt from what actually happened. The write above records
       # intent (it happens before the build), and the Telegram caption reads
@@ -185,8 +201,10 @@ platform :android do
   # take the build off alpha. That the ladder's own promotions all happen to go
   # upward is a Thor invariant, enforced by ThorRelease::PROMOTION_EDGES, which
   # this deliberately does not use.
-  def mirror_to_additional_tracks(source:, version_code:)
-    targets = ThorRelease.mirror_tracks_for(source)
+  # targets is passed in rather than looked up here on purpose - see the comment
+  # at the resolution site in prepare_release_artifacts. Nothing in this method
+  # may raise before the per-target rescue below.
+  def mirror_to_additional_tracks(targets:, source:, version_code:)
     return [] if targets.empty?
 
     mirrored = []

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -244,9 +244,19 @@ platform :android do
         # not recoverable at all. The caller rewrites track.txt from the return
         # value, so the announcement names only the tracks that really worked.
         UI.error("❌ Could not mirror v#{version_code} onto [#{target}]: #{e.message}")
-        puts "::warning title=Play mirror failed::v#{version_code} was uploaded to '#{source}' " \
-             "but NOT assigned to '#{target}'. The upload itself succeeded and must not be " \
-             "repeated — assign the release to '#{target}' in the Play Console instead."
+        # $stdout.puts, NOT puts. Inside a Fastfile `puts` is not Kernel#puts:
+        # fast_file.rb defines its own, which runs the puts ACTION and prints
+        # through UI.message - and UI.message prefixes every line with
+        # "[HH:MM:SS]: " unless FASTLANE_HIDE_TIMESTAMP is set, which this repo
+        # does not set. GitHub only parses a workflow command at the START of a
+        # line, so a bare `puts` here produces no annotation at all: the one
+        # notice telling a human that a published release needs a manual Play
+        # Console step would decay into an ordinary log line, in the middle of a
+        # green build. An explicit receiver bypasses the override.
+        $stdout.puts "::warning title=Play mirror failed::v#{version_code} was uploaded to " \
+                     "'#{source}' but NOT assigned to '#{target}'. The upload itself succeeded " \
+                     "and must not be repeated — assign the release to '#{target}' in the Play " \
+                     "Console instead."
       end
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,9 +6,10 @@ platform :android do
 
   # --- HELPER: Common Build Logic ---
   # The only uploading caller is the dev lane, which publishes to closed testing
-  # ('alpha'). The promote lanes call this with upload_to_store: false purely to
-  # build artifacts. There is deliberately no default — a lane that uploads must
-  # name where, and a lane that does not upload passes nothing.
+  # ('alpha') and then mirrors that same release onto internal testing without a
+  # second upload. The promote lanes call this with upload_to_store: false purely
+  # to build artifacts. There is deliberately no default — a lane that uploads
+  # must name where, and a lane that does not upload passes nothing.
   def prepare_release_artifacts(upload_to_store: false, track: nil, version_code: nil)
     # A lane that uploads must name a track this repo is allowed to upload to.
     # beta and production are NOT on that list: they are reached by promotion
@@ -142,19 +143,110 @@ platform :android do
         skip_upload_apk: true
       )
       UI.success("🚀 Deployed to Play Store [#{track}]!")
+
+      # Same release, additional tracks — no second upload. This runs AFTER the
+      # upload and never before it: the upload is the one step in the whole
+      # ladder that cannot be repeated, so nothing optional gets to run ahead of
+      # it. A mirror that fails leaves a correct, complete release on `track`.
+      mirrored = mirror_to_additional_tracks(source: track, version_code: final_version_code)
+
+      # Rewrite track.txt from what actually happened. The write above records
+      # intent (it happens before the build), and the Telegram caption reads
+      # this file — so a mirror that failed must not be able to announce a track
+      # the build never reached.
+      File.write(File.join(project_root, "track.txt"), ([track] + mirrored).join("+"))
     else
       UI.success("📦 Artifacts built successfully (Upload skipped)")
     end
   end
 
+  # Puts an ALREADY-UPLOADED version code on further tracks without uploading it
+  # again, so one build can be live on closed and internal testing at once.
+  #
+  # track_promote_to is the only shape that works, and the obvious alternative
+  # fails silently, which is why this comment is long. Passing
+  # `track: 'internal', version_code: N` with both artifact skips set writes
+  # NOTHING and still reports success: supply decides whether to touch a track
+  # from whether it uploaded new binaries, and it computes that
+  # (`uploading_new_binaries`) from the apk/aab version codes BEFORE any
+  # retained code is appended — with both skips true that list is empty, so
+  # update_track is never called, and with no track_promote_to and no rollout
+  # the promote and rollout branches are skipped too. The version code then
+  # feeds only the changelog step, which looks up an existing release holding it
+  # and hard-errors "Could not find release for version code" if the track has
+  # none. Verified against the pinned fastlane 2.237.0 (supply/lib/supply/
+  # uploader.rb), not inferred from the docs.
+  #
+  # "Promote" here does not mean "up". Play has no ordering over tracks;
+  # promote_track copies the source release object onto another track name, and
+  # it leaves the source track's release standing — in 2.237.0 there is no
+  # cross-track deactivation path at all (check_superseded_tracks and
+  # deactivate_on_promote are declared but referenced nowhere), so this cannot
+  # take the build off alpha. That the ladder's own promotions all happen to go
+  # upward is a Thor invariant, enforced by ThorRelease::PROMOTION_EDGES, which
+  # this deliberately does not use.
+  def mirror_to_additional_tracks(source:, version_code:)
+    targets = ThorRelease.mirror_tracks_for(source)
+    return [] if targets.empty?
+
+    mirrored = []
+
+    targets.each do |target|
+      UI.message("↔️  Mirroring #{version_code}: #{source} -> #{target} (no upload)")
+
+      begin
+        upload_to_play_store(
+          track: source,
+          track_promote_to: target,
+          track_promote_release_status: 'completed',
+          version_code: version_code,
+          # Both skips are load-bearing here for exactly the reason
+          # promote_to_track documents below: params[:aab] gets back-filled from
+          # the build's own output path, and without both flags this re-uploads
+          # the bundle and dies on "version code already used".
+          skip_upload_apk: true,
+          skip_upload_aab: true,
+          skip_upload_metadata: true,
+          # The mirror inherits the source release wholesale, notes included —
+          # which is what "the same release on both tracks" means. Writing
+          # changelogs again here would re-PUT the text the upload just wrote.
+          skip_upload_changelogs: true,
+          skip_upload_images: true,
+          skip_upload_screenshots: true
+        )
+        mirrored << target
+        UI.success("🚀 v#{version_code} is also on [#{target}]")
+      rescue StandardError => e
+        # Deliberately not fatal, and this is the one judgement call in the
+        # lane. The bytes are already on `source` and Play allows one upload per
+        # version code per app, so raising here would cost the GitHub release
+        # and the Telegram broadcast for a build that DID publish, and the
+        # re-run would fail on "version code already used". A missing mirror is
+        # one click in the Play Console; a published-but-unannounced release is
+        # not recoverable at all. The caller rewrites track.txt from the return
+        # value, so the announcement names only the tracks that really worked.
+        UI.error("❌ Could not mirror v#{version_code} onto [#{target}]: #{e.message}")
+        puts "::warning title=Play mirror failed::v#{version_code} was uploaded to '#{source}' " \
+             "but NOT assigned to '#{target}'. The upload itself succeeded and must not be " \
+             "repeated — assign the release to '#{target}' in the Play Console instead."
+      end
+    end
+
+    mirrored
+  end
+
   # --- LANES ---
 
-  desc "Dev: Build -> Play Store (Closed testing) -> Telegram -> GitHub Pre-release"
+  desc "Dev: Build -> Play Store (Closed + Internal testing) -> Telegram -> GitHub Pre-release"
   lane :distribute_dev do
     # 'alpha' is the de-facto track key for "Closed testing" in the Play Console. Google's own
     # track table documents only 'production', 'beta' and 'qa'; 'alpha' is fastlane/GPP convention,
     # and it is the key the production lane published to before 2026-08-02, so it is known to work
     # against this app's Play listing.
+    #
+    # The upload names one track, and only one: the mirror onto internal is
+    # driven by ThorRelease::MIRROR_TRACKS inside prepare_release_artifacts, so
+    # the second track cannot become a second upload by editing this line.
     prepare_release_artifacts(upload_to_store: true, track: 'alpha')
   end
 

--- a/fastlane/lib/thor_release.rb
+++ b/fastlane/lib/thor_release.rb
@@ -9,6 +9,10 @@
 # The ladder: dev uploads to alpha, master promotes alpha -> beta, production
 # promotes beta -> production. Exactly one branch ever uploads, which is what
 # makes Play's per-app (not per-track) version-code uniqueness a non-issue.
+#
+# The dev rung then MIRRORS its upload onto internal - the same release object
+# on a second track, with no second upload. That leaves the "exactly one branch
+# uploads" invariant untouched: mirroring moves no bytes.
 module ThorRelease
   class Error < StandardError; end
 
@@ -26,6 +30,23 @@ module ThorRelease
     'production' => 'beta'
   }.freeze
 
+  # uploaded track => the further tracks that same version code is assigned to
+  # once the upload has succeeded, without uploading it again.
+  #
+  # Deliberately NOT an entry in PROMOTION_EDGES. That map encodes the ladder's
+  # one-rung-at-a-time invariant, and internal sits below alpha, so an
+  # 'internal' => 'alpha' edge there would mean source_track_for('internal')
+  # starts answering - teaching the promote lanes a downward edge in the map
+  # whose whole purpose is to forbid unreviewed jumps. Mirroring is a different
+  # operation with a different guarantee, so it gets its own table.
+  #
+  # Every target must also be an UPLOAD_TRACK: the mirror is performed with
+  # track_promote_to, which creates a track by an unrecognised name just as
+  # readily as an upload does.
+  MIRROR_TRACKS = {
+    'alpha' => %w[internal].freeze
+  }.freeze
+
   def self.validate_upload_track!(track)
     normalised = track.to_s.strip
     unless UPLOAD_TRACKS.include?(normalised)
@@ -33,6 +54,28 @@ module ThorRelease
                    'beta and production are promotion-only: exactly one branch uploads to Play.'
     end
     normalised
+  end
+
+  # The extra tracks an upload to `track` is mirrored onto. An unmirrored track
+  # answers [] rather than raising: most tracks have no mirror, and "no mirror"
+  # is a normal answer, not a misconfiguration.
+  def self.mirror_tracks_for(track)
+    normalised = track.to_s.strip
+    targets = Array(MIRROR_TRACKS[normalised])
+
+    targets.each do |target|
+      if target == normalised
+        raise Error, "#{normalised} is listed as a mirror of itself - a mirror must name a different track."
+      end
+
+      unless UPLOAD_TRACKS.include?(target)
+        raise Error, "mirror target #{target.inspect} for #{normalised.inspect} is not in " \
+                     "UPLOAD_TRACKS (#{UPLOAD_TRACKS.join(', ')}). Mirroring uses track_promote_to, " \
+                     'which would create a phantom track by that name rather than fail.'
+      end
+    end
+
+    targets
   end
 
   def self.source_track_for(destination)

--- a/fastlane/test/test_thor_release.rb
+++ b/fastlane/test/test_thor_release.rb
@@ -129,6 +129,81 @@ class TestPromotionEdges < Minitest::Test
   def test_unknown_destination_is_rejected
     assert_raises(ThorRelease::Error) { ThorRelease.source_track_for('nonsense') }
   end
+
+  # Mirroring must NOT have taught this map a downward edge. If internal ever
+  # answers here, the promote lanes have gained a path that skips a rung, which
+  # is the one thing PROMOTION_EDGES exists to forbid.
+  def test_internal_is_not_a_promotion_destination
+    assert_raises(ThorRelease::Error) { ThorRelease.source_track_for('internal') }
+  end
+end
+
+class TestMirrorTracks < Minitest::Test
+  # The dev rung uploads once, to alpha, and the same release is then assigned
+  # to internal without a second upload.
+  def test_alpha_mirrors_onto_internal
+    assert_equal %w[internal], ThorRelease.mirror_tracks_for('alpha')
+  end
+
+  def test_strips_whitespace
+    assert_equal %w[internal], ThorRelease.mirror_tracks_for("  alpha\n")
+  end
+
+  # "No mirror" is the normal answer for every other track, and must not raise:
+  # prepare_release_artifacts asks this on every upload.
+  def test_internal_has_no_mirror
+    assert_empty ThorRelease.mirror_tracks_for('internal')
+  end
+
+  def test_promotion_only_tracks_have_no_mirror
+    assert_empty ThorRelease.mirror_tracks_for('beta')
+    assert_empty ThorRelease.mirror_tracks_for('production')
+  end
+
+  def test_unknown_track_has_no_mirror
+    assert_empty ThorRelease.mirror_tracks_for('nonsense')
+    assert_empty ThorRelease.mirror_tracks_for(nil)
+  end
+
+  # Every mirror target must be uploadable. Mirroring uses track_promote_to,
+  # which invents a track by an unrecognised name exactly as an upload does, so
+  # a typo in the table has to be a red build rather than a phantom track that
+  # testers never see.
+  def test_every_target_is_an_upload_track
+    ThorRelease::MIRROR_TRACKS.each_value do |targets|
+      targets.each { |t| assert_includes ThorRelease::UPLOAD_TRACKS, t }
+    end
+  end
+
+  # A mirror names a different track by definition; self-mirroring is a config
+  # typo that would otherwise ask Play to promote alpha onto alpha.
+  def test_a_self_mirror_is_rejected
+    with_mirror_tracks('alpha' => %w[alpha]) do
+      assert_raises(ThorRelease::Error) { ThorRelease.mirror_tracks_for('alpha') }
+    end
+  end
+
+  def test_a_non_uploadable_target_is_rejected
+    with_mirror_tracks('alpha' => %w[beta]) do
+      assert_raises(ThorRelease::Error) { ThorRelease.mirror_tracks_for('alpha') }
+    end
+  end
+
+  private
+
+  # Swaps the table so the guards can be exercised on a bad one without shipping
+  # a test-only hook in thor_release.rb. remove_const before const_set keeps
+  # Ruby from warning about reassigning a constant, and the ensure puts the real
+  # table back even when the assertion inside fails.
+  def with_mirror_tracks(table)
+    original = ThorRelease::MIRROR_TRACKS
+    ThorRelease.send(:remove_const, :MIRROR_TRACKS)
+    ThorRelease.const_set(:MIRROR_TRACKS, table.freeze)
+    yield
+  ensure
+    ThorRelease.send(:remove_const, :MIRROR_TRACKS)
+    ThorRelease.const_set(:MIRROR_TRACKS, original)
+  end
 end
 
 class TestCodePresenceAssertion < Minitest::Test

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -21,13 +21,14 @@ there is no arithmetic on the version number anywhere in the routing.
 
 | merge | workflow | Play | GitHub | Telegram |
 |---|---|---|---|---|
-| `<feature>` → `dev` | `1-dev-publish.yml` | **uploads** to `alpha` (Closed testing) | pre-release `v<name>-dev-<run>` | yes |
+| `<feature>` → `dev` | `1-dev-publish.yml` | **uploads** to `alpha` (Closed testing), then assigns that same release to `internal` | pre-release `v<name>-dev-<run>` | yes |
 | `dev` → `master` | `2-master-promote.yml` | promotes `alpha` → `beta` (Open testing) | pre-release `v<name>-beta-<run>` | no |
 | `master` → `production` | `3-production-promote.yml` | promotes `beta` → `production` | **release** `v<name>` (Latest) | yes |
 
 Only `1-dev-publish.yml` uploads an artifact. Play allows one upload per version code per app —
 not per track — so a second uploader is what produced `Version code NNNN has already been used`.
-The other two rungs move that same upload up a track.
+The other two rungs move that same upload up a track, and the `internal` mirror is not a second
+upload either: it assigns the release `alpha` already holds. Two tracks, one upload.
 
 Every rung still builds the APKs from its own commit: the GitHub assets, the Telegram broadcast
 and reproducibility all need an APK built from the tree being released. Only the Play artifact is
@@ -55,9 +56,9 @@ push with none fails before it builds.
 Sizes are checked pre-flight by `.github/scripts/check-notes-budget.sh`:
 
 - `telegram.md` — the **assembled** caption must fit 1024 UTF-16 units. The wrapper the workflow
-  adds measured 145–152 units on the ladder's own three branches (it varies by rung and actor);
-  `check-notes-budget.sh` defaults to 160. Telegram *rejects* an oversized caption rather than
-  truncating it.
+  adds measures 145–163 units on the ladder's own three branches (it varies by rung and actor);
+  `check-notes-budget.sh` defaults to 164, the most the ladder can ever pass it. Telegram *rejects*
+  an oversized caption rather than truncating it.
 - `playstore.txt` — at most 500 characters (Play's own limit; the checker fails above 500, not at
   it).
 
@@ -67,12 +68,19 @@ Run it yourself before opening the release PR:
 .github/scripts/check-notes-budget.sh 1.94.1
 ```
 
-The 160 default is a hand-run convenience, **not a universal ceiling**: the wrapper contains the
-ref name, so a `workflow_dispatch` from a long-named branch costs more — this branch measured 176.
-It covers `dev`, `master` and `production` with room to spare, which is what the ladder uses; if
-you are releasing from anything else, pass the measured wrapper size as a second argument. On the
-ladder itself the workflow measures the wrapper per run and passes the real number, so the default
-never decides a real release.
+The 164 default is a hand-run convenience, **not a universal ceiling**: the wrapper contains the
+ref name, so a `workflow_dispatch` from a long-named branch costs more — this branch measured 187.
+It is the largest number the three rungs can pass, chosen so a hand run is never *looser* than the
+release that follows; if you are releasing from anything else, pass the measured wrapper size as a
+second argument. On the ladder itself the workflow measures the wrapper per run and passes the real
+number, so the default never decides a real release.
+
+⚠️ It has **no room to spare** — it used to, and stopped. The gate cannot know the track yet
+(fastlane writes `track.txt` during the build), so it substitutes the longest label any rung emits,
+which is now the dev rung's two-track `Closed + Internal Testing`. That raised what CI passes on
+every rung — to 161/164 on `production` — so a default of 160 would now pass captions the release
+itself refuses. If a track label ever gets longer, this default moves with it;
+`test-caption-wrapper.sh` fails if it does not.
 
 ---
 
@@ -146,13 +154,13 @@ Use the `v` form; the fallback exists only for old directories.
 ### 2️⃣ `telegram.md` — the broadcast
 
 * **Format**: punchy markdown, emoji-led bullets, mobile-first.
-* **Size**: **under ~860 UTF-16 code units.** ⚠️ **Exceeding this broadcasts nothing — see the trap
+* **Size**: **under 860 UTF-16 code units.** ⚠️ **Exceeding this broadcasts nothing — see the trap
   below.** Measure UTF-16 units, not characters: most emoji count as **2**. The wrapper the
-  workflow adds is 145–152 units on the ladder's own three branches (it varies by rung and by actor),
-  but it **contains the branch name**, so a `workflow_dispatch` from a long-named branch measures
-  176 — which is why `release-rung.yml` measures it per run rather than assuming a constant.
-  `check-notes-budget.sh` defaults to 160 when you run it by hand — run it without a second argument
-  for a conservative pre-flight check.
+  workflow adds is 145–163 units on the ladder's own three branches (it varies by rung and by actor;
+  `dev` is the dearest because its caption names two tracks), but it **contains the branch name**, so
+  a `workflow_dispatch` from a long-named branch measures 187 — which is why `release-rung.yml`
+  measures it per run rather than assuming a constant. `check-notes-budget.sh` defaults to 164 when
+  you run it by hand — run it without a second argument for a conservative pre-flight check.
 * **Line breaks**: **MANDATORY** blank line between bullets, or Telegram's mobile client squeezes
   the whole thing into a dense block.
 
@@ -187,12 +195,14 @@ Redirecting that to `/dev/null` — which both sends in `telegram-release.yml` u
 reverts it to `--fail` and throws away the only line that says why. Do not add a `> /dev/null`.
 
 Either way the discovery lands *during* the release, which is why the budget is checked pre-flight
-instead. `release-rung.yml` prepends a header that costs **145–152 UTF-16 units on the ladder's own
+instead. `release-rung.yml` prepends a header that costs **145–163 UTF-16 units on the ladder's own
 three branches** (it varies by rung and by actor, and it counts the blank line that joins it to
-`telegram.md`), which is where the ~860 budget comes from. **152 is not a ceiling** — the header
-contains the branch name, so a `workflow_dispatch` from a long-named branch costs more; this branch
-measures 176. That is why `release-rung.yml` measures the header per run instead of assuming a
-constant, and why a file sized to exactly ~860 can pass on `dev` and be refused on a dispatch.
+`telegram.md`). The 860 budget is `1024 - 164`, and 164 is what the *gate* passes on `production`:
+it cannot know the track yet, so it prices every rung at the longest label — `dev`'s two-track
+`Closed + Internal Testing`. **163 is not a ceiling** — the header contains the branch name, so a
+`workflow_dispatch` from a long-named branch costs more; this branch measures 187. That is why
+`release-rung.yml` measures the header per run instead of assuming a constant, and why a file sized
+to exactly 860 can pass on `dev` and be refused on a dispatch.
 `telegram-release.yml` uses a shorter header and also appends a GitHub-link footer. For reference:
 v1.93.1 was 695 units (fine); v1.93.0 was 1008 (**already over the budget when it shipped**).
 


### PR DESCRIPTION
The dev rung now lands one build on **two** Play test tracks: it uploads to `alpha` as before, then assigns that same release to `internal`. No second upload happens, so *"exactly one uploader per version code"* — the rule the whole ladder exists to protect, because Play accepts a code once per **app**, not once per track — is untouched.

**This PR publishes nothing.** It carries no `versionCode` bump, and the dev rung passes `on_unchanged_version: skip`, so merging it builds for verification and uploads nothing. The new code's first real execution is the release merge (#384).

## The obvious implementation silently does nothing

Worth reading before reviewing the seam, because the natural version of this change is wrong in the worst possible way — it *reports success*.

Passing `track: 'internal', version_code: N` with both artifact skips set writes **no release at all** and exits 0. `supply` decides whether to touch a track from whether it uploaded new binaries, and it computes that (`uploading_new_binaries`) from the apk/aab version codes **before** any retained code is appended — with both skips true that list is empty, so `update_track` is never reached, and with no `track_promote_to` and no `rollout` the promote and rollout branches are skipped too. The version code then feeds only the changelog step, which looks up a release holding it and hard-errors *"Could not find release for version code"* when the track has none.

Read out of the **pinned fastlane 2.237.0** (`supply/lib/supply/uploader.rb`), not inferred from the docs. `track_promote_to` from a track that already holds the code is the path that actually assigns it.

Two follow-on facts that make this safe:

- **"Promote" does not mean "up".** Play has no ordering over tracks; `promote_track` copies the source release object onto another track name and leaves the source standing.
- **It cannot take the build off `alpha`.** In 2.237.0 there is no cross-track deactivation path at all — `check_superseded_tracks` and `deactivate_on_promote` are declared and referenced nowhere.

## Why `MIRROR_TRACKS` is not an entry in `PROMOTION_EDGES`

`PROMOTION_EDGES` encodes the ladder's one-rung-at-a-time invariant, and `internal` sits *below* `alpha`. An `'internal' => 'alpha'` entry there would make `source_track_for('internal')` start answering — teaching the promote lanes a downward edge in the map whose only job is to forbid rungs that skip a step. Mirroring is a different operation with a different guarantee, so it gets its own table, and a test pins that `source_track_for('internal')` keeps raising.

## Ordering and failure handling are the design

| | |
|---|---|
| **`alpha` first** | The mirror runs only after the upload succeeds. The upload is the one step in the ladder that cannot be repeated, so nothing optional runs ahead of it. |
| **A failed mirror does not fail the build** | The bytes are already on `alpha` and cannot be uploaded again. Raising would cost the GitHub release and the Telegram broadcast for a build that *did* publish, and the re-run would die on "version code already used". It logs `::warning::` with the remediation instead — a missing mirror is one click in the Play Console; an unannounced release is not recoverable. |
| **`track.txt` records outcome** | Rewritten *after* the mirror from what actually succeeded, so a failed mirror reads back as plain `alpha` and is announced as "Closed Testing". The file previously recorded intent (it is written before the build); for the two-track case it now records outcome, which is what the caption needs. |

## The caption's coupled sites, moved together

`test-caption-wrapper.sh` pins these to each other, so they change as a set:

- the send step gains an `alpha+internal)` arm — **without one the default arm broadcasts the raw key to users** with no error or warning;
- the pre-flight gate's substituted label becomes that same longest label. This also closes a latent hole: the gate takes `max(floor 160, measurement)`, and a 25-unit label measures 163 on `dev`, so the floor no longer silently wins there. Previously the substituted `Internal Testing` measured 154 on a `dev` push, the 160 floor won, and the gate was **3 units light** against a caption that size — with the failure landing *after* the Play upload;
- the documented per-rung table moves `dev 149/152 → 160/163`, and the long-ref counter-example `176 → 187`. Against v1.94.0's 847-unit `telegram.md` that is 1034/1024, so the anecdote is restated as the refusal it would now be rather than the one-unit pass it was.

## The second commit: the copy no test pinned

Review of the first commit found that number lives in **three** places, and I had moved one. The other two kept the old figures — and one of them is not a comment.

`check-notes-budget.sh`'s hand-run default was `160`, which *used to be exactly right*: while the longest label was `Internal Testing` the gate's measurement came out below 160 on all three rungs, the floor won everywhere, and 160 really was what the ladder used. Pricing every rung at the two-track label raises what the gate passes to **158/161 on beta and 161/164 on production** — the gate cannot know the track yet, so it prices every rung at the longest label — which left the default **4 units light on production**. A hand run would have green-lit a caption the release then refuses: the discovery this pre-flight exists to move *ahead* of the Play upload, moved back behind it. Default is now `164`, the largest wrapper the ladder can pass. The `1024 - 164 = 860` budget in the docs is unchanged, and is now exact rather than approximate.

The real fix is the missing pin. Assertions 1–5 parse `release-rung.yml` **only**, so the second copy could drift silently, and did, immediately. Assertion 6 adds three checks — the two tables agree, the cited long-ref figure agrees, and **the hand-run default is at least the maximum the gate can pass**. The last is the one that matters, being the only violation that is a false green rather than a stale comment. All three were mutation-tested: reverting the default to 160, staling the dev row to 149/152, and staling the long-ref cite to 176 each fail with a specific message.

That commit also corrects two figures I got wrong in the first: the gate is pessimistic by **13 units on beta and 15 on production**, not "11–15" — 11 is the *dev* delta when a mirror fails and the caption falls back to `Closed Testing`, which is not a promote rung. And `release-notes/README.md`'s routing table still described the dev rung as uploading to `alpha` alone.

`docs/branching-and-releases.md` needed no change — "roughly 860 units" survives the arithmetic. The figures in `docs/superpowers/plans/` are deliberately left alone: that document records what was designed in August, and back-dating it would erase the record rather than update it.

## The third commit: the lookup that sat outside its own rescue

`mirror_tracks_for` was called at the mirror site — *after* the Play upload. It can raise (both of its guards do), and a raise there is precisely the failure this feature was designed around: `Run Fastlane` goes red, so `Prepare Release Notes` is skipped, and with it `Send APK to Telegram` and `Create GitHub Release` (which also requires `prep_notes` to have succeeded). That leaves a version code live on Play that can never be re-uploaded and was never announced. The per-target `rescue` was written to prevent exactly that, and the lookup feeding it sat outside it.

It now resolves next to `validate_upload_track!`, which is pre-flight for the same reason, and the list is passed in.

**Severity, honestly: it was not reachable.** Only `alpha`/`internal` arrive (narrowed by the line above), `MIRROR_TRACKS` is frozen, and three tests pin both guards on every PR, so only a bad source edit could fire it — and that edit fails CI first. A reviewer flagged the shape and a second pass judged it unreachable; both are right. The reason to move it anyway is the asymmetry: resolving two statements earlier costs nothing, raising two steps later costs a release that cannot be re-published and was never broadcast.

## The fourth commit: the warning was never a warning

The failure path above logs `::warning title=Play mirror failed::…`. It was not reaching GitHub. Inside a Fastfile `puts` is **not** `Kernel#puts` — `fast_file.rb:444` defines its own, which runs the puts *action* and prints through `UI.message`, and `UI.message` prefixes every line with `"[HH:MM:SS]: "` unless `FASTLANE_HIDE_TIMESTAMP` is set, which this repo does not set anywhere. GitHub parses a workflow command only at the **start of a line**, so the annotation was never created.

That inverted the one line whose entire job is to be impossible to miss. A release that published to `alpha` but was **not** assigned to `internal` would say so as an ordinary timestamped log line, inside a build that stays green *by design* — and the remediation it names (assign the release in the Play Console; do not re-run) is the only way out, because the version code cannot be uploaded twice. `$stdout.puts` bypasses the override. The `UI.error` above it is unchanged and stays timestamped, which is right for a human-readable line.

Proven, not inferred: `fast_file.rb:444` dispatches to `PutsAction` → `UI.message`; `format_string` in fastlane_core's `shell.rb` returns `"[HH:MM:SS]: "` on that path; a bare `puts` and `$stdout.puts` were each run through a stand-in class carrying the same override, showing the prefix on one and not the other; and nothing in `.github/workflows`, `fastlane/` or the Gemfile sets `FASTLANE_HIDE_TIMESTAMP`.

`test-fastlane-lib.sh` now fails on any workflow command emitted through a bare `puts`, **plus** a non-vacuity check that at least one is emitted with an explicit receiver — otherwise deleting the annotation would make the first check pass trivially. Both mutation-tested: reintroducing the bare `puts` exits 1, and removing the annotation entirely also exits 1. The pattern is written `[$]stdout` rather than `\$stdout` because CI runs `shellcheck -x -S style`, where the escaped form inside single quotes raises SC2016 and reddens the job.

## Verification

```
run-tests.sh                     10 files, 0 failed
  test-caption-wrapper.sh        22 assertions (was 17; +3 checks and their setup)
  test-fastlane-lib.sh           35 runs, 49 assertions, 0 failures  (was 26/32)
                                 + 2 shell-level checks on the Fastfile's annotation
shellcheck -x -S style           exit 0 over every .github/scripts/**/*.sh — CI's exact
                                 invocation, not an approximation of it
mutation test                    each new assertion proven able to fail
signature check                  the hoisted call site proven to satisfy the new
                                 keyword signature by building the method from its
                                 own declaration and invoking it; no stale call site
shellcheck -S style              clean on both changed scripts
ruby -c                          Fastfile, thor_release.rb, test_thor_release.rb — all OK
yaml.safe_load                   all four workflow files parse
label mapping                    simulated for every track.txt value, incl. the failure one
check-notes-budget.sh (v1.94.2)  975/1024 at the new 164 default (49 spare)
                                 974/1024 at dev's real 163 wrapper
                                 998/1024 at the long-ref 187
                                 playstore 449/500
```

⚠️ **Correction to the first commit's message.** `84dca6f9` states the ruby suite went to "35 runs, 49 assertions (was 27/41)". The baseline is wrong — parent `7b930c58` measures **26 runs / 32 assertions**, confirmed by running it in a detached worktree. The commit is pushed and stays as written; 26/32 is the correct figure.

The budget check ran against the **real** v1.94.2 notes in a worktree of `chore/release-1942`, not against a placeholder — a longer track label eats caption units, and those notes are already written.

New tests: `mirror_tracks_for` for the happy path, whitespace, the three tracks with no mirror, an unknown track, `nil`, "every target is an upload track", and both guards (self-mirror, non-uploadable target) exercised by swapping the constant inside the test rather than adding a test-only hook to `thor_release.rb`.

## Not verified, and unverifiable from here

**That Play accepts the assignment at all.** It is API behaviour, no test in this repo reaches the network, and the first real execution is a push that publishes. This is handled rather than prevented: a rejected mirror leaves a correct, complete, truthfully-announced release on `alpha`, plus a warning annotation naming the one manual step.

Ordering was the owner's call — land this first (publishes nothing), then #384, so 1942 uploads to `alpha` and is assigned to `internal` by the same run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dev releases are uploaded once to Play alpha and mirrored to internal testing.
  * Release reporting and Telegram labels reflect both testing tracks.
  * Mirror failures generate warnings while preserving successful track updates.

* **Documentation**
  * Updated release and branching guidance to describe mirroring, sequencing, and failure behavior.
  * Updated caption-size guidance and defaults for longer track labels and references.

* **Tests**
  * Added coverage for mirror-track configurations, caption validation, and workflow command checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->