### PR TITLE
i18n: take the MissingTranslation exemption off strings_backup.xml

### DIFF
--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Backup and restore strings (#51 phase 2). Untranslated for now: these ship
-  English-only and are exempted from MissingTranslation at the file level, the
-  same way values/non-translatable.xml is. Translating them is a follow-up row,
-  not a blocker — see docs/follow-ups/app-data-backup-and-xapk-export.md.
-  Do NOT move these into values/strings.xml until values-ar, values-es,
-  values-fr and values-zh-rCN all carry them, or lint turns fatal.
+  Backup and restore strings (#51 phase 2). These were English-only for a while
+  behind a file-level MissingTranslation exemption; every translated locale now
+  carries them, so the exemption is gone and lint guards this file like any
+  other. Adding a string here therefore obliges you to add it to all seven
+  values-<locale>/strings_backup.xml (and values-pt-rBR only if Brazilian usage
+  differs) — that is the point of removing the marker. The tools namespace stays
+  for the two element-level PluralsCandidate suppressions further down.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="job_backing_up">Backing up</string>
     <string name="job_restoring">Restoring</string>
     <!--


### PR DESCRIPTION
Follow-up to #395, which deliberately left this out to keep that diff reviewable.

`app/src/main/res/values/strings_backup.xml` carried a **file-level
`tools:ignore="MissingTranslation"`**, plus a comment saying not to move the strings into
`values/strings.xml` "until `values-ar`, `values-es`, `values-fr` and `values-zh-rCN` all carry
them". They all carry them now — #395 backfilled 94 strings and 1 plural into those four locales
and shipped the full set in `pt`, `pt-rBR` and `pl` — so the marker has nothing left to defer.

## Why this is worth its own PR

The marker's cost was never that those strings shipped in English. It was that **nothing reported
they were**. The file built green for months while ~14% of the app was untranslated in every
language, and the follow-up row that was supposed to track it sized the job at "508 strings" — the
real figure was 675, because the row was counting the strings lint could see.

Leaving the marker in place would carry that forward: every string added to this file in future
would be exempt too, silently.

## `xmlns:tools` stays

Two strings further down (`restore_archive_version`, `passphrase_error_too_short`) carry
element-level `tools:ignore="PluralsCandidate"`. Removing the namespace declaration with those
still present does not parse, so only the file-level attribute goes.

## Verification

| Check | Result |
|---|---|
| `./gradlew :app:lintFossDebug` | **0 errors, 0 warnings**, 13 hints |
| `./gradlew :app:lintStoreRelease` | **0 errors, 0 warnings**, 13 hints |
| `MissingTranslation` issues in either report | **0** |

That last row is the point: the *same two commands passed before this change* while 94 strings were
missing from four locales, because the marker was suppressing precisely this check. Passing now,
with the check live, is what actually demonstrates the backfill was complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
