### PR TITLE
i18n: proofread ar, es, fr and zh-rCN — 26 defects every check passes

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -79,7 +79,7 @@
     <string name="others">أخرى</string>
     <string name="clear_all_cache">مسح جميع الذاكرة المؤقتة</string>
     <string name="clear_all_cache_subtitle">مسح الملفات المؤقتة لجميع التطبيقات لاستعادة مساحة التخزين</string>
-    <string name="clear_all_cache_confirm_desc">أندرويد هو من يقرر أي ذاكرة مؤقتة تُمسح، ولا يتيح لـ Thor الاختيار — تشمل العملية كل تطبيقات الجهاز، تطبيقات النظام وتطبيقاتك على حد سواء. لن يُمسّ أي شيء آخر: بياناتك وتسجيلات دخولك وإعداداتك تبقى كما هي. قد تفتح التطبيقات ببطء بسيط في المرة الأولى بينما تعيد بناء ذاكرتها المؤقتة.</string>
+    <string name="clear_all_cache_confirm_desc">Android هو من يقرر أي ذاكرة مؤقتة تُمسح، ولا يتيح لـ Thor الاختيار — تشمل العملية كل تطبيقات الجهاز، تطبيقات النظام وتطبيقاتك على حد سواء. لن يُمسّ أي شيء آخر: بياناتك وتسجيلات دخولك وإعداداتك تبقى كما هي. قد تفتح التطبيقات ببطء بسيط في المرة الأولى بينما تعيد بناء ذاكرتها المؤقتة.</string>
     <string name="clear_all_cache_running">جارٍ المسح…</string>
     <string name="clear_all_cache_running_desc">جارٍ العمل على كل تطبيقات الجهاز. قد يستغرق ذلك لحظة.</string>
     <string name="clear_all_cache_done_title">تم مسح الذاكرة المؤقتة</string>
@@ -205,23 +205,23 @@
     <string name="tile_no_apps">لا توجد تطبيقات</string>
     <!-- ar plural forms seeded from the base translation; pending native review -->
     <plurals name="tile_subtitle_format">
-        <item quantity="zero">%1$d تطبيقات · اضغط للتجميد</item>
-        <item quantity="one">%1$d تطبيقات · اضغط للتجميد</item>
-        <item quantity="two">%1$d تطبيقات · اضغط للتجميد</item>
+        <item quantity="zero">لا توجد تطبيقات · اضغط للتجميد</item>
+        <item quantity="one">تطبيق واحد · اضغط للتجميد</item>
+        <item quantity="two">تطبيقان · اضغط للتجميد</item>
         <item quantity="few">%1$d تطبيقات · اضغط للتجميد</item>
-        <item quantity="many">%1$d تطبيقات · اضغط للتجميد</item>
-        <item quantity="other">%1$d تطبيقات · اضغط للتجميد</item>
+        <item quantity="many">%1$d تطبيقًا · اضغط للتجميد</item>
+        <item quantity="other">%1$d تطبيق · اضغط للتجميد</item>
     </plurals>
     <string name="tile_grant_privilege_toast">امنح صلاحية Root / Shizuku / Dhizuku أولاً</string>
     <string name="tile_no_apps_toast">لا توجد تطبيقات في المجمد</string>
     <!-- ar plural forms seeded from the base translation; pending native review -->
     <plurals name="tile_freeze_success">
-        <item quantity="zero">تم تجميد %1$d تطبيقات</item>
-        <item quantity="one">تم تجميد %1$d تطبيقات</item>
-        <item quantity="two">تم تجميد %1$d تطبيقات</item>
+        <item quantity="zero">لم يتم تجميد أي تطبيق</item>
+        <item quantity="one">تم تجميد تطبيق واحد</item>
+        <item quantity="two">تم تجميد تطبيقين</item>
         <item quantity="few">تم تجميد %1$d تطبيقات</item>
-        <item quantity="many">تم تجميد %1$d تطبيقات</item>
-        <item quantity="other">تم تجميد %1$d تطبيقات</item>
+        <item quantity="many">تم تجميد %1$d تطبيقًا</item>
+        <item quantity="other">تم تجميد %1$d تطبيق</item>
     </plurals>
     <string name="tile_freeze_partial_failure">تم تجميد %1$d/%2$d تطبيقات (فشل %3$d)</string>
     <string name="tile_freeze_incomplete">تم تجميد %1$d/%2$d تطبيقات (%3$d لم تكتمل)</string>
@@ -242,23 +242,23 @@
     <string name="import_disabled_apps_title">استيراد التطبيقات المعطلة</string>
     <!-- ar plural forms seeded from the base translation; pending native review -->
     <plurals name="import_disabled_apps_desc">
-        <item quantity="zero">هناك %1$d تطبيق معطل غير موجود في قائمة المجمد. هل ترغب في إضافتها إلى المجمد؟</item>
-        <item quantity="one">هناك %1$d تطبيق معطل غير موجود في قائمة المجمد. هل ترغب في إضافتها إلى المجمد؟</item>
-        <item quantity="two">هناك %1$d تطبيق معطل غير موجود في قائمة المجمد. هل ترغب في إضافتها إلى المجمد؟</item>
-        <item quantity="few">هناك %1$d تطبيق معطل غير موجود في قائمة المجمد. هل ترغب في إضافتها إلى المجمد؟</item>
-        <item quantity="many">هناك %1$d تطبيق معطل غير موجود في قائمة المجمد. هل ترغب في إضافتها إلى المجمد؟</item>
+        <item quantity="zero">لا توجد تطبيقات معطلة خارج قائمة المجمد.</item>
+        <item quantity="one">هناك تطبيق واحد معطل غير موجود في قائمة المجمد. هل ترغب في إضافته إلى المجمد؟</item>
+        <item quantity="two">هناك تطبيقان معطلان غير موجودين في قائمة المجمد. هل ترغب في إضافتهما إلى المجمد؟</item>
+        <item quantity="few">هناك %1$d تطبيقات معطلة غير موجودة في قائمة المجمد. هل ترغب في إضافتها إلى المجمد؟</item>
+        <item quantity="many">هناك %1$d تطبيقًا معطلًا غير موجود في قائمة المجمد. هل ترغب في إضافتها إلى المجمد؟</item>
         <item quantity="other">هناك %1$d تطبيق معطل غير موجود في قائمة المجمد. هل ترغب في إضافتها إلى المجمد؟</item>
     </plurals>
     <string name="import_disabled_apps_button">استيراد التطبيقات المعطلة</string>
     <string name="no_disabled_apps_found">لم يتم العثور على تطبيقات معطلة أخرى.</string>
     <!-- ar plural forms seeded from the base translation; pending native review -->
     <plurals name="added_to_freezer_count_success">
-        <item quantity="zero">تمت إضافة %1$d تطبيقات إلى المجمد</item>
-        <item quantity="one">تمت إضافة %1$d تطبيقات إلى المجمد</item>
-        <item quantity="two">تمت إضافة %1$d تطبيقات إلى المجمد</item>
+        <item quantity="zero">لم تتم إضافة أي تطبيق إلى المجمد</item>
+        <item quantity="one">تمت إضافة تطبيق واحد إلى المجمد</item>
+        <item quantity="two">تمت إضافة تطبيقين إلى المجمد</item>
         <item quantity="few">تمت إضافة %1$d تطبيقات إلى المجمد</item>
-        <item quantity="many">تمت إضافة %1$d تطبيقات إلى المجمد</item>
-        <item quantity="other">تمت إضافة %1$d تطبيقات إلى المجمد</item>
+        <item quantity="many">تمت إضافة %1$d تطبيقًا إلى المجمد</item>
+        <item quantity="other">تمت إضافة %1$d تطبيق إلى المجمد</item>
     </plurals>
     <string name="add_to_freezer">إضافة للمجمد</string>
     <string name="freezer_add_warning_title">الإضافة تُجمّده فورًا</string>
@@ -286,12 +286,12 @@
     <string name="added_to_freezer_success">تمت الإضافة إلى المجمد</string>
     <!-- ar plural forms seeded from the base translation; pending native review -->
     <plurals name="unfrozen_count_success">
-        <item quantity="zero">تم إلغاء تجميد %1$d تطبيقات</item>
-        <item quantity="one">تم إلغاء تجميد %1$d تطبيقات</item>
-        <item quantity="two">تم إلغاء تجميد %1$d تطبيقات</item>
+        <item quantity="zero">لم يتم إلغاء تجميد أي تطبيق</item>
+        <item quantity="one">تم إلغاء تجميد تطبيق واحد</item>
+        <item quantity="two">تم إلغاء تجميد تطبيقين</item>
         <item quantity="few">تم إلغاء تجميد %1$d تطبيقات</item>
-        <item quantity="many">تم إلغاء تجميد %1$d تطبيقات</item>
-        <item quantity="other">تم إلغاء تجميد %1$d تطبيقات</item>
+        <item quantity="many">تم إلغاء تجميد %1$d تطبيقًا</item>
+        <item quantity="other">تم إلغاء تجميد %1$d تطبيق</item>
     </plurals>
     <string name="tile_unfreeze_partial_failure">تم إلغاء تجميد %1$d/%2$d تطبيقات (فشل %3$d)</string>
     <string name="tile_unfreeze_incomplete">تم إلغاء تجميد %1$d/%2$d تطبيقات (%3$d لم تكتمل)</string>
@@ -299,12 +299,12 @@
     <string name="failed_to_load_apps">فشل في تحميل التطبيقات</string>
     <!-- ar plural forms seeded from the base translation; pending native review -->
     <plurals name="removed_from_freezer_success">
-        <item quantity="zero">تمت إزالة %1$d تطبيقات من المجمد</item>
-        <item quantity="one">تمت إزالة %1$d تطبيقات من المجمد</item>
-        <item quantity="two">تمت إزالة %1$d تطبيقات من المجمد</item>
+        <item quantity="zero">لم تتم إزالة أي تطبيق من المجمد</item>
+        <item quantity="one">تمت إزالة تطبيق واحد من المجمد</item>
+        <item quantity="two">تمت إزالة تطبيقين من المجمد</item>
         <item quantity="few">تمت إزالة %1$d تطبيقات من المجمد</item>
-        <item quantity="many">تمت إزالة %1$d تطبيقات من المجمد</item>
-        <item quantity="other">تمت إزالة %1$d تطبيقات من المجمد</item>
+        <item quantity="many">تمت إزالة %1$d تطبيقًا من المجمد</item>
+        <item quantity="other">تمت إزالة %1$d تطبيق من المجمد</item>
     </plurals>
     <string name="killed_success">تم إنهاء %1$s</string>
     <string name="cache_cleared_success">تم مسح ذاكرة التخزين المؤقت لـ %1$s</string>
@@ -312,7 +312,7 @@
     <string name="data_cleared_success">تم مسح بيانات %1$s</string>
     <string name="suspended_success">تم تعليق %1$s</string>
     <string name="unsuspended_success">تم إلغاء تعليق %1$s</string>
-    <string name="unfreezing_app">جاري إلغاء تجميد %1$s…</string>
+    <string name="unfreezing_app">جارٍ إلغاء تجميد %1$s…</string>
     <string name="uninstall_success">تم إلغاء تثبيت %1$s</string>
     <string name="error_app_info_missing">خطأ: معلومات التطبيق مفقودة للإجراء</string>
     <string name="failed_to_load_app_details">فشل في تحميل تفاصيل التطبيق</string>
@@ -363,7 +363,7 @@
     <string name="section_services_title">الخدمات (%1$d)</string>
     <string name="section_receivers_title">مستقبلات البث (%1$d)</string>
     <string name="section_providers_title">موفرو المحتوى (%1$d)</string>
-    <string name="cd_collapse">طوي</string>
+    <string name="cd_collapse">طي</string>
     <string name="cd_expand">توسيع</string>
     <string name="components_none_declared">لم يتم الإعلان عن أي منها</string>
     <string name="section_native_libs_title">المكتبات الأصلية (.so)</string>
@@ -380,7 +380,7 @@
     <string name="try_again">حاول مجدداً</string>
     <string name="exit">خروج</string>
     <string name="title_thor_installer">مثبت Thor</string>
-    <string name="install_analyzing">جاري تحليل الحزمة…</string>
+    <string name="install_analyzing">جارٍ تحليل الحزمة…</string>
     <string name="install_downgrade_warning">سيؤدي هذا إلى خفض إصدار التطبيق.</string>
     <string name="install_downgrade_code_explainer">رمز الإصدار %1$s أقل من المثبَّت %2$s. يرتّب Android التحديثات حسب رمز الإصدار لا حسب اسم الإصدار، لذا قد يبدو التطبيق أحدث وهو في الواقع خفض للإصدار.</string>
     <string name="install_update_warning">سيؤدي هذا إلى تحديث التطبيق الحالي.</string>
@@ -489,7 +489,7 @@
     <string name="biometric_unavailable_message">قفل التطبيق مُفعَّل، لكن لا يوجد في هذا الجهاز ما يمكن إلغاء القفل به. قم بإعداد قفل شاشة أو تسجيل بصمة من إعدادات النظام ثم عُد — وسيسمح لك Thor بالدخول.</string>
     <string name="biometric_unavailable_message_biometric_only">قفل التطبيق مُفعَّل، لكن لا توجد بصمة مُسجَّلة على هذا الجهاز، وفي Android 9 لا يمكن لطلب إلغاء القفل قبول قفل الشاشة. سجِّل بصمة من إعدادات النظام ثم عُد — وسيسمح لك Thor بالدخول.</string>
     <string name="biometric_not_enrolled_toast">لا توجد بيانات حيوية مُسجَّلة — أعدّ قفل شاشة أو بصمة أولاً</string>
-    <string name="biometric_not_enrolled_toast_biometric_only">لا توجد بصمة مُسجَّلة — في أندرويد 9 لا يفتح قفل الشاشة تطبيق ثور، فسجّل بصمة أولاً</string>
+    <string name="biometric_not_enrolled_toast_biometric_only">لا توجد بصمة مُسجَّلة — في Android 9 لا يفتح قفل الشاشة تطبيق Thor، فسجّل بصمة أولاً</string>
     <string name="biometric_lock_unavailable_toast">لا يمكن تفعيل قفل التطبيق: لا توجد في هذا الجهاز مقاييس حيوية لإلغاء قفله</string>
     <string name="biometric_lock_disabled_no_biometric">تم إيقاف قفل التطبيق: لا توجد في هذا الجهاز مقاييس حيوية لإلغاء قفله</string>
     <string name="settings_lost_using_defaults">تعذّر على Thor قراءة إعداداتك، ويستخدم الآن الإعدادات الافتراضية: تحقّق من قفل التطبيق في الإعدادات</string>
@@ -604,14 +604,14 @@
     <string name="freeze_all_apps">تجميد الكل</string>
     <string name="shortcuts">الاختصارات</string>
     <string name="shortcut_add_all">إضافة جميع التطبيقات</string>
-    <string name="shortcut_added_named">تم إضافة %1$s إلى الشاشة الرئيسية</string>
-    <string name="shortcut_added">تم إضافة الاختصار إلى الشاشة الرئيسية</string>
+    <string name="shortcut_added_named">تمت إضافة %1$s إلى الشاشة الرئيسية</string>
+    <string name="shortcut_added">تمت إضافة الاختصار إلى الشاشة الرئيسية</string>
     <string name="pin_all_confirm_title">إضافة جميع التطبيقات إلى الشاشة الرئيسية؟</string>
     <!-- ar plural forms seeded from the base translation; pending native review -->
     <plurals name="pin_all_confirm_desc">
-        <item quantity="zero">سيؤدي هذا إلى إضافة اختصار على الشاشة الرئيسية لكل تطبيق من تطبيقاتك المجمدة الـ %1$d وقد يملأ شاشتك الرئيسية. ستطلب منك شاشة التشغيل تأكيد كل منها.</item>
-        <item quantity="one">سيؤدي هذا إلى إضافة اختصار على الشاشة الرئيسية لكل تطبيق من تطبيقاتك المجمدة الـ %1$d وقد يملأ شاشتك الرئيسية. ستطلب منك شاشة التشغيل تأكيد كل منها.</item>
-        <item quantity="two">سيؤدي هذا إلى إضافة اختصار على الشاشة الرئيسية لكل تطبيق من تطبيقاتك المجمدة الـ %1$d وقد يملأ شاشتك الرئيسية. ستطلب منك شاشة التشغيل تأكيد كل منها.</item>
+        <item quantity="zero">لا توجد لديك تطبيقات مجمدة لإضافتها إلى الشاشة الرئيسية.</item>
+        <item quantity="one">سيؤدي هذا إلى إضافة اختصار على الشاشة الرئيسية لتطبيقك المجمد الوحيد. ستطلب منك شاشة التشغيل تأكيده.</item>
+        <item quantity="two">سيؤدي هذا إلى إضافة اختصار على الشاشة الرئيسية لكلا تطبيقيك المجمدين. ستطلب منك شاشة التشغيل تأكيد كل منهما.</item>
         <item quantity="few">سيؤدي هذا إلى إضافة اختصار على الشاشة الرئيسية لكل تطبيق من تطبيقاتك المجمدة الـ %1$d وقد يملأ شاشتك الرئيسية. ستطلب منك شاشة التشغيل تأكيد كل منها.</item>
         <item quantity="many">سيؤدي هذا إلى إضافة اختصار على الشاشة الرئيسية لكل تطبيق من تطبيقاتك المجمدة الـ %1$d وقد يملأ شاشتك الرئيسية. ستطلب منك شاشة التشغيل تأكيد كل منها.</item>
         <item quantity="other">سيؤدي هذا إلى إضافة اختصار على الشاشة الرئيسية لكل تطبيق من تطبيقاتك المجمدة الـ %1$d وقد يملأ شاشتك الرئيسية. ستطلب منك شاشة التشغيل تأكيد كل منها.</item>
@@ -670,12 +670,12 @@
     <string name="action_save">حفظ</string>
     <string name="more_options">المزيد من الخيارات</string>
     <plurals name="profile_app_count">
-        <item quantity="zero">%1$d تطبيقات</item>
-        <item quantity="one">%1$d تطبيق</item>
-        <item quantity="two">%1$d تطبيقان</item>
+        <item quantity="zero">لا توجد تطبيقات</item>
+        <item quantity="one">تطبيق واحد</item>
+        <item quantity="two">تطبيقان</item>
         <item quantity="few">%1$d تطبيقات</item>
         <item quantity="many">%1$d تطبيقًا</item>
-        <item quantity="other">%1$d تطبيقات</item>
+        <item quantity="other">%1$d تطبيق</item>
     </plurals>
     <string name="fix_store_desc">يعيد Thor تثبيت كل تطبيق حتى يسجّل Android متجر Play كالتطبيق الذي ثبّته. تبقى بياناتك وإعداداتك كما هي.</string>
     <string name="fix_store_warning">قد يتوقف تحديث أي تطبيق لا يطابق توقيعه نسخة متجر Play. أزل تحديد ما تفضّل تركه دون تغيير.</string>

--- a/app/src/main/res/values-ar/strings_backup.xml
+++ b/app/src/main/res/values-ar/strings_backup.xml
@@ -133,9 +133,9 @@
     <string name="restore_archive_created">تم النسخ الاحتياطي في %1$s</string>
     <string name="restore_will_install_first">هذا التطبيق غير مثبَّت. سيثبّته Thor من النسخة الاحتياطية أولًا.</string>
     <plurals name="restore_include_obb">
-        <item quantity="zero">استعادة بيانات اللعبة أيضًا (%1$d ملف)</item>
-        <item quantity="one">استعادة بيانات اللعبة أيضًا (%1$d ملف)</item>
-        <item quantity="two">استعادة بيانات اللعبة أيضًا (%1$d ملفان)</item>
+        <item quantity="zero">استعادة بيانات اللعبة أيضًا</item>
+        <item quantity="one">استعادة بيانات اللعبة أيضًا (ملف واحد)</item>
+        <item quantity="two">استعادة بيانات اللعبة أيضًا (ملفان)</item>
         <item quantity="few">استعادة بيانات اللعبة أيضًا (%1$d ملفات)</item>
         <item quantity="many">استعادة بيانات اللعبة أيضًا (%1$d ملفًا)</item>
         <item quantity="other">استعادة بيانات اللعبة أيضًا (%1$d ملف)</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -156,7 +156,7 @@
     <string name="action_freeze">Congelar</string>
     <string name="action_unfreeze">Descongelar</string>
     <string name="action_suspend">Suspender</string>
-    <string name="action_unsuspend">Habilitar</string>
+    <string name="action_unsuspend">Reanudar</string>
     <string name="action_kill">Detener</string>
     <string name="action_cache">Caché</string>
     <string name="action_uninstall">Desinstalar</string>
@@ -164,7 +164,7 @@
 
     <!-- Action explainers -->
     <string name="explain_force_stop_title">Forzar detención</string>
-    <string name="explain_force_stop_body">Cierra la aplicación y todo lo que esté ejecutando ahora mismo. Sigue instalada y arranca de nuevo en cuanto tú o el sistema la abráis. No se borra nada.</string>
+    <string name="explain_force_stop_body">Cierra la aplicación y todo lo que esté ejecutando ahora mismo. Sigue instalada y arranca de nuevo en cuanto la abras tú o el sistema. No se borra nada.</string>
     <string name="explain_suspend_title">Suspender</string>
     <string name="explain_suspend_body">La aplicación sigue en tu lanzador, pero no se puede abrir: al tocarla aparece un diálogo del sistema. Esto se mantiene tras reiniciar, hasta que la reanudes. No se borra nada.</string>
     <string name="explain_freeze_title">Congelar</string>
@@ -308,7 +308,7 @@
     <string name="action_open">Abrir</string>
     <string name="action_force_stop">Forzar detención</string>
     <string name="action_in_freezer">En congelador</string>
-    <string name="action_add_freezer">Añadir congelador</string>
+    <string name="action_add_freezer">Añadir al congelador</string>
     <string name="action_clear_cache">Limpiar caché</string>
     <string name="action_clear_data">Borrar datos</string>
     <string name="info_app_version">Versión de la aplicación</string>
@@ -333,7 +333,7 @@
     <string name="section_services_title">Servicios (%1$d)</string>
     <string name="section_receivers_title">Receptores de transmisión (%1$d)</string>
     <string name="section_providers_title">Proveedores de contenido (%1$d)</string>
-    <string name="cd_collapse">Colapsar</string>
+    <string name="cd_collapse">Contraer</string>
     <string name="cd_expand">Expandir</string>
     <string name="components_none_declared">Ninguno declarado</string>
     <string name="section_native_libs_title">Librerías nativas (.so)</string>
@@ -497,12 +497,12 @@
     <string name="legacy_extension_title">Extensión heredada detectada</string>
     <string name="legacy_extension_desc">Se ha detectado una versión heredada de la extensión Stormbringer (escrita incorrectamente como \"Strombringer\"). Por favor, desinstálala para evitar conflictos e instala la versión actualizada.</string>
     <string name="action_export">Exportar</string>
-    <string name="export_explain_apk">Thor guarda esta aplicación como un único archivo de instalación (.apk) en la carpeta de abajo. Úsala para hacer una copia de seguridad o reinstalarla más tarde.</string>
+    <string name="export_explain_apk">Thor guarda esta aplicación como un único archivo de instalación (.apk) en la carpeta de abajo. Úsalo para hacer una copia de seguridad o reinstalarla más tarde.</string>
     <string name="export_explain_apks">Esta aplicación consta de varias partes divididas, que se agrupan en un único paquete (.apks) en la carpeta de abajo. Reinstálala en cualquier momento con el instalador de Thor.</string>
     <string name="export_explain_xapk">Thor empaqueta las partes de esta app en un único .xapk en la carpeta de abajo, un formato que otros instaladores también entienden. Los datos del juego (archivos OBB) se incluyen cuando el modo de acceso actual de Thor puede leerlos.</string>
     <string name="export_xapk_no_game_data">Thor no puede leer los datos del juego de esta app ahora mismo; normalmente eso significa que hace falta root o Shizuku. El .xapk se creará igualmente, sin ellos.</string>
     <string name="export_obb_included">Incluye %1$s de datos del juego.</string>
-    <string name="export_obb_partial">Algunos elementos de la carpeta de datos de esta app no son archivos de expansión y no se incluirán.</string>
+    <string name="export_obb_partial">Algunos elementos de la carpeta de datos del juego de esta app no son archivos de expansión y no se incluirán.</string>
     <string name="export_format">Formato</string>
     <string name="export_save_to">Guardar en</string>
     <string name="export_change">Cambiar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -301,7 +301,7 @@
     <string name="tab_libs_features">Bibliothèques et fonctionnalités</string>
     <string name="chip_system">Système</string>
     <string name="chip_user">Utilisateur</string>
-    <string name="chip_debug">Déboguer</string>
+    <string name="chip_debug">Débogage</string>
     <string name="dialog_clear_data_desc">Tous les fichiers, paramètres et bases de données de cette application seront définitivement supprimés.</string>
     <string name="uninstall_app_title">Désinstaller l\'application ?</string>
     <string name="uninstall_app_desc">Êtes-vous sûr de vouloir désinstaller %1$s ?</string>
@@ -327,7 +327,7 @@
     <string name="info_shared_data_dir">Répertoire de données partagées</string>
     <string name="info_signature_sha256">Empreinte numérique de signature SHA-256</string>
     <string name="info_bloat_description">Pourquoi elle est signalée</string>
-    <string name="no_permissions_found">Aucun permis trouvé</string>
+    <string name="no_permissions_found">Aucune autorisation trouvée</string>
     <string name="search_components_placeholder">Rechercher des composants&#8230;</string>
     <string name="section_activities_title">Activités (%1$d)</string>
     <string name="section_services_title">Services (%1$d)</string>
@@ -351,7 +351,7 @@
     <string name="exit">Quitter</string>
     <string name="title_thor_installer">Installateur Thor</string>
     <string name="install_analyzing">Analyse du paquet…</string>
-    <string name="install_downgrade_warning">Cela va dégrader l\'application.</string>
+    <string name="install_downgrade_warning">Cela va rétrograder l\'application.</string>
     <string name="install_downgrade_code_explainer">Le code de version %1$s est inférieur au %2$s installé. Android ordonne les mises à jour par code de version, et non par nom de version : une application peut sembler plus récente tout en étant une rétrogradation.</string>
     <string name="install_update_warning">Cela va mettre à jour l\'application existante.</string>
     <plurals name="install_permissions">
@@ -429,7 +429,7 @@
     <!-- Support Developer -->
     <string name="support_developer">Soutenir le développeur</string>
     <string name="support_developer_desc">Soutenir le développement continu de Thor</string>
-    <string name="support_developer_desc_detailed">Thor est open source et complètement sans publicité. S\'il vous a été utile, merci de considérer de soutenir mon travail :</string>
+    <string name="support_developer_desc_detailed">Thor est open source et complètement sans publicité. S\'il vous a été utile, merci d\'envisager de soutenir mon travail :</string>
     <string name="sponsor_github_title">Sponsoriser sur GitHub</string>
     <string name="sponsor_github_desc">Ponctuel ou mensuel, au plus près du code</string>
     <string name="become_patreon_title">Devenir Patreon</string>
@@ -442,7 +442,7 @@
     <string name="donate_paypal_desc">Envoyer un don unique directement</string>
 
     <!-- Support & Community Dashboard Section -->
-    <string name="support_community_title">Support &amp; Communauté</string>
+    <string name="support_community_title">Soutien &amp; Communauté</string>
     <string name="support_community_desc">Aidez-nous à maintenir et améliorer Thor en soutenant le développement ou en rejoignant notre communauté.</string>
     <string name="community_github">GitHub</string>
     <string name="community_telegram">Telegram</string>
@@ -499,7 +499,7 @@
     <string name="action_export">Exporter</string>
     <string name="export_explain_apk">Thor enregistre cette application sous forme d\'un fichier d\'installation unique (.apk) dans le dossier ci-dessous. Utilisez-le pour sauvegarder l\'application ou la réinstaller plus tard.</string>
     <string name="export_explain_apks">Cette application est composée de plusieurs parties distinctes, regroupées dans un seul paquet (.apks) dans le dossier ci-dessous. Réinstallez-la à tout moment avec l\'installateur de Thor.</string>
-    <string name="export_explain_xapk">Thor regroupe les parties de cette app dans un seul .xapk dans le dossier ci-dessous, un format que d\'autres installeurs comprennent aussi. Les données de jeu (fichiers OBB) sont incluses lorsque le mode d\'accès actuel de Thor peut les lire.</string>
+    <string name="export_explain_xapk">Thor regroupe les parties de cette app dans un seul .xapk dans le dossier ci-dessous, un format que d\'autres installateurs comprennent aussi. Les données de jeu (fichiers OBB) sont incluses lorsque le mode d\'accès actuel de Thor peut les lire.</string>
     <string name="export_xapk_no_game_data">Thor ne peut pas lire les données de jeu de cette app pour l\'instant — le plus souvent, cela signifie qu\'il faut root ou Shizuku. Le .xapk sera quand même créé, sans elles.</string>
     <string name="export_obb_included">Inclut %1$s de données de jeu.</string>
     <string name="export_obb_partial">Certains éléments du dossier de données de cette app ne sont pas des fichiers d\'extension et ne seront pas inclus.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -35,7 +35,7 @@
     <string name="release_candidate">发布候选版</string>
     <string name="source_code">源代码</string>
     <string name="community">社区</string>
-    <string name="kernel_status">内核状态: 已优化</string>
+    <string name="kernel_status">内核状态：已优化</string>
     <string name="built_with_precision">为高级用户精准打造</string>
     <string name="app_language">应用语言</string>
     <string name="select_language">选择语言</string>
@@ -59,7 +59,7 @@
     <string name="close">关闭</string>
     <string name="installed_label">已安装</string>
     <string name="new_version_label">新版本</string>
-    <string name="version_prefix">版本: </string>
+    <string name="version_prefix">版本：</string>
     <string name="error_title">错误</string>
     <string name="refresh">刷新</string>
     <string name="dismiss">关闭</string>
@@ -74,7 +74,7 @@
     <string name="install_from_file_subtitle">安装 APK、XAPK、APKS 或分割包</string>
     <string name="home_extensions_title">扩展</string>
     <string name="app_distribution">应用分布</string>
-    <string name="total_apps">总计: %1$d</string>
+    <string name="total_apps">总计：%1$d</string>
     <string name="others">其他</string>
     <string name="clear_all_cache">清除所有缓存</string>
     <string name="clear_all_cache_subtitle">清除所有应用的缓存文件以回收存储空间</string>
@@ -104,7 +104,7 @@
     <string name="view_mode">视图模式</string>
     <string name="grid">网格</string>
     <string name="list">列表</string>
-    <string name="order">排序:</string>
+    <string name="order">排序：</string>
     <string name="ascending">升序</string>
     <string name="descending">降序</string>
     <string name="filters">过滤器</string>
@@ -223,7 +223,7 @@
     <string name="unfreeze_all_apps_desc">启用目前在冻结列表中的所有应用</string>
     <string name="auto_freeze">自动冻结</string>
     <string name="auto_freeze_desc">屏幕锁定后自动冻结应用</string>
-    <string name="privilege_required_warning">需要权限 (Root、Shizuku 或 Dhizuku)</string>
+    <string name="privilege_required_warning">需要权限（Root、Shizuku 或 Dhizuku）</string>
     <string name="unfreeze_all_confirmation_title">解冻所有应用？</string>
     <string name="unfreeze_all_confirmation_desc">这将解冻（启用）目前在冻结列表中的所有应用。确定要继续吗？</string>
     <string name="import_disabled_apps_title">导入已禁用的应用</string>
@@ -242,8 +242,8 @@
     <string name="manage_extensions_desc">查看和配置已安装的 APK 插件</string>
     <string name="extension_manager">扩展管理器</string>
     <string name="extension_security_verified">已验证</string>
-    <string name="extension_security_debug">调试模式 (未验证)</string>
-    <string name="extension_security_untrusted">不受信任 (已屏蔽)</string>
+    <string name="extension_security_debug">调试模式（未验证）</string>
+    <string name="extension_security_untrusted">不受信任（已屏蔽）</string>
     <string name="get_extensions">获取扩展</string>
     <string name="no_extensions_installed">未安装任何扩展</string>
     <string name="no_extensions_desc">安装包名以 \"com.valhalla.thor.ext.\" 开头并使用相同密钥签名的 Thor 扩展 APK 以加载模块化规则。</string>
@@ -264,7 +264,7 @@
     </plurals>
     <string name="tile_unfreeze_partial_failure">已解冻 %1$d/%2$d 个应用（%3$d 个失败）</string>
     <string name="tile_unfreeze_incomplete">已解冻 %1$d/%2$d 个应用（%3$d 个未完成）</string>
-    <string name="error_format">错误: %1$s</string>
+    <string name="error_format">错误：%1$s</string>
     <string name="failed_to_load_apps">加载应用失败</string>
     <plurals name="removed_from_freezer_success">
         <item quantity="other">已从冻结列表中移除 %1$d 个应用</item>
@@ -300,8 +300,8 @@
     <string name="uninstall_app_desc">确定要卸载 %1$s 吗？</string>
     <string name="action_open">打开</string>
     <string name="action_force_stop">强行停止</string>
-    <string name="action_in_freezer">已冷冻</string>
-    <string name="action_add_freezer">添加冷冻</string>
+    <string name="action_in_freezer">已在冻结室</string>
+    <string name="action_add_freezer">添加至冻结室</string>
     <string name="action_clear_cache">清除缓存</string>
     <string name="action_clear_data">清除数据</string>
     <string name="info_app_version">应用版本</string>
@@ -373,13 +373,13 @@
     <string name="log_sharing_app">正在分享 %1$s</string>
     <string name="log_preparing_files">正在准备文件…</string>
     <string name="log_files_ready">✔ 文件就绪</string>
-    <string name="log_error">✘ 错误: %1$s</string>
+    <string name="log_error">✘ 错误：%1$s</string>
     <string name="log_reinstalling_app">正在重新安装 %1$s</string>
     <string name="log_applying_play_store_sig">正在应用 Google Play 商店签名…</string>
     <string name="log_reinstall_success">✔ 重新安装成功</string>
-    <string name="log_failed_with_msg">✘ 失败: %1$s</string>
+    <string name="log_failed_with_msg">✘ 失败：%1$s</string>
     <string name="log_uninstalling_system_app">正在卸载系统应用</string>
-    <string name="log_target_app">目标: %1$s</string>
+    <string name="log_target_app">目标：%1$s</string>
     <string name="log_uninstall_success">✔ 卸载成功</string>
     <string name="log_priv_uninstall_failed">✘ 特权卸载失败</string>
     <string name="log_attempting_system_uninstall">正在尝试系统卸载…</string>
@@ -399,7 +399,7 @@
     <string name="log_batch_preparing">[%1$d/%2$d] 正在准备 %3$s…</string>
     <string name="log_ready"> -> 就绪</string>
     <string name="log_success"> -> 成功</string>
-    <string name="log_failed"> -> 失败: %1$s</string>
+    <string name="log_failed"> -> 失败：%1$s</string>
 
     <!-- Warnings & UI components -->
     <string name="warning_unsafe_uninstall">此系统应用被归类为“不安全”。移除它有极高的风险导致设备无限重启，因此已阻止卸载。</string>
@@ -538,7 +538,7 @@
     <string name="usage_access_granted_subtitle">已授予 — 启用应用大小排序</string>
     <string name="usage_access_needed_subtitle">读取应用大小以进行按大小排序所需</string>
     <string name="usage_access_needed_title">需要使用情况访问权限</string>
-    <string name="usage_access_prompt_body">Thor 需要使用情况访问权限才能读取应用大小。请为 Thor 启用该权限，然后再次选择\"大小\"。您也可以在\"设置 → 权限\"中进行管理。</string>
+    <string name="usage_access_prompt_body">Thor 需要使用情况访问权限才能读取应用大小。请为 Thor 启用该权限，然后再次选择“大小”。您也可以在“设置 → 权限”中进行管理。</string>
     <string name="notification_access">通知</string>
     <string name="notification_access_granted_subtitle">批量冻结结果将以通知形式显示</string>
     <string name="notification_access_needed_subtitle">允许通知以查看批量冻结结果</string>
@@ -547,8 +547,8 @@
     <string name="installed_apps_permission_desc">您的设备限制了 Thor 在后台运行时可以看到的应用。请授予读取已安装应用列表的完全访问权限，以保持列表完整。</string>
     <string name="installed_apps_permission_grant">授予</string>
     <string name="freeze_mode">冻结模式</string>
-    <string name="suspend_instead_of_freeze">挂起代替冻结</string>
-    <string name="suspend_instead_of_freeze_desc">冻结（包括自动冻结）时挂起应用，而不是禁用它们。挂起的应用仍然可见但处于暂停状态。</string>
+    <string name="suspend_instead_of_freeze">暂停代替冻结</string>
+    <string name="suspend_instead_of_freeze_desc">冻结（包括自动冻结）时暂停应用，而不是禁用它们。被暂停的应用仍然可见，但无法打开。</string>
     <string name="skip_routine_freeze_confirmation">常规冻结不再确认</string>
     <string name="skip_routine_freeze_confirmation_desc">冻结系统应用时不再先询问，除非 UAD 列表已标记该应用。标记为 Expert 的应用仍会警告，不安全的应用仍会被阻止。</string>
     <string name="add_freezer_to_launcher">添加冻结室到启动器</string>
@@ -635,7 +635,7 @@
     <string name="export_list_share">分享列表</string>
     <string name="export_list_empty">此列表中没有可导出的应用</string>
     <string name="export_list_failed">无法保存列表</string>
-    <string name="clear_all_caches_requires_usage_access">没有「使用情况访问权限」，Shizuku 无法清除所有应用的缓存。必须告诉 Android 需要释放多少字节，而只有该权限才能测量缓存的大小。请在系统设置中授予 Thor 使用情况访问权限后重试。</string>
+    <string name="clear_all_caches_requires_usage_access">没有“使用情况访问权限”，Shizuku 无法清除所有应用的缓存。必须告诉 Android 需要释放多少字节，而只有该权限才能测量缓存的大小。请在系统设置中授予 Thor 使用情况访问权限后重试。</string>
     <string name="clear_all_caches_unsupported_dhizuku">Dhizuku 无法清除缓存。它没有可用于执行 Android 缓存清理的 shell，设备所有者 API 也没有对应的接口。请切换到 Root 或 Shizuku 模式。</string>
 
     <!-- 分类式设置页面 — 参见 values/strings_settings.xml -->


### PR DESCRIPTION
Third and last of the localization follow-ups. #395 shipped `pt`, `pt-rBR` and `pl` and backfilled
94 strings into the four older locales; #397 took the `MissingTranslation` exemption off
`strings_backup.xml`. This one reads `ar`, `es`, `fr` and `zh-rCN` — **26 defects, none of which
any check in this repo can see.**

## Why nothing caught these

Name-set parity, placeholder parity, CLDR quantity coverage, `lintFossDebug` and `lintStoreRelease`
all passed on these files before this PR and all pass after it. Every one of them answers *"is the
string present and well-formed?"* None answers *"is it correct in the language?"* — and these four
locales predate the parity tooling entirely.

`lint` is not neutral here either: its `Typos` check fires on **correct** Portuguese while sitting
silent on `تم تجميد 1 تطبيقات`.

## Arabic `<plurals>` — seven sets with six byte-identical forms

`tile_freeze_success` held `تم تجميد %1$d تطبيقات` in all six quantities, so `quantity="one"`
rendered **"froze 1 apps"**. Same shape in the tile subtitle, the add/remove/unfreeze toasts and
the pin-all dialog.

These could not be repaired mechanically, because the grammar differs per string:

| | rule | why it varies |
|---|---|---|
| `تم` vs `تمت` | gender of the **masdar**, not the count | `تجميد`/`إلغاء` masculine → `تم`; `إضافة`/`إزالة` feminine → `تمت`. Making all four agree would have broken two. |
| dual `تطبيقين` vs `تطبيقان` | **case**, from position | after a masdar it's the `مضاف إليه` → genitive; as a bare label → nominative. Both occur here. |
| `many` | accusative tamyiz `تطبيقًا` | `other` takes genitive singular `تطبيق`; `few` takes the paucal `تطبيقات`, which is what all six forms were frozen on |
| `zero` | drops the numeral | **reachable**: `BulkResultText` routes an empty run there and `BulkResultTextTest` asserts it, so `لم يتم تجميد أي تطبيق` is the honest string rather than "froze 0 apps" |

`import_disabled_apps_desc` failed the *opposite* way — frozen on the singular, so 3–10 read
`هناك 3 تطبيق معطل`. Its closing pronoun also splits three ways (`إضافته` / `إضافتهما` /
`إضافتها`), the same it/them distinction English draws and a single form cannot carry.

**`export_bulk_confirm_desc` keeps its six identical forms.** Its only count sits in
`أي %1$d من الملفات` — a definite plural after `مِن`, which takes no tamyiz. Identical by
construction, not by neglect. Included so the class isn't "fixed" wrongly later.

**Two more of this class were not on the list**: `profile_app_count` rendered `2 تطبيقان` and
`100 تطبيقات`; `restore_include_obb` rendered `2 ملفان`. A numeral and a dual noun cannot both
appear. They were caught by grepping the class rather than working the findings — the same reason
the ninth zh-rCN colon site below is in the diff.

## Arabic prose

`Thor`/`Android` were transliterated to `ثور`/`أندرويد` in three strings, against the rule the rest
of the file follows. `تم إضافة` → `تمت إضافة` twice. `جاري` → `جارٍ` twice. `cd_collapse` had
`طوي` for `طي`.

## Spanish

| string | was | issue |
|---|---|---|
| `action_add_freezer` | Añadir congelador | "add a freezer", not "add **to** the freezer" |
| `action_unsuspend` | Habilitar | that's the freezer's verb (enable), not suspend's → Reanudar |
| `export_explain_apk` | Úsala | agreed with *aplicación*; the referent is the *archivo* → Úsalo |
| `explain_force_stop_body` | …la abráis | *vosotros* for a subject that is "tú o el sistema" |
| `export_obb_partial` | carpeta de datos | dropped "del juego" from "game data folder" |
| `cd_collapse` | Colapsar | calque → Contraer |

## French

| string | was | issue |
|---|---|---|
| `no_permissions_found` | Aucun permis trouvé | *permis* is a permit/licence → Aucune autorisation trouvée |
| `chip_debug` | Déboguer | verb where the label is a noun → Débogage |
| `install_downgrade_warning` | dégrader | *degrade* → rétrograder |
| `export_explain_xapk` | installeurs | → installateurs |
| `support_developer_desc_detailed` | considérer de | anglicism → d'envisager de |
| `support_community_title` | Support & Communauté | section is about *supporting the developer* → Soutien |

## Chinese

- `action_add_freezer` / `action_in_freezer` used **冷冻** (refrigerate) where the rest of the file
  — including `add_to_freezer` eighteen lines earlier — uses **冻结室**.
- `suspend_instead_of_freeze`(`_desc`) used **挂起** where the other seventeen suspend strings use
  **暂停**, and the description then claimed a suspended app is *"visible but paused"*, which
  contradicts `explain_suspend_body`: it is visible but **cannot be opened**.
- **Punctuation class sweep**: nine strings had a half-width colon after Chinese text, three had
  half-width parentheses around Chinese content — both are full-width in zh-CN. `「」` → `“”`, and
  a pair of escaped ASCII quotes around Chinese text → curly quotes. The ASCII quotes around the
  **Latin identifiers** in `no_extensions_desc` and `legacy_extension_desc` deliberately stay ASCII.
- `version_prefix` also drops its trailing space: the full-width colon carries its own, and
  `PortableInstaller.kt:361` renders it as its own `Text` beside the version, so that space was the
  separator.

The review that produced this list had **eight** colon sites. The ninth (`order`) is here because
the sweep grepped the class.

## Verification

| Check | Result |
|---|---|
| `./gradlew :app:lintFossDebug` | 0 errors, 0 warnings, 13 hints |
| `./gradlew :app:lintStoreRelease` | 0 errors, 0 warnings, 13 hints |
| `./gradlew :app:testFossDebugUnitTest --rerun-tasks` | **1588 tests, 0 failures** |
| All 8 locales parse; placeholder parity vs `values/strings.xml` | clean |

**None of that is evidence the translations are right.** It is the same evidence that was green
while every defect above was in the tree. The actual evidence is that each Arabic plural set was
authored with its rationale and then adversarially re-checked against the callsite — which is how
`export_bulk_confirm_desc` survived as correct and `profile_app_count` was found broken.

## Still open

- API 33+ `LocaleList.getFirstMatch` ordering between `values-pt` and `values-pt-rBR` wants a
  device check (carried over from #395).
- `check-shizu-manifest.sh:273`'s locale allowlist has no `pl`.
- `shizu_store.json`'s `locales.fr.detailed_description` is 4165 chars, over Play's 4000 cap.
  Pre-existing and unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
