### PR TITLE
fix(deps): bump nanoid to 3.3.18 to resolve security advisory

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5802,9 +5802,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
Bumps `nanoid` from `3.3.16` to `3.3.18` in `web/package-lock.json` to resolve Dependabot High severity vulnerability.

### Validation
- `npm run build`: 0 errors.
- `npm test`: 16/16 test files passed (296 tests).
- `npm run check:a11y`: 0 defects.