### PR TITLE
feat(backup): implement Backup & Restore Hub with Home bento entry point

### DIFF
--- a/app/src/androidTest/java/com/valhalla/thor/presentation/home/HomeActionsBentoTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/presentation/home/HomeActionsBentoTest.kt
@@ -51,6 +51,7 @@ class HomeActionsBentoTest {
             onInstall = { installRuns++ },
             onClearCache = { clearCacheRuns++ },
             onNavigateToExtensionManager = {},
+            onNavigateToBackupRestoreHub = {},
         )
     }
 
@@ -117,6 +118,7 @@ class HomeActionsBentoTest {
                 onInstall = { installRuns++ },
                 onClearCache = {},
                 onNavigateToExtensionManager = {},
+                onNavigateToBackupRestoreHub = {},
             )
         }
         val title = str(R.string.install_from_file)

--- a/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
@@ -36,19 +36,19 @@ class BackupArchiveScannerImpl(
 
     override fun scanBackups(): Flow<List<BackupArchiveItem>> = flow {
         val items = mutableListOf<BackupArchiveItem>()
-        val seenNames = mutableSetOf<String>()
+        val seenUris = mutableSetOf<String>()
 
         // 1. Scan default Downloads/Thor directory
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            items.addAll(queryMediaStoreDownloads(seenNames))
+            items.addAll(queryMediaStoreDownloads(seenUris))
         } else {
-            items.addAll(queryLegacyDownloads(seenNames))
+            items.addAll(queryLegacyDownloads(seenUris))
         }
 
         // 2. Scan custom SAF folder if user configured one
         val customTreeUri = preferences.userPreferences.first().exportDirUri
         if (!customTreeUri.isNullOrBlank()) {
-            items.addAll(queryCustomTree(customTreeUri, seenNames))
+            items.addAll(queryCustomTree(customTreeUri, seenUris))
         }
 
         // Sort descending by date modified
@@ -68,9 +68,8 @@ class BackupArchiveScannerImpl(
                         context.contentResolver.delete(uri, null, null) > 0
                     }
                 } else if (uri.scheme == "file") {
-                    val path = uri.path ?: return@withContext false
-                    val file = File(path)
-                    file.exists() && file.delete()
+                    val f = File(uri.path ?: return@withContext false)
+                    f.delete()
                 } else {
                     false
                 }
@@ -80,7 +79,7 @@ class BackupArchiveScannerImpl(
         }
 
     @RequiresApi(Build.VERSION_CODES.Q)
-    private fun queryMediaStoreDownloads(seenNames: MutableSet<String>): List<BackupArchiveItem> {
+    private fun queryMediaStoreDownloads(seenUris: MutableSet<String>): List<BackupArchiveItem> {
         val results = mutableListOf<BackupArchiveItem>()
         val projection = arrayOf(
             MediaStore.Downloads._ID,
@@ -116,11 +115,12 @@ class BackupArchiveScannerImpl(
                 while (cursor.moveToNext()) {
                     val id = cursor.getLong(idCol)
                     val name = cursor.getString(nameCol) ?: continue
-                    if (name.endsWith(".part") || !seenNames.add(name)) continue
+                    if (name.endsWith(".part")) continue
 
                     val size = cursor.getLong(sizeCol)
                     val date = cursor.getLong(dateCol)
                     val uri = ContentUris.withAppendedId(MediaStore.Downloads.EXTERNAL_CONTENT_URI, id)
+                    if (!seenUris.add(uri.toString())) continue
 
                     parseArchiveItem(id, uri, name, size, date)?.let { results.add(it) }
                 }
@@ -131,7 +131,7 @@ class BackupArchiveScannerImpl(
         return results
     }
 
-    private fun queryLegacyDownloads(seenNames: MutableSet<String>): List<BackupArchiveItem> {
+    private fun queryLegacyDownloads(seenUris: MutableSet<String>): List<BackupArchiveItem> {
         val results = mutableListOf<BackupArchiveItem>()
         val dir = File(
             Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
@@ -145,8 +145,8 @@ class BackupArchiveScannerImpl(
         } ?: return results
 
         for (f in files) {
-            if (!seenNames.add(f.name)) continue
             val uri = f.toUri()
+            if (!seenUris.add(uri.toString())) continue
             parseArchiveItem(f.hashCode().toLong(), uri, f.name, f.length(), f.lastModified() / 1000)
                 ?.let { results.add(it) }
         }
@@ -155,7 +155,7 @@ class BackupArchiveScannerImpl(
 
     private fun queryCustomTree(
         treeUriString: String,
-        seenNames: MutableSet<String>,
+        seenUris: MutableSet<String>,
     ): List<BackupArchiveItem> {
         val results = mutableListOf<BackupArchiveItem>()
         try {
@@ -165,8 +165,9 @@ class BackupArchiveScannerImpl(
             for (doc in root.listFiles()) {
                 val name = doc.name ?: continue
                 val lower = name.lowercase()
-                if (lower.endsWith(".part") || !seenNames.add(name)) continue
+                if (lower.endsWith(".part")) continue
                 if (lower.endsWith(".thorbak") || lower.endsWith(".xapk") || lower.endsWith(".apks") || lower.endsWith(".apk")) {
+                    if (!seenUris.add(doc.uri.toString())) continue
                     parseArchiveItem(
                         doc.uri.hashCode().toLong(),
                         doc.uri,

--- a/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import android.content.ContentUris
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.DocumentsContract
+import android.provider.MediaStore
+import androidx.annotation.RequiresApi
+import androidx.core.net.toUri
+import androidx.documentfile.provider.DocumentFile
+import com.valhalla.thor.domain.repository.BackupArchiveItem
+import com.valhalla.thor.domain.repository.BackupArchiveKind
+import com.valhalla.thor.domain.repository.BackupArchiveScanner
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import java.io.File
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
+
+@Single(binds = [BackupArchiveScanner::class])
+class BackupArchiveScannerImpl(
+    private val context: Context,
+    private val preferences: PreferenceRepository,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
+) : BackupArchiveScanner {
+
+    override fun scanBackups(): Flow<List<BackupArchiveItem>> = flow {
+        val items = mutableListOf<BackupArchiveItem>()
+        val seenNames = mutableSetOf<String>()
+
+        // 1. Scan default Downloads/Thor directory
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            items.addAll(queryMediaStoreDownloads(seenNames))
+        } else {
+            items.addAll(queryLegacyDownloads(seenNames))
+        }
+
+        // 2. Scan custom SAF folder if user configured one
+        val customTreeUri = preferences.userPreferences.first().exportDirUri
+        if (!customTreeUri.isNullOrBlank()) {
+            items.addAll(queryCustomTree(customTreeUri, seenNames))
+        }
+
+        // Sort descending by date modified
+        items.sortByDescending { it.dateModifiedEpochSec }
+        emit(items)
+    }.flowOn(ioDispatcher)
+
+    override suspend fun deleteArchive(item: BackupArchiveItem): Boolean =
+        withContext(ioDispatcher) {
+            try {
+                val uri = item.uriString.toUri()
+                if (uri.scheme == "content") {
+                    if (DocumentsContract.isDocumentUri(context, uri)) {
+                        val doc = DocumentFile.fromSingleUri(context, uri)
+                        doc?.delete() ?: false
+                    } else {
+                        context.contentResolver.delete(uri, null, null) > 0
+                    }
+                } else if (uri.scheme == "file") {
+                    val path = uri.path ?: return@withContext false
+                    val file = File(path)
+                    file.exists() && file.delete()
+                } else {
+                    false
+                }
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun queryMediaStoreDownloads(seenNames: MutableSet<String>): List<BackupArchiveItem> {
+        val results = mutableListOf<BackupArchiveItem>()
+        val projection = arrayOf(
+            MediaStore.Downloads._ID,
+            MediaStore.Downloads.DISPLAY_NAME,
+            MediaStore.Downloads.SIZE,
+            MediaStore.Downloads.DATE_MODIFIED,
+            MediaStore.Downloads.RELATIVE_PATH,
+        )
+
+        val selection = "(${MediaStore.Downloads.RELATIVE_PATH} LIKE ? OR ${MediaStore.Downloads.RELATIVE_PATH} LIKE ?) AND (${MediaStore.Downloads.DISPLAY_NAME} LIKE ? OR ${MediaStore.Downloads.DISPLAY_NAME} LIKE ? OR ${MediaStore.Downloads.DISPLAY_NAME} LIKE ? OR ${MediaStore.Downloads.DISPLAY_NAME} LIKE ?)"
+        val selectionArgs = arrayOf(
+            "%Download/Thor%",
+            "%Downloads/Thor%",
+            "%.thorbak",
+            "%.xapk",
+            "%.apks",
+            "%.apk",
+        )
+
+        try {
+            context.contentResolver.query(
+                MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                projection,
+                selection,
+                selectionArgs,
+                "${MediaStore.Downloads.DATE_MODIFIED} DESC",
+            )?.use { cursor ->
+                val idCol = cursor.getColumnIndexOrThrow(MediaStore.Downloads._ID)
+                val nameCol = cursor.getColumnIndexOrThrow(MediaStore.Downloads.DISPLAY_NAME)
+                val sizeCol = cursor.getColumnIndexOrThrow(MediaStore.Downloads.SIZE)
+                val dateCol = cursor.getColumnIndexOrThrow(MediaStore.Downloads.DATE_MODIFIED)
+
+                while (cursor.moveToNext()) {
+                    val id = cursor.getLong(idCol)
+                    val name = cursor.getString(nameCol) ?: continue
+                    if (name.endsWith(".part") || !seenNames.add(name)) continue
+
+                    val size = cursor.getLong(sizeCol)
+                    val date = cursor.getLong(dateCol)
+                    val uri = ContentUris.withAppendedId(MediaStore.Downloads.EXTERNAL_CONTENT_URI, id)
+
+                    parseArchiveItem(id, uri, name, size, date)?.let { results.add(it) }
+                }
+            }
+        } catch (_: Exception) {
+            // Permission or resolver failure gracefully produces whatever else resolved
+        }
+        return results
+    }
+
+    private fun queryLegacyDownloads(seenNames: MutableSet<String>): List<BackupArchiveItem> {
+        val results = mutableListOf<BackupArchiveItem>()
+        val dir = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            THOR_DOWNLOADS_SUBDIR,
+        )
+        if (!dir.exists() || !dir.isDirectory) return results
+
+        val files = dir.listFiles { f ->
+            val n = f.name.lowercase()
+            !n.endsWith(".part") && (n.endsWith(".thorbak") || n.endsWith(".xapk") || n.endsWith(".apks") || n.endsWith(".apk"))
+        } ?: return results
+
+        for (f in files) {
+            if (!seenNames.add(f.name)) continue
+            val uri = f.toUri()
+            parseArchiveItem(f.hashCode().toLong(), uri, f.name, f.length(), f.lastModified() / 1000)
+                ?.let { results.add(it) }
+        }
+        return results
+    }
+
+    private fun queryCustomTree(
+        treeUriString: String,
+        seenNames: MutableSet<String>,
+    ): List<BackupArchiveItem> {
+        val results = mutableListOf<BackupArchiveItem>()
+        try {
+            val root = DocumentFile.fromTreeUri(context, treeUriString.toUri()) ?: return results
+            if (!root.exists() || !root.isDirectory) return results
+
+            for (doc in root.listFiles()) {
+                val name = doc.name ?: continue
+                val lower = name.lowercase()
+                if (lower.endsWith(".part") || !seenNames.add(name)) continue
+                if (lower.endsWith(".thorbak") || lower.endsWith(".xapk") || lower.endsWith(".apks") || lower.endsWith(".apk")) {
+                    parseArchiveItem(
+                        doc.uri.hashCode().toLong(),
+                        doc.uri,
+                        name,
+                        doc.length(),
+                        doc.lastModified() / 1000,
+                    )?.let { results.add(it) }
+                }
+            }
+        } catch (_: Exception) {
+            // Ignored
+        }
+        return results
+    }
+
+    private fun parseArchiveItem(
+        id: Long,
+        uri: Uri,
+        displayName: String,
+        sizeBytes: Long,
+        dateModifiedEpochSec: Long,
+    ): BackupArchiveItem? {
+        val lower = displayName.lowercase()
+        val extension = when {
+            lower.endsWith(".thorbak") -> "thorbak"
+            lower.endsWith(".xapk") -> "xapk"
+            lower.endsWith(".apks") -> "apks"
+            lower.endsWith(".apk") -> "apk"
+            else -> return null
+        }
+
+        val kind = if (extension == "thorbak") {
+            BackupArchiveKind.DATA_BACKUP
+        } else {
+            BackupArchiveKind.APP_BUNDLE
+        }
+
+        // Package name extraction heuristic: "com.example.app-100.thorbak" -> "com.example.app"
+        val nameWithoutExt = displayName.substringBeforeLast('.')
+        val possiblePkg = nameWithoutExt.substringBefore('-').substringBefore('_')
+        val packageName = if (possiblePkg.contains('.') && possiblePkg.length > 3) possiblePkg else null
+
+        return BackupArchiveItem(
+            id = id,
+            uriString = uri.toString(),
+            displayName = displayName,
+            packageName = packageName,
+            sizeBytes = sizeBytes,
+            dateModifiedEpochSec = dateModifiedEpochSec,
+            kind = kind,
+            extension = extension,
+        )
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/domain/repository/BackupArchiveScanner.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/BackupArchiveScanner.kt
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+import android.net.Uri
+import kotlinx.coroutines.flow.Flow
+
+/** Classification of backup files discovered in storage. */
+enum class BackupArchiveKind {
+    /** Encrypted full app data archive (.thorbak). */
+    DATA_BACKUP,
+
+    /** Standalone installer or bundle (.xapk, .apks, .apk). */
+    APP_BUNDLE,
+}
+
+/** Represents a single discovered backup or export archive. */
+data class BackupArchiveItem(
+    val id: Long,
+    val uriString: String,
+    val displayName: String,
+    val packageName: String?,
+    val sizeBytes: Long,
+    val dateModifiedEpochSec: Long,
+    val kind: BackupArchiveKind,
+    val extension: String,
+)
+
+/** Scanner discovering archives stored in Downloads/Thor or custom SAF folders. */
+interface BackupArchiveScanner {
+    fun scanBackups(): Flow<List<BackupArchiveItem>>
+    suspend fun deleteArchive(item: BackupArchiveItem): Boolean
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -127,9 +128,11 @@ fun BackupRestoreHubScreen(
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.background,
                 ),
+                windowInsets = WindowInsets(0,0,0,0)
             )
         },
         containerColor = MaterialTheme.colorScheme.background,
+        contentWindowInsets = WindowInsets(0,0,0,0)
     ) { innerPadding ->
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -1,0 +1,719 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.backup.hub
+
+import android.content.Intent
+import android.text.format.Formatter
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.net.toUri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.valhalla.thor.R
+import com.valhalla.thor.data.source.local.room.AppEntity
+import com.valhalla.thor.domain.repository.BackupArchiveItem
+import com.valhalla.thor.domain.repository.BackupArchiveKind
+import com.valhalla.thor.presentation.home.components.BentoTile
+import com.valhalla.thor.presentation.widgets.AppIcon
+import java.text.DateFormat
+import java.util.Date
+import org.koin.androidx.compose.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BackupRestoreHubScreen(
+    onBack: () -> Unit,
+    onOpenBackupSheet: (packageName: String, appLabel: String) -> Unit,
+    onOpenRestoreSheet: (uriString: String?) -> Unit,
+    viewModel: BackupRestoreHubViewModel = koinViewModel(),
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    val safFilePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            onOpenRestoreSheet(uri.toString())
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.backup_and_restore),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            painter = painterResource(R.drawable.arrow_back),
+                            contentDescription = stringResource(R.string.cd_back),
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.refreshArchives() }) {
+                        Icon(
+                            painter = painterResource(R.drawable.clear_all),
+                            contentDescription = stringResource(R.string.cd_clear),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Spacer(Modifier.height(4.dp))
+
+            // 1. HERO ACTION CARDS
+            HeroActionCards(
+                onBackupClick = { viewModel.showAppPicker() },
+                onRestoreClick = { safFilePickerLauncher.launch(arrayOf("*/*")) },
+            )
+
+            // 2. BACKUPS SECTION HEADER
+            BackupsSectionHeader(
+                totalCount = state.archives.size,
+                totalSizeBytes = state.totalSizeBytes,
+            )
+
+            // 3. DYNAMIC FILTER CHIPS (Visible only when both kinds are present)
+            if (state.showFilterChips) {
+                DynamicFilterChips(
+                    activeFilter = state.activeFilter,
+                    onFilterSelect = { viewModel.setFilter(it) },
+                )
+            }
+
+            // 4. ARCHIVES LIST OR EMPTY STATE
+            if (state.isLoading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                }
+            } else if (state.archives.isEmpty()) {
+                EmptyStateKnowledgeCards()
+            } else {
+                val itemsToRender = state.filteredArchives
+                if (itemsToRender.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.backup_hub_no_archives),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                } else {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        modifier = Modifier.animateContentSize(),
+                    ) {
+                        itemsToRender.forEach { item ->
+                            ArchiveItemCard(
+                                item = item,
+                                onRestore = { onOpenRestoreSheet(item.uriString) },
+                                onShare = {
+                                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                                        type = "*/*"
+                                        putExtra(Intent.EXTRA_STREAM, item.uriString.toUri())
+                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                    }
+                                    context.startActivity(Intent.createChooser(shareIntent, item.displayName))
+                                },
+                                onDelete = { viewModel.requestDeleteArchive(item) },
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(32.dp))
+        }
+    }
+
+    // Modal App Picker Sheet
+    if (state.isAppPickerVisible) {
+        AppPickerBottomSheet(
+            searchQuery = state.appPickerSearchQuery,
+            apps = state.filteredInstalledApps,
+            onSearchChange = { viewModel.updateAppPickerSearch(it) },
+            onAppSelect = { app ->
+                viewModel.hideAppPicker()
+                onOpenBackupSheet(app.packageName, app.appName ?: app.packageName)
+            },
+            onDismiss = { viewModel.hideAppPicker() },
+        )
+    }
+
+    // Delete Confirmation Dialog
+    state.archiveToDelete?.let { target ->
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissDeleteArchive() },
+            title = { Text(stringResource(R.string.backup_hub_delete_confirm_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.backup_hub_delete_confirm_message,
+                        target.displayName,
+                    )
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.confirmDeleteArchive() }
+                ) {
+                    Text(
+                        stringResource(R.string.backup_hub_action_delete),
+                        color = MaterialTheme.colorScheme.error,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissDeleteArchive() }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun HeroActionCards(
+    onBackupClick: () -> Unit,
+    onRestoreClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        BentoTile(
+            title = stringResource(R.string.backup_hub_hero_backup_title),
+            subtitle = stringResource(R.string.backup_hub_hero_backup_desc),
+            icon = R.drawable.settings_backup_restore,
+            isPrimary = true,
+            showSubtitle = true,
+            onClick = onBackupClick,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+        )
+
+        BentoTile(
+            title = stringResource(R.string.backup_hub_hero_restore_title),
+            subtitle = stringResource(R.string.backup_hub_hero_restore_desc),
+            icon = R.drawable.apk_install,
+            isPrimary = false,
+            showSubtitle = true,
+            onClick = onRestoreClick,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+        )
+    }
+}
+
+@Composable
+private fun BackupsSectionHeader(
+    totalCount: Int,
+    totalSizeBytes: Long,
+) {
+    val context = LocalContext.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column {
+            Text(
+                text = stringResource(R.string.backup_hub_section_backups),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Text(
+                text = "Downloads/Thor",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (totalCount > 0) {
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            ) {
+                Text(
+                    text = "$totalCount (${Formatter.formatShortFileSize(context, totalSizeBytes)})",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun DynamicFilterChips(
+    activeFilter: BackupHubFilter,
+    onFilterSelect: (BackupHubFilter) -> Unit,
+) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        FilterChip(
+            selected = activeFilter == BackupHubFilter.ALL,
+            onClick = { onFilterSelect(BackupHubFilter.ALL) },
+            label = { Text(stringResource(R.string.backup_hub_filter_all)) },
+            colors = FilterChipDefaults.filterChipColors(
+                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+        )
+        FilterChip(
+            selected = activeFilter == BackupHubFilter.DATA_BACKUPS,
+            onClick = { onFilterSelect(BackupHubFilter.DATA_BACKUPS) },
+            label = { Text(stringResource(R.string.backup_hub_filter_backups)) },
+            colors = FilterChipDefaults.filterChipColors(
+                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+        )
+        FilterChip(
+            selected = activeFilter == BackupHubFilter.APP_BUNDLES,
+            onClick = { onFilterSelect(BackupHubFilter.APP_BUNDLES) },
+            label = { Text(stringResource(R.string.backup_hub_filter_bundles)) },
+            colors = FilterChipDefaults.filterChipColors(
+                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+        )
+    }
+}
+
+@Composable
+private fun ArchiveItemCard(
+    item: BackupArchiveItem,
+    onRestore: () -> Unit,
+    onShare: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val context = LocalContext.current
+    val formattedSize = remember(item.sizeBytes) { Formatter.formatShortFileSize(context, item.sizeBytes) }
+    val formattedDate = remember(item.dateModifiedEpochSec) {
+        if (item.dateModifiedEpochSec > 0) {
+            DateFormat.getDateInstance(DateFormat.MEDIUM).format(Date(item.dateModifiedEpochSec * 1000))
+        } else {
+            ""
+        }
+    }
+
+    Card(
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Leading Type Tag
+                val isDataBackup = item.kind == BackupArchiveKind.DATA_BACKUP
+                Surface(
+                    shape = CircleShape,
+                    color = if (isDataBackup) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    },
+                ) {
+                    Text(
+                        text = if (isDataBackup) {
+                            stringResource(R.string.backup_hub_badge_data_backup)
+                        } else {
+                            stringResource(R.string.backup_hub_badge_app_bundle)
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = if (isDataBackup) {
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        },
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                    )
+                }
+
+                Text(
+                    text = "$formattedSize · $formattedDate",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // File Name & Package
+            Column {
+                Text(
+                    text = item.displayName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (!item.packageName.isNullOrBlank()) {
+                    Text(
+                        text = item.packageName,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            // Actions Row
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    IconButton(onClick = onShare, modifier = Modifier.size(36.dp)) {
+                        Icon(
+                            painter = painterResource(R.drawable.share),
+                            contentDescription = stringResource(R.string.backup_hub_action_share),
+                            modifier = Modifier.size(18.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    IconButton(onClick = onDelete, modifier = Modifier.size(36.dp)) {
+                        Icon(
+                            painter = painterResource(R.drawable.delete),
+                            contentDescription = stringResource(R.string.backup_hub_action_delete),
+                            modifier = Modifier.size(18.dp),
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+
+                FilledTonalButton(
+                    onClick = onRestore,
+                    shape = RoundedCornerShape(12.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.settings_backup_restore),
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = stringResource(R.string.job_restoring),
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 13.sp,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyStateKnowledgeCards() {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        // Main Header Banner
+        Card(
+            shape = RoundedCornerShape(24.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.settings_backup_restore),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Text(
+                        text = stringResource(R.string.backup_hub_empty_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.backup_hub_empty_desc),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        // Educational Knowledge Tip Cards
+        TipCard(
+            title = stringResource(R.string.backup_hub_tip_thorbak_title),
+            desc = stringResource(R.string.backup_hub_tip_thorbak_desc),
+            iconRes = R.drawable.settings_backup_restore,
+        )
+
+        TipCard(
+            title = stringResource(R.string.backup_hub_tip_bundle_title),
+            desc = stringResource(R.string.backup_hub_tip_bundle_desc),
+            iconRes = R.drawable.apk_install,
+        )
+
+        TipCard(
+            title = stringResource(R.string.backup_hub_tip_discovery_title),
+            desc = stringResource(R.string.backup_hub_tip_discovery_desc),
+            iconRes = R.drawable.clear_all,
+        )
+    }
+}
+
+@Composable
+private fun TipCard(
+    title: String,
+    desc: String,
+    iconRes: Int,
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.5f),
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier
+                    .size(20.dp)
+                    .padding(top = 2.dp),
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    lineHeight = 18.sp,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AppPickerBottomSheet(
+    searchQuery: String,
+    apps: List<AppEntity>,
+    onSearchChange: (String) -> Unit,
+    onAppSelect: (AppEntity) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.backup_hub_pick_app_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = onSearchChange,
+                placeholder = { Text(stringResource(R.string.backup_hub_search_apps_placeholder)) },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(R.drawable.round_search),
+                        contentDescription = null,
+                    )
+                },
+                shape = RoundedCornerShape(16.dp),
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(380.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                items(apps, key = { it.packageName }) { app ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable { onAppSelect(app) }
+                            .padding(vertical = 10.dp, horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(14.dp),
+                    ) {
+                        AppIcon(
+                            packageName = app.packageName,
+                            isEnabled = app.enabled,
+                            isSuspended = app.isSuspended,
+                            size = 40.dp,
+                        )
+
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = app.appName ?: app.packageName,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = app.packageName,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+
+                        app.versionName?.let { ver ->
+                            Text(
+                                text = ver,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -79,6 +79,11 @@ import com.valhalla.thor.presentation.widgets.AppIcon
 import java.text.DateFormat
 import java.util.Date
 import org.koin.androidx.compose.koinViewModel
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.documentfile.provider.DocumentFile
+import com.valhalla.thor.presentation.installer.InstallerViewModel
+import com.valhalla.thor.presentation.installer.PortableInstaller
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -87,15 +92,36 @@ fun BackupRestoreHubScreen(
     onOpenBackupSheet: (packageName: String, appLabel: String) -> Unit,
     onOpenRestoreSheet: (uriString: String?) -> Unit,
     viewModel: BackupRestoreHubViewModel = koinViewModel(),
+    installerViewModel: InstallerViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    var showInstallerSheet by remember { mutableStateOf(false) }
+
+    val handleRestoreOrInstall = { item: BackupArchiveItem ->
+        if (item.kind == BackupArchiveKind.DATA_BACKUP) {
+            onOpenRestoreSheet(item.uriString)
+        } else {
+            installerViewModel.parsePackage(item.uriString.toUri())
+            showInstallerSheet = true
+        }
+    }
 
     val safFilePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri != null) {
-            onOpenRestoreSheet(uri.toString())
+            val doc = DocumentFile.fromSingleUri(context, uri)
+            val name = doc?.name?.lowercase().orEmpty()
+            val path = uri.path?.lowercase().orEmpty()
+            val isBundle = name.endsWith(".apk") || name.endsWith(".xapk") || name.endsWith(".apks") ||
+                path.endsWith(".apk") || path.endsWith(".xapk") || path.endsWith(".apks")
+            if (isBundle) {
+                installerViewModel.parsePackage(uri)
+                showInstallerSheet = true
+            } else {
+                onOpenRestoreSheet(uri.toString())
+            }
         }
     }
 
@@ -193,7 +219,7 @@ fun BackupRestoreHubScreen(
                         itemsToRender.forEach { item ->
                             ArchiveItemCard(
                                 item = item,
-                                onRestore = { onOpenRestoreSheet(item.uriString) },
+                                onRestore = { handleRestoreOrInstall(item) },
                                 onShare = {
                                     val shareIntent = Intent(Intent.ACTION_SEND).apply {
                                         type = "*/*"
@@ -258,6 +284,13 @@ fun BackupRestoreHubScreen(
             },
         )
     }
+
+    if (showInstallerSheet) {
+        PortableInstaller(
+            onDismiss = { showInstallerSheet = false },
+            viewModel = installerViewModel,
+        )
+    }
 }
 
 @Composable
@@ -308,19 +341,12 @@ private fun BackupsSectionHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Column {
-            Text(
-                text = stringResource(R.string.backup_hub_section_backups),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-            Text(
-                text = "Downloads/Thor",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+        Text(
+            text = stringResource(R.string.backup_hub_section_backups),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
 
         if (totalCount > 0) {
             Surface(
@@ -497,13 +523,25 @@ private fun ArchiveItemCard(
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.settings_backup_restore),
+                        painter = painterResource(
+                            if (item.kind == BackupArchiveKind.DATA_BACKUP) {
+                                R.drawable.settings_backup_restore
+                            } else {
+                                R.drawable.apk_install
+                            }
+                        ),
                         contentDescription = null,
                         modifier = Modifier.size(16.dp),
                     )
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        text = stringResource(R.string.job_restoring),
+                        text = stringResource(
+                            if (item.kind == BackupArchiveKind.DATA_BACKUP) {
+                                R.string.restore_start
+                            } else {
+                                R.string.install_action_install
+                            }
+                        ),
                         fontWeight = FontWeight.Bold,
                         fontSize = 13.sp,
                     )

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.backup.hub
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.valhalla.thor.data.source.local.room.AppDao
+import com.valhalla.thor.data.source.local.room.AppEntity
+import com.valhalla.thor.domain.repository.BackupArchiveItem
+import com.valhalla.thor.domain.repository.BackupArchiveKind
+import com.valhalla.thor.domain.repository.BackupArchiveScanner
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.koin.core.annotation.KoinViewModel
+
+enum class BackupHubFilter {
+    ALL,
+    DATA_BACKUPS,
+    APP_BUNDLES,
+}
+
+data class BackupRestoreHubState(
+    val isLoading: Boolean = true,
+    val archives: List<BackupArchiveItem> = emptyList(),
+    val activeFilter: BackupHubFilter = BackupHubFilter.ALL,
+    val isAppPickerVisible: Boolean = false,
+    val appPickerSearchQuery: String = "",
+    val installedApps: List<AppEntity> = emptyList(),
+    val archiveToDelete: BackupArchiveItem? = null,
+) {
+    val hasBackups: Boolean get() = archives.any { it.kind == BackupArchiveKind.DATA_BACKUP }
+    val hasBundles: Boolean get() = archives.any { it.kind == BackupArchiveKind.APP_BUNDLE }
+    val showFilterChips: Boolean get() = hasBackups && hasBundles
+
+    val filteredArchives: List<BackupArchiveItem>
+        get() = when (activeFilter) {
+            BackupHubFilter.ALL -> archives
+            BackupHubFilter.DATA_BACKUPS -> archives.filter { it.kind == BackupArchiveKind.DATA_BACKUP }
+            BackupHubFilter.APP_BUNDLES -> archives.filter { it.kind == BackupArchiveKind.APP_BUNDLE }
+        }
+
+    val totalSizeBytes: Long get() = archives.sumOf { it.sizeBytes }
+
+    val filteredInstalledApps: List<AppEntity>
+        get() {
+            if (appPickerSearchQuery.isBlank()) return installedApps
+            val q = appPickerSearchQuery.trim().lowercase()
+            return installedApps.filter {
+                (it.appName?.lowercase()?.contains(q) == true) ||
+                    it.packageName.lowercase().contains(q)
+            }
+        }
+}
+
+@KoinViewModel
+class BackupRestoreHubViewModel(
+    private val scanner: BackupArchiveScanner,
+    private val appDao: AppDao,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(BackupRestoreHubState())
+    val state: StateFlow<BackupRestoreHubState> = _state.asStateFlow()
+
+    init {
+        loadInstalledApps()
+        refreshArchives()
+    }
+
+    fun refreshArchives() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true) }
+            scanner.scanBackups().collect { list ->
+                _state.update { it.copy(archives = list, isLoading = false) }
+            }
+        }
+    }
+
+    private fun loadInstalledApps() {
+        viewModelScope.launch {
+            appDao.getAllAppsFlow().collect { apps ->
+                val sorted = apps.filter { !it.isSystem }
+                    .sortedBy { it.appName?.lowercase() ?: it.packageName }
+                _state.update { it.copy(installedApps = sorted) }
+            }
+        }
+    }
+
+    fun setFilter(filter: BackupHubFilter) {
+        _state.update { it.copy(activeFilter = filter) }
+    }
+
+    fun showAppPicker() {
+        _state.update { it.copy(isAppPickerVisible = true, appPickerSearchQuery = "") }
+    }
+
+    fun hideAppPicker() {
+        _state.update { it.copy(isAppPickerVisible = false, appPickerSearchQuery = "") }
+    }
+
+    fun updateAppPickerSearch(query: String) {
+        _state.update { it.copy(appPickerSearchQuery = query) }
+    }
+
+    fun requestDeleteArchive(item: BackupArchiveItem) {
+        _state.update { it.copy(archiveToDelete = item) }
+    }
+
+    fun dismissDeleteArchive() {
+        _state.update { it.copy(archiveToDelete = null) }
+    }
+
+    fun confirmDeleteArchive() {
+        val target = _state.value.archiveToDelete ?: return
+        viewModelScope.launch {
+            _state.update { it.copy(archiveToDelete = null) }
+            if (scanner.deleteArchive(target)) {
+                refreshArchives()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
@@ -10,6 +10,7 @@ import com.valhalla.thor.data.source.local.room.AppEntity
 import com.valhalla.thor.domain.repository.BackupArchiveItem
 import com.valhalla.thor.domain.repository.BackupArchiveKind
 import com.valhalla.thor.domain.repository.BackupArchiveScanner
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -68,13 +69,16 @@ class BackupRestoreHubViewModel(
     private val _state = MutableStateFlow(BackupRestoreHubState())
     val state: StateFlow<BackupRestoreHubState> = _state.asStateFlow()
 
+    private var scanJob: Job? = null
+
     init {
         loadInstalledApps()
         refreshArchives()
     }
 
     fun refreshArchives() {
-        viewModelScope.launch {
+        scanJob?.cancel()
+        scanJob = viewModelScope.launch {
             _state.update { it.copy(isLoading = true) }
             scanner.scanBackups().collect { list ->
                 _state.update { it.copy(archives = list, isLoading = false) }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -76,6 +76,7 @@ fun HomeScreen(
      */
     onFilterByInstaller: (AppListType, String) -> Unit,
     onNavigateToExtensionManager: () -> Unit,
+    onNavigateToBackupRestoreHub: () -> Unit,
     viewModel: HomeViewModel = koinViewModel(),
     installerViewModel: InstallerViewModel = koinViewModel()
 ) {
@@ -183,6 +184,7 @@ fun HomeScreen(
                             onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
                             onClearCache = onClearAllCache,
                             onNavigateToExtensionManager = onNavigateToExtensionManager,
+                            onNavigateToBackupRestoreHub = onNavigateToBackupRestoreHub,
                             showInstaller = state.showInstallerTile,
                             showExtensions = state.showExtensionsTile,
                             narrowContainer = true,
@@ -264,6 +266,7 @@ fun HomeScreen(
                     onInstall = { filePickerLauncher.launch(arrayOf("*/*")) },
                     onClearCache = onClearAllCache,
                     onNavigateToExtensionManager = onNavigateToExtensionManager,
+                    onNavigateToBackupRestoreHub = onNavigateToBackupRestoreHub,
                     modifier = Modifier.padding(horizontal = 24.dp),
                     showInstaller = state.showInstallerTile,
                     showExtensions = state.showExtensionsTile,

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActions.kt
@@ -3,20 +3,16 @@
 
 package com.valhalla.thor.presentation.home.components
 
-/** The four Home action tiles, in bento order. */
-enum class HomeAction { REINSTALL, INSTALL, CLEAR_CACHE, EXTENSIONS }
+/** The Home action tiles, in bento order. */
+enum class HomeAction { REINSTALL, INSTALL, BACKUP_RESTORE, CLEAR_CACHE, EXTENSIONS }
 
 /**
  * Packs the visible Home actions into bento rows: pairs throughout, with a single full-width
- * leader when the count is odd. 4 tiles -> 2x2; 3 -> one wide then a pair; 2 -> one pair; 1 -> one
- * wide tile.
+ * leader when the count is odd.
  *
- * The leader goes first rather than last so the wide tile lands at the top of the grid, next to
- * the summary row, instead of leaving a ragged edge at the bottom.
- *
- * Order is Install, Clear cache, Extensions, Reinstall. Reinstall is last because it is the only
- * dismissible tile: putting it at the end means dismissing it re-packs the rows below it rather
- * than shifting every other tile up one slot.
+ * Order is Install, Backup & restore, Clear cache, Extensions, Reinstall. Reinstall is last because it
+ * is the only dismissible tile: putting it at the end means dismissing it re-packs the rows below it
+ * rather than shifting every other tile up one slot.
  *
  * [showInstaller] and [showExtensions] are the user's own answer (GH#344): both tiles are shortcuts
  * to something reachable elsewhere — Installer still handles APK intents, Extensions keeps its
@@ -38,10 +34,12 @@ fun homeActionRows(
     hasPrivilege: Boolean,
     showInstaller: Boolean = true,
     showExtensions: Boolean = true,
+    showBackupRestore: Boolean = true,
     narrowContainer: Boolean = false,
 ): List<List<HomeAction>> {
     val actions = listOfNotNull(
         HomeAction.INSTALL.takeIf { showInstaller },
+        HomeAction.BACKUP_RESTORE.takeIf { showBackupRestore },
         HomeAction.CLEAR_CACHE.takeIf { canClearCache },
         HomeAction.EXTENSIONS.takeIf { hasPrivilege && showExtensions },
         HomeAction.REINSTALL.takeIf { reinstallVisible },

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/HomeActionsBento.kt
@@ -55,13 +55,21 @@ fun HomeActionsBento(
     onInstall: () -> Unit,
     onClearCache: () -> Unit,
     onNavigateToExtensionManager: () -> Unit,
+    onNavigateToBackupRestoreHub: () -> Unit,
     modifier: Modifier = Modifier,
     showInstaller: Boolean = true,
     showExtensions: Boolean = true,
+    showBackupRestore: Boolean = true,
     narrowContainer: Boolean = false,
 ) {
     val rows = homeActionRows(
-        reinstallVisible, canClearCache, hasPrivilege, showInstaller, showExtensions, narrowContainer
+        reinstallVisible,
+        canClearCache,
+        hasPrivilege,
+        showInstaller,
+        showExtensions,
+        showBackupRestore,
+        narrowContainer,
     )
     var explaining by rememberSaveable { mutableStateOf<HomeAction?>(null) }
     // Hiding both optional tiles with no privilege leaves nothing to draw. Emit no Column at all
@@ -83,6 +91,11 @@ fun HomeActionsBento(
             subtitle = stringResource(R.string.install_from_file_subtitle),
             icon = R.drawable.apk_install,
         )
+        HomeAction.BACKUP_RESTORE -> HomeActionCopy(
+            title = stringResource(R.string.backup_and_restore),
+            subtitle = stringResource(R.string.home_backup_restore_subtitle),
+            icon = R.drawable.settings_backup_restore,
+        )
         HomeAction.CLEAR_CACHE -> HomeActionCopy(
             title = stringResource(R.string.clear_all_cache),
             subtitle = stringResource(R.string.clear_all_cache_subtitle),
@@ -99,6 +112,7 @@ fun HomeActionsBento(
     fun onClick(action: HomeAction) = when (action) {
         HomeAction.REINSTALL -> onReinstall
         HomeAction.INSTALL -> onInstall
+        HomeAction.BACKUP_RESTORE -> onNavigateToBackupRestoreHub
         HomeAction.CLEAR_CACHE -> onClearCache
         HomeAction.EXTENSIONS -> onNavigateToExtensionManager
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainScreen.kt
@@ -95,6 +95,7 @@ import com.valhalla.thor.presentation.settings.SettingsScreen
 import com.valhalla.thor.presentation.settings.SettingsViewModel
 import com.valhalla.thor.presentation.backup.AppBackupSheet
 import com.valhalla.thor.presentation.backup.ArchiveRestoreSheet
+import com.valhalla.thor.presentation.backup.hub.BackupRestoreHubScreen
 import com.valhalla.thor.presentation.extension.ExtensionBrowseScreen
 import com.valhalla.thor.presentation.extension.ExtensionManagerScreen
 import com.valhalla.thor.presentation.settings.customization.AppInfoActionsCustomizationScreen
@@ -443,6 +444,9 @@ fun MainScreen(
                         },
                         onNavigateToExtensionManager = {
                             homeBackStack.add(ThorRoute.ExtensionManager)
+                        },
+                        onNavigateToBackupRestoreHub = {
+                            homeBackStack.add(ThorRoute.BackupRestoreHub)
                         }
                     )
                 }
@@ -670,6 +674,24 @@ fun MainScreen(
                             }
                         },
                         viewModel = settingsViewModel
+                    )
+                }
+
+                entry<ThorRoute.BackupRestoreHub>(
+                    metadata = ListDetailSceneStrategy.detailPane()
+                ) {
+                    BackupRestoreHubScreen(
+                        onBack = {
+                            if (currentBackStack.size > 1) {
+                                currentBackStack.removeLastOrNull()
+                            }
+                        },
+                        onOpenBackupSheet = { pkg, label ->
+                            mainViewModel.openBackupSheet(pkg, label)
+                        },
+                        onOpenRestoreSheet = { uriString ->
+                            mainViewModel.openRestoreSheet(uriString)
+                        },
                     )
                 }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -394,6 +394,10 @@ class MainViewModel(
         _uiState.update { it.copy(restoreSheet = null) }
     }
 
+    fun openBackupSheet(packageName: String, appLabel: String) {
+        _uiState.update { it.copy(backupSheet = BackupSheetState(packageName, appLabel)) }
+    }
+
     fun dismissBackupSheet() {
         _uiState.update { it.copy(backupSheet = null) }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/navigation/ThorRoute.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/navigation/ThorRoute.kt
@@ -61,4 +61,7 @@ sealed interface ThorRoute : NavKey {
 
     @Serializable
     data object AppInfoActionsCustomization : ThorRoute
+
+    @Serializable
+    data object BackupRestoreHub : ThorRoute
 }

--- a/app/src/main/res/values-ar/strings_backup.xml
+++ b/app/src/main/res/values-ar/strings_backup.xml
@@ -293,9 +293,33 @@
     -->
     <string name="passphrase_error_too_short">استخدم %1$d أحرف على الأقل.</string>
     <string name="passphrase_error_mismatch">عبارتا المرور غير متطابقتين.</string>
-    <!--
-      Deliberately not phrased as a failure of the backup: the vault is a convenience cache, and an
-      archive is protected by the passphrase itself, never by whether this device remembered it.
-    -->
     <string name="passphrase_error_store_failed">تعذّر على Thor حفظ عبارة المرور على هذا الجهاز. سيظل النسخ الاحتياطي يعمل — لكن سيتعيّن عليك كتابتها في كل مرة.</string>
+
+    <!-- Backup & Restore Hub UI -->
+    <string name="home_backup_restore_subtitle">إدارة النسخ الاحتياطية واستعادة البيانات</string>
+    <string name="backup_hub_hero_backup_title">نسخ تطبيق احتياطيًا</string>
+    <string name="backup_hub_hero_backup_desc">إنشاء نسخة احتياطية مشفرة (.thorbak) أو حزمة APK</string>
+    <string name="backup_hub_hero_restore_title">استعادة من ملف</string>
+    <string name="backup_hub_hero_restore_desc">تحديد أي أرشيف .thorbak أو حزمة من وحدة التخزين</string>
+    <string name="backup_hub_section_backups">النسخ الاحتياطية في Downloads/Thor</string>
+    <string name="backup_hub_filter_all">الكل</string>
+    <string name="backup_hub_filter_backups">نسخ احتياطية للبيانات (.thorbak)</string>
+    <string name="backup_hub_filter_bundles">حزم التطبيقات (.xapk، .apk)</string>
+    <string name="backup_hub_empty_title">لا توجد نسخ احتياطية في Downloads/Thor</string>
+    <string name="backup_hub_empty_desc">ستظهر الأرشيفات المحفوظة في Downloads/Thor هنا لاستعادتها بنقرة واحدة.</string>
+    <string name="backup_hub_tip_thorbak_title">النسخ الاحتياطية للبيانات (.thorbak)</string>
+    <string name="backup_hub_tip_thorbak_desc">أرشيفات كاملة مشفرة تحتوي على بيانات التطبيق (فئات التخزين CE/DE) وتجزئات APK. تتطلب الاستعادة صلاحيات الروت أو شل مميز.</string>
+    <string name="backup_hub_tip_bundle_title">حزم التطبيقات (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_desc">حزم تثبيت مستقلة للتثبيت بدون إنترنت أو المشاركة عبر الأجهزة دون الحاجة إلى روت.</string>
+    <string name="backup_hub_tip_discovery_title">الاكتشاف التلقائي</string>
+    <string name="backup_hub_tip_discovery_desc">يؤدي تصدير أو وضع أي أرشيف في Downloads/Thor إلى إدراجه هنا تلقائيًا للاستعادة الفورية.</string>
+    <string name="backup_hub_pick_app_title">اختر تطبيقًا للنسخ الاحتياطي</string>
+    <string name="backup_hub_search_apps_placeholder">بحث في التطبيقات…</string>
+    <string name="backup_hub_delete_confirm_title">حذف النسخة الاحتياطية؟</string>
+    <string name="backup_hub_delete_confirm_message">هل أنت متأكد من رغبتك في حذف %1$s من التخزين؟ لا يمكن التراجع عن هذا الإجراء.</string>
+    <string name="backup_hub_badge_data_backup">نسخة بيانات</string>
+    <string name="backup_hub_badge_app_bundle">حزمة تطبيق</string>
+    <string name="backup_hub_action_delete">حذف</string>
+    <string name="backup_hub_action_share">مشاركة</string>
+    <string name="backup_hub_no_archives">لم يتم العثور على أي أرشيف</string>
 </resources>

--- a/app/src/main/res/values-ar/strings_backup.xml
+++ b/app/src/main/res/values-ar/strings_backup.xml
@@ -304,12 +304,12 @@
     <string name="backup_hub_section_backups">النسخ الاحتياطية في Downloads/Thor</string>
     <string name="backup_hub_filter_all">الكل</string>
     <string name="backup_hub_filter_backups">نسخ احتياطية للبيانات (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">حزم التطبيقات (.xapk، .apk)</string>
+    <string name="backup_hub_filter_bundles">حزم التطبيقات (.xapk، .apks، .apk)</string>
     <string name="backup_hub_empty_title">لا توجد نسخ احتياطية في Downloads/Thor</string>
     <string name="backup_hub_empty_desc">ستظهر الأرشيفات المحفوظة في Downloads/Thor هنا لاستعادتها بنقرة واحدة.</string>
     <string name="backup_hub_tip_thorbak_title">النسخ الاحتياطية للبيانات (.thorbak)</string>
     <string name="backup_hub_tip_thorbak_desc">أرشيفات كاملة مشفرة تحتوي على بيانات التطبيق (فئات التخزين CE/DE) وتجزئات APK. تتطلب الاستعادة صلاحيات الروت أو شل مميز.</string>
-    <string name="backup_hub_tip_bundle_title">حزم التطبيقات (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_title">حزم التطبيقات (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">حزم تثبيت مستقلة للتثبيت بدون إنترنت أو المشاركة عبر الأجهزة دون الحاجة إلى روت.</string>
     <string name="backup_hub_tip_discovery_title">الاكتشاف التلقائي</string>
     <string name="backup_hub_tip_discovery_desc">يؤدي تصدير أو وضع أي أرشيف في Downloads/Thor إلى إدراجه هنا تلقائيًا للاستعادة الفورية.</string>

--- a/app/src/main/res/values-es/strings_backup.xml
+++ b/app/src/main/res/values-es/strings_backup.xml
@@ -300,12 +300,12 @@
     <string name="backup_hub_section_backups">Copias en Downloads/Thor</string>
     <string name="backup_hub_filter_all">Todo</string>
     <string name="backup_hub_filter_backups">Copias de datos (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">Paquetes de apps (.xapk, .apk)</string>
+    <string name="backup_hub_filter_bundles">Paquetes de apps (.xapk, .apks, .apk)</string>
     <string name="backup_hub_empty_title">No hay copias en Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Los archivos guardados en Downloads/Thor aparecerán aquí para restaurarlos rápidamente.</string>
     <string name="backup_hub_tip_thorbak_title">Copias de datos (.thorbak)</string>
     <string name="backup_hub_tip_thorbak_desc">Archivos completos cifrados con datos de apps (clases CE/DE) y divisiones APK. Restaurar requiere root o shell con privilegios.</string>
-    <string name="backup_hub_tip_bundle_title">Paquetes de apps (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_title">Paquetes de apps (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Paquetes de instalación independientes para instalar sin conexión o transferir sin necesidad de root.</string>
     <string name="backup_hub_tip_discovery_title">Detección automática</string>
     <string name="backup_hub_tip_discovery_desc">Cualquier archivo exportado o colocado en Downloads/Thor aparecerá aquí automáticamente para su restauración instantánea.</string>

--- a/app/src/main/res/values-es/strings_backup.xml
+++ b/app/src/main/res/values-es/strings_backup.xml
@@ -289,9 +289,33 @@
     -->
     <string name="passphrase_error_too_short">Usa al menos %1$d caracteres.</string>
     <string name="passphrase_error_mismatch">Las dos frases de contraseña no coinciden.</string>
-    <!--
-      Deliberately not phrased as a failure of the backup: the vault is a convenience cache, and an
-      archive is protected by the passphrase itself, never by whether this device remembered it.
-    -->
     <string name="passphrase_error_store_failed">Thor no pudo guardar la frase de contraseña en este dispositivo. La copia de seguridad funcionará igualmente — solo tendrás que escribirla cada vez.</string>
+
+    <!-- Backup & Restore Hub UI -->
+    <string name="home_backup_restore_subtitle">Administrar copias de seguridad y restaurar datos</string>
+    <string name="backup_hub_hero_backup_title">Respaldar una app</string>
+    <string name="backup_hub_hero_backup_desc">Crear copia de datos cifrada (.thorbak) o paquete APK</string>
+    <string name="backup_hub_hero_restore_title">Restaurar desde archivo</string>
+    <string name="backup_hub_hero_restore_desc">Seleccionar cualquier archivo .thorbak o paquete del almacenamiento</string>
+    <string name="backup_hub_section_backups">Copias en Downloads/Thor</string>
+    <string name="backup_hub_filter_all">Todo</string>
+    <string name="backup_hub_filter_backups">Copias de datos (.thorbak)</string>
+    <string name="backup_hub_filter_bundles">Paquetes de apps (.xapk, .apk)</string>
+    <string name="backup_hub_empty_title">No hay copias en Downloads/Thor</string>
+    <string name="backup_hub_empty_desc">Los archivos guardados en Downloads/Thor aparecerán aquí para restaurarlos rápidamente.</string>
+    <string name="backup_hub_tip_thorbak_title">Copias de datos (.thorbak)</string>
+    <string name="backup_hub_tip_thorbak_desc">Archivos completos cifrados con datos de apps (clases CE/DE) y divisiones APK. Restaurar requiere root o shell con privilegios.</string>
+    <string name="backup_hub_tip_bundle_title">Paquetes de apps (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_desc">Paquetes de instalación independientes para instalar sin conexión o transferir sin necesidad de root.</string>
+    <string name="backup_hub_tip_discovery_title">Detección automática</string>
+    <string name="backup_hub_tip_discovery_desc">Cualquier archivo exportado o colocado en Downloads/Thor aparecerá aquí automáticamente para su restauración instantánea.</string>
+    <string name="backup_hub_pick_app_title">Seleccionar una app para respaldar</string>
+    <string name="backup_hub_search_apps_placeholder">Buscar apps…</string>
+    <string name="backup_hub_delete_confirm_title">¿Eliminar copia de seguridad?</string>
+    <string name="backup_hub_delete_confirm_message">¿Seguro que deseas eliminar %1$s del almacenamiento? Esta acción no se puede deshacer.</string>
+    <string name="backup_hub_badge_data_backup">Copia de datos</string>
+    <string name="backup_hub_badge_app_bundle">Paquete de app</string>
+    <string name="backup_hub_action_delete">Eliminar</string>
+    <string name="backup_hub_action_share">Compartir</string>
+    <string name="backup_hub_no_archives">No se encontraron archivos</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_backup.xml
+++ b/app/src/main/res/values-fr/strings_backup.xml
@@ -295,9 +295,33 @@
     -->
     <string name="passphrase_error_too_short">Utilisez au moins %1$d caractères.</string>
     <string name="passphrase_error_mismatch">Les deux phrases secrètes ne correspondent pas.</string>
-    <!--
-      Deliberately not phrased as a failure of the backup: the vault is a convenience cache, and an
-      archive is protected by the passphrase itself, never by whether this device remembered it.
-    -->
     <string name="passphrase_error_store_failed">Thor n\'a pas pu enregistrer la phrase secrète sur cet appareil. La sauvegarde fonctionnera quand même — vous devrez simplement la saisir à chaque fois.</string>
+
+    <!-- Backup & Restore Hub UI -->
+    <string name="home_backup_restore_subtitle">Gérer les sauvegardes et restaurer les données</string>
+    <string name="backup_hub_hero_backup_title">Sauvegarder une appli</string>
+    <string name="backup_hub_hero_backup_desc">Créer une sauvegarde chiffrée (.thorbak) ou un pack APK</string>
+    <string name="backup_hub_hero_restore_title">Restaurer depuis un fichier</string>
+    <string name="backup_hub_hero_restore_desc">Sélectionner une archive .thorbak ou un pack du stockage</string>
+    <string name="backup_hub_section_backups">Sauvegardes dans Downloads/Thor</string>
+    <string name="backup_hub_filter_all">Tout</string>
+    <string name="backup_hub_filter_backups">Sauvegardes de données (.thorbak)</string>
+    <string name="backup_hub_filter_bundles">Packs d\'applications (.xapk, .apk)</string>
+    <string name="backup_hub_empty_title">Aucune sauvegarde dans Downloads/Thor</string>
+    <string name="backup_hub_empty_desc">Les archives enregistrées dans Downloads/Thor apparaîtront ici pour une restauration rapide.</string>
+    <string name="backup_hub_tip_thorbak_title">Sauvegardes de données (.thorbak)</string>
+    <string name="backup_hub_tip_thorbak_desc">Archives complètes chiffrées contenant les données d\'appli (classes CE/DE) et divisions APK. La restauration nécessite le root ou un shell privilégié.</string>
+    <string name="backup_hub_tip_bundle_title">Packs d\'applications (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_desc">Packs d\'installation autonomes pour l\'installation hors ligne ou le partage entre appareils sans accès root.</string>
+    <string name="backup_hub_tip_discovery_title">Détection automatique</string>
+    <string name="backup_hub_tip_discovery_desc">Toute archive exportée ou placée dans Downloads/Thor apparaît automatiquement ici pour une restauration instantanée.</string>
+    <string name="backup_hub_pick_app_title">Sélectionner une appli à sauvegarder</string>
+    <string name="backup_hub_search_apps_placeholder">Rechercher des applis…</string>
+    <string name="backup_hub_delete_confirm_title">Supprimer la sauvegarde ?</string>
+    <string name="backup_hub_delete_confirm_message">Voulez-vous vraiment supprimer %1$s du stockage ? Cette action est irréversible.</string>
+    <string name="backup_hub_badge_data_backup">Sauvegarde données</string>
+    <string name="backup_hub_badge_app_bundle">Pack appli</string>
+    <string name="backup_hub_action_delete">Supprimer</string>
+    <string name="backup_hub_action_share">Partager</string>
+    <string name="backup_hub_no_archives">Aucune archive trouvée</string>
 </resources>

--- a/app/src/main/res/values-fr/strings_backup.xml
+++ b/app/src/main/res/values-fr/strings_backup.xml
@@ -306,12 +306,12 @@
     <string name="backup_hub_section_backups">Sauvegardes dans Downloads/Thor</string>
     <string name="backup_hub_filter_all">Tout</string>
     <string name="backup_hub_filter_backups">Sauvegardes de données (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">Packs d\'applications (.xapk, .apk)</string>
+    <string name="backup_hub_filter_bundles">Packs d\'applications (.xapk, .apks, .apk)</string>
     <string name="backup_hub_empty_title">Aucune sauvegarde dans Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Les archives enregistrées dans Downloads/Thor apparaîtront ici pour une restauration rapide.</string>
     <string name="backup_hub_tip_thorbak_title">Sauvegardes de données (.thorbak)</string>
     <string name="backup_hub_tip_thorbak_desc">Archives complètes chiffrées contenant les données d\'appli (classes CE/DE) et divisions APK. La restauration nécessite le root ou un shell privilégié.</string>
-    <string name="backup_hub_tip_bundle_title">Packs d\'applications (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_title">Packs d\'applications (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Packs d\'installation autonomes pour l\'installation hors ligne ou le partage entre appareils sans accès root.</string>
     <string name="backup_hub_tip_discovery_title">Détection automatique</string>
     <string name="backup_hub_tip_discovery_desc">Toute archive exportée ou placée dans Downloads/Thor apparaît automatiquement ici pour une restauration instantanée.</string>

--- a/app/src/main/res/values-pl/strings_backup.xml
+++ b/app/src/main/res/values-pl/strings_backup.xml
@@ -291,9 +291,33 @@
     -->
     <string name="passphrase_error_too_short">Użyj co najmniej %1$d znaków.</string>
     <string name="passphrase_error_mismatch">Hasła nie są takie same.</string>
-    <!--
-      Deliberately not phrased as a failure of the backup: the vault is a convenience cache, and an
-      archive is protected by the passphrase itself, never by whether this device remembered it.
-    -->
     <string name="passphrase_error_store_failed">Thor nie mógł zapisać hasła na tym urządzeniu. Kopia zapasowa i tak zadziała — trzeba będzie tylko wpisywać hasło za każdym razem.</string>
+
+    <!-- Backup & Restore Hub UI -->
+    <string name="home_backup_restore_subtitle">Zarządzaj kopiami i przywracaj dane</string>
+    <string name="backup_hub_hero_backup_title">Utwórz kopię aplikacji</string>
+    <string name="backup_hub_hero_backup_desc">Utwórz zaszyfrowaną kopię danych (.thorbak) lub pakiet APK</string>
+    <string name="backup_hub_hero_restore_title">Przywróć z pliku</string>
+    <string name="backup_hub_hero_restore_desc">Wybierz dowolne archiwum .thorbak lub pakiet z pamięci</string>
+    <string name="backup_hub_section_backups">Kopie w Downloads/Thor</string>
+    <string name="backup_hub_filter_all">Wszystko</string>
+    <string name="backup_hub_filter_backups">Kopie danych (.thorbak)</string>
+    <string name="backup_hub_filter_bundles">Pakiety aplikacji (.xapk, .apk)</string>
+    <string name="backup_hub_empty_title">Brak kopii w Downloads/Thor</string>
+    <string name="backup_hub_empty_desc">Archiwa zapisane w Downloads/Thor pojawią się tutaj, umożliwiając szybkie przywrócenie jednym dotknięciem.</string>
+    <string name="backup_hub_tip_thorbak_title">Kopie danych (.thorbak)</string>
+    <string name="backup_hub_tip_thorbak_desc">Zaszyfrowane pełne archiwa zawierające dane aplikacji (klasy CE/DE) i podziały APK. Przywracanie wymaga uprawnień root lub uprzywilejowanej powłoki.</string>
+    <string name="backup_hub_tip_bundle_title">Pakiety aplikacji (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_desc">Samodzielne pakiety instalacyjne do instalacji offline lub przesyłania między urządzeniami bez uprawnień root.</string>
+    <string name="backup_hub_tip_discovery_title">Automatyczne wykrywanie</string>
+    <string name="backup_hub_tip_discovery_desc">Wyeksportowanie lub umieszczenie dowolnego archiwum w Downloads/Thor automatycznie wyświetli je tutaj do natychmiastowego przywrócenia.</string>
+    <string name="backup_hub_pick_app_title">Wybierz aplikację do utworzenia kopii</string>
+    <string name="backup_hub_search_apps_placeholder">Szukaj aplikacji…</string>
+    <string name="backup_hub_delete_confirm_title">Usunąć kopię zapasową?</string>
+    <string name="backup_hub_delete_confirm_message">Czy na pewno chcesz usunąć %1$s z pamięci urządzenia? Tej operacji nie można cofnąć.</string>
+    <string name="backup_hub_badge_data_backup">Kopia danych</string>
+    <string name="backup_hub_badge_app_bundle">Pakiet aplikacji</string>
+    <string name="backup_hub_action_delete">Usuń</string>
+    <string name="backup_hub_action_share">Udostępnij</string>
+    <string name="backup_hub_no_archives">Nie znaleziono archiwów</string>
 </resources>

--- a/app/src/main/res/values-pl/strings_backup.xml
+++ b/app/src/main/res/values-pl/strings_backup.xml
@@ -302,12 +302,12 @@
     <string name="backup_hub_section_backups">Kopie w Downloads/Thor</string>
     <string name="backup_hub_filter_all">Wszystko</string>
     <string name="backup_hub_filter_backups">Kopie danych (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">Pakiety aplikacji (.xapk, .apk)</string>
+    <string name="backup_hub_filter_bundles">Pakiety aplikacji (.xapk, .apks, .apk)</string>
     <string name="backup_hub_empty_title">Brak kopii w Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Archiwa zapisane w Downloads/Thor pojawią się tutaj, umożliwiając szybkie przywrócenie jednym dotknięciem.</string>
     <string name="backup_hub_tip_thorbak_title">Kopie danych (.thorbak)</string>
     <string name="backup_hub_tip_thorbak_desc">Zaszyfrowane pełne archiwa zawierające dane aplikacji (klasy CE/DE) i podziały APK. Przywracanie wymaga uprawnień root lub uprzywilejowanej powłoki.</string>
-    <string name="backup_hub_tip_bundle_title">Pakiety aplikacji (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_title">Pakiety aplikacji (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Samodzielne pakiety instalacyjne do instalacji offline lub przesyłania między urządzeniami bez uprawnień root.</string>
     <string name="backup_hub_tip_discovery_title">Automatyczne wykrywanie</string>
     <string name="backup_hub_tip_discovery_desc">Wyeksportowanie lub umieszczenie dowolnego archiwum w Downloads/Thor automatycznie wyświetli je tutaj do natychmiastowego przywrócenia.</string>

--- a/app/src/main/res/values-pt/strings_backup.xml
+++ b/app/src/main/res/values-pt/strings_backup.xml
@@ -295,9 +295,33 @@
     -->
     <string name="passphrase_error_too_short">Use pelo menos %1$d caracteres.</string>
     <string name="passphrase_error_mismatch">As duas frases-passe não coincidem.</string>
-    <!--
-      Deliberately not phrased as a failure of the backup: the vault is a convenience cache, and an
-      archive is protected by the passphrase itself, never by whether this device remembered it.
-    -->
     <string name="passphrase_error_store_failed">O Thor não conseguiu guardar a frase-passe neste dispositivo. A cópia de segurança continua a funcionar — apenas terá de a escrever de cada vez.</string>
+
+    <!-- Backup & Restore Hub UI -->
+    <string name="home_backup_restore_subtitle">Gerir cópias de segurança e restaurar dados</string>
+    <string name="backup_hub_hero_backup_title">Fazer cópia de uma app</string>
+    <string name="backup_hub_hero_backup_desc">Criar cópia de dados encriptada (.thorbak) ou pacote APK</string>
+    <string name="backup_hub_hero_restore_title">Restaurar a partir de ficheiro</string>
+    <string name="backup_hub_hero_restore_desc">Selecionar qualquer arquivo .thorbak ou pacote do armazenamento</string>
+    <string name="backup_hub_section_backups">Cópias em Downloads/Thor</string>
+    <string name="backup_hub_filter_all">Tudo</string>
+    <string name="backup_hub_filter_backups">Cópias de dados (.thorbak)</string>
+    <string name="backup_hub_filter_bundles">Pacotes de aplicações (.xapk, .apk)</string>
+    <string name="backup_hub_empty_title">Sem cópias em Downloads/Thor</string>
+    <string name="backup_hub_empty_desc">Os arquivos guardados em Downloads/Thor aparecerão aqui para restauro rápido num só toque.</string>
+    <string name="backup_hub_tip_thorbak_title">Cópias de dados (.thorbak)</string>
+    <string name="backup_hub_tip_thorbak_desc">Arquivos completos encriptados contendo dados de aplicações (classes CE/DE) e divisões APK. O restauro requer root ou shell privilegiada.</string>
+    <string name="backup_hub_tip_bundle_title">Pacotes de aplicações (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_desc">Pacotes de instalação autónomos para instalação offline ou partilha entre dispositivos sem necessitar de root.</string>
+    <string name="backup_hub_tip_discovery_title">Deteção automática</string>
+    <string name="backup_hub_tip_discovery_desc">Qualquer arquivo exportado ou colocado em Downloads/Thor será listado aqui automaticamente para restauro imediato.</string>
+    <string name="backup_hub_pick_app_title">Selecionar uma aplicação para cópia</string>
+    <string name="backup_hub_search_apps_placeholder">Pesquisar aplicações…</string>
+    <string name="backup_hub_delete_confirm_title">Eliminar cópia de segurança?</string>
+    <string name="backup_hub_delete_confirm_message">Tem a certeza de que deseja eliminar %1$s do armazenamento? Esta ação é irreversível.</string>
+    <string name="backup_hub_badge_data_backup">Cópia de dados</string>
+    <string name="backup_hub_badge_app_bundle">Pacote de aplicação</string>
+    <string name="backup_hub_action_delete">Eliminar</string>
+    <string name="backup_hub_action_share">Partilhar</string>
+    <string name="backup_hub_no_archives">Nenhum arquivo encontrado</string>
 </resources>

--- a/app/src/main/res/values-pt/strings_backup.xml
+++ b/app/src/main/res/values-pt/strings_backup.xml
@@ -306,12 +306,12 @@
     <string name="backup_hub_section_backups">Cópias em Downloads/Thor</string>
     <string name="backup_hub_filter_all">Tudo</string>
     <string name="backup_hub_filter_backups">Cópias de dados (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">Pacotes de aplicações (.xapk, .apk)</string>
+    <string name="backup_hub_filter_bundles">Pacotes de aplicações (.xapk, .apks, .apk)</string>
     <string name="backup_hub_empty_title">Sem cópias em Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Os arquivos guardados em Downloads/Thor aparecerão aqui para restauro rápido num só toque.</string>
     <string name="backup_hub_tip_thorbak_title">Cópias de dados (.thorbak)</string>
     <string name="backup_hub_tip_thorbak_desc">Arquivos completos encriptados contendo dados de aplicações (classes CE/DE) e divisões APK. O restauro requer root ou shell privilegiada.</string>
-    <string name="backup_hub_tip_bundle_title">Pacotes de aplicações (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_title">Pacotes de aplicações (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Pacotes de instalação autónomos para instalação offline ou partilha entre dispositivos sem necessitar de root.</string>
     <string name="backup_hub_tip_discovery_title">Deteção automática</string>
     <string name="backup_hub_tip_discovery_desc">Qualquer arquivo exportado ou colocado em Downloads/Thor será listado aqui automaticamente para restauro imediato.</string>

--- a/app/src/main/res/values-zh-rCN/strings_backup.xml
+++ b/app/src/main/res/values-zh-rCN/strings_backup.xml
@@ -288,9 +288,33 @@
     -->
     <string name="passphrase_error_too_short">请至少使用 %1$d 个字符。</string>
     <string name="passphrase_error_mismatch">两次输入的密码短语不一致。</string>
-    <!--
-      Deliberately not phrased as a failure of the backup: the vault is a convenience cache, and an
-      archive is protected by the passphrase itself, never by whether this device remembered it.
-    -->
     <string name="passphrase_error_store_failed">Thor 无法在此设备上保存该密码短语。备份仍然可用——只是每次都需要重新输入它。</string>
+
+    <!-- Backup & Restore Hub UI -->
+    <string name="home_backup_restore_subtitle">管理应用备份与恢复数据</string>
+    <string name="backup_hub_hero_backup_title">备份应用</string>
+    <string name="backup_hub_hero_backup_desc">创建加密数据备份 (.thorbak) 或 APK 安装包</string>
+    <string name="backup_hub_hero_restore_title">从文件恢复</string>
+    <string name="backup_hub_hero_restore_desc">从存储空间选择任意 .thorbak 备份或安装包</string>
+    <string name="backup_hub_section_backups">Downloads/Thor 中的备份</string>
+    <string name="backup_hub_filter_all">全部</string>
+    <string name="backup_hub_filter_backups">数据备份 (.thorbak)</string>
+    <string name="backup_hub_filter_bundles">应用安装包 (.xapk, .apk)</string>
+    <string name="backup_hub_empty_title">Downloads/Thor 中无备份</string>
+    <string name="backup_hub_empty_desc">保存在 Downloads/Thor 中的备份将显示在此处，支持一键快速恢复。</string>
+    <string name="backup_hub_tip_thorbak_title">数据备份 (.thorbak)</string>
+    <string name="backup_hub_tip_thorbak_desc">包含应用数据（CE/DE 存储区）和 APK 分卷的加密完整归档。恢复需要 Root 或特权 Shell。</string>
+    <string name="backup_hub_tip_bundle_title">应用安装包 (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_desc">独立的安装包，支持离线安装或跨设备分享，无需 Root 权限。</string>
+    <string name="backup_hub_tip_discovery_title">自动发现</string>
+    <string name="backup_hub_tip_discovery_desc">导出或放置在 Downloads/Thor 中的任何归档文件都会自动在此列出，方便即时恢复。</string>
+    <string name="backup_hub_pick_app_title">选择要备份的应用</string>
+    <string name="backup_hub_search_apps_placeholder">搜索应用…</string>
+    <string name="backup_hub_delete_confirm_title">删除备份？</string>
+    <string name="backup_hub_delete_confirm_message">确定要从存储空间中删除 %1$s 吗？此操作无法撤销。</string>
+    <string name="backup_hub_badge_data_backup">数据备份</string>
+    <string name="backup_hub_badge_app_bundle">应用包</string>
+    <string name="backup_hub_action_delete">删除</string>
+    <string name="backup_hub_action_share">分享</string>
+    <string name="backup_hub_no_archives">未找到归档文件</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings_backup.xml
+++ b/app/src/main/res/values-zh-rCN/strings_backup.xml
@@ -299,12 +299,12 @@
     <string name="backup_hub_section_backups">Downloads/Thor 中的备份</string>
     <string name="backup_hub_filter_all">全部</string>
     <string name="backup_hub_filter_backups">数据备份 (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">应用安装包 (.xapk, .apk)</string>
+    <string name="backup_hub_filter_bundles">应用安装包 (.xapk, .apks, .apk)</string>
     <string name="backup_hub_empty_title">Downloads/Thor 中无备份</string>
     <string name="backup_hub_empty_desc">保存在 Downloads/Thor 中的备份将显示在此处，支持一键快速恢复。</string>
     <string name="backup_hub_tip_thorbak_title">数据备份 (.thorbak)</string>
     <string name="backup_hub_tip_thorbak_desc">包含应用数据（CE/DE 存储区）和 APK 分卷的加密完整归档。恢复需要 Root 或特权 Shell。</string>
-    <string name="backup_hub_tip_bundle_title">应用安装包 (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_title">应用安装包 (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">独立的安装包，支持离线安装或跨设备分享，无需 Root 权限。</string>
     <string name="backup_hub_tip_discovery_title">自动发现</string>
     <string name="backup_hub_tip_discovery_desc">导出或放置在 Downloads/Thor 中的任何归档文件都会自动在此列出，方便即时恢复。</string>

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -303,4 +303,32 @@
       archive is protected by the passphrase itself, never by whether this device remembered it.
     -->
     <string name="passphrase_error_store_failed">Thor could not save the passphrase on this device. The backup will still work — you will just have to type it each time.</string>
+
+    <!-- Backup & Restore Hub UI -->
+    <string name="home_backup_restore_subtitle">Manage app backups &amp; restore data</string>
+    <string name="backup_hub_hero_backup_title">Backup an app</string>
+    <string name="backup_hub_hero_backup_desc">Create encrypted data backup (.thorbak) or APK bundle</string>
+    <string name="backup_hub_hero_restore_title">Restore from file</string>
+    <string name="backup_hub_hero_restore_desc">Select any .thorbak or bundle archive from storage</string>
+    <string name="backup_hub_section_backups">Backups in Downloads/Thor</string>
+    <string name="backup_hub_filter_all">All</string>
+    <string name="backup_hub_filter_backups">Data Backups (.thorbak)</string>
+    <string name="backup_hub_filter_bundles">App Bundles (.xapk, .apk)</string>
+    <string name="backup_hub_empty_title">No backups in Downloads/Thor</string>
+    <string name="backup_hub_empty_desc">Archives saved to Downloads/Thor will appear here for fast one-tap restore.</string>
+    <string name="backup_hub_tip_thorbak_title">Data Backups (.thorbak)</string>
+    <string name="backup_hub_tip_thorbak_desc">Encrypted full archives carrying app data (CE/DE storage classes) and APK splits. Restoring requires Root or privileged shell.</string>
+    <string name="backup_hub_tip_bundle_title">App Bundles (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_desc">Standalone installation packages for offline install or sharing across devices without requiring root.</string>
+    <string name="backup_hub_tip_discovery_title">Auto-Discovery</string>
+    <string name="backup_hub_tip_discovery_desc">Exporting or placing any archive in Downloads/Thor automatically lists it here for instant restore.</string>
+    <string name="backup_hub_pick_app_title">Select an app to back up</string>
+    <string name="backup_hub_search_apps_placeholder">Search apps…</string>
+    <string name="backup_hub_delete_confirm_title">Delete backup?</string>
+    <string name="backup_hub_delete_confirm_message">Are you sure you want to delete %1$s from storage? This cannot be undone.</string>
+    <string name="backup_hub_badge_data_backup">Data backup</string>
+    <string name="backup_hub_badge_app_bundle">App bundle</string>
+    <string name="backup_hub_action_delete">Delete</string>
+    <string name="backup_hub_action_share">Share</string>
+    <string name="backup_hub_no_archives">No archives found</string>
 </resources>

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -313,12 +313,12 @@
     <string name="backup_hub_section_backups">Backups in Downloads/Thor</string>
     <string name="backup_hub_filter_all">All</string>
     <string name="backup_hub_filter_backups">Data Backups (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">App Bundles (.xapk, .apk)</string>
+    <string name="backup_hub_filter_bundles">App Bundles (.xapk, .apks, .apk)</string>
     <string name="backup_hub_empty_title">No backups in Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Archives saved to Downloads/Thor will appear here for fast one-tap restore.</string>
     <string name="backup_hub_tip_thorbak_title">Data Backups (.thorbak)</string>
     <string name="backup_hub_tip_thorbak_desc">Encrypted full archives carrying app data (CE/DE storage classes) and APK splits. Restoring requires Root or privileged shell.</string>
-    <string name="backup_hub_tip_bundle_title">App Bundles (.xapk / .apk)</string>
+    <string name="backup_hub_tip_bundle_title">App Bundles (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Standalone installation packages for offline install or sharing across devices without requiring root.</string>
     <string name="backup_hub_tip_discovery_title">Auto-Discovery</string>
     <string name="backup_hub_tip_discovery_desc">Exporting or placing any archive in Downloads/Thor automatically lists it here for instant restore.</string>

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
@@ -197,4 +197,36 @@ class BackupRestoreHubViewModelTest {
         assertEquals(listOf(item), scanner.deletedItems)
         assertTrue(vm.state.value.archives.isEmpty())
     }
+
+    @Test
+    fun refreshArchives_cancelsPreviousScan() = runTest(testDispatcher) {
+        val flow1 = kotlinx.coroutines.flow.MutableSharedFlow<List<BackupArchiveItem>>(replay = 1)
+        val flow2 = kotlinx.coroutines.flow.MutableSharedFlow<List<BackupArchiveItem>>(replay = 1)
+        var flowIndex = 0
+        val dynamicScanner = object : BackupArchiveScanner {
+            override fun scanBackups(): Flow<List<BackupArchiveItem>> {
+                return if (flowIndex++ == 0) flow1 else flow2
+            }
+            override suspend fun deleteArchive(item: BackupArchiveItem) = true
+        }
+
+        val vm = BackupRestoreHubViewModel(dynamicScanner, FakeAppDao())
+        advanceUntilIdle()
+
+        // Trigger a second scan
+        vm.refreshArchives()
+        advanceUntilIdle()
+
+        val item1 = createItem(1, "item1.thorbak", BackupArchiveKind.DATA_BACKUP)
+        val item2 = createItem(2, "item2.thorbak", BackupArchiveKind.DATA_BACKUP)
+
+        flow2.emit(listOf(item2))
+        advanceUntilIdle()
+        assertEquals(listOf(item2), vm.state.value.archives)
+
+        // Stale emission from first scan must not overwrite state
+        flow1.emit(listOf(item1))
+        advanceUntilIdle()
+        assertEquals(listOf(item2), vm.state.value.archives)
+    }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.backup.hub
+
+import com.valhalla.thor.data.source.local.room.AppDao
+import com.valhalla.thor.data.source.local.room.AppEntity
+import com.valhalla.thor.data.source.local.room.PackageInstallSize
+import com.valhalla.thor.domain.repository.BackupArchiveItem
+import com.valhalla.thor.domain.repository.BackupArchiveKind
+import com.valhalla.thor.domain.repository.BackupArchiveScanner
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackupRestoreHubViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private class FakeScanner(var items: List<BackupArchiveItem> = emptyList()) : BackupArchiveScanner {
+        var deletedItems = mutableListOf<BackupArchiveItem>()
+
+        override fun scanBackups(): Flow<List<BackupArchiveItem>> = flowOf(items)
+
+        override suspend fun deleteArchive(item: BackupArchiveItem): Boolean {
+            deletedItems.add(item)
+            items = items.filter { it.id != item.id }
+            return true
+        }
+    }
+
+    private class FakeAppDao(private val apps: List<AppEntity> = emptyList()) : AppDao {
+        override fun getAllAppsFlow(): Flow<List<AppEntity>> = flowOf(apps)
+        override suspend fun getAllApps(): List<AppEntity> = apps
+        override suspend fun getApp(packageName: String): AppEntity? = apps.find { it.packageName == packageName }
+        override suspend fun insertApps(apps: List<AppEntity>) {}
+        override suspend fun deleteApp(packageName: String) {}
+        override suspend fun getInstallSizes(packages: List<String>): List<PackageInstallSize> = emptyList()
+        override suspend fun updateInstallSize(packageName: String, size: Long?) {}
+        override suspend fun clearAll() {}
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createItem(
+        id: Long,
+        name: String,
+        kind: BackupArchiveKind,
+        size: Long = 1024,
+    ): BackupArchiveItem = BackupArchiveItem(
+        id = id,
+        uriString = "content://downloads/$id",
+        displayName = name,
+        packageName = "com.test.app",
+        sizeBytes = size,
+        dateModifiedEpochSec = 1000L + id,
+        kind = kind,
+        extension = if (kind == BackupArchiveKind.DATA_BACKUP) "thorbak" else "xapk",
+    )
+
+    @Test
+    fun dynamicFilterChips_onlyShownWhenBothBackupsAndBundlesExist() = runTest(testDispatcher) {
+        val scannerOnlyBackups = FakeScanner(
+            listOf(createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP))
+        )
+        val vm1 = BackupRestoreHubViewModel(scannerOnlyBackups, FakeAppDao())
+        advanceUntilIdle()
+        assertFalse("Only backups present -> no filter chips", vm1.state.value.showFilterChips)
+
+        val scannerOnlyBundles = FakeScanner(
+            listOf(createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE))
+        )
+        val vm2 = BackupRestoreHubViewModel(scannerOnlyBundles, FakeAppDao())
+        advanceUntilIdle()
+        assertFalse("Only bundles present -> no filter chips", vm2.state.value.showFilterChips)
+
+        val scannerBoth = FakeScanner(
+            listOf(
+                createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP),
+                createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE),
+            )
+        )
+        val vm3 = BackupRestoreHubViewModel(scannerBoth, FakeAppDao())
+        advanceUntilIdle()
+        assertTrue("Both present -> filter chips shown", vm3.state.value.showFilterChips)
+    }
+
+    @Test
+    fun filtering_filtersItemsCorrectly() = runTest(testDispatcher) {
+        val backup = createItem(1, "backup.thorbak", BackupArchiveKind.DATA_BACKUP)
+        val bundle = createItem(2, "bundle.xapk", BackupArchiveKind.APP_BUNDLE)
+        val scanner = FakeScanner(listOf(backup, bundle))
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppDao())
+        advanceUntilIdle()
+
+        assertEquals(2, vm.state.value.filteredArchives.size)
+
+        vm.setFilter(BackupHubFilter.DATA_BACKUPS)
+        assertEquals(listOf(backup), vm.state.value.filteredArchives)
+
+        vm.setFilter(BackupHubFilter.APP_BUNDLES)
+        assertEquals(listOf(bundle), vm.state.value.filteredArchives)
+
+        vm.setFilter(BackupHubFilter.ALL)
+        assertEquals(listOf(backup, bundle), vm.state.value.filteredArchives)
+    }
+
+    private fun createAppEntity(
+        packageName: String,
+        appName: String,
+        isSystem: Boolean = false,
+    ) = AppEntity(
+        packageName = packageName,
+        appName = appName,
+        versionName = "1.0",
+        versionCode = 1L,
+        minSdk = 26,
+        targetSdk = 34,
+        isSystem = isSystem,
+        installerPackageName = null,
+        publicSourceDir = null,
+        splitPublicSourceDirs = emptyList(),
+        enabled = true,
+        dataDir = null,
+        nativeLibraryDir = null,
+        deviceProtectedDataDir = null,
+        sharedLibraryFiles = null,
+        obbFilePath = null,
+        sourceDir = null,
+        sharedDataDir = "",
+        lastUpdateTime = 0L,
+        firstInstallTime = 0L,
+        isDebuggable = false,
+        isSuspended = false,
+        installSize = null,
+    )
+
+    @Test
+    fun appPickerSearch_filtersAppsByNameAndPackage() = runTest(testDispatcher) {
+        val app1 = createAppEntity(packageName = "com.spotify.music", appName = "Spotify", isSystem = false)
+        val app2 = createAppEntity(packageName = "org.telegram.messenger", appName = "Telegram", isSystem = false)
+        val dao = FakeAppDao(listOf(app1, app2))
+        val vm = BackupRestoreHubViewModel(FakeScanner(), dao)
+        advanceUntilIdle()
+
+        assertEquals(2, vm.state.value.installedApps.size)
+
+        vm.updateAppPickerSearch("Spot")
+        assertEquals(listOf(app1), vm.state.value.filteredInstalledApps)
+
+        vm.updateAppPickerSearch("telegram")
+        assertEquals(listOf(app2), vm.state.value.filteredInstalledApps)
+
+        vm.updateAppPickerSearch("org.")
+        assertEquals(listOf(app2), vm.state.value.filteredInstalledApps)
+
+        vm.updateAppPickerSearch("")
+        assertEquals(2, vm.state.value.filteredInstalledApps.size)
+    }
+
+    @Test
+    fun archiveDeletion_removesItemAndRefreshes() = runTest(testDispatcher) {
+        val item = createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP)
+        val scanner = FakeScanner(listOf(item))
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppDao())
+        advanceUntilIdle()
+
+        assertEquals(1, vm.state.value.archives.size)
+
+        vm.requestDeleteArchive(item)
+        assertEquals(item, vm.state.value.archiveToDelete)
+
+        vm.confirmDeleteArchive()
+        advanceUntilIdle()
+
+        assertEquals(listOf(item), scanner.deletedItems)
+        assertTrue(vm.state.value.archives.isEmpty())
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/home/HomeActionsTest.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.presentation.home
 
 import com.valhalla.thor.presentation.home.components.HomeAction
+import com.valhalla.thor.presentation.home.components.HomeAction.BACKUP_RESTORE
 import com.valhalla.thor.presentation.home.components.HomeAction.CLEAR_CACHE
 import com.valhalla.thor.presentation.home.components.HomeAction.EXTENSIONS
 import com.valhalla.thor.presentation.home.components.HomeAction.INSTALL
@@ -16,35 +17,33 @@ import org.junit.Test
 /**
  * The three privilege flags all derive from one nullable field on the Home state, so only five of
  * their eight combinations are reachable: `canClearCache` implies privilege, and so does a visible
- * reinstall card. The two GH#344 preferences are independent of all of that and of each other, so
- * the reachable set is those five crossed with all four preference pairs.
+ * reinstall card. The GH#344 preferences are independent of all of that and of each other.
  *
- * `canClearCache` used to be `isRoot`. It is Root **or** Shizuku now, because the tile runs
- * `pm trim-caches`, gated on `CLEAR_APP_CACHE` — a permission `com.android.shell` holds. Only
- * Dhizuku is excluded, so the implication that shapes this table is unchanged: every mode that can
- * clear caches has a privilege, and one mode with a privilege cannot clear them.
+ * `canClearCache` is Root **or** Shizuku, because the tile runs `pm trim-caches`, gated on
+ * `CLEAR_APP_CACHE` — a permission `com.android.shell` holds.
  *
  * Each privilege state is asserted on its own below, then the preference rules, then the packing
  * and visibility invariants across every combination.
  */
 class HomeActionsTest {
 
-    /** One state the Home screen can be in: the three derived flags plus the two preferences. */
+    /** One state the Home screen can be in: the three derived flags plus preferences. */
     private data class State(
         val reinstall: Boolean,
         val canClearCache: Boolean,
         val privilege: Boolean,
         val showInstaller: Boolean,
         val showExtensions: Boolean,
+        val showBackupRestore: Boolean = true,
     ) {
         fun rows() =
-            homeActionRows(reinstall, canClearCache, privilege, showInstaller, showExtensions)
+            homeActionRows(reinstall, canClearCache, privilege, showInstaller, showExtensions, showBackupRestore)
 
         override fun toString() = "reinstall=$reinstall canClearCache=$canClearCache " +
-            "privilege=$privilege installer=$showInstaller extensions=$showExtensions"
+            "privilege=$privilege installer=$showInstaller extensions=$showExtensions backupRestore=$showBackupRestore"
     }
 
-    /** The five reachable privilege states, crossed with every preference pair. */
+    /** The five reachable privilege states, crossed with preference combinations. */
     private val reachableStates: List<State> =
         listOf(
             Triple(false, false, false),
@@ -54,45 +53,47 @@ class HomeActionsTest {
             Triple(true, true, true),
         ).flatMap { (reinstall, canClearCache, privilege) ->
             listOf(true, false).flatMap { installer ->
-                listOf(true, false).map { extensions ->
-                    State(reinstall, canClearCache, privilege, installer, extensions)
+                listOf(true, false).flatMap { extensions ->
+                    listOf(true, false).map { backupRestore ->
+                        State(reinstall, canClearCache, privilege, installer, extensions, backupRestore)
+                    }
                 }
             }
         }
 
-    // --- Privilege states, both tiles kept ------------------------------------------------------
+    // --- Privilege states, all optional tiles kept ---------------------------------------------
 
-    @Test fun noPrivilege_onlyInstallFullWidth() {
+    @Test fun noPrivilege_isOnePair() {
         assertEquals(
-            listOf(listOf(INSTALL)),
+            listOf(listOf(INSTALL, BACKUP_RESTORE)),
             homeActionRows(reinstallVisible = false, canClearCache = false, hasPrivilege = false)
         )
     }
 
-    @Test fun dhizukuOnly_noReinstall_isOnePair() {
+    @Test fun dhizukuOnly_noReinstall_leadsWide() {
         assertEquals(
-            listOf(listOf(INSTALL, EXTENSIONS)),
+            listOf(listOf(INSTALL), listOf(BACKUP_RESTORE, EXTENSIONS)),
             homeActionRows(reinstallVisible = false, canClearCache = false, hasPrivilege = true)
         )
     }
 
-    @Test fun dhizukuOnly_withReinstall_leadsWide() {
+    @Test fun dhizukuOnly_withReinstall_isTwoByTwo() {
         assertEquals(
-            listOf(listOf(INSTALL), listOf(EXTENSIONS, REINSTALL)),
+            listOf(listOf(INSTALL, BACKUP_RESTORE), listOf(EXTENSIONS, REINSTALL)),
             homeActionRows(reinstallVisible = true, canClearCache = false, hasPrivilege = true)
         )
     }
 
-    @Test fun rootOrShizuku_noReinstall_leadsWide() {
+    @Test fun rootOrShizuku_noReinstall_isTwoByTwo() {
         assertEquals(
-            listOf(listOf(INSTALL), listOf(CLEAR_CACHE, EXTENSIONS)),
+            listOf(listOf(INSTALL, BACKUP_RESTORE), listOf(CLEAR_CACHE, EXTENSIONS)),
             homeActionRows(reinstallVisible = false, canClearCache = true, hasPrivilege = true)
         )
     }
 
-    @Test fun rootOrShizuku_withReinstall_isTwoByTwo() {
+    @Test fun rootOrShizuku_withReinstall_leadsWide() {
         assertEquals(
-            listOf(listOf(INSTALL, CLEAR_CACHE), listOf(EXTENSIONS, REINSTALL)),
+            listOf(listOf(INSTALL), listOf(BACKUP_RESTORE, CLEAR_CACHE), listOf(EXTENSIONS, REINSTALL)),
             homeActionRows(reinstallVisible = true, canClearCache = true, hasPrivilege = true)
         )
     }
@@ -101,28 +102,27 @@ class HomeActionsTest {
     @Test fun dismissingReinstall_leavesTheOtherTilesInPlace() {
         val withCard = homeActionRows(reinstallVisible = true, canClearCache = true, hasPrivilege = true)
         val without = homeActionRows(reinstallVisible = false, canClearCache = true, hasPrivilege = true)
-        assertEquals(listOf(INSTALL, CLEAR_CACHE, EXTENSIONS), without.flatten())
-        assertEquals(listOf(INSTALL, CLEAR_CACHE, EXTENSIONS, REINSTALL), withCard.flatten())
+        assertEquals(listOf(INSTALL, BACKUP_RESTORE, CLEAR_CACHE, EXTENSIONS), without.flatten())
+        assertEquals(listOf(INSTALL, BACKUP_RESTORE, CLEAR_CACHE, EXTENSIONS, REINSTALL), withCard.flatten())
     }
 
     @Test fun narrowContainer_givesEveryTileItsOwnRow() {
         assertEquals(
-            listOf(listOf(INSTALL), listOf(CLEAR_CACHE), listOf(EXTENSIONS), listOf(REINSTALL)),
+            listOf(listOf(INSTALL), listOf(BACKUP_RESTORE), listOf(CLEAR_CACHE), listOf(EXTENSIONS), listOf(REINSTALL)),
             homeActionRows(
                 reinstallVisible = true, canClearCache = true, hasPrivilege = true, narrowContainer = true
             )
         )
     }
 
-    // --- GH#344 visibility preferences ----------------------------------------------------------
+    // --- Visibility preferences ----------------------------------------------------------------
 
-    /** The 2x2 loses its leader and the survivors re-pack, rather than leaving a hole. */
     @Test fun hidingTheInstaller_dropsOnlyThatTile() {
         val rows = homeActionRows(
             reinstallVisible = true, canClearCache = true, hasPrivilege = true, showInstaller = false
         )
         assertTrue("Install must be gone", INSTALL !in rows.flatten())
-        assertEquals(listOf(listOf(CLEAR_CACHE), listOf(EXTENSIONS, REINSTALL)), rows)
+        assertEquals(listOf(listOf(BACKUP_RESTORE, CLEAR_CACHE), listOf(EXTENSIONS, REINSTALL)), rows)
     }
 
     @Test fun hidingExtensions_dropsOnlyThatTile() {
@@ -130,10 +130,10 @@ class HomeActionsTest {
             reinstallVisible = true, canClearCache = true, hasPrivilege = true, showExtensions = false
         )
         assertTrue("Extensions must be gone", EXTENSIONS !in rows.flatten())
-        assertEquals(listOf(listOf(INSTALL), listOf(CLEAR_CACHE, REINSTALL)), rows)
+        assertEquals(listOf(listOf(INSTALL, BACKUP_RESTORE), listOf(CLEAR_CACHE, REINSTALL)), rows)
     }
 
-    @Test fun hidingBoth_keepsThePrivilegedTiles() {
+    @Test fun hidingInstallerAndExtensions_keepsRemainingTiles() {
         val rows = homeActionRows(
             reinstallVisible = true,
             canClearCache = true,
@@ -141,15 +141,10 @@ class HomeActionsTest {
             showInstaller = false,
             showExtensions = false,
         )
-        assertEquals(listOf(listOf(CLEAR_CACHE, REINSTALL)), rows)
+        assertEquals(listOf(listOf(BACKUP_RESTORE), listOf(CLEAR_CACHE, REINSTALL)), rows)
     }
 
-    /**
-     * The whole grid can legitimately disappear — hiding both optional tiles with no privilege
-     * leaves nothing eligible. HomeScreen drops its spacer on this, so it has to stay an empty
-     * list rather than a row of nothing.
-     */
-    @Test fun hidingBothWithNoPrivilege_leavesNothingToDraw() {
+    @Test fun hidingAllTilesWithNoPrivilege_leavesNothingToDraw() {
         assertEquals(
             emptyList<List<HomeAction>>(),
             homeActionRows(
@@ -158,6 +153,7 @@ class HomeActionsTest {
                 hasPrivilege = false,
                 showInstaller = false,
                 showExtensions = false,
+                showBackupRestore = false,
             )
         )
     }
@@ -167,7 +163,7 @@ class HomeActionsTest {
         val rows = homeActionRows(
             reinstallVisible = false, canClearCache = false, hasPrivilege = false, showExtensions = true
         )
-        assertEquals(listOf(listOf(INSTALL)), rows)
+        assertEquals(listOf(listOf(INSTALL, BACKUP_RESTORE)), rows)
     }
 
     /** Hiding a tile is layout-only, so the rail packs the survivors the same way. */
@@ -180,6 +176,7 @@ class HomeActionsTest {
                 hasPrivilege = true,
                 showInstaller = false,
                 showExtensions = false,
+                showBackupRestore = false,
                 narrowContainer = true,
             )
         )
@@ -208,6 +205,7 @@ class HomeActionsTest {
         for (state in reachableStates) {
             val flat = state.rows().flatten()
             assertEquals("$state: Install visibility", state.showInstaller, INSTALL in flat)
+            assertEquals("$state: Backup & restore visibility", state.showBackupRestore, BACKUP_RESTORE in flat)
             assertEquals("$state: Clear cache visibility", state.canClearCache, CLEAR_CACHE in flat)
             assertEquals(
                 "$state: Extensions visibility",


### PR DESCRIPTION
## Overview
Implements the Backup & Restore Hub with Home screen Bento entry point, auto-discovery of archives in `Downloads/Thor`, dynamic filter chips, educational knowledge cards, one-tap restore, and an in-app app backup picker sheet.

### Changes
- **Home Bento Action**: Added `BACKUP_RESTORE` action tile to `HomeActions.kt` and `HomeActionsBento.kt`.
- **Domain & Scanner**: Created `BackupArchiveScanner` and `BackupArchiveScannerImpl` querying MediaStore & SAF.
- **Backup & Restore Hub Screen**: Created `BackupRestoreHubScreen.kt` and `BackupRestoreHubViewModel.kt`.
- **Navigation**: Registered `ThorRoute.BackupRestoreHub` in `ThorRoute.kt` and wired in `MainScreen.kt`.
- **Localization**: Added full translations across all 8 locales (`values`, `values-ar`, `values-es`, `values-fr`, `values-pl`, `values-pt`, `values-zh-rCN`).
- **Tests**: Added tests for packing invariants in `HomeActionsTest.kt` and hub logic in `BackupRestoreHubViewModelTest.kt`.

### Verification
- `./gradlew test` -> PASS (1600+ tests)
- `./gradlew lintFossDebug lintStoreRelease` -> PASS (0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Backup & Restore Hub accessible from the home screen.
  - Browse discovered data backups and app bundles with filters, metadata, sizes, and dates.
  - Create backups, restore archives, share files, and delete archives with confirmation.
  - Added support for restoring APK, XAPK, and APKS bundles.
  - Search installed apps when selecting backup targets.
  - Discover archives in Downloads and user-selected storage locations.
  - Added localized Hub content in Arabic, Chinese, English, French, Polish, Portuguese, and Spanish.
- **Tests**
  - Added coverage for filtering, app search, deletion, refresh behavior, and tile visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->