### PR TITLE
fix(web): add 10s timeout to IndexNow and verify staged deployment directory

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -380,7 +380,7 @@ jobs:
       # Submits live URLs to IndexNow protocol on production deploys
       - name: Submit IndexNow
         if: steps.creds.outputs.present == 'true' && steps.target.outputs.env == 'production'
-        run: npm run submit:indexnow || true
+        run: node scripts/submit-indexnow.mjs .vercel/output/static || true
 
       # Replaces the PR comment Vercel's Git integration would have posted.
       # Written with `gh` rather than a third-party action so the deploy path

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "check:a11y": "node scripts/check-a11y.mjs dist",
     "check:sitemap": "node scripts/check-sitemap.mjs dist",
     "check:screenshots": "node scripts/check-screenshots.mjs dist",
-    "submit:indexnow": "node scripts/submit-indexnow.mjs dist",
+    "submit:indexnow": "node scripts/submit-indexnow.mjs",
     "test": "vitest run",
     "build": "npm run check:types && astro build && npm run check:links && npm run check:claims && npm run check:markup && npm run check:sitemap && npm run check:screenshots"
   },

--- a/web/scripts/indexnow.test.mjs
+++ b/web/scripts/indexnow.test.mjs
@@ -49,20 +49,22 @@ describe('IndexNow protocol implementation', () => {
     expect(result.urlsCount).toBe(1)
   })
 
-  it('handles successful API response (HTTP 200/202)', async () => {
+  it('handles successful API response (HTTP 200/202) and passes signal', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       status: 200,
       statusText: 'OK',
     })
 
+    const customSignal = new AbortController().signal
     const urls = ['https://thor.trinadhthatakula.com/']
-    const result = await submitIndexNow({ urls, fetchFn: mockFetch })
+    const result = await submitIndexNow({ urls, fetchFn: mockFetch, signal: customSignal })
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
     const [endpoint, req] = mockFetch.mock.calls[0]
     expect(endpoint).toBe('https://api.indexnow.org/indexnow')
     expect(req.method).toBe('POST')
     expect(req.headers['Content-Type']).toContain('application/json')
+    expect(req.signal).toBe(customSignal)
 
     const body = JSON.parse(req.body)
     expect(body.key).toBe(INDEXNOW.key)
@@ -70,6 +72,12 @@ describe('IndexNow protocol implementation', () => {
 
     expect(result.ok).toBe(true)
     expect(result.status).toBe(200)
+  })
+
+  it('fails gracefully when key file is missing in target directory', () => {
+    const check = verifyKeyFile(join(WEB_DIR, 'nonexistent_dir'), INDEXNOW.key)
+    expect(check.ok).toBe(false)
+    expect(check.error).toContain('Key file not found')
   })
 
   it('handles API rejection or failure gracefully', async () => {

--- a/web/scripts/submit-indexnow.mjs
+++ b/web/scripts/submit-indexnow.mjs
@@ -68,6 +68,7 @@ export async function submitIndexNow(options = {}) {
   const endpoint = options.endpoint ?? INDEXNOW.endpoint
   const dryRun = options.dryRun ?? false
   const fetchFn = options.fetchFn ?? globalThis.fetch
+  const signal = options.signal ?? AbortSignal.timeout(10_000)
 
   const payload = buildIndexNowPayload(urls, options)
 
@@ -89,6 +90,7 @@ export async function submitIndexNow(options = {}) {
         'User-Agent': 'Thor-IndexNow-Client/1.0',
       },
       body: JSON.stringify(payload),
+      signal,
     })
 
     // 200 (OK) or 202 (Accepted) indicates success per IndexNow spec
@@ -115,10 +117,10 @@ export async function submitIndexNow(options = {}) {
  */
 async function main() {
   const isDryRun = process.argv.includes('--dry-run')
-  const distDir = dirArg() || join(WEB_DIR, 'dist')
+  const targetDir = dirArg() || join(WEB_DIR, 'dist')
 
-  // Verify key file
-  const keyCheck = verifyKeyFile(existsSync(distDir) ? distDir : join(WEB_DIR, 'public'))
+  // Verify key file in the target build directory
+  const keyCheck = verifyKeyFile(targetDir)
   if (!keyCheck.ok) {
     console.error(`submit-indexnow: ERROR — ${keyCheck.error}`)
     process.exit(1)


### PR DESCRIPTION
## Summary
- Adds default 10-second timeout (`AbortSignal.timeout(10_000)`) to IndexNow HTTP requests while preserving custom `signal` injection.
- Updates `submit-indexnow.mjs` to verify the key file directly in the target build directory (`dist/` by default or provided path).
- Removes hard-coded `dist` argument from `submit:indexnow` in `package.json`.
- Updates `.github/workflows/web-deploy.yml` to pass the staged deployment directory (`.vercel/output/static`) to IndexNow submission.
- Adds test coverage for timeout signal propagation and missing target directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production IndexNow submissions to target the correct deployed files.
  * Added a 10-second timeout to prevent stalled submission requests.
  * Restricted verification to the selected deployment directory, avoiding incorrect fallback behavior.

* **Tests**
  * Added coverage for request timeouts and missing-directory error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->