### PR TITLE
feat(export): run a single-app export on WorkManager, and release 1943

### DIFF
--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -15,6 +15,7 @@ import com.rosan.dhizuku.api.Dhizuku
 import com.valhalla.bypass.Bypass
 import com.valhalla.thor.core.ThorShellConfig
 import com.valhalla.thor.data.backup.ArchiveOrphanSweeper
+import com.valhalla.thor.data.backup.job.LaunchSweepBarrier
 import com.valhalla.thor.data.permission.SelfPermissionGranter
 import com.valhalla.thor.data.service.AutoFreezeManager
 import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper
@@ -190,6 +191,14 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
     private val archiveOrphanSweeper: ArchiveOrphanSweeper by inject()
 
     /**
+     * Released once the sweep below is over, and the only thing standing between a re-run export and
+     * the sweep deleting its staging tree. Resolved here rather than injected into the worker alone,
+     * because a barrier only works if both halves hold the *same* instance — which is what `@Single`
+     * guarantees and what a worker-side `LaunchSweepBarrier()` would silently not.
+     */
+    private val launchSweepBarrier: LaunchSweepBarrier by inject()
+
+    /**
      * Resolved here because a Koin `@Single` nobody injects is never constructed, so its observer
      * would never start — the same reason [autoFreezeManager] is resolved eagerly.
      *
@@ -308,13 +317,24 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
             // launch that cannot delete a stale temp file is still a launch. The interruption warning
             // the report may carry is the restore screen's to show; Application has no UI, so the
             // report here is a log line and the breadcrumb is left standing for Task 17 to clear.
-            runCatching { withContext(ioDispatcher) { archiveOrphanSweeper.sweep() } }
-                .onFailure { throwable ->
-                    // Same rethrow as above: runCatching swallows CancellationException, and
-                    // appScope.cancel() in onTerminate must not be logged as a sweep failure.
-                    if (throwable is CancellationException) throw throwable
-                    Logger.e("ThorApp", "archive orphan sweep failed", throwable)
-                }
+            try {
+                runCatching { withContext(ioDispatcher) { archiveOrphanSweeper.sweep() } }
+                    .onFailure { throwable ->
+                        // Same rethrow as above: runCatching swallows CancellationException, and
+                        // appScope.cancel() in onTerminate must not be logged as a sweep failure.
+                        if (throwable is CancellationException) throw throwable
+                        Logger.e("ThorApp", "archive orphan sweep failed", throwable)
+                    }
+            } finally {
+                // AppExportWorker blocks on this before it stages anything, because the sweep above
+                // deletes `externalCacheDir/obb_out` wholesale and a worker WorkManager re-ran at
+                // process start is writing into that very tree. See LaunchSweepBarrier.
+                //
+                // In a `finally`, so the release survives a sweep that threw and a scope that was
+                // cancelled: neither is a reason to leave an export pinned on "Preparing" until the
+                // barrier's own timeout, and a sweep that failed has still stopped deleting.
+                launchSweepBarrier.markSwept()
+            }
         }
 
         // Below API 33 nothing else notices a language change: the platform has no per-app locale to

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/AppExportWorker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/AppExportWorker.kt
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.backup.job
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.work.WorkerParameters
+import com.valhalla.thor.R
+import com.valhalla.thor.domain.model.AppExportRequest
+import com.valhalla.thor.domain.model.EXPORT_LABEL_KEY
+import com.valhalla.thor.domain.model.ThorJobKind
+import com.valhalla.thor.domain.model.ThorJobProgress
+import com.valhalla.thor.domain.model.ThorJobStage
+import com.valhalla.thor.domain.repository.AppBundleFileStore
+import com.valhalla.thor.domain.repository.AppRepository
+import com.valhalla.thor.domain.usecase.ExportAppUseCase
+import com.valhalla.thor.domain.usecase.ExportSession
+import com.valhalla.thor.util.Logger
+import org.koin.android.annotation.KoinWorker
+
+private const val TAG = "AppExportWorker"
+
+/**
+ * One app packaged as `.apk`/`.apks`/`.xapk` and written where the user asked, behind a foreground
+ * service.
+ *
+ * The whole job is one call into [ExportAppUseCase.exportInto]; what this class actually owns is
+ * everything around it — the four strings the request arrived as, the `AppInfo` re-resolution, a
+ * destination check that fails before the packaging rather than after it, and **an outcome sentence
+ * on every terminal path**, which is what the notification the user sees at the end is made of.
+ *
+ * ### It does not open its own session
+ *
+ * [ExportAppUseCase.openSession] resolves the destination *and clears the saved-folder preference*
+ * when that folder has gone. That is a write, it belongs to the tap the user just made, and running
+ * it here would let a job enqueued yesterday silently reset today's setting. The foreground resolves
+ * the session; the resolved destination travels in [AppExportRequest.treeUri]; this constructs an
+ * [ExportSession] from it and reads no preference at all.
+ *
+ * ### It does not report cancellation
+ *
+ * Nothing here calls `noteResult` on the way out of a stop, and that is deliberate rather than
+ * missing. A stopped worker is not necessarily a finished one: WorkManager stops workers for its own
+ * reasons — a constraint, a quota, the process going away — and then **re-runs them**, so a shade
+ * row saying "Export stopped before it finished. Nothing was saved." would be a lie told at the exact
+ * moment the export was about to succeed. A genuine user cancel is reported by the screen instead,
+ * off `ThorJobStatus.Cancelled`, which only WorkManager's own terminal state can produce.
+ *
+ * `sheetTarget` is null for the same kind of reason: an export has no sheet worth reopening
+ * mid-flight — the progress is in the notification and the outcome is a second notification — so a
+ * tap resumes the app and nothing more.
+ */
+@KoinWorker
+internal class AppExportWorker(
+    appContext: Context,
+    params: WorkerParameters,
+    notifications: ThorJobNotifications,
+    registry: JobRegistry,
+    private val exportApp: ExportAppUseCase,
+    private val appRepository: AppRepository,
+    private val fileStore: AppBundleFileStore,
+    private val launchSweep: LaunchSweepBarrier,
+    sheetTargets: JobSheetTargets,
+) : ThorJobWorker(appContext, params, notifications, registry, sheetTargets) {
+
+    override val kind = ThorJobKind.APP_EXPORT
+
+    /**
+     * The app's real label, unlike either archive worker's — and for free.
+     *
+     * This is read on the `setForeground` deadline path, where those two deliberately show the
+     * package name rather than spend the budget on a `PackageManager` round trip. An export does not
+     * face that trade: the label was resolved in the foreground, at tap time, and travels in the
+     * request. So the shade shows "Clash of Clans" from the very first frame instead of
+     * `com.supercell.clashofclans` until the worker catches up.
+     */
+    override val initialLabel: String
+        get() = inputData.getString(EXPORT_LABEL_KEY).orEmpty()
+
+    override val sheetTarget: JobSheetTarget? = null
+
+    override suspend fun runJob(): Result {
+        val request = AppExportRequest.fromMap(inputData.keyValueMap)
+            ?: return failNoted(getString(R.string.export_job_unreadable))
+
+        publish(ThorJobProgress(ThorJobStage.PREPARING, getString(R.string.export_job_preparing, request.label)))
+
+        // Before anything is staged, and unconditionally — see LaunchSweepBarrier for why an export is
+        // the first job on this seam that can lose a race to the launch sweep, and why waiting costs
+        // nothing outside the one process start where the two overlap.
+        if (!launchSweep.awaitSwept()) {
+            Logger.e(TAG, "launch sweep did not finish; refusing to stage ${request.packageName}")
+            return failNoted(getString(R.string.export_job_cleanup_busy))
+        }
+
+        // Re-resolved, never carried: the request holds a package name precisely because
+        // publicSourceDir and splitPublicSourceDirs are snapshots that an update invalidates. Null
+        // here is the app having been uninstalled since the tap, which is a sentence, not an error.
+        val appInfo = appRepository.getAppDetails(request.packageName)
+            ?: return failNoted(getString(R.string.export_job_app_gone, request.label))
+
+        // Checked up front rather than discovered by the write failing. Packaging a 4 GB game and
+        // *then* finding out the folder's grant was revoked spends ten minutes to produce a failure
+        // that was knowable in a millisecond — and the recovery ("pick the folder again") is the same
+        // either way. Downloads carries no grant and needs no check.
+        request.treeUri?.let { tree ->
+            if (!fileStore.isTreeWritable(tree)) {
+                return failNoted(getString(R.string.export_job_folder_gone))
+            }
+        }
+
+        publish(
+            ThorJobProgress(
+                ThorJobStage.CAPTURING,
+                getString(R.string.export_job_packaging, request.label, request.format.extension),
+            )
+        )
+
+        // SINGLE_STAGING_DIR, the same scope the foreground path used, because this *is* the
+        // one-app export — a batch takes a scope of its own so the two cannot wipe each other's
+        // half-written copy, and there is no batch on this seam yet.
+        val session = ExportSession(request.target, ExportAppUseCase.SINGLE_STAGING_DIR)
+        val destination = exportApp.exportInto(appInfo, request.format, session)
+            .getOrElse { cause ->
+                Logger.e(TAG, "export of ${request.packageName} failed", cause)
+                // The cause's own words, not a generic sentence. The builder computes and phrases the
+                // one failure a user can act on — "about 1.4 GB more is needed" — and flattening that
+                // to "Export failed" throws away the only part that says what to do next.
+                return failNoted(
+                    getString(
+                        R.string.export_failed,
+                        exportFailureReason(cause) ?: getString(R.string.export_failed_unknown),
+                    )
+                )
+            }
+
+        // The sentence this whole class exists to be able to say. Noted rather than returned, because
+        // `doWork`'s `finally` is what posts it and the `finally` runs on paths a `Result` does not
+        // survive; the success `Data` would only be read by a screen that is still open.
+        noteResult(getString(R.string.export_job_saved, request.label, destination))
+        return Result.success()
+    }
+
+    /**
+     * Fail *and* leave the reason in the shade, which are two different things and both are needed.
+     *
+     * `fail` puts the sentence in the output `Data`, where the export screen reads it — and reads it
+     * only while that screen exists. An export is a background job the user was invited to walk away
+     * from; the notification is the report for the case where they did. Every `return` in [runJob]
+     * that is not the success goes through here, so there is no path that ends the job in silence.
+     */
+    private fun failNoted(reason: String): Result {
+        noteResult(reason)
+        return fail(reason)
+    }
+
+    private fun getString(@StringRes resId: Int, vararg formatArgs: Any): String =
+        applicationContext.getString(resId, *formatArgs)
+}
+
+/**
+ * What a failed export should say went wrong, or null when the cause said nothing usable.
+ *
+ * Exists as a function, top-level and testable, for one reason: `AppBundleBuilderImpl` phrases the
+ * shortfall failure itself — "not enough free space to pack this app's game data — about 1.4 GB more
+ * is needed" — and that string is the entire actionable content of the failure. A caller that
+ * substitutes its own wording, or that reaches for `Throwable.toString()` and prints
+ * `java.io.IOException: …` at the user, destroys it. This is the seam where that could be lost, so
+ * this is where it is pinned.
+ *
+ * Blank is treated as absent: `IllegalStateException()` with no message and one carrying `""` are the
+ * same amount of information, and "Export failed: " with nothing after the colon reads as a bug.
+ *
+ * No bounding here — [ThorJobWorker.fail] and [ThorJobWorker.noteResult] both apply
+ * [boundedForJobData] at their own boundary, which is where `Data`'s 10 KB rule actually lives.
+ */
+internal fun exportFailureReason(cause: Throwable): String? =
+    cause.message?.takeIf { it.isNotBlank() }

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ExportJobLauncherImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ExportJobLauncherImpl.kt
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.backup.job
+
+import android.content.Context
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.workDataOf
+import com.valhalla.thor.domain.model.AppExportRequest
+import com.valhalla.thor.domain.model.THOR_JOB_CHAIN
+import com.valhalla.thor.domain.model.ThorJobKind
+import com.valhalla.thor.domain.model.jobTag
+import com.valhalla.thor.domain.repository.ExportJobLauncher
+import com.valhalla.thor.domain.repository.ThorJobWatcher
+import java.util.UUID
+import org.koin.core.annotation.Single
+
+/**
+ * The one place a Thor export job is started.
+ *
+ * Almost nothing, which is the point of it being separate from [ThorJobLauncher]: the whole reason
+ * that class is long is key derivation and the ordering rules around [ArchiveKeyHolder], and an
+ * export has neither. What is left is the shared [enqueueUniqueJob] — which is `internal` and
+ * top-level precisely so this could reuse it rather than grow a second, subtly different, awaited
+ * `Operation`.
+ *
+ * `onAbandoned` is left at its default for the same reason: an export that never reaches the database
+ * has nothing held in memory to release. The caller's null return is the entire cleanup.
+ *
+ * [THOR_JOB_CHAIN], not [com.valhalla.thor.domain.model.THOR_SWEEP_CHAIN]: an export moves bytes, and
+ * the chain's argument is about disk. Serialising it behind a running backup is the intended
+ * behaviour — the two would otherwise stage a multi-gigabyte bundle each, at once, on the same
+ * volume.
+ *
+ * The watch half is delegated rather than reimplemented. `status` and `runningJobFor` are written
+ * against [ThorJobKind] and a job id and contain nothing archive-specific; a second copy here would
+ * be a second place for `WorkInfo.State` to be mapped, and the mapping's subtle case — a null
+ * `WorkInfo` meaning "pruned", not "failed" — is exactly the kind that gets copied wrong.
+ */
+@Single(binds = [ExportJobLauncher::class])
+class ExportJobLauncherImpl(
+    private val context: Context,
+    watcher: ThorJobWatcher,
+) : ExportJobLauncher, ThorJobWatcher by watcher {
+
+    /**
+     * @param request already resolved — its destination came from `ExportAppUseCase.openSession` on
+     *   the foreground, at tap time. Nothing here re-reads a preference, so a job enqueued now and run
+     *   an hour later writes where the user was told it would.
+     *
+     * Tagged with [jobTag] so a screen can ask "is this app already exporting?". The chain name cannot
+     * answer that — every job shares it — and without the tag `APPEND_OR_REPLACE` would happily queue
+     * a second identical export behind the first on a double tap.
+     */
+    override suspend fun startExport(request: AppExportRequest): UUID? {
+        val work = OneTimeWorkRequestBuilder<AppExportWorker>()
+            .setInputData(workDataOf(*request.toMap().toList().toTypedArray()))
+            .addTag(jobTag(ThorJobKind.APP_EXPORT, request.packageName))
+            .build()
+
+        return enqueueUniqueJob(context, THOR_JOB_CHAIN, work)
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/LaunchSweepBarrier.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/LaunchSweepBarrier.kt
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.backup.job
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
+import org.koin.core.annotation.Single
+
+/**
+ * "The launch sweep has finished" — the one thing a worker started at process start has to know
+ * before it stages anything.
+ *
+ * `ArchiveOrphanSweeper.sweep()` runs once per process, from `ThorApplication.onCreate`, and it
+ * `deleteRecursively()`s `externalCacheDir/obb_out` **wholesale**. Its stated justification is that
+ * "any export — archive or share — that was still using it died with the process", and that was true
+ * of every writer of that tree while every writer was a foreground operation. It stopped being true
+ * the moment an export became a `CoroutineWorker`: WorkManager re-runs an interrupted worker *in the
+ * next process*, and the next process is the one running the sweep. The two then start together and
+ * the sweep deletes the live build's staging directory out from under it — for an OBB game, gigabytes
+ * of it, halfway through the copy that took the user ten minutes the first time.
+ *
+ * The archive workers do not need this and are not wired to it. Both hold their key in
+ * [ArchiveKeyHolder], which is process memory, so a re-run has no key and fails before it reaches the
+ * bundle builder — the same property that makes them safe to re-run makes them incapable of hitting
+ * this race. `AppExportWorker` is the first job on the seam that genuinely runs to completion after a
+ * process death, so it is the first that can lose to the sweep.
+ *
+ * **Not a lock.** It is completed once, by the launch, and every later `await` returns immediately —
+ * so the ordinary case (a user taps export minutes into a session) pays a resumption and nothing
+ * else. Nothing re-arms it; there is exactly one launch sweep per process.
+ *
+ * Pure `kotlinx.coroutines` on purpose: this holds a startup-ordering rule that is worth pinning, and
+ * a JVM test can reach a `CompletableDeferred` where it can never reach a `Worker` or an
+ * `Application`.
+ */
+@Single
+class LaunchSweepBarrier {
+
+    private val swept = CompletableDeferred<Unit>()
+
+    /**
+     * The sweep is over — released or not, successfully or not.
+     *
+     * Called from a `finally`, which is the only placement that works. A sweep that *throws* has
+     * still stopped deleting, so a worker held back from a tree nobody is touching any more is held
+     * back for nothing; and the `runCatching` around the sweep swallows everything except
+     * cancellation, so "it failed" is not a signal that reaches here at all.
+     *
+     * Idempotent — `CompletableDeferred.complete` returns false on an already-completed one and does
+     * nothing else.
+     */
+    fun markSwept() {
+        swept.complete(Unit)
+    }
+
+    /**
+     * Wait for the launch sweep, and say whether it actually arrived.
+     *
+     * @return false on timeout, and a caller must treat that as "do not stage", not as "close
+     *   enough". The window this guards is a wholesale `deleteRecursively()` on a tree the caller is
+     *   about to write gigabytes into; proceeding on a timeout is the exact race the class exists to
+     *   close, just with a log line in front of it.
+     *
+     * The timeout is not there because the sweep is slow — it is a handful of `delete()` calls and an
+     * empty-ledger short-circuit, and it is normally over before the first frame. It is there because
+     * the coroutine that runs it is launched on the application scope *after* a preference read, and
+     * a `Flow.first()` that never emits would otherwise leave a foreground service pinned on
+     * "Preparing" with no timeout anywhere in the system to end it. Two minutes is far past anything
+     * a working sweep needs and far short of a user's patience for a notification that never moves.
+     */
+    suspend fun awaitSwept(timeoutMs: Long = SWEEP_WAIT_TIMEOUT_MS): Boolean =
+        withTimeoutOrNull(timeoutMs) { swept.await() } != null
+
+    companion object {
+        const val SWEEP_WAIT_TIMEOUT_MS = 120_000L
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobLauncher.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobLauncher.kt
@@ -22,6 +22,7 @@ import com.valhalla.thor.domain.model.ThorJobKind
 import com.valhalla.thor.domain.model.jobTag
 import com.valhalla.thor.domain.repository.ArchiveJobLauncher
 import com.valhalla.thor.domain.repository.ThorJobStatus
+import com.valhalla.thor.domain.repository.ThorJobWatcher
 import com.valhalla.thor.util.Logger
 import java.util.UUID
 import java.util.concurrent.ExecutionException
@@ -47,7 +48,11 @@ private const val TAG = "ThorJobLauncher"
  * to show while it runs. It is also the only way the worker never sees a passphrase: the derived key
  * goes into [ArchiveKeyHolder] under the request's id and the passphrase stays with the caller.
  */
-@Single(binds = [ArchiveJobLauncher::class])
+// ThorJobWatcher is listed explicitly even though ArchiveJobLauncher extends it: Koin binds exactly
+// the types named here and does not walk a supertype chain, so `ExportJobLauncherImpl`'s delegate
+// parameter would be an unresolvable dependency — and with `strictSafety` on, that fails the *build*
+// rather than the first injection.
+@Single(binds = [ArchiveJobLauncher::class, ThorJobWatcher::class])
 class ThorJobLauncher(
     private val context: Context,
     private val keys: ArchiveKeyHolder,

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobNotifications.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/ThorJobNotifications.kt
@@ -203,6 +203,7 @@ class ThorJobNotifications(private val context: Context) {
     private fun titleFor(kind: ThorJobKind) = when (kind) {
         ThorJobKind.ARCHIVE_BACKUP -> R.string.job_backing_up
         ThorJobKind.ARCHIVE_RESTORE -> R.string.job_restoring
+        ThorJobKind.APP_EXPORT -> R.string.job_exporting
     }
 
     /**
@@ -217,9 +218,14 @@ class ThorJobNotifications(private val context: Context) {
      * monochrome layer at 200dp, drawn with the safe-zone padding that format requires; scaled into a
      * 24dp status bar slot it renders as a speck. A notification small icon has to be a 24dp asset
      * drawn for 24dp.
+     *
+     * An export gets `arrow_downward` rather than the archive symbol, because in the shade the icon
+     * is the only thing distinguishing two of Thor's rows before either is expanded — and a user who
+     * started an export and a backup should be able to tell which one is still going.
      */
     private fun iconFor(kind: ThorJobKind) = when (kind) {
         ThorJobKind.ARCHIVE_BACKUP, ThorJobKind.ARCHIVE_RESTORE -> R.drawable.settings_backup_restore
+        ThorJobKind.APP_EXPORT -> R.drawable.arrow_downward
     }
 
     /**

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppExportRequest.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppExportRequest.kt
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+const val EXPORT_PACKAGE_KEY = "thor.export.pkg"
+const val EXPORT_FORMAT_KEY = "thor.export.format"
+const val EXPORT_LABEL_KEY = "thor.export.label"
+const val EXPORT_TREE_KEY = "thor.export.tree"
+
+/**
+ * Everything the export worker needs, as four short strings.
+ *
+ * This becomes a `WorkRequest`'s input `Data`, which WorkManager writes to its own SQLite database
+ * and hands back to a re-run in a fresh process. So the rule for what belongs here is not "would it
+ * fit" — it is "will it still be true tomorrow".
+ *
+ * **[AppInfo] is `@Serializable` and would fit, and must not be here.** `publicSourceDir`,
+ * `sourceDir`, `splitPublicSourceDirs` and `lastUpdateTime` are snapshots of an installed package,
+ * and a worker re-run after an update would export paths that no longer exist. Only the package name
+ * travels; the worker re-resolves through `appRepository.getAppDetails(pkg)`, which is what
+ * `AppArchiveWorker` already does. If the app was updated meanwhile the export is of the new bytes,
+ * which is correct; if it was uninstalled the lookup returns null and the worker words that.
+ *
+ * @param format a [BundleFormat] name, and **never** recomputed with [BundleFormat.autoFor] on the
+ *   worker side. `autoFor` can never return [BundleFormat.XAPK], so recomputing would silently
+ *   downgrade the one format the user has to ask for by name — and it is the format with the game
+ *   data in it, so the downgrade would be invisible until the reinstall failed to run.
+ * @param label the app's label as it read at tap time. Display-only, and here rather than resolved
+ *   in the worker because it is read on the `setForeground` deadline path, where a `PackageManager`
+ *   call is not something to be spending that budget on.
+ * @param treeUri the persisted SAF tree, or null for Downloads. **Absence, not null**, once this is
+ *   a map: `workDataOf` throws on a null value in production, exactly as it does on a `Set`. There is
+ *   deliberately no "is Downloads" boolean beside it — the foreground resolved a definite choice and
+ *   two fields could disagree.
+ */
+data class AppExportRequest(
+    val packageName: String,
+    val format: BundleFormat,
+    val label: String,
+    val treeUri: String? = null,
+) {
+
+    fun toMap(): Map<String, Any> = buildMap {
+        put(EXPORT_PACKAGE_KEY, packageName)
+        put(EXPORT_FORMAT_KEY, format.name)
+        put(EXPORT_LABEL_KEY, label)
+        treeUri?.let { put(EXPORT_TREE_KEY, it) }
+    }
+
+    /** Where this request writes. Rebuilt from [treeUri]'s presence, which is the only record of it. */
+    val target: ExportTargetChoice
+        get() = treeUri?.let(ExportTargetChoice::Custom) ?: ExportTargetChoice.Downloads
+
+    companion object {
+
+        /**
+         * @return null when the map cannot describe a runnable export. The worker turns that into a
+         *   worded `Result.failure()` — never `Result.retry()`, which would re-read the same
+         *   unusable map forever.
+         *
+         * An unrecognised format is null rather than a fallback. The alternative is to guess, and
+         * the only guess available is `autoFor`, which cannot produce XAPK — so the fallback would
+         * quietly hand back a different file from the one that was asked for. A job enqueued by a
+         * newer build and run after a downgrade is the case this covers, and refusing it is the
+         * honest answer.
+         */
+        fun fromMap(map: Map<String, Any?>): AppExportRequest? {
+            val packageName = (map[EXPORT_PACKAGE_KEY] as? String)?.takeIf { it.isNotBlank() }
+                ?: return null
+            val format = (map[EXPORT_FORMAT_KEY] as? String)
+                ?.let { name -> BundleFormat.entries.firstOrNull { it.name == name } }
+                ?: return null
+            val label = (map[EXPORT_LABEL_KEY] as? String)?.takeIf { it.isNotBlank() }
+                ?: return null
+            return AppExportRequest(
+                packageName = packageName,
+                format = format,
+                label = label,
+                // Blank is treated as absent, not as a tree named "". A blank grant is not
+                // resolvable, and Downloads is the destination the user gets when there is no
+                // usable folder anyway.
+                treeUri = (map[EXPORT_TREE_KEY] as? String)?.takeIf { it.isNotBlank() },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/domain/model/ThorJob.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ThorJob.kt
@@ -55,18 +55,33 @@ const val JOB_WARNINGS_KEY = "thor.job.warnings"
 /**
  * The long-running jobs Thor runs through WorkManager.
  *
- * Two for now. Exports and bulk actions are meant to join them — that is why nothing in this file or
- * in `ThorJobWorker` mentions archives.
+ * Three. Bulk actions are meant to join them — that is why nothing in this file or in
+ * `ThorJobWorker` mentions archives.
  *
  * **Append only. Never insert or reorder.** `ThorJobNotifications` derives a notification id from
  * `BASE_NOTIFICATION_ID + ordinal`, and that same number is the `PendingIntent` request code for the
  * row's tap target. Inserting a kind renumbers every kind after it, which hands a live notification
  * the request code of a different job. [jobKindFromId] is deliberately immune to this — the tap extra
  * travels as [id], not as an ordinal — but the id arithmetic is not.
+ *
+ * [APP_EXPORT] is appended rather than slotted next to the archive kinds it reads like a sibling of,
+ * for exactly that reason: it takes ids 1102/1202, and putting it second would have moved
+ * `ARCHIVE_RESTORE` from 1101 to 1102 — silently, and only visibly on a device holding a live restore
+ * notification across the update.
  */
 enum class ThorJobKind(val id: String) {
     ARCHIVE_BACKUP("archive-backup"),
     ARCHIVE_RESTORE("archive-restore"),
+
+    /**
+     * A single app packaged as `.apk`/`.apks`/`.xapk` and written to Downloads or a picked folder.
+     *
+     * The one job on this seam that is honestly durable across process death. Both archive kinds hold
+     * their key in memory (`ArchiveKeyHolder`) and so fail by design on a re-run; an export's whole
+     * input is four short strings, and the SAF grant it may carry is persisted, so WorkManager's free
+     * re-run of an interrupted worker actually produces the file the user asked for.
+     */
+    APP_EXPORT("app-export"),
 }
 
 /**

--- a/app/src/main/java/com/valhalla/thor/domain/repository/ExportJobLauncher.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/ExportJobLauncher.kt
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+import com.valhalla.thor.domain.model.AppExportRequest
+import java.util.UUID
+
+/**
+ * Start a single-app export, and watch it.
+ *
+ * Separate from [ArchiveJobLauncher] rather than a third method on it, because the two share none of
+ * what makes that interface awkward: an export derives no key, holds no passphrase, and hands the
+ * worker nothing that has to be in memory before the worker starts. Folding it in would have given
+ * every export call site a view of `ArchiveKeyHolder`'s ordering rules for no reason.
+ *
+ * It extends [ThorJobWatcher] for the same reason [ArchiveJobLauncher] does: a screen that starts a
+ * job needs to follow it, and splitting "start" from "watch" across two injected types buys nothing
+ * but a second constructor parameter.
+ */
+interface ExportJobLauncher : ThorJobWatcher {
+
+    /**
+     * @return the enqueued job's id, or null when the request never made it into WorkManager's
+     *   database — which is a real outcome and not a theoretical one, and the caller must say so
+     *   rather than showing a progress bar for a job that will never run. See `enqueueUniqueJob`.
+     */
+    suspend fun startExport(request: AppExportRequest): UUID?
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.text.format.Formatter
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -27,7 +26,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
@@ -37,6 +35,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -55,6 +54,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.rememberViewModelStoreOwner
 import coil3.compose.AsyncImage
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppInfo
@@ -63,13 +64,29 @@ import com.valhalla.thor.domain.model.ObbProbe
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.ExportAppUseCase
+import com.valhalla.thor.presentation.common.JobFinish
+import com.valhalla.thor.presentation.common.JobRunningFrame
+import com.valhalla.thor.presentation.common.RequestNotificationsWhenJobStarts
 import com.valhalla.thor.presentation.utils.AppIconModel
+import com.valhalla.thor.util.Logger
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
+
+/** How long a finished export stays on screen before the sheet closes itself. */
+private const val SUCCESS_LINGER_MS = 3_000L
 
 /**
  * Destination picker + explainer for exporting an installed app's bundle. Self-contained
  * (hosts its own SAF picker and Koin dependencies); shown from the App Info surfaces.
+ *
+ * The Export button hands the work to `AppExportWorker` and this sheet becomes a watcher. That is the
+ * whole of the change from the version that called `ExportAppUseCase` inline and toasted the result:
+ * a toast needs the process to still be in the foreground when the export finishes, which for a 4 GB
+ * game it very often is not. The job's notification is now the report, and it arrives whether or not
+ * anyone is looking at this sheet — which is also why the running frame's Background button is an
+ * invitation rather than an apology.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,6 +96,15 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
     val preferenceRepository = koinInject<PreferenceRepository>()
     val systemRepository = koinInject<SystemRepository>()
     val scope = rememberCoroutineScope()
+
+    // Scoped to this composition, as `AppBackupSheet` scopes its own: an export sheet opened for a
+    // second app must not inherit the first one's phase. Dismissing the sheet clears the view model
+    // with the composition, so reopening asks WorkManager again from scratch — which is exactly what
+    // `attach` below is for.
+    val viewModel = koinViewModel<ExportViewModel>(
+        viewModelStoreOwner = rememberViewModelStoreOwner()
+    )
+    val phase by viewModel.phase.collectAsStateWithLifecycle()
 
     // Two options, never three. The native container for this app — .apk for a monolithic app,
     // .apks for a split one — plus .xapk, which is meaningful either way because it is the format
@@ -94,12 +120,8 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
     // non-composable lambdas below (remember/coroutine/onClick) where stringResource
     // cannot be called.
     val defaultDestLabel = stringResource(R.string.export_dest_downloads)
-    val exportSavedFormat = stringResource(R.string.export_saved)
-    val exportFailedFormat = stringResource(R.string.export_failed)
-    val exportFailedUnknown = stringResource(R.string.export_failed_unknown)
 
     var targetLabel by remember { mutableStateOf(defaultDestLabel) }
-    var exporting by remember { mutableStateOf(false) }
     // Defaults to autoFor(), i.e. the format the builder has always picked on its own, so an
     // export where nobody touches the row is byte-for-byte what shipped before the selector existed.
     var format by remember(appInfo.packageName) { mutableStateOf(formatOptions.first()) }
@@ -112,6 +134,16 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
         obbProbe = systemRepository.probeObb(appInfo.packageName)
     }
 
+    // Pick up an export of this app that is already running — the user backgrounded the sheet and came
+    // back. Without it the form reappears over a live job and a second tap appends a duplicate to the
+    // chain, both writing into the same staging directory.
+    LaunchedEffect(appInfo.packageName) { viewModel.attach(appInfo.packageName) }
+
+    // The job's only surface once this sheet is gone is a notification, and `ThorJobNotifications`
+    // returns early when notifications are off — so an export started in that state runs invisibly and
+    // finishes invisibly. Asked at the moment the job is accepted, not when the button is pressed.
+    RequestNotificationsWhenJobStarts(jobActive = phase.running)
+
     // There used to be a LaunchedEffect here that forced the selection off XAPK whenever the probe
     // came back Undetermined. It went with the chip's `enabled` gate below and with the matching
     // throw in AppBundleBuilderImpl: together they made "Thor could not read Android/obb" refuse the
@@ -120,32 +152,16 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
     // the export proceeds and says what it did; see `shouldWarnUnreadableObb`.
 
     val runExport = {
-        exporting = true
-        scope.launch {
-            val result = exportUseCase(appInfo, format)
-            exporting = false
-            result
-                .onSuccess {
-                    Toast.makeText(
-                        context,
-                        exportSavedFormat.format(it),
-                        Toast.LENGTH_LONG
-                    ).show()
-                    onDismiss()
-                }
-                .onFailure {
-                    Toast.makeText(
-                        context,
-                        exportFailedFormat.format(it.message ?: exportFailedUnknown),
-                        Toast.LENGTH_LONG
-                    ).show()
-                }
-        }
+        viewModel.start(
+            packageName = appInfo.packageName,
+            label = appInfo.appName ?: appInfo.packageName,
+            format = format,
+        )
     }
 
     // On API <= 28, writing to the public Downloads directory needs WRITE_EXTERNAL_STORAGE
     // granted at runtime. Run the export regardless of the grant result: SAF export still
-    // works when denied, and the export itself surfaces success/failure.
+    // works when denied, and the job itself surfaces success/failure.
     val permLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { runExport() }
@@ -154,10 +170,19 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
         ActivityResultContracts.OpenDocumentTree()
     ) { uri ->
         if (uri != null) {
-            context.contentResolver.takePersistableUriPermission(
-                uri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-            )
+            // runCatching because the persist can be refused: the grant table is capped (128 entries
+            // per app on most builds) and some providers hand back a tree they will not persist at
+            // all. Unguarded, that SecurityException propagates out of the picker callback and takes
+            // the Activity down at the moment the user picked a folder. Saving the URI anyway is
+            // deliberate — the grant is live for this process either way, so the export the user is
+            // about to run still works; what is lost is remembering the folder next launch, and
+            // `openSession` already clears a saved tree it cannot write to.
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                )
+            }.onFailure { Logger.w("Export", "could not persist $uri: $it") }
             scope.launch {
                 preferenceRepository.setExportDirUri(uri.toString())
                 targetLabel = exportUseCase.currentTargetLabel()
@@ -189,7 +214,9 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
                 letterSpacing = 2.sp
             )
 
-            // App identity card + format badge
+            // App identity card + format badge. Outside the `when` below, so the running and outcome
+            // frames still say which app they are about — a notification can arrive over any screen
+            // and the user coming back to this sheet may have started more than one thing.
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -242,178 +269,276 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
                 )
             }
 
-            // Format
-            Text(
-                text = stringResource(R.string.export_format).uppercase(),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 1.sp
-            )
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                formatOptions.forEach { option ->
-                    FilterChip(
-                        selected = option == format,
-                        onClick = { format = option },
-                        // Only the export in flight disables a chip now. The probe verdict no longer
-                        // does: a disabled .xapk chip was how "we could not read Android/obb" reached
-                        // the user, and it read as "this app cannot be exported as .xapk" when the
-                        // truth was usually that there was nothing to pack. The verdict is still
-                        // shown — as a note under the row, which the user can act on — rather than
-                        // enforced as a refusal.
-                        enabled = !exporting,
-                        // A file extension, not copy — the same token in every locale, so it is
-                        // built from BundleFormat rather than from a translated string.
-                        label = { Text(".${option.extension}") },
-                        colors = FilterChipDefaults.filterChipColors(
-                            selectedContainerColor = MaterialTheme.colorScheme.primary,
-                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary
-                        )
+            // Three frames, and the order settles the one pair that can overlap: `running` outranks a
+            // `finished` left over from a previous export, which the reattach collector can pick up
+            // before `watch` clears the banner.
+            val finished = phase.finished
+            when {
+                // The form is *gone* while the job runs, not disabled. Two chips, a destination row
+                // and two buttons used to sit here with `enabled = !exporting` on each — a form the
+                // user can read, cannot use, and has to scroll past to reach the one thing moving.
+                //
+                // `onBackground` is `onDismiss` and nothing else: dismissing drops this watcher, the
+                // worker carries on, and its notification takes over the reporting.
+                phase.running -> JobRunningFrame(
+                    phase = phase,
+                    queuedLabel = stringResource(R.string.export_job_queued),
+                    backgroundLabel = stringResource(R.string.export_job_background),
+                    backgroundDescription = stringResource(R.string.export_job_background_desc),
+                    onBackground = onDismiss,
+                )
+
+                finished is JobFinish.Succeeded -> {
+                    // Three seconds, then the sheet closes itself: the file is written and the form
+                    // underneath has nothing left to offer except writing it again. Keyed on `Unit`,
+                    // so the timer belongs to this frame rather than outliving it.
+                    LaunchedEffect(Unit) {
+                        delay(SUCCESS_LINGER_MS)
+                        onDismiss()
+                    }
+                    ExportOutcome(finish = finished, onDismiss = onDismiss)
+                }
+
+                finished != null -> ExportOutcome(
+                    finish = finished,
+                    // `dismissResult`, not `onDismiss`: a failure puts the user back on a form they
+                    // may want to retry from — a different destination, a different format — so
+                    // clearing the banner is the right thing rather than closing the sheet.
+                    onDismiss = viewModel::dismissResult,
+                )
+
+                else -> {
+                    // Format
+                    Text(
+                        text = stringResource(R.string.export_format).uppercase(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 1.sp
                     )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        formatOptions.forEach { option ->
+                            FilterChip(
+                                selected = option == format,
+                                onClick = { format = option },
+                                // Nothing disables a chip now. The probe verdict never did — a
+                                // disabled .xapk chip was how "we could not read Android/obb" reached
+                                // the user, and it read as "this app cannot be exported as .xapk"
+                                // when the truth was usually that there was nothing to pack — and the
+                                // export in flight no longer needs to, because this whole frame is
+                                // replaced while one is running.
+                                // A file extension, not copy — the same token in every locale, so it
+                                // is built from BundleFormat rather than from a translated string.
+                                label = { Text(".${option.extension}") },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary
+                                )
+                            )
+                        }
+                    }
+
+                    // Plain-language explanation of the selected format, plus what the .xapk will
+                    // actually carry. This is the only place the user learns whether their game data
+                    // is going in, so it has to follow the selection rather than sit above it.
+                    Text(
+                        text = stringResource(
+                            when (format) {
+                                BundleFormat.APK -> R.string.export_explain_apk
+                                BundleFormat.APKS -> R.string.export_explain_apks
+                                BundleFormat.XAPK -> R.string.export_explain_xapk
+                            }
+                        ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    // The three OBB notes, in the order the user needs them: how much is going in,
+                    // what is being left out, and that we could not tell either way. All three are
+                    // notes and none of them blocks the Export button.
+                    val obbBytesToShow = obbSizeBytesToShow(format, obbProbe)
+                    if (obbBytesToShow > 0) {
+                        Text(
+                            text = stringResource(
+                                R.string.export_obb_included,
+                                Formatter.formatShortFileSize(context, obbBytesToShow)
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    if (shouldNotePartialObb(format, obbProbe)) {
+                        // Not a refusal. The format cannot carry anything but .obb files, so a bundle
+                        // without those extras is complete by the format's own definition — the user
+                        // is told, and decides.
+                        Text(
+                            text = stringResource(R.string.export_obb_partial),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    if (shouldWarnUnreadableObb(format, obbProbe)) {
+                        Text(
+                            text = stringResource(R.string.export_xapk_no_game_data),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+
+                    // Destination
+                    Text(
+                        text = stringResource(R.string.export_save_to).uppercase(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 1.sp
+                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(
+                                MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.6f)
+                            )
+                            .padding(start = 16.dp, top = 10.dp, bottom = 10.dp, end = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.storage),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Text(
+                            text = targetLabel,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                        FilledTonalButton(onClick = { picker.launch(null) }) {
+                            Icon(
+                                painter = painterResource(R.drawable.open_in),
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(Modifier.width(6.dp))
+                            Text(stringResource(R.string.export_change))
+                        }
+                    }
+
+                    // Actions
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        OutlinedButton(
+                            onClick = onDismiss,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(R.string.cancel))
+                        }
+                        Button(
+                            onClick = {
+                                // A custom SAF folder writes via DocumentFile and needs no
+                                // WRITE_EXTERNAL_STORAGE — only the legacy Downloads path (API <= 28)
+                                // does.
+                                val usingCustomFolder = targetLabel != defaultDestLabel
+                                if (!usingCustomFolder &&
+                                    Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+                                    ContextCompat.checkSelfPermission(
+                                        context,
+                                        Manifest.permission.WRITE_EXTERNAL_STORAGE
+                                    ) != PackageManager.PERMISSION_GRANTED
+                                ) {
+                                    permLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                                } else {
+                                    runExport()
+                                }
+                            },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            // No spinner and no "Exporting…" label. The button does not stay on
+                            // screen long enough to need either — `phase.running` swaps this whole
+                            // frame for JobRunningFrame on the same recomposition.
+                            Text(stringResource(R.string.action_export))
+                        }
+                    }
                 }
             }
+        }
+    }
+}
 
-            // Plain-language explanation of the selected format, plus what the .xapk will actually
-            // carry. This is the only place the user learns whether their game data is going in,
-            // so it has to follow the selection rather than sit above it.
-            Text(
+/**
+ * How a finished export is reported on the sheet.
+ *
+ * Four sentences for three outcomes, split on [JobFinish.workerRan] — the same shape as
+ * `BackupOutcome`, because the same things can happen and the user needs to tell them apart.
+ *
+ * | Outcome | Copy |
+ * |---|---|
+ * | `Succeeded` | it was exported |
+ * | `Failed(workerRan = true)` | the worker's own sentence, or "unknown error" |
+ * | `Failed(workerRan = false)` | it did not start, so nothing was saved |
+ * | `Cancelled(workerRan = true)` | it stopped before finishing; nothing was saved |
+ * | `Cancelled(workerRan = false)` | the chain cancelled it before it started |
+ *
+ * There is no half-written-file sentence, and there should not be: an export writes to a staging
+ * directory the builder wipes on entry and only publishes at the end, so a stopped export leaves the
+ * destination folder exactly as it found it.
+ */
+@Composable
+private fun ExportOutcome(finish: JobFinish, onDismiss: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        when (finish) {
+            is JobFinish.Succeeded -> Text(
+                text = stringResource(R.string.export_job_done),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+
+            is JobFinish.Failed -> Text(
+                text = if (finish.workerRan) {
+                    stringResource(
+                        R.string.export_failed,
+                        finish.reason ?: stringResource(R.string.export_failed_unknown)
+                    )
+                } else {
+                    // The enqueue returned no id, or the block around it threw. Both are decided
+                    // before a job exists, so there is no worker sentence to show and none is faked.
+                    stringResource(R.string.export_failed_not_started)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error
+            )
+
+            is JobFinish.Cancelled -> Text(
                 text = stringResource(
-                    when (format) {
-                        BundleFormat.APK -> R.string.export_explain_apk
-                        BundleFormat.APKS -> R.string.export_explain_apks
-                        BundleFormat.XAPK -> R.string.export_explain_xapk
+                    if (finish.workerRan) {
+                        R.string.export_job_stopped
+                    } else {
+                        // WorkManager cancels the dependents of a prerequisite that fails, and every
+                        // Thor job is appended to one chain — so the common cancel is an export that
+                        // was queued behind a failing job and never entered `doWork`.
+                        R.string.export_failed_not_started
                     }
                 ),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.error
             )
-
-            // The three OBB notes, in the order the user needs them: how much is going in, what is
-            // being left out, and — the case this fix is about — that we could not tell either way.
-            // All three are notes and none of them blocks the Export button.
-            val obbBytesToShow = obbSizeBytesToShow(format, obbProbe)
-            if (obbBytesToShow > 0) {
-                Text(
-                    text = stringResource(
-                        R.string.export_obb_included,
-                        Formatter.formatShortFileSize(context, obbBytesToShow)
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            if (shouldNotePartialObb(format, obbProbe)) {
-                // Not a refusal. The format cannot carry anything but .obb files, so a bundle
-                // without those extras is complete by the format's own definition — the user is
-                // told, and decides.
-                Text(
-                    text = stringResource(R.string.export_obb_partial),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            if (shouldWarnUnreadableObb(format, obbProbe)) {
-                Text(
-                    text = stringResource(R.string.export_xapk_no_game_data),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp)
-                )
-            }
-
-            // Destination
-            Text(
-                text = stringResource(R.string.export_save_to).uppercase(),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 1.sp
-            )
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.6f))
-                    .padding(start = 16.dp, top = 10.dp, bottom = 10.dp, end = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.storage),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp)
-                )
-                Text(
-                    text = targetLabel,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
-                )
-                FilledTonalButton(
-                    onClick = { picker.launch(null) },
-                    enabled = !exporting
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.open_in),
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
-                    )
-                    Spacer(Modifier.width(6.dp))
-                    Text(stringResource(R.string.export_change))
-                }
-            }
-
-            // Actions
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                OutlinedButton(
-                    onClick = onDismiss,
-                    enabled = !exporting,
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text(stringResource(R.string.cancel))
-                }
-                Button(
-                    enabled = !exporting,
-                    onClick = {
-                        // A custom SAF folder writes via DocumentFile and needs no
-                        // WRITE_EXTERNAL_STORAGE — only the legacy Downloads path (API <= 28) does.
-                        val usingCustomFolder = targetLabel != defaultDestLabel
-                        if (!usingCustomFolder &&
-                            Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
-                            ContextCompat.checkSelfPermission(
-                                context,
-                                Manifest.permission.WRITE_EXTERNAL_STORAGE
-                            ) != PackageManager.PERMISSION_GRANTED
-                        ) {
-                            permLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                        } else {
-                            runExport()
-                        }
-                    },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    if (exporting) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(18.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onPrimary
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(stringResource(R.string.export_in_progress))
-                    } else {
-                        Text(stringResource(R.string.action_export))
-                    }
-                }
-            }
+        }
+        // The dismiss the failure frames need: without it a banner sits over the form until the sheet
+        // is closed, and the retry the user wants is behind it. Harmless on the success frame, which
+        // dismisses itself three seconds later anyway — this is the button that skips the wait.
+        TextButton(onClick = onDismiss) {
+            Text(stringResource(R.string.dismiss))
         }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportBottomSheet.kt
@@ -141,7 +141,9 @@ fun ExportBottomSheet(appInfo: AppInfo, onDismiss: () -> Unit) {
 
     // The job's only surface once this sheet is gone is a notification, and `ThorJobNotifications`
     // returns early when notifications are off — so an export started in that state runs invisibly and
-    // finishes invisibly. Asked at the moment the job is accepted, not when the button is pressed.
+    // finishes invisibly. Asked as soon as the sheet commits to an export: `start` sets `running`
+    // before the enqueue resolves, so this fires on the tap rather than on acceptance. Prompting for an
+    // enqueue that then fails costs a dialog and nothing else.
     RequestNotificationsWhenJobStarts(jobActive = phase.running)
 
     // There used to be a LaunchedEffect here that forced the selection off XAPK whenever the probe

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportViewModel.kt
@@ -69,10 +69,16 @@ class ExportViewModel(
         attachedTo = packageName
         launchGuarded {
             launcher.runningJobFor(ThorJobKind.APP_EXPORT, packageName).collect { id ->
-                // `watching == null` rather than unconditionally: this flow re-emits the same id, and
-                // re-watching would restart the collector — and with it the `finished = null` clear in
-                // [watch] — over a job that has already reported its outcome.
-                if (id != null && watching == null) watch(id)
+                // Guarded rather than unconditional: this flow re-emits the same id, and re-watching
+                // would restart the collector — and with it the `finished = null` clear in [watch] —
+                // over a job that has already reported its outcome.
+                //
+                // Liveness, not nullness. [watch]'s `onFailure` settles the phase but cannot null the
+                // field its own `launchGuarded` is still being assigned into, so a collector that
+                // throws parks a *completed* Job here; `== null` would then refuse to reattach for the
+                // rest of this sheet's life. A live watcher keeps `isActive` true, so every state that
+                // has one behaves exactly as before.
+                if (id != null && watching?.isActive != true) watch(id)
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ExportViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ExportViewModel.kt
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import androidx.lifecycle.ViewModel
+import com.valhalla.thor.data.backup.job.JobRegistry
+import com.valhalla.thor.domain.model.AppExportRequest
+import com.valhalla.thor.domain.model.BundleFormat
+import com.valhalla.thor.domain.model.ExportTargetChoice
+import com.valhalla.thor.domain.model.ThorJobKind
+import com.valhalla.thor.domain.repository.ExportJobLauncher
+import com.valhalla.thor.domain.usecase.ExportAppUseCase
+import com.valhalla.thor.presentation.common.JobFinish
+import com.valhalla.thor.presentation.common.JobPhase
+import com.valhalla.thor.presentation.common.reduce
+import com.valhalla.thor.presentation.launchGuarded
+import java.util.UUID
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.KoinViewModel
+
+/**
+ * The job half of the export sheet: enqueue one, follow it, and say how it went.
+ *
+ * Deliberately *only* the job. Format, destination label and the OBB probe stay in `ExportBottomSheet`
+ * where they already were — they are inputs the user is still editing, they survive nothing, and
+ * moving them here would have made this commit a rewrite of the sheet rather than a change of what
+ * the Export button does.
+ *
+ * The destination, though, is resolved **here and now** rather than in the worker, and that is the one
+ * piece of ordering worth stating: [ExportAppUseCase.openSession] clears the saved-folder preference
+ * when the folder has gone, and that write belongs to the tap the user just made. A worker re-run
+ * tomorrow calling `openSession` would reset today's setting on the strength of yesterday's grant.
+ * So the session is opened on this side, the resolved target travels in the request, and
+ * `AppExportWorker` reads no preference at all.
+ */
+@KoinViewModel
+class ExportViewModel(
+    private val exportUseCase: ExportAppUseCase,
+    private val launcher: ExportJobLauncher,
+    private val registry: JobRegistry,
+) : ViewModel() {
+
+    private val _phase = MutableStateFlow(JobPhase())
+    val phase: StateFlow<JobPhase> = _phase.asStateFlow()
+
+    private var watching: Job? = null
+    private var attachedTo: String? = null
+
+    /**
+     * Pick up an export of [packageName] that is already running, if there is one.
+     *
+     * Not a nicety. The sheet invites the user to walk away mid-export, and the way back in is App
+     * Info → Export — which without this shows a fresh Export button over a live job. Tapping it
+     * appends a *second* export of the same app to the chain, and both write into the same staging
+     * directory: `ExportSession`'s own KDoc describes what that does to the zip.
+     *
+     * Idempotent per package, because the sheet calls it from a `LaunchedEffect` that a recomposition
+     * can re-run.
+     */
+    fun attach(packageName: String) {
+        if (attachedTo == packageName) return
+        attachedTo = packageName
+        launchGuarded {
+            launcher.runningJobFor(ThorJobKind.APP_EXPORT, packageName).collect { id ->
+                // `watching == null` rather than unconditionally: this flow re-emits the same id, and
+                // re-watching would restart the collector — and with it the `finished = null` clear in
+                // [watch] — over a job that has already reported its outcome.
+                if (id != null && watching == null) watch(id)
+            }
+        }
+    }
+
+    /**
+     * Enqueue an export and follow it.
+     *
+     * @param label the app's label as it reads right now. Display-only, and resolved on this side
+     *   because the worker reads it on the `setForeground` deadline path.
+     */
+    fun start(packageName: String, label: String, format: BundleFormat) {
+        // A second tap in the frame before the button leaves the composition. The chain would accept
+        // it — `APPEND_OR_REPLACE` appends rather than refusing — so nothing below would catch it.
+        if (_phase.value.running) return
+        // Cleared synchronously, before the coroutine. Nothing is watching yet, so for that whole
+        // window this is the only thing that can take the previous run's banner down.
+        _phase.value = JobPhase(running = true)
+
+        launchGuarded(
+            // `openSession` touches DataStore and the SAF provider, and an uncaught throw out of
+            // `viewModelScope` kills the process. Everything in the block below happens before an id
+            // exists, so `workerRan = false` is not a guess.
+            onFailure = { notStarted() }
+        ) {
+            val session = exportUseCase.openSession(ExportAppUseCase.SINGLE_STAGING_DIR)
+            val request = AppExportRequest(
+                packageName = packageName,
+                format = format,
+                label = label,
+                // Absence, not null — `workDataOf` throws on a null value. `AppExportRequest.toMap`
+                // omits the key, and `target` rebuilds Downloads from its absence.
+                treeUri = (session.target as? ExportTargetChoice.Custom)?.treeUri,
+            )
+            val id = launcher.startExport(request)
+            if (id == null) notStarted() else watch(id)
+        }
+    }
+
+    /** Clear the outcome banner, putting the form back. The failure paths' only way out. */
+    fun dismissResult() = _phase.update { it.copy(finished = null) }
+
+    /**
+     * Follow one job: its published progress and its WorkManager state, until it settles.
+     *
+     * Only one at a time — a sheet shows one app's export — so an earlier watcher is cancelled here
+     * rather than left collecting a job whose result nothing will read.
+     */
+    private fun watch(jobId: UUID) {
+        stopWatching()
+        watching = launchGuarded(
+            // A throw out of either collector would otherwise leave `running` true with no watcher
+            // left to clear it: the bar sticks, Export stays gone, and the only way out is killing the
+            // app. A settle with no outcome releases the watcher without claiming a file was or was
+            // not written.
+            onFailure = { _phase.update { it.copy(running = false, queued = false, settled = true) } }
+        ) {
+            // The invariant, and it is this function's job because both callers reach here: [start],
+            // and the `runningJobFor` collector in [attach], which picks up a job this sheet did not
+            // enqueue. **Nothing from job A may be on screen once a watcher attaches to job B.** Only
+            // [start] clears anything of its own, so the reattach path starts from whatever the last
+            // settle left — which is the banner, still up.
+            _phase.update { it.copy(running = true, finished = null) }
+            launch {
+                // Assigned, never filtered. The registry is keyed by job id, so this flow holds this
+                // job's progress and nothing else's — including the null a job that has not published
+                // yet correctly has. Filtering that null is how job A's bar ends up over job B's work.
+                registry.progressOf(jobId).collect { progress ->
+                    _phase.update { it.copy(progress = progress) }
+                }
+            }
+            launcher.status(jobId).collect { status ->
+                if (_phase.updateAndGet { it.reduce(status) }.settled) stopWatching()
+            }
+        }
+    }
+
+    /**
+     * **Cancels the coroutine it is called from** when the status collector reaches a terminal state.
+     * That is intended — the status flow never completes on its own — but it means nothing placed
+     * after the `collect` in [watch] would run, so cleanup does not belong there. The `progressOf`
+     * child collector is cancelled with it.
+     */
+    private fun stopWatching() {
+        watching?.cancel()
+        watching = null
+    }
+
+    /**
+     * Nothing was enqueued: no worker was constructed and no byte was written, so the banner can say
+     * so outright instead of hedging. A null reason is not a missing one — there is no worker to have
+     * produced a sentence.
+     */
+    private fun notStarted() {
+        _phase.value = JobPhase(
+            finished = JobFinish.Failed(reason = null, workerRan = false),
+            settled = true,
+        )
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/common/JobPhase.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/common/JobPhase.kt
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.common
+
+import com.valhalla.thor.domain.model.ThorJobProgress
+import com.valhalla.thor.domain.repository.ThorJobStatus
+
+/**
+ * How a job ended, as a screen has to report it.
+ *
+ * The shape is `AppBackupViewModel`'s `BackupFinish`, lifted out of the backup package because the
+ * export sheet needs the identical three outcomes and the identical [workerRan] split. It is not a
+ * generalisation made in advance: the second consumer arrived, and one of these per job kind is how
+ * the `Cancelled(workerRan = …)` distinction below gets forgotten in the third copy.
+ *
+ * `BackupFinish` and `RestoreFinish` are deliberately **not** repointed at this in the same commit —
+ * that is a rename across two view models, their sheets and their tests, and it would bury the export
+ * feature it is meant to serve. See `docs/follow-ups/`.
+ */
+sealed interface JobFinish {
+
+    /**
+     * Whether a worker actually ran, which is what decides the second sentence on screen.
+     *
+     * "Nothing was saved and nothing was started" and "it ran and then failed" are different things
+     * to have to act on, and a UI that cannot tell them apart says the vaguer one to both.
+     */
+    val workerRan: Boolean
+
+    /**
+     * @param warnings the sentences the worker put in `JOB_WARNINGS_KEY`, in order.
+     *
+     * A class rather than an object because a job can succeed *and* have something the user must be
+     * told. Export produces none today; carrying the list anyway is what keeps this usable by the
+     * restore path, which is the one that has them.
+     */
+    data class Succeeded(val warnings: List<String> = emptyList()) : JobFinish {
+        override val workerRan: Boolean get() = true
+    }
+
+    /**
+     * @param reason the sentence the worker put in `JOB_ERROR_KEY`, or null.
+     *
+     * **Null is still a failure.** WorkManager produces a bare `Result.failure()` on some of its own
+     * paths, and a screen keying "did it fail?" off a non-null reason reports those as nothing at all.
+     */
+    data class Failed(val reason: String?, override val workerRan: Boolean) : JobFinish
+
+    /** The only outcome whose [workerRan] genuinely varies — see [reduce]'s `Cancelled` arm. */
+    data class Cancelled(override val workerRan: Boolean) : JobFinish
+}
+
+/**
+ * Everything a screen shows about one job, and the two bits of history needed to read the next status.
+ *
+ * A value, reduced by [reduce] from the statuses a [ThorJobStatus] flow emits. Keeping [seenLive] and
+ * [seenRunning] *in* the phase rather than in the collecting view model is the whole reason this is
+ * testable without a device: the reduction becomes a pure function of (phase, status) and every
+ * ordering that mattered on the backup side — a late attach that misses RUNNING, a `Gone` that arrives
+ * before the row is written — is a two-line test rather than a fake WorkManager.
+ *
+ * @param running the job exists and has not finished. Set before the first status arrives, because
+ *   WorkManager's flow is not guaranteed to answer in the same frame and a Start button over a job
+ *   that is already writing invites a second one.
+ * @param queued running *and* waiting behind something else. Every Thor job is appended to one chain.
+ * @param progress the worker's last published `ThorJobProgress`, or null when it has published none.
+ *   Not cleared on settle: what clears it is whatever starts the next job.
+ * @param finished the outcome, once there is one. Null both before a job settles and after the user
+ *   dismisses the banner.
+ * @param settled whether the watcher may stop collecting. Distinct from `finished != null` — a job
+ *   whose record WorkManager pruned under a live watcher is over with nothing to report.
+ * @param seenLive whether any non-`Gone` status has been observed. See the `Gone` arm of [reduce].
+ * @param seenRunning whether `Running` specifically has been observed. Only `Cancelled` reads it.
+ */
+data class JobPhase(
+    val running: Boolean = false,
+    val queued: Boolean = false,
+    val progress: ThorJobProgress? = null,
+    val finished: JobFinish? = null,
+    val settled: Boolean = false,
+    val seenLive: Boolean = false,
+    val seenRunning: Boolean = false,
+)
+
+/**
+ * Fold one status into the phase.
+ *
+ * Every arm below was a bug on the backup side first; the comments say which.
+ */
+fun JobPhase.reduce(status: ThorJobStatus): JobPhase = when (status) {
+    // Both are "the job exists and has not finished", which is why they share `running`. `queued` is
+    // the part that differs and the part the user can act on.
+    ThorJobStatus.Pending -> copy(running = true, queued = true, seenLive = true)
+
+    ThorJobStatus.Running ->
+        copy(running = true, queued = false, seenLive = true, seenRunning = true)
+
+    is ThorJobStatus.Succeeded -> settle(JobFinish.Succeeded(status.warnings))
+
+    // `workerRan = true` unconditionally rather than from [seenRunning]: every FAILED Thor produces is
+    // `doWork` returning `Result.failure()`, and a watcher that attached late can miss RUNNING but
+    // cannot make the run un-happen. The one FAILED that does not mean the worker ran is a
+    // `WorkerFactory` that could not build it; over-reported here on purpose.
+    is ThorJobStatus.Failed -> settle(JobFinish.Failed(status.reason, workerRan = true))
+
+    // The one terminal state that does not say for itself whether work happened. WorkManager cancels
+    // the dependents of a prerequisite that fails and every job is appended to one chain, so the
+    // common cancel is a job queued behind a failing one that never entered `doWork` — "Thor did not
+    // start it" rather than "Thor tried and failed".
+    ThorJobStatus.Cancelled -> settle(JobFinish.Cancelled(workerRan = seenRunning))
+
+    // `Gone` is a null `WorkInfo`, and a row that has not been written yet is null too: the launcher
+    // does not await `enqueue()`, so WorkManager writes the row on its own executor after the id has
+    // been handed back and this collector has already subscribed. Both readings arrive as the same
+    // value and only the order tells them apart.
+    //
+    // After the job has been seen alive: the record went away underneath a live watcher. Terminal, but
+    // with no outcome to report — hence `settle(null)` rather than a `Failed`.
+    //
+    // Before that: ignored. Settling here would take the bar down a frame after the tap, re-enable
+    // the button and invite a duplicate enqueue.
+    ThorJobStatus.Gone -> if (seenLive) settle(null) else this
+}
+
+/**
+ * `progress` survives on purpose — see [JobPhase.progress]. Nulling it here is invisible on screen
+ * (every sheet reads the bar under `if (running)`, which this clears) and it deletes the fixture the
+ * "a second run does not open on the first one's bar" tests are built from.
+ */
+private fun JobPhase.settle(finish: JobFinish?): JobPhase =
+    copy(running = false, queued = false, finished = finish, settled = true)

--- a/app/src/main/java/com/valhalla/thor/presentation/common/JobPhase.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/common/JobPhase.kt
@@ -110,10 +110,11 @@ fun JobPhase.reduce(status: ThorJobStatus): JobPhase = when (status) {
     // start it" rather than "Thor tried and failed".
     ThorJobStatus.Cancelled -> settle(JobFinish.Cancelled(workerRan = seenRunning))
 
-    // `Gone` is a null `WorkInfo`, and a row that has not been written yet is null too: the launcher
-    // does not await `enqueue()`, so WorkManager writes the row on its own executor after the id has
-    // been handed back and this collector has already subscribed. Both readings arrive as the same
-    // value and only the order tells them apart.
+    // `Gone` is a null `WorkInfo`, and null is what "no row for this id" looks like as well as "the
+    // row was pruned". `enqueueUniqueJob` awaits the `Operation`, so an id handed back normally does
+    // have a row — but an enqueue that fails *after* the caller stopped waiting, and an id recovered
+    // from `runningJobFor` that WorkManager prunes in between, both produce a leading null. Nothing in
+    // the value distinguishes them from a terminal one; only the order does.
     //
     // After the job has been seen alive: the record went away underneath a live watcher. Terminal, but
     // with no outcome to report — hence `settle(null)` rather than a `Failed`.

--- a/app/src/main/java/com/valhalla/thor/presentation/common/JobRunningFrame.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/common/JobRunningFrame.kt
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * What a sheet is while its job is live: the bar, what the worker says it is doing, and a way to leave.
+ *
+ * The Background button is honest about what it does because of where the work runs. The job is a
+ * WorkManager foreground service, so dismissing the sheet drops this sheet's *watcher* and nothing
+ * else. Reopening finds the same job again through `runningJobFor`, and the ongoing notification
+ * carries the progress meanwhile, which is what makes leaving a real option rather than an
+ * abandonment.
+ *
+ * No Cancel button, deliberately: the notification already carries one built from
+ * `WorkManager.createCancelPendingIntent`, and a second cancel affordance on a surface that is about
+ * to be dismissed is a control whose result the user would not be watching.
+ *
+ * Every sentence is a parameter rather than a string resource read in here. The frame is shared and
+ * the copy is not: "waiting behind another backup or restore" is wrong over an export, and a shared
+ * key that had to cover both would end up saying "waiting" and nothing else. Passing them in also
+ * keeps this composable free of `R`, so it renders the same in a preview as in a sheet.
+ *
+ * @param queuedLabel shown only while [JobPhase.queued]. Says where the job is and stops there —
+ *   a dependent whose prerequisite fails is cancelled, so "starting soon" would be a promise
+ *   WorkManager has not made.
+ */
+@Composable
+fun JobRunningFrame(
+    phase: JobPhase,
+    queuedLabel: String,
+    backgroundLabel: String,
+    backgroundDescription: String,
+    onBackground: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        val percent = phase.progress?.percent
+        if (percent == null) {
+            // Indeterminate, never a determinate bar pinned at 0. A job that has published no
+            // progress — or one whose stage has no total to measure against — is not "0% done", and a
+            // bar that says so reads as stuck for however long the preparing stage takes.
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        } else {
+            LinearProgressIndicator(
+                progress = { percent / 100f },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        if (phase.queued) {
+            Text(
+                text = queuedLabel,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        phase.progress?.let {
+            Text(
+                text = it.label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        // Above the button rather than below it: it is the sentence that makes the button's one word
+        // mean something, and a caption under a button is read after it has been pressed.
+        Text(
+            text = backgroundDescription,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Button(onClick = onBackground, modifier = Modifier.fillMaxWidth()) {
+            Text(backgroundLabel)
+        }
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -546,7 +546,7 @@
     <string name="export_job_queued">في انتظار انتهاء مهمة أخرى.</string>
     <string name="export_job_preparing">جارٍ تجهيز %1$s</string>
     <string name="export_job_packaging">جارٍ تحزيم %1$s بصيغة ‎.%2$s</string>
-    <string name="export_job_writing">جارٍ الكتابة إلى %1$s</string>
+    <string name="export_job_cleanup_busy">لا يزال ثور ينظّف مخلفات التشغيل السابق. أعد محاولة التصدير بعد قليل.</string>
     <string name="export_job_saved">تم تصدير %1$s إلى %2$s</string>
     <string name="export_job_stopped">توقّف التصدير قبل أن يكتمل. لم يتم حفظ أي شيء.</string>
     <string name="export_failed_not_started">لم يبدأ التصدير، لذلك لم يتم حفظ أي شيء.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -543,6 +543,16 @@
     <string name="export_failed_unknown">خطأ غير معروف</string>
     <string name="export_dest_downloads">التنزيلات/Thor</string>
     <string name="export_dest_selected">المجلد المحدد</string>
+    <string name="export_job_queued">في انتظار انتهاء مهمة أخرى.</string>
+    <string name="export_job_preparing">جارٍ تجهيز %1$s</string>
+    <string name="export_job_packaging">جارٍ تحزيم %1$s بصيغة ‎.%2$s</string>
+    <string name="export_job_writing">جارٍ الكتابة إلى %1$s</string>
+    <string name="export_job_saved">تم تصدير %1$s إلى %2$s</string>
+    <string name="export_job_stopped">توقّف التصدير قبل أن يكتمل. لم يتم حفظ أي شيء.</string>
+    <string name="export_failed_not_started">لم يبدأ التصدير، لذلك لم يتم حفظ أي شيء.</string>
+    <string name="export_job_app_gone">لم يعد %1$s مثبتًا، لذلك لم يكن هناك ما يمكن تصديره.</string>
+    <string name="export_job_folder_gone">لم يعد بإمكان Thor الكتابة في ذلك المجلد. اختره من جديد.</string>
+    <string name="export_job_unreadable">تعذّر على Thor قراءة ما يجب تصديره.</string>
 
     <string name="action_export_selected">تصدير</string>
     <string name="export_bulk_confirm_title">تصدير التطبيقات المحددة؟</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -545,7 +545,7 @@
     <string name="export_job_queued">في انتظار انتهاء مهمة أخرى.</string>
     <string name="export_job_preparing">جارٍ تجهيز %1$s</string>
     <string name="export_job_packaging">جارٍ تحزيم %1$s بصيغة ‎.%2$s</string>
-    <string name="export_job_cleanup_busy">لا يزال ثور ينظّف مخلفات التشغيل السابق. أعد محاولة التصدير بعد قليل.</string>
+    <string name="export_job_cleanup_busy">لا يزال Thor ينظّف مخلفات التشغيل السابق. أعد محاولة التصدير بعد قليل.</string>
     <string name="export_job_saved">تم تصدير %1$s إلى %2$s</string>
     <string name="export_job_background">في الخلفية</string>
     <string name="export_job_background_desc">يستمر التصدير حتى لو أغلقت هذه النافذة. يعرض الإشعار مدى تقدّمه.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -537,7 +537,6 @@
     <string name="export_format">الصيغة</string>
     <string name="export_save_to">حفظ في</string>
     <string name="export_change">تغيير</string>
-    <string name="export_in_progress">جاري التصدير…</string>
     <string name="export_saved">تم الحفظ في %1$s</string>
     <string name="export_failed">فشل التصدير: %1$s</string>
     <string name="export_failed_unknown">خطأ غير معروف</string>
@@ -548,6 +547,9 @@
     <string name="export_job_packaging">جارٍ تحزيم %1$s بصيغة ‎.%2$s</string>
     <string name="export_job_cleanup_busy">لا يزال ثور ينظّف مخلفات التشغيل السابق. أعد محاولة التصدير بعد قليل.</string>
     <string name="export_job_saved">تم تصدير %1$s إلى %2$s</string>
+    <string name="export_job_background">في الخلفية</string>
+    <string name="export_job_background_desc">يستمر التصدير حتى لو أغلقت هذه النافذة. يعرض الإشعار مدى تقدّمه.</string>
+    <string name="export_job_done">تم التصدير.</string>
     <string name="export_job_stopped">توقّف التصدير قبل أن يكتمل. لم يتم حفظ أي شيء.</string>
     <string name="export_failed_not_started">لم يبدأ التصدير، لذلك لم يتم حفظ أي شيء.</string>
     <string name="export_job_app_gone">لم يعد %1$s مثبتًا، لذلك لم يكن هناك ما يمكن تصديره.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -503,7 +503,6 @@
     <string name="export_format">Formato</string>
     <string name="export_save_to">Guardar en</string>
     <string name="export_change">Cambiar</string>
-    <string name="export_in_progress">Exportando…</string>
     <string name="export_saved">Guardado en %1$s</string>
     <string name="export_failed">Error de exportación: %1$s</string>
     <string name="export_failed_unknown">error desconocido</string>
@@ -514,6 +513,9 @@
     <string name="export_job_packaging">Empaquetando %1$s como .%2$s</string>
     <string name="export_job_cleanup_busy">Thor aún está limpiando lo que quedó de la última sesión. Inténtalo de nuevo en un momento.</string>
     <string name="export_job_saved">%1$s se exportó a %2$s</string>
+    <string name="export_job_background">Segundo plano</string>
+    <string name="export_job_background_desc">La exportación sigue si cierras esto. Su notificación muestra cuánto lleva hecho.</string>
+    <string name="export_job_done">Exportado.</string>
     <string name="export_job_stopped">La exportación se detuvo antes de terminar. No se guardó nada.</string>
     <string name="export_failed_not_started">La exportación no llegó a empezar, así que no se guardó nada.</string>
     <string name="export_job_app_gone">%1$s ya no está instalada, así que no había nada que exportar.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -512,7 +512,7 @@
     <string name="export_job_queued">Esperando a que termine otra tarea.</string>
     <string name="export_job_preparing">Preparando %1$s</string>
     <string name="export_job_packaging">Empaquetando %1$s como .%2$s</string>
-    <string name="export_job_writing">Escribiendo en %1$s</string>
+    <string name="export_job_cleanup_busy">Thor aún está limpiando lo que quedó de la última sesión. Inténtalo de nuevo en un momento.</string>
     <string name="export_job_saved">%1$s se exportó a %2$s</string>
     <string name="export_job_stopped">La exportación se detuvo antes de terminar. No se guardó nada.</string>
     <string name="export_failed_not_started">La exportación no llegó a empezar, así que no se guardó nada.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -509,6 +509,16 @@
     <string name="export_failed_unknown">error desconocido</string>
     <string name="export_dest_downloads">Descargas/Thor</string>
     <string name="export_dest_selected">Carpeta seleccionada</string>
+    <string name="export_job_queued">Esperando a que termine otra tarea.</string>
+    <string name="export_job_preparing">Preparando %1$s</string>
+    <string name="export_job_packaging">Empaquetando %1$s como .%2$s</string>
+    <string name="export_job_writing">Escribiendo en %1$s</string>
+    <string name="export_job_saved">%1$s se exportó a %2$s</string>
+    <string name="export_job_stopped">La exportación se detuvo antes de terminar. No se guardó nada.</string>
+    <string name="export_failed_not_started">La exportación no llegó a empezar, así que no se guardó nada.</string>
+    <string name="export_job_app_gone">%1$s ya no está instalada, así que no había nada que exportar.</string>
+    <string name="export_job_folder_gone">Thor ya no puede escribir en esa carpeta. Vuelve a elegirla.</string>
+    <string name="export_job_unreadable">Thor no pudo leer qué se debía exportar.</string>
 
     <string name="action_export_selected">Exportar</string>
     <string name="export_bulk_confirm_title">¿Exportar las aplicaciones seleccionadas?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -509,6 +509,16 @@
     <string name="export_failed_unknown">erreur inconnue</string>
     <string name="export_dest_downloads">Téléchargements/Thor</string>
     <string name="export_dest_selected">Dossier sélectionné</string>
+    <string name="export_job_queued">En attente de la fin d\'une autre tâche.</string>
+    <string name="export_job_preparing">Préparation de %1$s</string>
+    <string name="export_job_packaging">Empaquetage de %1$s en .%2$s</string>
+    <string name="export_job_writing">Écriture dans %1$s</string>
+    <string name="export_job_saved">%1$s exportée vers %2$s</string>
+    <string name="export_job_stopped">L\'exportation s\'est arrêtée avant la fin. Rien n\'a été enregistré.</string>
+    <string name="export_failed_not_started">L\'exportation n\'a pas démarré, donc rien n\'a été enregistré.</string>
+    <string name="export_job_app_gone">%1$s n\'est plus installée : il n\'y avait rien à exporter.</string>
+    <string name="export_job_folder_gone">Thor ne peut plus écrire dans ce dossier. Choisissez-le à nouveau.</string>
+    <string name="export_job_unreadable">Thor n\'a pas pu lire ce qui devait être exporté.</string>
 
     <string name="action_export_selected">Exporter</string>
     <string name="export_bulk_confirm_title">Exporter les applications sélectionnées ?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -503,7 +503,6 @@
     <string name="export_format">Format</string>
     <string name="export_save_to">Enregistrer sous</string>
     <string name="export_change">Modifier</string>
-    <string name="export_in_progress">Exportation en cours…</string>
     <string name="export_saved">Enregistré dans %1$s</string>
     <string name="export_failed">Échec de l\'exportation : %1$s</string>
     <string name="export_failed_unknown">erreur inconnue</string>
@@ -514,6 +513,9 @@
     <string name="export_job_packaging">Empaquetage de %1$s en .%2$s</string>
     <string name="export_job_cleanup_busy">Thor termine le nettoyage de sa session précédente. Réessayez l\'export dans un instant.</string>
     <string name="export_job_saved">%1$s exportée vers %2$s</string>
+    <string name="export_job_background">Arrière-plan</string>
+    <string name="export_job_background_desc">L\'exportation continue si vous fermez cette fenêtre. Sa notification indique où elle en est.</string>
+    <string name="export_job_done">Exportation terminée.</string>
     <string name="export_job_stopped">L\'exportation s\'est arrêtée avant la fin. Rien n\'a été enregistré.</string>
     <string name="export_failed_not_started">L\'exportation n\'a pas démarré, donc rien n\'a été enregistré.</string>
     <string name="export_job_app_gone">%1$s n\'est plus installée : il n\'y avait rien à exporter.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -512,7 +512,7 @@
     <string name="export_job_queued">En attente de la fin d\'une autre tâche.</string>
     <string name="export_job_preparing">Préparation de %1$s</string>
     <string name="export_job_packaging">Empaquetage de %1$s en .%2$s</string>
-    <string name="export_job_writing">Écriture dans %1$s</string>
+    <string name="export_job_cleanup_busy">Thor termine le nettoyage de sa session précédente. Réessayez l\'export dans un instant.</string>
     <string name="export_job_saved">%1$s exportée vers %2$s</string>
     <string name="export_job_stopped">L\'exportation s\'est arrêtée avant la fin. Rien n\'a été enregistré.</string>
     <string name="export_failed_not_started">L\'exportation n\'a pas démarré, donc rien n\'a été enregistré.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -501,6 +501,16 @@
     <string name="export_failed_unknown">未知错误</string>
     <string name="export_dest_downloads">下载/Thor</string>
     <string name="export_dest_selected">选定文件夹</string>
+    <string name="export_job_queued">正在等待另一项任务完成。</string>
+    <string name="export_job_preparing">正在准备 %1$s</string>
+    <string name="export_job_packaging">正在将 %1$s 打包为 .%2$s</string>
+    <string name="export_job_writing">正在写入 %1$s</string>
+    <string name="export_job_saved">%1$s 已导出到 %2$s</string>
+    <string name="export_job_stopped">导出未完成便已停止，未保存任何内容。</string>
+    <string name="export_failed_not_started">导出尚未开始，未保存任何内容。</string>
+    <string name="export_job_app_gone">%1$s 已不再安装，因此没有可导出的内容。</string>
+    <string name="export_job_folder_gone">Thor 无法再写入该文件夹，请重新选择。</string>
+    <string name="export_job_unreadable">Thor 无法读取要导出的内容。</string>
 
     <string name="action_export_selected">导出</string>
     <string name="export_bulk_confirm_title">导出所选应用？</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -495,7 +495,6 @@
     <string name="export_format">格式</string>
     <string name="export_save_to">保存至</string>
     <string name="export_change">更改</string>
-    <string name="export_in_progress">正在导出…</string>
     <string name="export_saved">已保存至 %1$s</string>
     <string name="export_failed">导出失败：%1$s</string>
     <string name="export_failed_unknown">未知错误</string>
@@ -506,6 +505,9 @@
     <string name="export_job_packaging">正在将 %1$s 打包为 .%2$s</string>
     <string name="export_job_cleanup_busy">Thor 仍在清理上次运行遗留的文件。请稍后重试导出。</string>
     <string name="export_job_saved">%1$s 已导出到 %2$s</string>
+    <string name="export_job_background">后台运行</string>
+    <string name="export_job_background_desc">关闭此界面后导出仍会继续。通知会显示进度。</string>
+    <string name="export_job_done">已导出。</string>
     <string name="export_job_stopped">导出未完成便已停止，未保存任何内容。</string>
     <string name="export_failed_not_started">导出尚未开始，未保存任何内容。</string>
     <string name="export_job_app_gone">%1$s 已不再安装，因此没有可导出的内容。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -504,7 +504,7 @@
     <string name="export_job_queued">正在等待另一项任务完成。</string>
     <string name="export_job_preparing">正在准备 %1$s</string>
     <string name="export_job_packaging">正在将 %1$s 打包为 .%2$s</string>
-    <string name="export_job_writing">正在写入 %1$s</string>
+    <string name="export_job_cleanup_busy">Thor 仍在清理上次运行遗留的文件。请稍后重试导出。</string>
     <string name="export_job_saved">%1$s 已导出到 %2$s</string>
     <string name="export_job_stopped">导出未完成便已停止，未保存任何内容。</string>
     <string name="export_failed_not_started">导出尚未开始，未保存任何内容。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,27 @@
     <string name="export_dest_downloads">Downloads/Thor</string>
     <string name="export_dest_selected">Selected folder</string>
 
+    <!-- Export as a background job. The sheet hands the work to a Worker and can then be dismissed,
+         so every sentence below has to stand on its own in a notification with no sheet behind it:
+         each one names the app or the folder rather than relying on what the user was looking at.
+
+         export_job_saved is the outcome row on the success path. It is the only report a user who
+         backgrounded the export ever sees — ThorJobWorker's `finally` removes the ongoing row — so
+         it names both the app and where the file actually landed. -->
+    <string name="export_job_queued">Waiting behind another job.</string>
+    <string name="export_job_preparing">Getting %1$s ready</string>
+    <string name="export_job_packaging">Packaging %1$s as .%2$s</string>
+    <string name="export_job_writing">Writing to %1$s</string>
+    <string name="export_job_saved">%1$s exported to %2$s</string>
+    <!-- The armed fallback for a stop that returns no Result at all: WorkManager discards a
+         cancelled worker's Result, so a worded failure cannot travel that way. Any path that *can*
+         word itself replaces this before returning. -->
+    <string name="export_job_stopped">Export stopped before it finished. Nothing was saved.</string>
+    <string name="export_failed_not_started">The export didn\'t start, so nothing was saved.</string>
+    <string name="export_job_app_gone">%1$s isn\'t installed any more, so there was nothing to export.</string>
+    <string name="export_job_folder_gone">Thor can\'t write to that folder any more. Pick the folder again.</string>
+    <string name="export_job_unreadable">Thor couldn\'t read what to export.</string>
+
     <!-- Bulk export (multi-select toolbox). Scope is deliberately "the apps you picked", never
          "back up everything": the count-bearing strings below all read as composites of two
          independent counts, so none of them is a <plurals> candidate. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,7 +232,7 @@
     <string name="export_job_queued">Waiting behind another job.</string>
     <string name="export_job_preparing">Getting %1$s ready</string>
     <string name="export_job_packaging">Packaging %1$s as .%2$s</string>
-    <string name="export_job_writing">Writing to %1$s</string>
+    <string name="export_job_cleanup_busy">Thor is still tidying up from its last run. Try the export again in a moment.</string>
     <string name="export_job_saved">%1$s exported to %2$s</string>
     <!-- The armed fallback for a stop that returns no Result at all: WorkManager discards a
          cancelled worker's Result, so a worded failure cannot travel that way. Any path that *can*

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,7 +215,6 @@
     <string name="export_format">Format</string>
     <string name="export_save_to">Save to</string>
     <string name="export_change">Change</string>
-    <string name="export_in_progress">Exporting…</string>
     <string name="export_saved">Saved to %1$s</string>
     <string name="export_failed">Export failed: %1$s</string>
     <string name="export_failed_unknown">unknown error</string>
@@ -234,6 +233,16 @@
     <string name="export_job_packaging">Packaging %1$s as .%2$s</string>
     <string name="export_job_cleanup_busy">Thor is still tidying up from its last run. Try the export again in a moment.</string>
     <string name="export_job_saved">%1$s exported to %2$s</string>
+    <!-- The Background button and the sentence that makes its one word mean something. Separate from
+         backup_background/_desc, which say the same thing about a different job: those live in
+         strings_backup.xml under a file-level MissingTranslation ignore, so borrowing them would put
+         an untranslated button in a translated sheet. -->
+    <string name="export_job_background">Background</string>
+    <string name="export_job_background_desc">The export keeps running if you close this. Its notification shows how far it has got.</string>
+    <!-- On screen only, and only for the three seconds before the sheet closes itself. The
+         destination is not repeated here — the notification is where export_job_saved names it, and
+         the sheet the user is still looking at is the one surface that does not need telling. -->
+    <string name="export_job_done">Exported.</string>
     <!-- The armed fallback for a stop that returns no Result at all: WorkManager discards a
          cancelled worker's Result, so a worded failure cannot travel that way. Any path that *can*
          word itself replaces this before returning. -->

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -11,6 +11,13 @@
     <string name="job_backing_up">Backing up</string>
     <string name="job_restoring">Restoring</string>
     <!--
+      Here rather than in values/strings.xml with the rest of the export copy, because this is a job
+      *title* and titleFor() reads all three from one place. It also inherits this file's
+      MissingTranslation exemption, which its two siblings already rely on; the export sentences it
+      appears above are translated, since they live in the enforced file.
+    -->
+    <string name="job_exporting">Exporting</string>
+    <!--
       Named for the channel's scope, not for the feature that opened it. A user silencing this is
       silencing every long-running job Thor reports — bulk actions are meant to join backups on it —
       and a switch labelled "Backup and restore" would not have told them that. The channel id is
@@ -18,7 +25,7 @@
       second one; a channel's name is updatable, its importance is not once the user has touched it.
     -->
     <string name="job_channel_name">Background jobs</string>
-    <string name="job_channel_description">Progress for backups, restores and bulk actions running in the background</string>
+    <string name="job_channel_description">Progress for exports, backups, restores and bulk actions running in the background</string>
 
     <string name="action_backup">Back up</string>
     <string name="backup_unsupported">Thor cannot read another app\'s private data with the access it has right now. This needs root, or Shizuku started from root.</string>

--- a/app/src/test/java/com/valhalla/thor/data/backup/job/AppExportWorkerReasonTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/backup/job/AppExportWorkerReasonTest.kt
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.backup.job
+
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * `AppExportWorker` itself needs an Android runtime; [exportFailureReason] is top-level for exactly
+ * that reason, and compiles into `AppExportWorkerKt`, so naming it here does not load the worker.
+ */
+class AppExportWorkerReasonTest {
+
+    @Test
+    fun `the builder's space shortfall wording survives verbatim`() {
+        // The one export failure a user can act on, and the only place it is phrased is inside
+        // AppBundleBuilderImpl. Anything here that paraphrased, prefixed or truncated it would take
+        // "about 1.4 GB more is needed" off the screen and leave "Export failed" in its place.
+        val message = "not enough free space to pack this app's game data — about 1.4 GB more is needed"
+
+        assertEquals(message, exportFailureReason(IOException(message)))
+    }
+
+    @Test
+    fun `a cause with no message reports none rather than a class name`() {
+        // Not `toString()`. That renders "java.lang.IllegalStateException", which is a sentence about
+        // Thor's implementation shown to someone who wanted an APK.
+        assertNull(exportFailureReason(IllegalStateException()))
+    }
+
+    @Test
+    fun `a blank message is treated as no message`() {
+        // "Export failed: " with nothing after the colon reads as a bug in Thor, which is worse than
+        // the honest "unknown error" the caller substitutes.
+        assertNull(exportFailureReason(IllegalStateException("   ")))
+        assertNull(exportFailureReason(IllegalStateException("")))
+    }
+
+    @Test
+    fun `an unbounded message is passed through, because bounding belongs at the Data boundary`() {
+        // Deliberately NOT capped here. `fail` and `noteResult` both apply boundedForJobData at the
+        // boundary where Data's 10 KB rule lives; a second cap here would silently shorten a message
+        // that was going to be shortened correctly anyway, and would drift from the real limit.
+        val long = "x".repeat(MAX_JOB_MESSAGE_CHARS * 4)
+
+        assertEquals(long, exportFailureReason(IOException(long)))
+        assertEquals(MAX_JOB_MESSAGE_CHARS, long.boundedForJobData().length)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/backup/job/LaunchSweepBarrierTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/backup/job/LaunchSweepBarrierTest.kt
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.backup.job
+
+import java.io.IOException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LaunchSweepBarrierTest {
+
+    @Test
+    fun `a waiter already suspended when the sweep ends is released`() = runTest {
+        // UNDISPATCHED so the waiter genuinely reaches its suspension point before markSwept runs.
+        // On the default StandardTestDispatcher the child would not start until this coroutine
+        // suspends, and the test would silently degrade into the already-marked case below — the
+        // ordering it exists to pin is the one where the worker got there first.
+        val barrier = LaunchSweepBarrier()
+        var swept = false
+
+        val waiter = launch(start = CoroutineStart.UNDISPATCHED) { swept = barrier.awaitSwept() }
+        assertFalse(swept)
+
+        barrier.markSwept()
+        waiter.join()
+
+        assertTrue(swept)
+    }
+
+    @Test
+    fun `waiting after the sweep has already run returns immediately`() = runTest {
+        // The ordinary case by a wide margin: the sweep is over milliseconds into the process and the
+        // user taps export minutes later. If this ever blocked, every export would pay the timeout.
+        val barrier = LaunchSweepBarrier()
+        barrier.markSwept()
+
+        assertTrue(barrier.awaitSwept())
+    }
+
+    @Test
+    fun `a sweep that never finishes times out rather than pinning the job forever`() = runTest {
+        // runTest's scheduler skips the delay, so this asserts the outcome and not the duration.
+        val barrier = LaunchSweepBarrier()
+
+        assertFalse(barrier.awaitSwept())
+    }
+
+    @Test
+    fun `a timeout is reported as false and not raised as an exception`() = runTest {
+        // withTimeout would throw and be caught by ThorJobWorker's generic handler, which reports
+        // "unknown error" — the one sentence that tells the user nothing. withTimeoutOrNull is what
+        // lets the worker word this itself.
+        val barrier = LaunchSweepBarrier()
+
+        val outcome = runCatching { barrier.awaitSwept(1L) }
+
+        assertNull(outcome.exceptionOrNull())
+        assertEquals(false, outcome.getOrNull())
+    }
+
+    @Test
+    fun `marking twice is not an error`() = runTest {
+        // ThorApplication marks from a `finally`, and a future caller adding a success-path mark would
+        // otherwise be a crash at startup rather than a no-op.
+        val barrier = LaunchSweepBarrier()
+
+        barrier.markSwept()
+        barrier.markSwept()
+
+        assertTrue(barrier.awaitSwept())
+    }
+
+    @Test
+    fun `a sweep that threw still releases the waiters`() = runTest {
+        // The `finally` placement, stated as a test. A sweep that failed has stopped deleting, so
+        // holding an export behind it protects nothing and costs two minutes.
+        val barrier = LaunchSweepBarrier()
+
+        runCatching {
+            try {
+                throw IOException("sweep failed")
+            } finally {
+                barrier.markSwept()
+            }
+        }
+
+        assertTrue(barrier.awaitSwept())
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/AppExportRequestTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/AppExportRequestTest.kt
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppExportRequestTest {
+
+    private fun request(
+        packageName: String = "com.example.game",
+        format: BundleFormat = BundleFormat.XAPK,
+        label: String = "Example Game",
+        treeUri: String? = null,
+    ) = AppExportRequest(packageName, format, label, treeUri)
+
+    @Test
+    fun `a request survives the round trip through Data`() {
+        val original = request(treeUri = "content://tree/primary%3AExports")
+
+        assertEquals(original, AppExportRequest.fromMap(original.toMap()))
+    }
+
+    @Test
+    fun `a Downloads request survives the round trip too`() {
+        val original = request(treeUri = null)
+
+        assertEquals(original, AppExportRequest.fromMap(original.toMap()))
+    }
+
+    @Test
+    fun `every value handed to Data is a type Data accepts`() {
+        // `workDataOf` throws at enqueue time — in production, on the user's tap — for a Set, an enum
+        // or a null. This request carries an enum and a nullable field, so both are converted here
+        // rather than at the call site, and this is what says so.
+        val values = request(treeUri = "content://tree/x").toMap().values
+
+        assertTrue(values.all { it is String })
+    }
+
+    @Test
+    fun `an absent tree means Downloads, and is absent rather than null`() {
+        val map = request(treeUri = null).toMap()
+
+        // Not `map[EXPORT_TREE_KEY] == null` — that is true either way. The key must not be present
+        // at all, because a null *value* is what `workDataOf` refuses.
+        assertEquals(false, map.containsKey(EXPORT_TREE_KEY))
+        assertEquals(ExportTargetChoice.Downloads, request(treeUri = null).target)
+    }
+
+    @Test
+    fun `a tree uri resolves to the custom target it names`() {
+        assertEquals(
+            ExportTargetChoice.Custom("content://tree/primary%3AExports"),
+            request(treeUri = "content://tree/primary%3AExports").target,
+        )
+    }
+
+    @Test
+    fun `an unrecognised format is refused rather than guessed`() {
+        // The only guess available is BundleFormat.autoFor, which can never return XAPK — so a
+        // fallback would hand back a .apks where the user asked for the container with their game
+        // data in it, and nothing would say so. A job enqueued by a newer build and run after a
+        // downgrade is the case; refusing is the honest answer.
+        val map = request().toMap().toMutableMap().apply { put(EXPORT_FORMAT_KEY, "AAB") }
+
+        assertNull(AppExportRequest.fromMap(map))
+    }
+
+    @Test
+    fun `the format is matched by name and not by ordinal`() {
+        for (format in BundleFormat.entries) {
+            val restored = AppExportRequest.fromMap(request(format = format).toMap())
+
+            assertEquals(format, restored?.format)
+        }
+    }
+
+    @Test
+    fun `a missing or blank required key is refused`() {
+        for (key in listOf(EXPORT_PACKAGE_KEY, EXPORT_FORMAT_KEY, EXPORT_LABEL_KEY)) {
+            assertNull(AppExportRequest.fromMap(request().toMap() - key))
+            assertNull(
+                AppExportRequest.fromMap(request().toMap().toMutableMap().apply { put(key, "  ") })
+            )
+        }
+    }
+
+    @Test
+    fun `a blank tree uri is read as absent rather than as a folder named nothing`() {
+        val map = request().toMap().toMutableMap().apply { put(EXPORT_TREE_KEY, "") }
+
+        assertEquals(ExportTargetChoice.Downloads, AppExportRequest.fromMap(map)?.target)
+    }
+
+    @Test
+    fun `an empty map is refused`() {
+        assertNull(AppExportRequest.fromMap(emptyMap()))
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/ThorJobTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/ThorJobTest.kt
@@ -83,6 +83,30 @@ class ThorJobTest {
     }
 
     @Test
+    fun `each kind keeps the notification id it shipped with`() {
+        // BASE + ordinal is both the notification id and the PendingIntent request code, and a
+        // PendingIntent outlives the code that built it — a row the system is still showing across an
+        // app update is holding whatever the *old* build wrote. So reordering this enum hands a live
+        // notification the request code of a different job, and nothing about that is visible at
+        // build time, in a test that only checks the block gap, or on the developer's device.
+        //
+        // Pinned as literal ordinals rather than as "APP_EXPORT is last", because the failure being
+        // guarded is renumbering, and only the numbers state it.
+        assertEquals(0, ThorJobKind.ARCHIVE_BACKUP.ordinal)
+        assertEquals(1, ThorJobKind.ARCHIVE_RESTORE.ordinal)
+        assertEquals(2, ThorJobKind.APP_EXPORT.ordinal)
+
+        assertEquals(
+            1102,
+            ThorJobNotifications.BASE_NOTIFICATION_ID + ThorJobKind.APP_EXPORT.ordinal,
+        )
+        assertEquals(
+            1202,
+            ThorJobNotifications.BASE_RESULT_NOTIFICATION_ID + ThorJobKind.APP_EXPORT.ordinal,
+        )
+    }
+
+    @Test
     fun `an unknown total reports no percentage rather than zero`() {
         // Same tri-state rule as DataClassSize and ObbProbe: "not known" is not "none". A bar pinned
         // at 0% for a job that is running reads as broken.

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/ExportViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/ExportViewModelTest.kt
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import com.valhalla.thor.data.backup.job.JobRegistry
+import com.valhalla.thor.domain.model.AppExportRequest
+import com.valhalla.thor.domain.model.ThorJobKind
+import com.valhalla.thor.domain.repository.ExportJobLauncher
+import com.valhalla.thor.domain.repository.ThorJobStatus
+import com.valhalla.thor.domain.usecase.ExportAppUseCase
+import com.valhalla.thor.presentation.FakeAppBundleBuilder
+import com.valhalla.thor.presentation.FakeAppBundleFileStore
+import com.valhalla.thor.presentation.FakePreferenceRepository
+import com.valhalla.thor.presentation.MainDispatcherRule
+import java.util.UUID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The export sheet's view model — specifically the `runningJobFor` reattach guard.
+ *
+ * `UnconfinedTestDispatcher`, the rule's default and deliberately *not* the `StandardTestDispatcher`
+ * its backup sibling uses: `viewModelScope` is `Dispatchers.Main.immediate`, so an unconfined
+ * dispatcher reproduces the one ordering that matters here — a collector that throws before its own
+ * `launch` has returned, which means `watching` is assigned a Job that is already dead. A standard
+ * dispatcher defers the body past the assignment and cannot reach that state at all.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ExportViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(dispatcher)
+
+    // --- doubles -------------------------------------------------------------------------------
+
+    /**
+     * @param running what `runningJobFor` emits. A `MutableSharedFlow` rather than a `MutableStateFlow`
+     *   because one test re-emits the *same* id, which a state flow would conflate away — and that
+     *   re-emission is the case the guard exists for.
+     */
+    private class FakeLauncher(
+        val running: MutableSharedFlow<UUID?> = MutableSharedFlow(replay = 1),
+    ) : ExportJobLauncher {
+
+        /**
+         * Per-id status flows. An id with no entry here gets one that throws on collect, which is how
+         * a test stages a watcher failure without needing the export machinery to fail for real.
+         */
+        val statusesFor: MutableMap<UUID, MutableStateFlow<ThorJobStatus>> = mutableMapOf()
+
+        /** Every `status` call, in order — the only way to see that a *new* watcher attached. */
+        val statusCalls: MutableList<UUID> = mutableListOf()
+
+        override suspend fun startExport(request: AppExportRequest): UUID? = null
+
+        override fun status(jobId: UUID): Flow<ThorJobStatus> {
+            statusCalls += jobId
+            return statusesFor[jobId] ?: flow { error("no status flow for $jobId") }
+        }
+
+        override fun runningJobFor(kind: ThorJobKind, target: String): Flow<UUID?> = running
+    }
+
+    private fun viewModel(launcher: FakeLauncher) = ExportViewModel(
+        // Never invoked by these tests — nothing here calls `start` — but the constructor needs one,
+        // and a real use case over the existing fakes is cheaper than a fourth port.
+        exportUseCase = ExportAppUseCase(
+            bundleBuilder = FakeAppBundleBuilder(),
+            preferenceRepository = FakePreferenceRepository(),
+            fileStore = FakeAppBundleFileStore(),
+            ioDispatcher = dispatcher,
+        ),
+        launcher = launcher,
+        registry = JobRegistry(),
+    )
+
+    private val first = UUID.fromString("00000000-0000-0000-0000-00000000e401")
+    private val second = UUID.fromString("00000000-0000-0000-0000-00000000e402")
+
+    // --- tests ---------------------------------------------------------------------------------
+
+    @Test
+    fun `a watcher that throws does not lock the sheet out of every later job`() =
+        runTest(dispatcher) {
+            // The guard used to read `watching == null`, and `watch`'s own `onFailure` cannot null the
+            // field its `launchGuarded` is still being assigned into. So a collector that threw parked
+            // a *completed* Job in `watching`, and from then on `runningJobFor` had nothing it could
+            // hand over: every later export ran with the form still showing over it, and a tap on that
+            // form appended a second export into the same staging directory.
+            val launcher = FakeLauncher()
+            val vm = viewModel(launcher)
+            vm.attach("com.example.app")
+
+            // No entry in `statusesFor`, so this one throws on collect.
+            launcher.running.emit(first)
+            testScheduler.advanceUntilIdle()
+            assertEquals(listOf(first), launcher.statusCalls)
+            assertEquals(false, vm.phase.value.running)
+            assertTrue(vm.phase.value.settled)
+
+            // The second job gets a status flow of its own on purpose: sharing one would let the dead
+            // watcher answer for it, and a view model that never reattached would pass anyway.
+            launcher.statusesFor[second] = MutableStateFlow(ThorJobStatus.Running)
+            launcher.running.emit(second)
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(listOf(first, second), launcher.statusCalls)
+            assertEquals(true, vm.phase.value.running)
+        }
+
+    @Test
+    fun `a live watcher survives the same id being re-emitted`() = runTest(dispatcher) {
+        // What the guard was there for in the first place, and what the liveness form must not lose:
+        // re-watching restarts the collector, and with it `watch`'s `finished = null`, over a job that
+        // may already have reported its outcome.
+        val launcher = FakeLauncher()
+        launcher.statusesFor[first] = MutableStateFlow(ThorJobStatus.Running)
+        val vm = viewModel(launcher)
+        vm.attach("com.example.app")
+
+        launcher.running.emit(first)
+        testScheduler.advanceUntilIdle()
+        assertEquals(listOf(first), launcher.statusCalls)
+
+        launcher.running.emit(first)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf(first), launcher.statusCalls)
+        assertEquals(true, vm.phase.value.running)
+    }
+
+    @Test
+    fun `attach is idempotent for the package it is already on`() = runTest(dispatcher) {
+        // The sheet calls it from a `LaunchedEffect` a recomposition can re-run. A second collector on
+        // `runningJobFor` would be a second claimant on the same guard.
+        val launcher = FakeLauncher()
+        launcher.statusesFor[first] = MutableStateFlow(ThorJobStatus.Running)
+        val vm = viewModel(launcher)
+        vm.attach("com.example.app")
+        vm.attach("com.example.app")
+
+        launcher.running.emit(first)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf(first), launcher.statusCalls)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/common/JobPhaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/common/JobPhaseTest.kt
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.common
+
+import com.valhalla.thor.domain.model.ThorJobProgress
+import com.valhalla.thor.domain.model.ThorJobStage
+import com.valhalla.thor.domain.repository.ThorJobStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The orderings that were bugs on the backup side, restated as a pure function.
+ *
+ * Every one of these previously needed a fake `ArchiveJobLauncher`, a `runTest` and a view model to
+ * assert; folding `seenLive`/`seenRunning` into [JobPhase] is what makes them two lines each.
+ */
+class JobPhaseTest {
+
+    @Test
+    fun `pending is running and queued`() {
+        val phase = JobPhase().reduce(ThorJobStatus.Pending)
+
+        assertTrue(phase.running)
+        assertTrue(phase.queued)
+        assertFalse(phase.settled)
+    }
+
+    @Test
+    fun `running clears queued`() {
+        // The transition the user actually watches: the "waiting behind another job" line has to go
+        // away by itself, not on the next thing the worker publishes.
+        val phase = JobPhase().reduce(ThorJobStatus.Pending).reduce(ThorJobStatus.Running)
+
+        assertTrue(phase.running)
+        assertFalse(phase.queued)
+    }
+
+    @Test
+    fun `success carries the worker's warnings through`() {
+        // A job can succeed *and* have something the user must be told. Dropping the list here would
+        // make the restore path's partial-placement warning unreportable.
+        val phase = JobPhase().reduce(ThorJobStatus.Succeeded(listOf("game data was not placed")))
+
+        assertEquals(
+            JobFinish.Succeeded(listOf("game data was not placed")),
+            phase.finished
+        )
+        assertTrue(phase.settled)
+        assertFalse(phase.running)
+    }
+
+    @Test
+    fun `a failure counts as having run even when RUNNING was never observed`() {
+        // A watcher that attaches late — the reattach path — can miss RUNNING entirely. It cannot
+        // make the run un-happen, and reporting "nothing was started" over a worker that packaged
+        // half a gigabyte and then failed is the wrong recovery to offer.
+        val phase = JobPhase().reduce(ThorJobStatus.Failed("no space left"))
+
+        assertEquals(JobFinish.Failed("no space left", workerRan = true), phase.finished)
+    }
+
+    @Test
+    fun `a failure with no reason is still a failure`() {
+        // WorkManager produces a bare Result.failure() on some of its own paths. A screen keying
+        // "did it fail?" off a non-null reason reports those as nothing at all.
+        val phase = JobPhase().reduce(ThorJobStatus.Failed(null))
+
+        val finished = phase.finished
+        assertTrue(finished is JobFinish.Failed)
+        assertNull((finished as JobFinish.Failed).reason)
+        assertTrue(phase.settled)
+    }
+
+    @Test
+    fun `a cancel after RUNNING says the worker ran`() {
+        val phase = JobPhase()
+            .reduce(ThorJobStatus.Running)
+            .reduce(ThorJobStatus.Cancelled)
+
+        assertEquals(JobFinish.Cancelled(workerRan = true), phase.finished)
+    }
+
+    @Test
+    fun `a cancel before RUNNING says it never started`() {
+        // The common cancel, and the reason `Cancelled` is not folded into `Failed`: every Thor job
+        // is appended to one chain, and WorkManager cancels the dependents of a prerequisite that
+        // fails. Such a job never entered `doWork`, so "Thor did not start it" is the true sentence.
+        val phase = JobPhase()
+            .reduce(ThorJobStatus.Pending)
+            .reduce(ThorJobStatus.Cancelled)
+
+        assertEquals(JobFinish.Cancelled(workerRan = false), phase.finished)
+    }
+
+    @Test
+    fun `a Gone before the job was ever seen alive is ignored`() {
+        // The launcher does not await enqueue(), so WorkManager writes the row on its own executor
+        // after the id comes back and after this reduction has already seen a null WorkInfo. Settling
+        // here would take the bar down a frame after the tap and invite a duplicate enqueue.
+        val phase = JobPhase(running = true).reduce(ThorJobStatus.Gone)
+
+        assertTrue(phase.running)
+        assertFalse(phase.settled)
+        assertNull(phase.finished)
+    }
+
+    @Test
+    fun `a Gone after the job was seen alive settles with nothing to report`() {
+        // The record went away underneath a live watcher. Terminal — so the watcher is released and
+        // the form comes back — but not a failure and not a success anyone witnessed.
+        val phase = JobPhase()
+            .reduce(ThorJobStatus.Running)
+            .reduce(ThorJobStatus.Gone)
+
+        assertTrue(phase.settled)
+        assertFalse(phase.running)
+        assertNull(phase.finished)
+    }
+
+    @Test
+    fun `settling leaves the last progress in place`() {
+        // Deliberate, and it was tried the other way. Nulling it is invisible on screen — every sheet
+        // reads the bar under `if (running)`, which settling clears — and it deletes the fixture the
+        // "a second run does not open on the first one's bar" assertions are built from.
+        val progress = ThorJobProgress(ThorJobStage.CAPTURING, "Packaging Maps as .xapk")
+        val phase = JobPhase(progress = progress)
+            .reduce(ThorJobStatus.Running)
+            .reduce(ThorJobStatus.Succeeded())
+
+        assertEquals(progress, phase.progress)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/common/JobPhaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/common/JobPhaseTest.kt
@@ -98,8 +98,8 @@ class JobPhaseTest {
 
     @Test
     fun `a Gone before the job was ever seen alive is ignored`() {
-        // The launcher does not await enqueue(), so WorkManager writes the row on its own executor
-        // after the id comes back and after this reduction has already seen a null WorkInfo. Settling
+        // A null `WorkInfo` is "no row for this id" as much as it is "the row was pruned" — an id
+        // recovered from `runningJobFor` and pruned in between reads exactly like a fresh one. Settling
         // here would take the bar down a frame after the tap and invite a duplicate enqueue.
         val phase = JobPhase(running = true).reduce(ThorJobStatus.Gone)
 

--- a/docs/workers/README.md
+++ b/docs/workers/README.md
@@ -7,7 +7,7 @@ debugging a job that never showed up. For the branch/release side of the repo se
 [`branching-and-releases.md`](../branching-and-releases.md); for deferred work see
 [`follow-ups/README.md`](../follow-ups/README.md).
 
-**Last verified:** 2026-08-13 (UTC) against branch `feat/job-seam-generalise` @ `ba65dc16`. Dates here
+**Last verified:** 2026-08-14 (UTC) against branch `feat/export-job-seam` @ `b56143c6`. Dates here
 are UTC, matching the GitHub timestamps they can be checked against. Every line number below was
 opened, not grepped for; if you move code, move the anchor.
 
@@ -15,43 +15,63 @@ opened, not grepped for; if you move code, move the anchor.
 
 ## The answer, in four lines
 
-**Two operations use WorkManager.** Back up **one** app to an encrypted `.thorbak`, and restore
-**one** app from one. Both are single-app, both are archive work, and both go onto the same unique
-chain, so they serialise and never run at once.
+**Three operations use WorkManager.** Back up **one** app to an encrypted `.thorbak`, restore **one**
+app from one, and export **one** app as `.apk`/`.apks`/`.xapk`. All three are single-app, all three
+move bytes, and all three go onto the same unique chain, so they serialise and never run at once.
 
 Everything else Thor does in the background — including the **multi-app export that shares the word
 "backup"**, and every bulk freeze, unfreeze, force-stop, cache clear and reinstall — is a coroutine on
 a process-lifetime scope or a `viewModelScope`. See [What is *not* on WorkManager](#what-is-not-on-workmanager-and-why).
 
+> ⚠️ **"Export" means two different things in this repo.** *Single*-app export is a job (`APP_EXPORT`,
+> below). *Multi*-app export — the "backup all" path in `BackupRunner` — is not, and its non-adoption
+> is argued rather than pending. Read the kind, not the verb.
+
 ---
 
-## The two jobs
+## The three jobs
 
-| | `ARCHIVE_BACKUP` | `ARCHIVE_RESTORE` |
-|---|---|---|
-| `ThorJobKind.id` | `archive-backup` | `archive-restore` |
-| Worker | `ArchiveBackupWorker` — `AppArchiveWorker.kt:61` | `ArchiveRestoreWorker` — `AppArchiveWorker.kt:236` |
-| Unique chain | `THOR_JOB_CHAIN` = `"thor.job.chain"` | same chain |
-| Started by | `ThorJobLauncher.startBackup` (`:64`), from `AppBackupViewModel:361` | `ThorJobLauncher.startRestore` (`:102`), from `ArchiveRestoreViewModel:751` |
-| Work tag | `thor.job.archive-backup.<pkg>` | `thor.job.archive-restore.<pkg>` |
-| Input `Data` | `thor.backup.package` (String), `thor.backup.classes` (String[]), `thor.backup.bundle` (Boolean), `thor.backup.salt` (Base64 String) | `thor.restore.uri`, `thor.restore.package` (String), `thor.restore.classes` (String[]), `thor.restore.obb` (Boolean) |
-| Output on success | bare `Result.success()` — no data | `Result.success(workDataOf(JOB_WARNINGS_KEY to …))`, a String[] |
-| Output on failure | `JOB_ERROR_KEY` = `"thor.job.error"`, one sentence | same |
-| Runs foreground | yes (`dataSync`) | yes (`dataSync`) |
+| | `ARCHIVE_BACKUP` | `ARCHIVE_RESTORE` | `APP_EXPORT` |
+|---|---|---|---|
+| `ThorJobKind.id` | `archive-backup` | `archive-restore` | `app-export` |
+| Worker | `ArchiveBackupWorker` — `AppArchiveWorker.kt:61` | `ArchiveRestoreWorker` — `AppArchiveWorker.kt:236` | `AppExportWorker` — `AppExportWorker.kt:55` |
+| Unique chain | `THOR_JOB_CHAIN` = `"thor.job.chain"` | same chain | same chain |
+| Started by | `ThorJobLauncher.startBackup` (`:69`), from `AppBackupViewModel:361` | `ThorJobLauncher.startRestore` (`:107`), from `ArchiveRestoreViewModel:751` | `ExportJobLauncherImpl.startExport` (`:55`), from `ExportViewModel:109` |
+| Work tag | `thor.job.archive-backup.<pkg>` | `thor.job.archive-restore.<pkg>` | `thor.job.app-export.<pkg>` |
+| Input `Data` | `thor.backup.package` (String), `thor.backup.classes` (String[]), `thor.backup.bundle` (Boolean), `thor.backup.salt` (Base64 String) | `thor.restore.uri`, `thor.restore.package` (String), `thor.restore.classes` (String[]), `thor.restore.obb` (Boolean) | `thor.export.pkg`, `thor.export.format` (a `BundleFormat` **name**), `thor.export.label`, `thor.export.tree` (SAF tree, **absent** for Downloads) — all String |
+| Output on success | bare `Result.success()` — no data | `Result.success(workDataOf(JOB_WARNINGS_KEY to …))`, a String[] | bare `Result.success()` — the sentence goes to the shade via `noteResult`, not to `Data` |
+| Output on failure | `JOB_ERROR_KEY` = `"thor.job.error"`, one sentence | same | same, **and** the same sentence is posted as an outcome notification (`failNoted`, `AppExportWorker.kt:153`) |
+| `sheetTarget` | the backup sheet | the restore sheet | **null** — a tap resumes the app and nothing more |
+| Runs foreground | yes (`dataSync`) | yes (`dataSync`) | yes (`dataSync`) |
 
 **How a user gets there.** Backup: the app-info surfaces open the backup sheet, plus a second host —
 `MainViewModel.BackupSheetState` (`MainViewModel.kt:205`), which is *only* ever opened by a
 notification tap. Restore: the Settings → Restore row, or a notification tap routed through
-`JobSheetLaunchActivity` (`AndroidManifest.xml:391`, `exported="false"`, `noHistory="true"`).
+`JobSheetLaunchActivity` (`AndroidManifest.xml:391`, `exported="false"`, `noHistory="true"`). Export:
+the Export button in `ExportBottomSheet`; there is no notification route back, by the `sheetTarget`
+decision above.
+
+### Why export has its own launcher
+
+`ExportJobLauncherImpl` (`ExportJobLauncherImpl.kt:41`) is thirty lines because everything long about
+`ThorJobLauncher` is key derivation and the ordering rules around `ArchiveKeyHolder`, and an export
+has neither — no passphrase, no key, nothing to release when an enqueue is abandoned. It shares the
+one thing worth sharing, `enqueueUniqueJob`, and delegates the whole watch half by
+`ThorJobWatcher by watcher` rather than mapping `WorkInfo.State` a second time.
+
+The one thing it must not skip is the **tag**: the chain name cannot tell one package's export from
+another's, and without `jobTag` a double tap appends a second identical export behind the first.
 
 ### The `Data` contract, and the one rule that is only half written down
 
 `androidx.work.Data` accepts a small set of types. In Thor that is **String, Boolean and
-`Array<String>`** — a `Set` or an enum passed to `workDataOf` throws **at enqueue time, in
-production**. `ArchiveBackupRequest.toMap()` states this in its KDoc (`ArchiveBackupRequest.kt:47-54`);
+`Array<String>`** — a `Set`, an enum, or a null value passed to `workDataOf` throws **at enqueue time,
+in production**. `ArchiveBackupRequest.toMap()` states this in its KDoc (`ArchiveBackupRequest.kt:47-54`)
+and `AppExportRequest` states it again for the null case (`AppExportRequest.kt:32-35`, which is why
+`treeUri` is *absent* rather than null when the destination is Downloads);
 `ArchiveRestoreRequest.toMap()` (`ArchiveRestoreRequest.kt:40`) is the identical shape, serialised the
-same way at `ThorJobLauncher.kt:116`, and **says nothing**. Half the enqueued payloads in the app are
-covered by that comment and half are not.
+same way at `ThorJobLauncher.kt:116`, and **says nothing**. Two of the three enqueued payloads carry
+that comment; the rule is still enforced by nothing but comments.
 
 `fromMap` returns `null` for anything it cannot turn into a runnable job, and the worker converts that
 into `Result.failure()` with a reason — never `Result.retry()`, which would re-read the same unusable
@@ -75,18 +95,42 @@ job waited its turn.
 
 ---
 
-## ⚠️ Being on WorkManager here does **not** mean durable
+## ⚠️ Being on WorkManager here does **not** mean durable — for two of the three
 
-Both workers open by taking their AES key out of process memory, and both fail immediately if it is
-gone:
+Both **archive** workers open by taking their AES key out of process memory, and both fail immediately
+if it is gone:
 
 - `AppArchiveWorker.kt:128-130` — *"this backup's key is no longer in memory — start it again"*
 - `AppArchiveWorker.kt:282-283` — the same for restore
 
-So a reboot or an OOM kill does **not** resume the job. WorkManager re-runs the worker, and the worker
-refuses. That is the intended design (`§9.2`), not a gap to close — but it means "it's a Worker, so it
-survives" is false here, and anyone reasoning about a new job kind should decide explicitly which side
-of that line it sits on.
+So a reboot or an OOM kill does **not** resume either archive job. WorkManager re-runs the worker, and
+the worker refuses. That is the intended design (`§9.2`), not a gap to close — but it means "it's a
+Worker, so it survives" is false there, and anyone reasoning about a new job kind should decide
+explicitly which side of that line it sits on.
+
+### `APP_EXPORT` sits on the other side, and that is what `LaunchSweepBarrier` is for
+
+An export holds no key. Its whole input is four strings that are still true tomorrow, so a re-run in a
+fresh process runs the export **for real**, to completion. It is the first job on this seam that does.
+
+That is a feature and it broke an assumption. `ArchiveOrphanSweeper.sweep()` runs once per process
+from `ThorApplication.onCreate` and `deleteRecursively()`s `externalCacheDir/obb_out` **wholesale**,
+justified by "any export still using it died with the process" — true while every writer of that tree
+was a foreground operation. A worker WorkManager re-ran *in this process* is writing into it right
+now, and for an OBB game that is gigabytes deleted mid-copy.
+
+`LaunchSweepBarrier` (`LaunchSweepBarrier.kt:38`) closes it. `AppExportWorker.runJob` blocks on
+`awaitSwept()` **before it stages anything** (`AppExportWorker.kt:92`) and refuses on timeout rather
+than proceeding; `ThorApplication` completes it from a `finally` around the sweep
+(`ThorApplication.kt:336`), so a sweep that threw or a cancelled scope still releases it. It is not a
+lock — one `CompletableDeferred`, completed once per process, so every later `await` returns
+immediately and the ordinary case pays a resumption. `SWEEP_WAIT_TIMEOUT_MS` is 120 s
+(`LaunchSweepBarrier.kt:76`), sized against a user's patience for a stuck notification rather than
+against the sweep, which is over before the first frame.
+
+**Any future job that stages into a swept directory must take this barrier too.** The archive workers
+are exempt only because their key-in-memory refusal makes them incapable of reaching a builder after a
+process death — the property that makes them non-durable is the same one that makes them safe here.
 
 **What WorkManager actually buys Thor is four things:**
 
@@ -97,8 +141,8 @@ of that line it sits on.
    from the app.
 4. A **serialising chain** that holds peak disk to one job however many backups the user starts.
 
-Nothing on that list is retry-on-reboot, and none of the four workers' inputs asks for it: neither
-request sets `Constraints`, `setExpedited`, `setInitialDelay` or `setBackoffCriteria`.
+Nothing on that list is retry-on-reboot, and none of the three requests asks for it: not one sets
+`Constraints`, `setExpedited`, `setInitialDelay` or `setBackoffCriteria`.
 
 > One consequence of no `setExpedited`: WorkManager never calls `getForegroundInfoAsync()` for this
 > work — it does that only for expedited `WorkSpec`s. `getForegroundInfo()` is still on the deadline
@@ -113,26 +157,40 @@ All of it lives in `app/src/main/java/com/valhalla/thor/data/backup/job/`.
 | Class | Job |
 |---|---|
 | `ThorJobWorker` | `abstract … : CoroutineWorker`. Owns the foreground notification, progress throttling, one failure policy, and the `finally` that cleans up. `doWork()` and `getForegroundInfo()` are **`final`**. |
-| `ThorJobLauncher` | `@Single(binds = [ArchiveJobLauncher::class])`. Derives the key, builds the request, and owns enqueue / status / cancel. |
-| `enqueueUniqueJob(context, chainName, work, onAbandoned)` | Top-level `internal suspend fun` (`ThorJobLauncher.kt:240`) — the one enqueue expression in the app, extracted so the next launcher shares it rather than copying it. |
+| `ThorJobLauncher` | `@Single(binds = [ArchiveJobLauncher::class])`. Derives the key, builds the request, and owns enqueue / status / cancel for the two archive kinds. |
+| `ExportJobLauncherImpl` | `@Single(binds = [ExportJobLauncher::class])`. The export half — no key, so almost nothing: one tagged request and the shared enqueue. Watches by delegation. |
+| `enqueueUniqueJob(context, chainName, work, onAbandoned)` | Top-level `internal suspend fun` (`ThorJobLauncher.kt:245`) — the one enqueue expression in the app, extracted so the next launcher shares it rather than copying it. It now has two callers, which is the whole reason it is not a private method. |
 | `JobRegistry` | In-memory progress channel, used **instead of** `ListenableWorker.setProgress` (which has zero call sites anywhere in `app/src`). |
 | `ThorJobNotifications` | `@Single`. Owns the shade rows, the ids, the channel and the cancel action. |
 | `ArchiveKeyHolder`, `JobSheetTargets` | The two process-memory side channels: key material and notification tap targets. |
-| `ThorJobWatcher` | Split off `ArchiveJobLauncher` so a screen can watch a job without being able to start one. |
+| `LaunchSweepBarrier` | The startup-ordering rule: no job stages into a swept directory until the launch sweep is over. `@Single`, pure `kotlinx.coroutines`, one `CompletableDeferred`. |
+| `ThorJobWatcher` | Split off `ArchiveJobLauncher` so a screen can watch a job without being able to start one. Both launcher interfaces extend it. |
+
+On the presentation side, `JobPhase` (`presentation/common/JobPhase.kt`) is the shared reduction of
+`ThorJobStatus` into what a screen shows, and `JobRunningFrame` the shared progress frame. The export
+sheet uses both; the two archive sheets still carry their own `BackupFinish`/`RestoreFinish` copies of
+the same shape and have not been repointed yet.
 
 ### Adding a new job kind
 
-1. Append to `ThorJobKind` (`ThorJob.kt:67`). **Append only — never insert or reorder** (see below).
+1. Append to `ThorJobKind` (`ThorJob.kt:72`). **Append only — never insert or reorder** (see below).
+   `APP_EXPORT` (`:84`) is appended rather than slotted beside the archive kinds it reads like a
+   sibling of, for exactly that reason.
 2. Subclass `ThorJobWorker` and implement the four abstract members: `kind`, `initialLabel`,
-   `sheetTarget`, `runJob()`.
+   `sheetTarget`, `runJob()`. `sheetTarget` may be null — see `APP_EXPORT`, which has no sheet worth
+   reopening mid-flight.
 3. Override the two `open` members if you need them: `runsForeground` (default `true`,
    `ThorJobWorker.kt:80`) and `onJobFinished()` (`:227` — non-suspend, on the cancellation path, and
    **must not throw**).
 4. Annotate the class `@KoinWorker`.
-5. Add an arm to `ThorJobNotifications.titleFor` (`:203`) and `iconFor` (`:221`). Both are `when`s with
+5. Add an arm to `ThorJobNotifications.titleFor` (`:203`) and `iconFor` (`:226`). Both are `when`s with
    **no `else`**, so a new kind is a compile error until someone has worded it. That is the mechanism,
    not an inconvenience.
-6. Call `enqueueUniqueJob(...)` from a launcher with the right chain name.
+6. Call `enqueueUniqueJob(...)` from a launcher with the right chain name, and **tag the request**
+   `jobTag(kind, target)` — the chain name is shared, so it is the tag that answers "is this already
+   running for this app?" and stops a double tap queueing a duplicate.
+7. Decide whether a re-run in a fresh process is a real run. If it is, and the job stages into a
+   directory the launch sweep deletes, take `LaunchSweepBarrier` before staging.
 
 Useful helpers a subclass already has: `noteResult(message)` (`:203`), `retargetSheet(target)` (`:238`),
 `fail(reason)` (`:258`), `publish(progress)` (`:280`).
@@ -146,7 +204,7 @@ Useful helpers a subclass already has: `noteResult(message)` (`:203`), `retarget
 
 | Name | Value | For | Producers today |
 |---|---|---|---|
-| `THOR_JOB_CHAIN` | `"thor.job.chain"` | anything that **moves bytes** | 2 (`startBackup`, `startRestore`) |
+| `THOR_JOB_CHAIN` | `"thor.job.chain"` | anything that **moves bytes** | 3 (`startBackup`, `startRestore`, `startExport`) |
 | `THOR_SWEEP_CHAIN` | `"thor.sweep.chain"` | privilege **sweeps** — bulk freeze, unfreeze, force-stop, cache clear, reinstall | **0** |
 
 `THOR_SWEEP_CHAIN` exists, is documented at length (`ThorJob.kt:23-40`), and is asserted about by three
@@ -166,7 +224,8 @@ freeze writes no bytes, so queueing a five-second sweep behind an hour-long back
 
 ### `ExistingWorkPolicy.APPEND_OR_REPLACE`, precisely
 
-One call site: `ThorJobLauncher.kt:253-259`. Read from work-runtime 2.11.2's `EnqueueRunnable`:
+One call site: `ThorJobLauncher.kt:258-264`, now reached by both launchers. Read from work-runtime
+2.11.2's `EnqueueRunnable`:
 
 - Any chain leaf **live** (ENQUEUED / RUNNING / BLOCKED / SUCCEEDED) ⇒ the newcomer is appended as a
   **dependent** and enters BLOCKED. It waits.
@@ -180,7 +239,7 @@ notification is ever posted and the UI sees `Failed(reason = null)`.
 
 ### The enqueue is awaited
 
-`enqueueUniqueJob` calls `operation.awaitSuccess()` (`ThorJobLauncher.kt:261`). This matters: a
+`enqueueUniqueJob` calls `operation.awaitSuccess()` (`ThorJobLauncher.kt:266`). This matters: a
 `WorkSpec` insert that fails, a corrupt WorkManager database or a rejected executor task all arrive as
 a *failed* `Operation`, and catching only what is thrown synchronously catches argument validation and
 nothing else. Without the wait, the launcher returned an id for a row that does not exist, and the
@@ -188,7 +247,8 @@ screen sat on a progress bar forever with no timeout anywhere.
 
 If the caller's coroutine is cancelled mid-wait, the work is already WorkManager's, so the key is
 **not** released — but `whenFailed` keeps watching the future for the one outcome that means no worker
-will run (`ThorJobLauncher.kt:274-276`, `:335`).
+will run (`ThorJobLauncher.kt:279-281`, `:340`). An export passes no `onAbandoned` at all: nothing is
+held in memory for it, so the launcher's null return *is* the whole cleanup.
 
 > 🕳️ **Four comments in the tree still say the opposite** — *"`ThorJobLauncher` does not await
 > `enqueue()`"* — at `AppBackupViewModel.kt:432`, `ArchiveRestoreViewModel.kt:882`,
@@ -211,8 +271,8 @@ WorkManager prunes finished work — not an error.
 | Thing | Value | Where |
 |---|---|---|
 | Channel | `"thor.jobs"`, `IMPORTANCE_LOW` | `ThorJobNotifications.CHANNEL_ID` |
-| Ongoing row id | `1100 + kind.ordinal` | `BASE_NOTIFICATION_ID` |
-| Outcome row id | `1200 + kind.ordinal` | `BASE_RESULT_NOTIFICATION_ID` |
+| Ongoing row id | `1100 + kind.ordinal` — backup 1100, restore 1101, export **1102** | `BASE_NOTIFICATION_ID` |
+| Outcome row id | `1200 + kind.ordinal` — backup 1200, restore 1201, export **1202** | `BASE_RESULT_NOTIFICATION_ID` |
 | Outcome row lifetime | 10 s (`setTimeoutAfter`) | `TIMEOUT_MS` |
 | Progress throttle | at most one update/second, or on a stage change | `NOTIFICATION_INTERVAL_MS`, `ThorJobWorker.kt:25` |
 | Message cap | 512 chars, ellipsised | `MAX_JOB_MESSAGE_CHARS`, `ThorJobWorker.kt:298` |
@@ -227,6 +287,18 @@ terminal path; an outcome posted under the same id would be cancelled microsecon
 `WorkerWrapper` records CANCELLED and drops the output `Data`. So a sweep stopped at 7 of 20 cannot
 report that count through `Result.success(...)`. Posting from the worker's own `finally` is the only
 route those counts survive by, and that is what `noteResult` is for.
+
+`APP_EXPORT` is the first kind to use it on the **success** path as well. An export is a job the user
+was explicitly invited to walk away from, so its report cannot be a screen's to render: "Saved
+*Clash of Clans* to Downloads" is `noteResult` at `AppExportWorker.kt:141`, and every failing `return`
+in `runJob` goes through `failNoted`, which notes *and* fails. There is no path out of that worker
+that ends in silence.
+
+The one thing it deliberately does **not** report is a stop. A stopped worker is not a finished one —
+WorkManager stops workers for its own reasons and then re-runs them — so "Nothing was saved" posted
+from the cancellation path would be a lie told at the moment the export was about to succeed. A
+genuine user cancel is worded by the screen instead, off `ThorJobStatus.Cancelled`, which only
+WorkManager's own terminal state can produce.
 
 ### ⚠️ The notification gate — a real hole today
 
@@ -244,7 +316,9 @@ user is left with:
 - On **API 33+** the system's Task Manager row exists, but it renders the app and a **Stop** button —
   not a notification's actions, so the cancel `PendingIntent` never reaches it. Its Stop force-stops the
   process, which runs **none** of `ThorJobWorker`'s `finally`: no registry clear, no key drop, no
-  notification cancel. A restore is covered by §8.5's breadcrumb; a backup relies on the launch sweep.
+  notification cancel. A restore is covered by §8.5's breadcrumb; a backup relies on the launch sweep;
+  an **export is re-run** by WorkManager in the next process and genuinely completes — which is the
+  behaviour `LaunchSweepBarrier` exists to make safe, and the reason it is not optional.
 
 `areNotificationsEnabled()` is also false when the permission *is* held but notifications are off
 app-wide, so granting `POST_NOTIFICATIONS` is necessary and not always sufficient.
@@ -260,21 +334,23 @@ Not one of these is a `ListenableWorker`. They are coroutines, on three differen
 
 | Operation | Where it runs | Anchor |
 |---|---|---|
-| **Multi-app export** ("backup all") | process-lifetime `@Single` scope | `BackupRunner.kt:58`, scope `:63` |
+| **Multi-app export** ("backup all") — *not* the single-app export, which is `APP_EXPORT` above | process-lifetime `@Single` scope | `BackupRunner.kt:58`, scope `:63` |
 | **Bulk freeze / unfreeze engine** | process-lifetime `@Single` scope, 5-wide fan-out, 30 s deadline | `BulkFreezeRunner.kt:73`, scope `:84` |
 | Bulk reinstall, uninstall, force-stop, cache clear, share, suspend, unsuspend | `viewModelScope` | `MainViewModel.performLoggedMultiAction`, `AppListViewModel`'s bulk branch |
 | Counted freeze from the Freezer buttons | `viewModelScope` — **bypasses `BulkFreezeRunner`** | `MainViewModel.performCountedFreeze` |
 | Auto-freeze | own scopes | `AutoFreezeManager.kt:49-50` |
 | Dynamic shortcuts | own scope | `FreezerShortcutManager.kt:52` |
 | QS tile + freezer launcher | own scopes | `FreezerTileService.kt:107`, `FreezerLaunchActivity.kt:49` |
-| Launch-time sweeps | app scope | `ThorApplication.kt:204` |
+| Launch-time sweeps | app scope — and `APP_EXPORT` now waits on it, see `LaunchSweepBarrier` | `ThorApplication.kt:321`, release at `:336` |
 | Privilege probing | own scope | `PrivilegeManager.kt:57` |
 | Archive key expiry | own scope, 1 h timer | `ArchiveKeyHolder.kt:50` |
 | Install / auto-reinstall broadcasts | `goAsync()` | `AutoReinstallReceiver.kt:40`, `InstallReceiver.kt:34` |
 | Extension + freezer bridge IPC | `runBlocking` with a timeout | `ExtensionOpsProvider.kt`, `FreezerBridgeProvider.kt` |
 
 `BackupRunner`'s **non**-adoption is deliberate and argued in its own KDoc (`BackupRunner.kt:47`) — read
-that before "fixing" it.
+that before "fixing" it. Single-app export moving onto the seam does not settle the batch case; the
+batch would need a staging scope of its own so the two cannot wipe each other's half-written copy
+(`AppExportWorker.kt:120-123`).
 
 **`MultiAppAction` has exactly ten members**: `ReInstall`, `Uninstall`, `Freeze`, `UnFreeze`, `Share`,
 `Backup`, `Kill`, `ClearCache`, `Suspend`, `UnSuspend`. There is **no** bulk clear-data and **no** bulk
@@ -306,8 +382,13 @@ Verifiable, and currently invisible from the build file:
   declares only the last of those itself. All three extras are in the merged manifest.
 - **A Play Console Foreground Service declaration** for `FOREGROUND_SERVICE_DATA_SYNC` now stands
   between the repo and a `store` release. That overlay lives in `main`
-  (`AndroidManifest.xml:416-419`), so it ships in **both** flavours; `follow-ups/README.md:234` (row 23)
-  already records it as one of two things blocking a `store` release.
+  (`AndroidManifest.xml:418-421`), so it ships in **both** flavours; `follow-ups/README.md:234` (row 23)
+  already records it as one of two things blocking a `store` release. The declaration is a **video**,
+  with no text field, so what it can show is limited to what a Play reviewer can reproduce on a stock
+  device — which rules out backup and restore, both of which are privileged on every path.
+  **`APP_EXPORT` is the surface that exists to be filmable**: unprivileged, one tap, and honestly
+  described by the picker's "Local processing: import or export" row. Row 23 says "bulk APK export";
+  that predates this work, and single-app export is what ships first.
 - **Thor ships `androidx.work.impl.background.systemjob.SystemJobService`** (merged manifest `:463-468`),
   so the app *does* use JobScheduler — via WorkManager. The "no JobScheduler" claim above is true of
   Thor's own code and false as a statement about the shipped app.
@@ -316,17 +397,18 @@ Verifiable, and currently invisible from the build file:
 
 ### Initialisation
 
-Koin's `workManagerFactory()` (`ThorApplication.kt:227`) — which performs `WorkManager.initialize()` —
+Koin's `workManagerFactory()` (`ThorApplication.kt:248`) — which performs `WorkManager.initialize()` —
 installs a `DelegatingWorkerFactory`. There is no `Configuration.Provider`. The manifest
-`tools:node="remove"`s `androidx.startup`'s `WorkManagerInitializer` (`AndroidManifest.xml:424-433`) so
+`tools:node="remove"`s `androidx.startup`'s `WorkManagerInitializer` (`AndroidManifest.xml:426-435`) so
 there is exactly one initializer; the merged manifest confirms it took effect (`InitializationProvider`
 lists only `EmojiCompat`, `ProcessLifecycle` and `ProfileInstaller`).
 
 > ⚠️ **One process, and the seam depends on it.** The merged manifest contains exactly one
-> `android:process` attribute — `:root` on `ThorRootService`. `ArchiveKeyHolder`, `JobRegistry` and
-> `JobSheetTargets` are process-memory singletons, so the whole seam works only because the worker runs
-> in the **same process** as the ViewModel reading them. Give any of these components an
-> `android:process` and three side channels break silently.
+> `android:process` attribute — `:root` on `ThorRootService`. `ArchiveKeyHolder`, `JobRegistry`,
+> `JobSheetTargets` and now `LaunchSweepBarrier` are process-memory singletons, so the whole seam works
+> only because the worker runs in the **same process** as the ViewModel reading them — and, for the
+> barrier, as the `Application` that completes it. Give any of these components an `android:process`
+> and four side channels break silently.
 
 ---
 
@@ -349,24 +431,34 @@ That dumps the queued, running and recently-completed `WorkSpec`s — chain name
 
 ## Test coverage — the honest position
 
-**64 JVM tests across six files**, and **not one file in `app/src/test` or `app/src/androidTest`
+**95 JVM tests across ten files**, and **not one file in `app/src/test` or `app/src/androidTest`
 imports `androidx.work`**:
 
 | File | `@Test`s |
 |---|---|
 | `data/backup/job/AppArchiveWorkerTest.kt` | 21 |
 | `data/backup/job/JobSheetTargetsTest.kt` | 14 |
-| `domain/model/ThorJobTest.kt` | 10 |
+| `domain/model/ThorJobTest.kt` | 11 |
+| `domain/model/AppExportRequestTest.kt` | 10 |
+| `presentation/common/JobPhaseTest.kt` | 10 |
 | `data/backup/job/ArchiveKeyHolderTest.kt` | 8 |
 | `data/backup/job/JobRegistryTest.kt` | 6 |
+| `data/backup/job/LaunchSweepBarrierTest.kt` | 6 |
 | `data/backup/job/EnqueueFailureWatchTest.kt` | 5 |
+| `data/backup/job/AppExportWorkerReasonTest.kt` | 4 |
 
-There is no `work-testing`, no Robolectric and no mockk on the classpath. What those 64 cover is the
+There is no `work-testing`, no Robolectric and no mockk on the classpath. What those 95 cover is the
 seam's constants, its holders, and the top-level sentence builders that were deliberately hoisted out of
 the workers so a JVM test could reach them (`wrongKeyReason`, `restoreFailureReason`, `obbNotice`,
-`refusalReason`, `boundedForJobData`, `whenFailed`). What they do **not** cover is every chain-behaviour
-claim in this document — those are read from WorkManager's source and confirmed against its bytecode,
-and proving them is device-only.
+`refusalReason`, `exportFailureReason`, `boundedForJobData`, `whenFailed`). What they do **not** cover
+is every chain-behaviour claim in this document — those are read from WorkManager's source and confirmed
+against its bytecode, and proving them is device-only.
+
+Two of those files are the pattern worth copying rather than the count. `LaunchSweepBarrier` and
+`JobPhase` were both written as plain Kotlin — a `CompletableDeferred` and a pure
+`(phase, status) -> phase` — *because* a JVM test can reach neither a `Worker` nor an `Application`.
+Every ordering that had to be argued from a fake launcher and a `runTest` on the archive side is two
+lines in `JobPhaseTest`.
 
 `app/src/androidTest` contains zero `WorkManager`/`Worker` hits of any kind.
 
@@ -378,11 +470,13 @@ and proving them is device-only.
 |---|---|
 | `THOR_SWEEP_CHAIN` has no producers | The whole sweep half of the seam is dead code awaiting the bulk-actions work. |
 | The cross-chain `su` argument | Two chains let a sweep run beside a restore, which the KDoc's own FIFO-session reasoning argues against. Unresolved. |
-| Notifications gate silently — **narrowed, not closed** | `update` and `postResult` still return early when notifications are off, so a job in that state has no surface. Two things now make that state unlikely rather than fixable: `SelfPermissionGranter` takes `POST_NOTIFICATIONS` as soon as root or Shizuku is live, and `RequestNotificationsWhenJobStarts` asks when a job is accepted without it (both sheets). Neither reaches an **app-wide mute**, which is the only off state below API 33 and no `pm` verb or app-op can undo — only Settings. So a muted user on 28–32 still gets a silent job, by design. |
+| Notifications gate silently — **narrowed, not closed** | `update` and `postResult` still return early when notifications are off, so a job in that state has no surface. Two things now make that state unlikely rather than fixable: `SelfPermissionGranter` takes `POST_NOTIFICATIONS` as soon as root or Shizuku is live, and `RequestNotificationsWhenJobStarts` asks when a job is accepted without it (all three sheets). Neither reaches an **app-wide mute**, which is the only off state below API 33 and no `pm` verb or app-op can undo — only Settings. So a muted user on 28–32 still gets a silent job, by design. |
 | `getStopReason()` unread | A system-killed FGS is reported to the user as an ordinary cancel. |
-| Four stale comments | They claim the enqueue is not awaited. It is. |
-| `ArchiveRestoreRequest` carries no `Data`-schema KDoc | Its twin does; the rule is enforced by that one comment. |
-| Everything past `beginUniqueWork` is desk-verified | No `work-testing`, no instrumented coverage. |
+| Four stale comments | They claim the enqueue is not awaited. It is. `AppBackupViewModel.kt:432`, `ArchiveRestoreViewModel.kt:882`, `AppBackupViewModelTest.kt:739`, `ArchiveRestoreViewModelTest.kt:1453`. |
+| `ArchiveRestoreRequest` carries no `Data`-schema KDoc | Its two siblings do; the rule is enforced by comments alone. |
+| Two copies of one finished shape | `BackupFinish`/`RestoreFinish` duplicate `JobFinish`, and `BackupRunning`/`RestoreRunning` duplicate `JobRunningFrame`. The export sheet uses the shared pair; repointing the archive sheets is a rename across two view models, two sheets and their tests, and is not done. |
+| `LaunchSweepBarrier` is opt-in | Nothing makes a new worker take it. It is a rule in a KDoc and a step in the checklist above; a job that stages into `obb_out` and forgets it loses the same race silently. |
+| Everything past `beginUniqueWork` is desk-verified | No `work-testing`, no instrumented coverage. The barrier's *race* in particular is closed by reasoning; `LaunchSweepBarrierTest` pins the deferred's behaviour, not the sweep's timing. |
 
 ---
 
@@ -393,4 +487,6 @@ and proving them is device-only.
 - [`../../CLAUDE.md`](../../CLAUDE.md) — module layout, gateways, DI rules.
 - `ThorJob.kt` and `ThorJobWorker.kt` KDocs are the primary source for chain policy and the
   no-`Result.retry()` rule. Where this document and a KDoc disagree, check the code: seven comments in
-  this subsystem were found stale on 2026-08-13.
+  this subsystem were found stale on 2026-08-13, and the retracted "the launcher does not await
+  `enqueue()`" claim was copied into two *new* files on 2026-08-14 before being caught. A retracted
+  comment spreads by being the nearest example to hand.

--- a/fastlane/metadata/android/en-US/changelogs/1943.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1943.txt
@@ -1,0 +1,11 @@
+• 💾 Back up an app and its data to one encrypted file, and restore it later. First test phase — try it on an app you can afford to lose.
+
+• 📤 Exporting an app now runs in the background and says when it's saved.
+
+• 🎮 Games with extra data export and install as one .xapk.
+
+• ⚙️ Settings has eight sections, a search box, and two panes on a tablet.
+
+• 🔑 Thor can remember your backup passphrase, or forget it on request.
+
+• 🧊 Unfreeze now unpauses too, and batches report what worked.

--- a/fastlane/metadata/android/hi-IN/changelogs/1943.txt
+++ b/fastlane/metadata/android/hi-IN/changelogs/1943.txt
@@ -1,0 +1,11 @@
+• 💾 Back up an app and its data to one encrypted file, and restore it later. First test phase — try it on an app you can afford to lose.
+
+• 📤 Exporting an app now runs in the background and says when it's saved.
+
+• 🎮 Games with extra data export and install as one .xapk.
+
+• ⚙️ Settings has eight sections, a search box, and two panes on a tablet.
+
+• 🔑 Thor can remember your backup passphrase, or forget it on request.
+
+• 🧊 Unfreeze now unpauses too, and batches report what worked.

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ org.gradle.welcome=never
 initialVersionCode=1921
 # REQUIRED: The active source of truth for our release manager
 # Logic: 1822 -> 1.82.2 (based on math: code/1000 . code%1000/10 . code%10)
-versionCode=1942
+versionCode=1943
 # versionName intentionally omitted — auto-calculated from versionCode by the
 # resolveVersionName()/calculateVersionName() helpers in app/build.gradle.kts
 # (1908 -> 1.90.8). Per CLAUDE.md, never set versionName directly; bump versionCode only.

--- a/release-notes/v1.94.3/github.md
+++ b/release-notes/v1.94.3/github.md
@@ -115,10 +115,11 @@ Three notes stated rather than glossed:
 * **A stopped export reports nothing from the worker.** WorkManager stops workers for its own
   reasons and then re-runs them, so a shade row saying "nothing was saved" would be a lie told at the
   exact moment the export was about to succeed. A genuine cancel is worded by the screen.
-* **This is also the feature that unblocks a `store` release.** Play requires a video declaration for
-  `FOREGROUND_SERVICE_DATA_SYNC`, and a reviewer can only verify what they can reproduce on a stock
-  device. Backup and restore need root or Shizuku on every path. Export needs neither, which is why
-  it is the surface the declaration will show.
+* **This is also the feature the blocked `store` release was waiting for.** Play requires a video
+  declaration for `FOREGROUND_SERVICE_DATA_SYNC`, and a reviewer can only verify what they can
+  reproduce on a stock device. Backup and restore need root or Shizuku on every path. Export needs
+  neither, which is why it is the surface the declaration will show. It does not lift the block by
+  itself — the video still has to be recorded on a stock device and the declaration submitted.
 
 Under the hood this is the third job on the seam (`3fa28f75`, `193d893e`, `b56143c6`), and it is the
 first that genuinely survives a process death: the archive jobs hold their key in memory and refuse a

--- a/release-notes/v1.94.3/github.md
+++ b/release-notes/v1.94.3/github.md
@@ -1,0 +1,456 @@
+# Thor v1.94.3 Release Notes
+
+**This release is v1.94.2 plus one feature, because v1.94.2 never reached anybody.** Its dev rung
+failed at the Play upload — `You must let us know whether your app uses any Foreground Service
+permissions` — and because that rejection happens inside `commit_current_edit!`, the Play edit was
+refused atomically. No tag was cut, no GitHub release was published, nothing was broadcast. Version
+code 1942 was then spent on a hand-uploaded internal build, so it cannot be reused; 1943 is the code
+that carries this work.
+
+Everything v1.94.2 described is therefore still new to everyone reading this, and the sections below
+are carried forward unchanged. The one addition is the reason 1943 exists as a separate build:
+**exporting an app now runs in the background.**
+
+Read the backup warning below before installing. One of these features ships deliberately unfinished,
+and the notes say so rather than letting the first person to try it find out.
+
+---
+
+## ⚠️ Backup & restore is in its first test phase
+
+**Back up an app you can afford to lose, and check the restore, before you trust it with one you
+cannot.**
+
+This is not a hedge added to the copy at the end. It is what the work actually looks like:
+
+* Nothing that replaces an app's data has ever run inside a test. That region is a WorkManager job
+  driving privileged shell commands against another app's data directory, and there is no JVM seam
+  anywhere in it. The unit tests in this release cover the container format, the key derivation, the
+  gates, the sizing arithmetic and the view models — **none of them writes to a real app's data
+  directory, because none of them can.**
+* Both Critical defects the review found were the same shape — *the backup cannot be restored* —
+  and both existed because, until late in the branch, **nothing wrote an archive with the real
+  backup path and read it back with the real restore path.** The commit that finally did
+  (`0e9fef25`) found them immediately. That is a strong hint about what else on-device use will
+  turn up.
+* Backup itself only reads. A failed backup cannot damage the app it was reading — Thor says so
+  explicitly in the failure copy. **Restore is the destructive half**, and it is the half to be
+  careful with.
+
+Restore is already gated hard: a signer mismatch is refused outright, an unverifiable signature is
+refused, an archive from a newer Thor is refused, and the replace itself sits behind an explicit
+"I understand this replaces the app's current data" confirmation. Those gates are tested. What is
+untested is what happens *after* you pass them, on your device, on your ROM.
+
+---
+
+## ✨ Highlights
+
+* 📤 **Exporting an app runs in the background.** Start an export, leave Thor, and it carries on —
+  with a progress notification, and a second notification naming the file when it lands.
+* 💾 **Back up an app and its data** into a single encrypted `.thorbak` — app data, startup data,
+  files and media on shared storage, and the app's own installer, each chosen separately.
+* ♻️ **Restore one later**, with every check shown before anything is replaced, and honest copy
+  about what was touched when something stops part-way.
+* 🔑 **A passphrase Thor can remember on the device, or forget when you ask.** Thor cannot recover
+  it, and says so at the point you choose it.
+* 🔔 **Backups and restores run in the background** with a progress notification, and tapping that
+  notification reopens that job's own sheet.
+* 🎮 **Games with expansion files export and install as one `.xapk`**, game data included, with the
+  App Info screen reporting how much of it there is.
+* 🐛 **The `.xapk` chip stopped refusing apps it should have accepted** — a fix for two stacked
+  defects found on hardware two days after the feature merged.
+* ⚙️ **Settings now has eight sections and a search box**, and opens a second pane on a tablet or
+  an unfolded phone.
+* 👂 **Every settings switch is readable by a screen reader.** All twelve announced as a button
+  with no on/off state before this release.
+* 🧊 **Unfreeze now clears both halves of frozen.** An app frozen by being *paused* came back
+  still paused, while the confirmation counted it as unfrozen.
+* 🔢 **A batch reports what actually happened.** Bulk unfreeze said "Unfrozen 12 apps" whether
+  twelve, one or none of them came back — and a run that reached the end could still sign off with
+  a "Stopped" line.
+* 🛑 **Thor skips itself in a Kill or Uninstall batch.** "Select all → Uninstall" reached Thor
+  itself, and with root or Shizuku it succeeded.
+* ⏹ **Bulk share can be stopped**, and hands over whatever it had already prepared.
+* 💳 **A subscription gets confirmed on paths where Thor never asked.** The backstop for a purchase
+  whose callback never arrives was being skipped in precisely the state it exists for.
+* 📥 **A failed export no longer costs you the file it was replacing.**
+* 🔐 **A privileged Thor grants its own permissions** instead of asking you to approve something it
+  can already do.
+
+---
+
+## What's Changed
+
+### 📤 Exporting an app runs in the background — the one thing 1943 adds
+
+Exporting a `.apk`, `.apks` or `.xapk` used to hold the sheet open. The button showed a spinner, the
+whole form sat there greyed out, and a toast reported the result — which meant the report only
+arrived if Thor was still in the foreground when the packaging finished. For a 4 GB game it very
+often was not, so the one message that mattered was the one most likely to be missing.
+
+An export is now a WorkManager job behind the same `dataSync` foreground service the archive jobs
+use. What that changes for you:
+
+* **You can leave.** The running frame has a **Background** button; dismissing the sheet drops the
+  screen's watcher and the export carries on. Reopening the sheet finds the same job still running
+  rather than a fresh form.
+* **It reports either way.** Progress is in the notification, and the outcome is a second
+  notification — *"Saved Clash of Clans to Downloads"*, or the actual reason it failed, with the
+  builder's own wording kept intact so *"about 1.4 GB more is needed"* survives to the shade instead
+  of being flattened to "Export failed".
+* **A second tap cannot eat the first export.** Both runs stage through the same folder, which the
+  builder wipes on entry, so a duplicate would have deleted the other's half-written copy and
+  finished a truncated zip "successfully". The sheet reattaches to the live job instead of offering
+  the form again.
+* **The form disappears while a job runs** rather than being disabled. Two chips, a destination row
+  and two dead buttons are something you can read, cannot use, and have to scroll past to reach the
+  only thing that is moving.
+
+Three notes stated rather than glossed:
+
+* **Multi-app export is *not* on this.** "Backup all" is still a plain coroutine on a
+  process-lifetime scope, and its non-adoption is argued in its own source rather than pending. This
+  release moves the single-app path only.
+* **A stopped export reports nothing from the worker.** WorkManager stops workers for its own
+  reasons and then re-runs them, so a shade row saying "nothing was saved" would be a lie told at the
+  exact moment the export was about to succeed. A genuine cancel is worded by the screen.
+* **This is also the feature that unblocks a `store` release.** Play requires a video declaration for
+  `FOREGROUND_SERVICE_DATA_SYNC`, and a reviewer can only verify what they can reproduce on a stock
+  device. Backup and restore need root or Shizuku on every path. Export needs neither, which is why
+  it is the surface the declaration will show.
+
+Under the hood this is the third job on the seam (`3fa28f75`, `193d893e`, `b56143c6`), and it is the
+first that genuinely survives a process death: the archive jobs hold their key in memory and refuse a
+re-run, while an export's whole input is four strings that are still true tomorrow. That exposed a
+race nothing had hit before — the launch-time cleanup deletes the staging tree wholesale, on the
+reasoning that anything using it "died with the process", which stops being true the moment
+WorkManager re-runs a worker *in* that process. A one-shot startup barrier now holds an export back
+until the sweep is over, and refuses to stage rather than proceeding if it times out.
+
+### 💾 App backup and restore (#379, #381)
+
+**Where it is.** *Back up* is in an app's action row. *Restore a backup* is in
+Settings → Backup & restore, alongside the passphrase.
+
+**What goes in the file.** One `.thorbak` container, encrypted with AES-256-GCM in framed chunks so
+a corrupted archive fails loudly at the damaged chunk rather than decrypting into rubbish. Four
+classes of data are offered, each ticked or not on its own:
+
+| Shown as | What it is |
+|---|---|
+| App data | the app's private data directory |
+| Startup data | the device-encrypted data an app reads before first unlock |
+| Files on shared storage | `Android/data` |
+| Media on shared storage | `Android/media` |
+
+The app's installer can be included too, which is what lets an archive restore an app that is no
+longer on the device. On its own it is refused — an installer with no data is just an APK, and Thor
+says that rather than writing a file that cannot restore anything.
+
+**The passphrase.** Chosen per backup, confirmed twice, and **not recoverable** — the warning sits
+next to the field, not in a FAQ. Thor will remember it on the device if you ask, and forget it on
+request from Settings. Changing the remembered passphrase does not re-encrypt anything already
+written: every archive still opens only with the passphrase it was made with, which the Settings
+copy states outright.
+
+**What it needs.** Root, or Shizuku started from root. Anything less cannot read another app's
+private data, so Thor refuses with that sentence rather than offering a button that fails — and the
+same refusal names what is planned instead: partial backups without root, in Thor 2.0.
+
+**Running.** Jobs go through WorkManager as a foreground service, so closing Thor does not stop a
+backup. The notification carries progress, and tapping it reopens the sheet belonging to *that*
+job. Only one archive job runs at a time; a queued one says so.
+
+**Restoring.** Every gate is shown before anything destructive happens:
+
+* **Refused** — the backup was made from an app signed by a different developer; the installed
+  app's signature cannot be read; the app is absent and the archive holds no installer; the archive
+  was written by a newer Thor; the archive does not say what format it is in.
+* **Warned** — the installed app is *older* than the backup (apps can crash on data from a newer
+  version); app data is selected without the startup data some apps need alongside it.
+
+Then the confirmation, then the replace. If it stops part-way, Thor says the app's data may be
+incomplete and that restoring again is the fix — and if it never started, it says that instead, so
+"failed" and "failed after changing your device" are never the same message.
+
+**What the review found.** Recorded here because the accountability record is the point of this
+file:
+
+* **Restore derived its key with Thor's current KDF rounds rather than the rounds recorded in the
+  archive** (`279d1582`). Any archive written before a rounds change would never open again.
+* **A replaced archive could leave the previous app's signer behind** (`09994a89`), so the signer
+  check — the one gate standing between an archive and another app's data — could be checking the
+  wrong app.
+* The `lib` symlink was being packed into the archive (`dd14a7e2`); the archive was written
+  somewhere other than the folder the sheet's own caption named (`4d399329`); a failed publish
+  stranded the partial file and could hand out a name already taken (`5aa575d5`); a killed write
+  could erase the ledger, and the copies a restore strands were not swept (`6acb4814`).
+* Several rounds went the other way — untested cipher guards deleted rather than documented
+  (`311cad28`), and four test claims retracted for naming a guard they did not actually cover
+  (`79c2b96e`).
+
+**The sheets** (#381). Both halves became sheets rather than screens: a running backup collapses to
+a bar with a way out and closes itself on success; restore reopens from its own notification. The
+review of that change found four ways the reopen handoff could open the wrong thing (`87c3d5fb`),
+and two overlapping reads that could split the sheet's identity in half (`3cbb47a8`, `d9603327`).
+
+### 🎮 Game data in `.xapk` (#376, #378)
+
+Expansion files (OBB) now travel with the app. Export packs them into the `.xapk`; installing a
+`.xapk` puts them back under `Android/obb`. The App Info screen reports how much game data an app
+has, or says plainly that it cannot check right now.
+
+The probe reads another app's storage on Thor's privileges, and an expansion **filename is
+controlled by the app being read**, so the guards are the substance of this work: a leaf name that
+tries to escape its directory is refused, symlinks are not followed on any privileged path, the
+package directory is checked and not merely the leaf, the entry count is capped, a repeated leaf is
+refused, and a `stat` that cannot measure a file **fails closed** rather than guessing at a size.
+
+**#378 is the hardware fix**, and it is worth reading as a pair of lessons:
+
+* **The probe killed the root shell.** Its script ended with a top-level `exit`. Odin's root
+  channel is *one long-lived `su` session*, so that `exit` did not end a script — it ended the
+  session, and everything Thor asked for afterwards came back with no result code. Shizuku spawns a
+  fresh shell per command and was completely unaffected, so **the same code failed on root and
+  passed on Shizuku**, which is exactly how it reached a device.
+* **A tri-state was collapsed to a boolean.** The probe answers *present*, *absent* or *cannot
+  tell*. The export gate read *cannot tell* as *no game data* and disabled the `.xapk` chip — for
+  the roughly 70% of apps that have no expansion files at all, which is to say most of them.
+* A `.xapk` built from an app with no game data now writes `"expansions": []` rather than omitting
+  the key, so a reader can tell "none" from "this file predates the field".
+
+### ⚙️ Settings: eight doors, and a second pane (#383)
+
+One long scrolling panel became an index of eight categories — Appearance, Home screen, Freezer,
+Installing & sharing, Security, Backup & restore, Extensions, About & support — at most two levels
+deep, with a **search box** that finds a setting by name, opens its category and highlights the row
+on arrival. On a tablet or an unfolded phone the category opens *beside* the index instead of on
+top of it.
+
+Every row's description is **two lines** now. The old switch row was one line with an opt-in
+marquee that started on a tap *on the subtitle* — a nested tap target inside a row whose whole
+surface already toggles the setting, so the gesture that revealed the description was
+indistinguishable from the one that changed it. Two lines fit every description Thor ships, in all
+five locales, so the scrolling text had nothing left to reveal.
+
+Three defects the review caught, all of which had shipped in the first push:
+
+* **The back stack leaked.** Picking a category while the Extension Manager was open pushed onto a
+  stack that never unwound, because the guard assumed only a category could sit on top — and the
+  Extension Manager is itself a detail pane, so the index stays visible beside it and you can pick
+  a category from there. Reproduced on hardware and confirmed fixed there.
+* **Usage Access and Notification Access were dead once granted.** Both guarded on the permission
+  still being *missing*, while the row reports the value the user is *asking for* — so switching
+  either off called the handler, the handler returned, and the switch snapped back with nothing
+  opened.
+* **No settings switch was readable by a screen reader.** The row was `clickable` (a button, with
+  no state) while the `Switch` beside it had its semantics cleared to stop the setting being
+  offered twice — so between them, nothing carried on or off, across all twelve toggles.
+
+Pinned by nine JVM tests over the catalogue (the exhaustive `when` proves every row reaches a
+branch, and says nothing about whether every category reaches a row) and seven instrumented tests
+over the switch row. Verified by hand on a Pixel 10 Pro Fold at 851 dp unfolded and 411 dp folded.
+
+### 🔢 The batch actions stop claiming work they did not do (#385)
+
+This began as groundwork for moving the bulk actions onto the job seam, and turned into a set of
+corrections that had to land first. Moving a batch that lies onto a background worker only makes the
+lie harder to see.
+
+**Unfreeze was clearing half of frozen.** An app can be frozen two ways — disabled, or *suspended*
+(what the Freezer's suspend mode, the quick-settings tile and extensions use). Both bulk unfreeze
+paths only re-enabled. So an app frozen by being paused came back still paused, still unusable, and
+its row was redrawn as unfrozen anyway. The Freezer's group unfreeze was worse than a partial fix:
+it planned the work from the app's *last known* flags, and for a paused app that plan came out empty
+— **it made no privileged call at all and returned success.** Both paths now always ask the system to
+unpause before re-enabling, instead of deciding from stale state.
+
+**The counts were unconditional.** Bulk unfreeze reported `Unfrozen %d apps` over the size of the
+selection, and marked every selected row as enabled, *whatever the system had actually answered* —
+so a run in which every app failed (privilege lost mid-batch, a ROM that refuses) was reported to
+the user as twelve successes. It now reports `Unfroze 3/12 apps (9 failed)`, and only the apps that
+really came back are redrawn.
+
+**A finished batch could describe itself as interrupted.** Tapping Stop while the last app was being
+processed produced "Stopped — 20 of 20 apps were processed." The gate tested whether a stop had been
+*requested* rather than whether anything was actually left undone. A completed destructive batch
+reporting itself as stopped is an invitation to run it again, so this touches all six batches that
+share the progress log — force-stop, clear cache, uninstall, reinstall, pause, unpause — plus bulk
+share.
+
+**Thor no longer force-stops or uninstalls itself.** Thor is in its own app list, so "select all →
+Kill" was two taps from killing the process running the batch: the remaining apps were abandoned
+silently and the progress log vanished with no report of where it had got to. "Select all →
+Uninstall" reached Thor too, and with root or Shizuku it *worked* — you could uninstall the app you
+were using, from inside it. Both now skip Thor and say so in the log.
+
+**Bulk share got a Stop button.** It is the slowest batch in the app — it builds an installable
+bundle per app — and it was the only one without a way out, so a 50-app share had to be waited out
+or force-stopped. Stopping now still hands the share sheet everything already prepared.
+
+**A second tap no longer eats the first run's file.** Export list and Share list both stage through
+one folder that is wiped when a run starts, so tapping again while a run was live could delete the
+file the first run had just handed to the share sheet. The second tap is now ignored.
+
+**The background-work notification switch was renamed** from "Backup and restore" to "Background
+jobs", because bulk actions are going to share it and nobody should end up silencing more than they
+agreed to. The channel id is unchanged, so this renames the existing switch rather than adding a
+second one — and, disclosed rather than glossed: **that rename is English-only for now.** The
+running notification also stops using the snowflake, which is Thor's *frozen app* icon, so every
+backup in progress had been advertising itself as a freeze.
+
+### 💳 Subscriptions: the sweep that was skipped exactly when it was needed (#386)
+
+Supporters' subscriptions were being refunded again after the v1.94.0 fix. First, what did *not*
+happen: nothing regressed. The acknowledgement path is byte-identical on `production`, `master` and
+`dev`, and last changed at versionCode 1933 — before v1.94.0 shipped. These are gaps that fix did
+not reach.
+
+Google refunds a purchase Thor fails to acknowledge within three days. The backstop for that is a
+sweep that asks Play for every subscription it knows about and confirms whatever is still
+unconfirmed — and it opened with `if (!isConnected) return`. That guard was pure loss. Verified
+against the artifact Gradle actually resolves (billing 9.1.0), a query on a disconnected client
+does not fail; it **rebinds**:
+
+```text
+BillingClientImpl.queryPurchasesAsync -> submits Callable zzbp
+zzbp.call()      -> BillingClientImpl.zzay(this, zzdq.zzb())   // synthetic accessor
+zzay(impl, long) -> impl.zzbx(long)
+zzbx(long)       -> zzby() ; zzaI(int).get(timeout) ; Math.pow + Thread.sleep
+```
+
+`zzbx` is the same helper already sitting at the head of the acknowledgement call — which is exactly
+why acknowledging was deliberately left unguarded. The sweep belonged in that set and had been left
+out of it. Asking a disconnected client rebuilds the binding; returning early guarantees nothing is
+swept.
+
+Resuming the app compounded it, because the sweep ran only inside the connected branch. Past the
+reconnect ladder's five attempts a resume answers *exhausted*, and any resume inside the 30-second
+cooldown answers *too soon* — in both cases the reconnect was a no-op, so **a resume with a dropped
+binding swept nothing for the remaining life of the process.** The sweep now runs on every resume
+regardless.
+
+Three more on the same path:
+
+* **Response code 7 now triggers a sweep instead of a toast.** Play answers `ITEM_ALREADY_OWNED`
+  when a purchase exists and is not being handed over — which is what it does when an earlier
+  acknowledgement never landed, making it the single code most likely to mean *you owe Play a
+  confirmation right now*. The purchase list is null on that path, so asking is the only route to
+  the token. The toast went too: "Billing error: 7" blamed the buyer for something they did not do.
+* **A cancelled attempt releases its purchase.** The token is claimed before the coroutine starts,
+  and two paths ended it without reaching either exit — so a stranded token made every later sweep
+  skip that purchase for the life of the process, which is the refund this code exists to prevent.
+* **Retries 4 → 6.** Four attempts spent the entire budget in about seven seconds. The failure they
+  exist for is a flaky network in the seconds after you return from the Play sheet — a lift, a
+  tunnel, a Wi-Fi handover — and seven seconds outlasts none of them.
+
+**Stated plainly, because this is the second attempt at the same bug:** this narrows the window, it
+does not close it. A buyer whose process dies mid-confirmation and who never reopens Thor inside
+Play's three days is still refunded, because the sweep only runs while the app is open. Closing that
+needs acknowledgement from a server Thor does not have, and is filed rather than claimed. This file
+is also **on no test classpath by construction** — the billing library is a Play-flavour-only
+dependency and the unit tests run against the FOSS flavour — so it is verified against bytecode and
+by hand, not by a test and not yet on a device.
+
+### 🔐 A privileged Thor stops asking, and an export stops deleting (#387)
+
+Three unrelated corrections that were finished in time to ride this release.
+
+**Thor grants its own permissions when it can.** Once it has root, Shizuku or Dhizuku, asking you to
+approve a runtime permission is asking permission to do something it can already do to itself, so it
+now grants what it has declared. Notification state is read through the same question the notifier
+itself asks rather than a permission check, because those two answers diverge the moment someone
+turns notifications off in system settings without revoking the permission. Nine JVM tests over the
+model.
+
+**A job that starts without notification access now asks for it**, at the moment the job starts,
+from the sheet that started it. A backup or restore running without it produces no progress
+notification at all, which is indistinguishable from nothing having happened. As of this release the
+export sheet asks the same question, for the same reason.
+
+**An export no longer deletes the old file before the new one exists.** Exporting over an existing
+file removed it first, so an export that failed or was interrupted left you with neither. Each
+backend now stages its bytes and settles once: the document picker writes a `.part` and renames over
+the replaced file at the end; the media store resolves the replaced row **before** inserting,
+because it de-duplicates a colliding display name at insert time rather than replacing it; the
+legacy Downloads path renames within one volume. The accepted cost, stated rather than hidden: an
+export killed mid-write leaves a `.part` file in the destination folder instead of a truncated one
+under the real name, and nothing sweeps it.
+
+**Verification, across everything in this release:** #385 and #387 are covered by unit tests
+wherever a JVM seam exists, #386 has none available to it at all, and the export job is covered at
+the seams a JVM test can reach — the request's `Data` round trip, the status reduction the screen
+renders, the startup barrier, and the failure wording. **None of it has been on a device.** The parts
+that most want a device are exactly the parts no JVM test can stand in for — the privileged
+gateways, the platform file APIs, the foreground service, and a real Play billing connection.
+
+---
+
+## 🔧 Internal
+
+* **WorkManager 2.11.2** and `koin-androidx-workmanager` join the build — Thor had no long-running
+  job seam before v1.94.2, and now has a reusable one carrying three job kinds (`c3956c6a`).
+* **AGP 9.4.0-alpha07 → alpha08**, **Gradle 9.6.1 → 9.7.0**, and four bumps in the maven group
+  (#377).
+* The `#51` plan documents still described a **WorkManager throttle the source had already
+  retracted** (#380) — the code was corrected in-branch and the docs were not, which is its own
+  small lesson about where a retraction has to be swept.
+* Localisation: the OBB export copy was retracted and rewritten across all five locales
+  (`25e6b10e`), the Arabic app name is kept as "Thor" rather than transliterated (`e9095478`), and
+  the Chinese export explainer no longer opens a sentence with a bare file extension (`6948d0c0`).
+  The export job's own copy — the queued line, the Background button, and the sentence the outcome
+  notification carries — was written into all five locales with it (`1a806e4e`), and the now-unused
+  in-progress button label was removed from every one of them. The one new string in #385 — the line
+  saying Thor skipped itself — **was translated into the other four locales without a native
+  reader**, and is the weakest copy in this release. Corrections welcome.
+* **The job seam was generalised so something that is not an archive can use it** (#385): the
+  encryption-key handling moved out of the shared base class into the two archive jobs, job-watching
+  became its own interface, and enqueue-and-confirm became one shared function. v1.94.2 listed the
+  second queue and the after-the-fact completion notification as **built-ahead with no producer**.
+  The completion notification now has one — the export's outcome row is exactly that mechanism in
+  use. The second queue still has none.
+* **The dev rung now puts its one upload on two Play tracks** (#388): `dev` uploads to `alpha` and
+  then *assigns that same release* to `internal`, which is not a second upload and is non-fatal if
+  it fails. Play allows one upload per version code per app, so a second uploader would be an error
+  rather than a shortcut.
+* `docs/workers/README.md` records which operations actually run on WorkManager — **three** as of
+  this release, not two — and what the rest are, because the naming misleads in both directions. It
+  states its gaps rather than hiding them, including the one this release created: `LaunchSweepBarrier`
+  is opt-in, and a future job that stages into the swept tree and forgets it loses the same race
+  silently.
+* A retraction that had already been made once got copied forward anyway. Four comments in the tree
+  claim the job launcher does not await its enqueue; it has awaited it since that function grew an
+  awaited `Operation`, and two *new* files picked the claim up from the nearest example to hand
+  before it was caught (`f43b5f29`). The four originals are now listed by file and line so the next
+  sweep has somewhere to start.
+
+⚠️ **Tag naming, for anyone following a compare link:** only a *production* release mints a plain
+`v<version>` tag. Neither `v1.94.1` nor `v1.94.2` reached production, and v1.94.2 never published at
+all, so neither of those tags exists. The pre-release tag `v1.94.1-dev-12` is the one that resolves,
+and the link below uses it.
+
+---
+
+## 🛠 Commits Log (`v1.94.1-dev-12...dev`)
+
+* `f43b5f29` — record the third job on the seam, and retract a comment that had just been spread
+* `b56143c6` — hand a single-app export to the worker, and let the user walk away
+* `193d893e` — run a single-app export on a worker that always says how it went
+* `3fa28f75` — give export a job kind and a contract that survives a re-run
+* `1a806e4e` — the sentences an export says when nobody is watching, in five locales
+* `9ed08d06` — #384 release 1942 — backup and restore, in its first test phase (never published)
+* `82d08433` — #388 put the dev rung's build on internal as well as alpha
+* `7b930c58` — #387 grant our own permissions, ask for notifications when a job starts, and stop
+  deleting an export before its replacement exists
+* `0ef6732d` — #386 stop the guard that skipped the sweep Play refunds you for missing
+* `bf4dff26` — #385 make the batch actions tell the truth, and generalise the job seam
+* `e210768f` — #383 Settings: eight doors, and a second pane on wide windows
+* `4c5edad9` — #381 both archive surfaces are sheets, and a job notification reopens its own
+* `d3315c3f` — #380 finish the throttle retraction the source got and the docs did not
+* `940480ef` — #379 app data backup and restore (#51 phase 2)
+* `0fd72541` — #378 stop `.xapk` export refusing every app whose game data it cannot read
+* `73b47e5e` — #377 bump the maven group with 4 updates
+* `91100e58` — #376 OBB support in `.xapk` export and install (#164)
+
+**Full changelog**: https://github.com/trinadhthatakula/Thor/compare/v1.94.1-dev-12...dev

--- a/release-notes/v1.94.3/playstore.txt
+++ b/release-notes/v1.94.3/playstore.txt
@@ -1,0 +1,11 @@
+• 💾 Back up an app and its data to one encrypted file, and restore it later. First test phase — try it on an app you can afford to lose.
+
+• 📤 Exporting an app now runs in the background and says when it's saved.
+
+• 🎮 Games with extra data export and install as one .xapk.
+
+• ⚙️ Settings has eight sections, a search box, and two panes on a tablet.
+
+• 🔑 Thor can remember your backup passphrase, or forget it on request.
+
+• 🧊 Unfreeze now unpauses too, and batches report what worked.

--- a/release-notes/v1.94.3/telegram.md
+++ b/release-notes/v1.94.3/telegram.md
@@ -1,0 +1,19 @@
+💾 **Thor v1.94.3 — back up an app, export in the background.**
+
+⚠️ **Backup & restore is in its first test phase.** Try it on an app you can afford to lose.
+
+**New:**
+
+• 📤 **Exporting an app runs in the background.** Close Thor and it carries on; a notification says when it's saved.
+
+• 💾 **Back up an app and its data** into one encrypted `.thorbak` — app data, shared storage and the installer, each chosen separately.
+
+• ♻️ **Restore it later.** Every check is shown before anything is replaced.
+
+• 🔑 **A passphrase Thor can remember**, or forget when you ask. It cannot be recovered.
+
+• 🎮 **Games with extra data** export and install as one `.xapk`.
+
+• ⚙️ **Settings now has eight sections**, a search box, and two panes on a tablet.
+
+• 🧊 **Unfreeze now unpauses too**, and batches report what worked.


### PR DESCRIPTION
## What this is

Two things in one branch, because the second exists to ship the first:

1. **Single-app export moves onto the job seam** — a WorkManager job behind the same `dataSync` foreground service the archive jobs use, so you can start an export and leave.
2. **Release 1943**, carrying v1.94.2's notes forward. v1.94.2 was built and **never published**: the dev rung failed at `client.commit_current_edit!` with *"You must let us know whether your app uses any Foreground Service permissions"*, and that rejection is atomic — no `v1.94.2` tag, no GitHub release, no broadcast on any channel. Code 1942 was then spent on a hand-uploaded internal build, so it cannot be reused.

Per the owner's instruction this ships from the feature branch rather than a separate `chore/release-1943` branch.

## Why export, specifically

Play requires a video declaration for `FOREGROUND_SERVICE_DATA_SYNC`, and a reviewer can only verify what they can reproduce on a stock device. Backup and restore need root or Shizuku on **every** path, so a video of either is unverifiable by the person who has to approve it. Export needs neither privilege. It is the surface that exists to be filmable — that reasoning is now written into `docs/workers/README.md` rather than living in a chat log.

## What changes for a user

* **You can leave.** The running frame has a **Background** button; dismissing the sheet drops the screen's watcher and the export carries on. Reopening finds the same job running rather than a fresh form.
* **It reports either way.** Progress in the notification, outcome in a second notification — *"Saved <app> to Downloads"*, or the real reason it failed, with the builder's own wording preserved so *"about 1.4 GB more is needed"* survives to the shade instead of flattening to "Export failed". Previously the result was a toast, which only arrived if Thor was still foregrounded when a 4 GB game finished packaging.
* **A second tap cannot eat the first export.** Both runs stage through one folder the builder wipes on entry, so a duplicate would have deleted the other's half-written copy and finished a truncated zip *successfully*. The sheet reattaches instead of re-offering the form.
* **The form disappears while a job runs** rather than sitting greyed out above the only thing that is moving.

## Three things deliberately **not** done

* **Multi-app export stays a plain coroutine.** "Backup all" is unchanged and its non-adoption is argued in `BackupRunner`'s own KDoc. This branch moves the single-app path only.
* **A WorkManager-stopped export reports nothing from the worker.** WorkManager stops workers for its own reasons and then re-runs them; a shade row saying "nothing was saved" would be a lie told at the moment the export was about to succeed. A genuine cancel is worded by the screen.
* **`sheetTarget` is null for `APP_EXPORT`.** Tapping the progress notification opens Thor, not a sheet — the export sheet is per-app-info and there is no route that reconstructs it from a package name alone.

## The race this exposed, and `LaunchSweepBarrier`

`APP_EXPORT` is the first job on this seam that genuinely **completes** on a re-run. Both archive workers refuse one, because their encryption key is process memory; an export's whole input is four strings that are still true tomorrow.

That falsifies an assumption the launch-time cleanup was built on. `ArchiveOrphanSweeper.sweep()` `deleteRecursively()`s `externalCacheDir/obb_out` wholesale, reasoning that anything using it "died with the process" — which stops being true the instant WorkManager re-runs a worker **in** that process. A one-shot `CompletableDeferred`, completed from a `finally` in `ThorApplication`, holds an export back until the sweep is over; on timeout (120 s) it **refuses to stage** rather than proceeding.

Stated as a gap rather than glossed: **the barrier is opt-in.** A future job that stages into the swept tree and forgets to take it loses the same race, silently. That is written into the doc's known-gaps section and into the "adding a new job kind" checklist.

## Docs

`docs/workers/README.md` opened by saying *two* operations use WorkManager. There are three. Beyond the arithmetic, two of its claims were true only of a seam carrying archive work:

* *"Being on WorkManager here does not mean durable"* now holds for **two of the three**, and the doc names which side each kind sits on.
* *"Export" means two different things in this repo* — a warning up top says to read the kind, not the verb.

Also folded in, because a doc commit is the only honest place for it: `JobPhase.kt` and `JobPhaseTest.kt` carried the **retracted** *"the launcher does not await `enqueue()`"* comment, which I copied out of the backup side four commits earlier. `enqueueUniqueJob` has awaited its `Operation` since it grew `awaitSuccess()`; the doc has a callout counting **four** stale copies and I had quietly made it six. Both now give the reason that is actually load-bearing — a null `WorkInfo` is "no row for this id" as much as "the row was pruned", and only the order tells them apart. The four remaining sites are now listed by file and line.

⚠️ `CLAUDE.md` says "exactly two operations" and is **not** in this branch: it is gitignored (`.gitignore:35`) and has never been tracked, so its copy of the claim cannot be corrected from the repo. `docs/workers/README.md` is the copy to trust.

## Release 1943

`github.md` keeps every v1.94.2 section intact — they are still news to everyone, since nobody received them — and opens by saying what happened to the release they were written for. Added: the export section, a Highlights bullet, #388 in Internal (the dev rung now assigns its one upload to `internal` as well as `alpha`), and two corrections to Internal claims that went stale inside the same release.

`sync-shizu-changelog.sh` is deliberately **not** run: it resolves `versionCode` from `origin/production`, so during prep it syncs the last *production* release, prints "already current" and exits 0 while the new version never lands. `shizu_store.json` is untouched and still pins 1940, which `check-shizu-manifest.sh` confirms is correct.

## Verification

| Check | Result |
|---|---|
| `:app:testFossDebugUnitTest --rerun-tasks` | **1579 tests, 0 failures** across 116 suites (counts parsed from `test-results/**/*.xml`) |
| `check-notes-budget.sh 1.94.3` | playstore **484/500** chars; telegram **976/1024** caption units |
| `.github/scripts/test/run-tests.sh` | **10 files, 0 failed** — locale parity among them |
| `check-shizu-manifest.sh` | all checks passed |
| `1943.txt` in both locales | byte-identical to `playstore.txt` (a locale missing its file does not fall back — it blanks that locale's what's-new) |
| Closing keywords in notes | none (`master` is the default branch, so a `dev` → `master` body would act on them) |

New JVM coverage on this branch: `AppExportRequestTest` (10), `JobPhaseTest` (10), `LaunchSweepBarrierTest` (6), `AppExportWorkerReasonTest` (4) — the `Data` round trip, the status reduction the screen renders, the startup barrier, and the failure wording.

**Not on a device.** The parts that most want one are exactly the parts no JVM test can stand in for: the foreground service, the platform file APIs, and the notification behaviour across a real process death. Filming the declaration video is the next step and will exercise all three.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background single-app exports with APK and XAPK support.
  * Export to Downloads or custom folders continues while the app is backgrounded.
  * Added progress tracking, completion notifications, cancellation, retry, and actionable failure messages.
  * Export screens reconnect to active jobs after reopening.
  * Added detailed export status messages in supported languages.

* **Bug Fixes**
  * Improved startup cleanup coordination to prevent exports from beginning prematurely.

* **Documentation**
  * Updated worker documentation and release notes for background exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->