### PR TITLE
feat(backup): support non-root backup/restore & fix hub restore button

### DIFF
--- a/app/src/main/java/com/valhalla/thor/ThorApplication.kt
+++ b/app/src/main/java/com/valhalla/thor/ThorApplication.kt
@@ -20,9 +20,12 @@ import com.valhalla.thor.data.permission.SelfPermissionGranter
 import com.valhalla.thor.data.service.AutoFreezeManager
 import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.presentation.settings.BillingProcessor
 import com.valhalla.thor.presentation.utils.AppIconFetcher
 import com.valhalla.thor.presentation.utils.AppIconKeyer
+import com.valhalla.thor.presentation.utils.ArchiveIconFetcher
+import com.valhalla.thor.presentation.utils.ArchiveIconKeyer
 import com.valhalla.thor.util.AppLocale
 import com.valhalla.thor.util.LocaleManager
 import com.valhalla.thor.util.LocaleRevision
@@ -174,11 +177,15 @@ class ThorApplication : Application(), SingletonImageLoader.Factory {
         }
     }
 
+    private val systemRepository: SystemRepository by inject()
+
     override fun newImageLoader(context: PlatformContext): ImageLoader {
         return ImageLoader.Builder(context)
             .components {
                 add(AppIconKeyer())
                 add(AppIconFetcher.Factory(context))
+                add(ArchiveIconKeyer())
+                add(ArchiveIconFetcher.Factory(context, systemRepository))
             }
             .crossfade(true)
             .build()

--- a/app/src/main/java/com/valhalla/thor/data/backup/DataArchiveCapabilityCache.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/DataArchiveCapabilityCache.kt
@@ -3,6 +3,7 @@
 
 package com.valhalla.thor.data.backup
 
+import com.valhalla.thor.domain.model.DataClass
 import com.valhalla.thor.domain.model.PrivilegeState
 import com.valhalla.thor.domain.repository.AppDataProbe
 import com.valhalla.thor.domain.repository.PrivilegeStateProvider
@@ -10,6 +11,23 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Single
+
+/**
+ * Capability details for data backup and restore.
+ */
+data class DataArchiveCapability(
+    val isSupported: Boolean,
+    val canReadPrivateData: Boolean,
+) {
+    fun supportedClasses(): Set<DataClass> =
+        if (canReadPrivateData) {
+            DataClass.entries.toSet()
+        } else if (isSupported) {
+            setOf(DataClass.EXTERNAL_DATA, DataClass.EXTERNAL_MEDIA)
+        } else {
+            emptySet()
+        }
+}
 
 /**
  * "Can this device back up app data?", answered once per privilege state.
@@ -27,9 +45,9 @@ class DataArchiveCapabilityCache(
 
     private val mutex = Mutex()
 
-    private var cached: Pair<PrivilegeState, Boolean>? = null
+    private var cached: Pair<PrivilegeState, DataArchiveCapability>? = null
 
-    suspend fun isSupported(): Boolean {
+    suspend fun capability(): DataArchiveCapability {
         // Await the first resolved state rather than reading the raw snapshot. `state.value` is the
         // default on cold start: `isReady = false, active = NONE` — `hasAnyPrivilege` would be false
         // and we'd return false immediately, even on a rooted device, until both the privilege probe
@@ -39,13 +57,23 @@ class DataArchiveCapabilityCache(
         val state = privilegeState.state.first { it.isReady }
         // No surface to probe through. Shelling out would raise a `su` prompt on a device where the
         // user granted nothing — and the answer is derived, not measured, so it is not cached.
-        if (!state.hasAnyPrivilege) return false
+        if (!state.hasAnyPrivilege) {
+            return DataArchiveCapability(isSupported = false, canReadPrivateData = false)
+        }
 
         mutex.withLock {
             cached?.let { (key, value) -> if (key == state) return value }
             val supported = probe.probeDataArchiveCapability()
-            cached = state to supported
-            return supported
+            val privateData = if (supported) probe.probePrivateDataCapability() else false
+            val cap = DataArchiveCapability(isSupported = supported, canReadPrivateData = privateData)
+            cached = state to cap
+            return cap
         }
     }
+
+    suspend fun isSupported(): Boolean = capability().isSupported
+
+    suspend fun canReadPrivateData(): Boolean = capability().canReadPrivateData
+
+    suspend fun supportedClasses(): Set<DataClass> = capability().supportedClasses()
 }

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/AppArchiveWorker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/AppArchiveWorker.kt
@@ -278,85 +278,67 @@ internal class ArchiveRestoreWorker(
 
     override suspend fun runJob(): Result {
         val request = ArchiveRestoreRequest.fromMap(inputData.keyValueMap)
-            ?: return fail("this restore's request could not be read")
+            ?: run {
+                Logger.e(TAG, "ArchiveRestoreRequest could not be read from input data")
+                return fail("this restore's request could not be read")
+            }
         val key = keys.take(id.toString())
-            ?: return fail("this restore's key is no longer in memory — start it again")
+            ?: run {
+                Logger.e(TAG, "ArchiveRestoreKey is missing from memory for id $id")
+                return fail("this restore's key is no longer in memory — start it again")
+            }
 
-        // Two failures, two sentences. This job holds no file picker, so neither is an instruction —
-        // but "that file is not a Thor backup" and "Thor could not read that file" send the user to
-        // different places, and the job's reason is what the finished notification shows.
+        Logger.i(TAG, "Running restore job for package=${request.packageName}, classes=${request.classes}, uri=${request.uriString}, restoreObb=${request.restoreObb}")
+
         val source = when (val opened = sources.open(request.uriString)) {
             is ArchiveOpenOutcome.Opened -> opened.source
-            ArchiveOpenOutcome.NotAnArchive ->
+            ArchiveOpenOutcome.NotAnArchive -> {
+                Logger.e(TAG, "Archive source open failed: NotAnArchive")
                 return fail("that file is not a Thor backup")
-            ArchiveOpenOutcome.Unreadable ->
+            }
+            ArchiveOpenOutcome.Unreadable -> {
+                Logger.e(TAG, "Archive source open failed: Unreadable")
                 return fail("Thor could not read that backup file")
+            }
         }
 
         return source.use {
-            // Exhaustive on purpose, and left exhaustive on purpose. `ArchiveHeaderOutcome` has two
-            // arms today and the review asked whether a third — an `Unreadable` distinct from
-            // `NotAnArchive` — should be added. It is not added here: the type and its only producer
-            // are `OpenArchiveUseCase`'s, outside this slice, and adding an `else ->` here *first*
-            // would trade the compiler error that forces this site to be revisited for silence. This
-            // `when` failing to compile is the mechanism by which a new arm gets a considered
-            // sentence rather than a default one, so it stays the way it is until the arm exists.
             val header = when (val read = openArchive.readHeader(source)) {
                 is ArchiveHeaderOutcome.Read -> read.header
-                is ArchiveHeaderOutcome.NotAnArchive -> return@use fail(read.reason)
+                is ArchiveHeaderOutcome.NotAnArchive -> {
+                    Logger.e(TAG, "readHeader failed: ${read.reason}")
+                    return@use fail(read.reason)
+                }
             }
-            // The URI named a different archive than the screen was looking at. A `content://` URI is
-            // a handle to a document, not to bytes.
+            Logger.i(TAG, "Read header: schema=${header.schemaVersion}, classes=${header.heldClasses()}, bundle=${header.appBundle != null}")
             if (header.packageName != request.packageName) {
+                Logger.e(TAG, "Header package mismatch: header=${header.packageName}, request=${request.packageName}")
                 return@use fail("that backup file is not ${request.packageName}'s any more")
             }
-            // Before a byte is decrypted, because the key in hand may not be this archive's — see
-            // [wrongKeyReason].
-            wrongKeyReason(header, key, cipher)?.let { return@use fail(it) }
+            wrongKeyReason(header, key, cipher)?.let {
+                Logger.e(TAG, "wrongKeyReason: $it")
+                return@use fail(it)
+            }
 
-            // Resolved once and handed to the use case below, which would otherwise ask the
-            // repository for the same package a second line later. `null` is "not installed", which
-            // is a state the gate handles — see `installFirst`.
             val app = appRepository.getAppDetails(request.packageName)
-            // The same assembly the restore screen ran before it offered the button, from the same
-            // use case: two spellings of "installed" is two gates, and only one of them would have
-            // been the one the user was shown.
             val installed = app?.let { installedFacts(it) }
-            // Re-run, not replay. The app may have arrived or gone while this waited on the chain,
-            // and this gate is the only signer comparison in the whole restore: when it answers
-            // installFirst = false the use case deliberately performs none of its own, because the
-            // check already happened here. Skipping it would make "sideload a fake com.whatsapp,
-            // restore, read everything" work. It also rejects SCHEMA_TOO_NEW, INVALID_PACKAGE_NAME
-            // and INVALID_USER_ID, which is what keeps untrusted header fields out of shell paths.
             val decision = evaluateArchiveRestoreGate(header, installed, request.classes)
+            Logger.i(TAG, "Gate decision: $decision (installed=$installed)")
             val allowed = decision as? ArchiveRestoreDecision.Allowed
-                ?: return@use fail(
-                    "this backup can no longer be restored: " +
-                        refusalReason((decision as ArchiveRestoreDecision.Refused).reason)
-                )
-            // Not in the brief; see the report. The gate ran twice — once on the confirm screen and
-            // again here — and this run can produce warnings the first never showed, because the app
-            // may have been updated or removed while the job sat in the chain. There is no UI at this
-            // point, so the log is where they go.
-            // `.name`: these are `ArchiveRestoreWarning` enum entries, not sentences. The user-facing
-            // wording lives with the screen that shows them (Task 17); a second copy here would be a
-            // second thing to translate and a second thing to drift.
+                ?: run {
+                    val reason = refusalReason((decision as ArchiveRestoreDecision.Refused).reason)
+                    Logger.e(TAG, "Gate refused restore: $reason")
+                    return@use fail("this backup can no longer be restored: $reason")
+                }
             allowed.warnings.forEach { warning -> Logger.w(TAG, "gate warning: ${warning.name}") }
 
             when (
-                // `withContext(ioDispatcher)`, and not because the use case asks politely: it takes no
-                // dispatcher of its own and blocks on the caller's for the decrypt and the bundle copy.
-                // Run on WorkManager's own executor this would block a pool thread for the length of a
-                // multi-gigabyte restore, and the cancellation checkpoints inside it are only prompt
-                // because `io` is elastic.
                 val outcome = withContext(ioDispatcher) {
                     restore(
                         source = source,
                         header = header,
                         key = key,
                         classes = request.orderedClasses(),
-                        // From the gate's own decision, never from a fresh "is it installed?" probe —
-                        // the two can disagree, and only this one has compared the signers.
                         installFirst = allowed.installFirst,
                         restoreObb = request.restoreObb,
                         appLabel = app?.appName ?: request.packageName,
@@ -365,9 +347,7 @@ internal class ArchiveRestoreWorker(
                 }
             ) {
                 is ArchiveRestoreOutcome.Completed -> {
-                    // The only reader of `Completed.obb` in the app — its KDoc used to say nothing
-                    // read it. Logged in full at every arm, and turned into a sentence only for the
-                    // arm no other channel covers; see [obbNotice].
+                    Logger.i(TAG, "ArchiveRestoreOutcome.Completed: restored=${outcome.classesRestored}, warnings=${outcome.warnings}")
                     outcome.obb?.let { Logger.i(TAG, "game data placement: $it") }
                     val warnings = outcome.warnings + listOfNotNull(obbNotice(outcome.obb))
                     warnings.forEach { Logger.w(TAG, it) }

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -17,6 +17,7 @@ import androidx.core.graphics.createBitmap
 import com.valhalla.thor.domain.model.AnalyzedPackage
 import com.valhalla.thor.domain.model.AppMetadata
 import com.valhalla.thor.domain.model.StagedPackage
+import com.valhalla.thor.domain.model.escapeShellArg
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.util.getDisplayName
 import kotlinx.coroutines.CoroutineDispatcher
@@ -101,7 +102,9 @@ class AppAnalyzerImpl(
                 if (!path.isNullOrBlank()) {
                     val tempToken = UUID.randomUUID().toString()
                     val tmpPath = "/data/local/tmp/thor_staged_$tempToken"
-                    val cmd = "cat '$path' > '$tmpPath' 2>/dev/null && chmod 666 '$tmpPath' 2>/dev/null"
+                    val src = path.escapeShellArg()
+                    val dst = tmpPath.escapeShellArg()
+                    val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
                     val res = systemRepository.executeShellCommand(cmd).getOrNull()
                     if (res != null && res.first == 0) {
                         val tmpFile = File(tmpPath)
@@ -114,10 +117,10 @@ class AppAnalyzerImpl(
                                 }
                                 readMetadata(bundleFile, apkFile, displayName)
                             } finally {
-                                systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                                systemRepository.executeShellCommand("rm -f $dst")
                             }
                         } else {
-                            systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                            systemRepository.executeShellCommand("rm -f $dst")
                             Result.failure(Exception("Could not open the selected file."))
                         }
                     } else {

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -37,11 +37,14 @@ import java.util.UUID
  * restore extracts before the swap). A file-private declaration of that name would win over an import
  * of the public one in this file without a warning, so the two are spelled apart.
  */
+import com.valhalla.thor.domain.repository.SystemRepository
+
 private const val INSTALL_STAGING_DIR_NAME = "staged_installs"
 
 @Single(binds = [AppAnalyzer::class])
 class AppAnalyzerImpl(
     private val context: Context,
+    private val systemRepository: SystemRepository,
     @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : AppAnalyzer {
 
@@ -68,10 +71,8 @@ class AppAnalyzerImpl(
         val apkFile = File(context.cacheDir, "analysis_$token.apk")
 
         val metadata = try {
-            val input = context.contentResolver.openInputStream(uri)
-            if (input == null) {
-                Result.failure(Exception("Could not open the selected file."))
-            } else {
+            val input = runCatching { context.contentResolver.openInputStream(uri) }.getOrNull()
+            if (input != null) {
                 // The extraction budget applied at the door. A content provider is not an archive
                 // — there is no compression ratio to bound — but a hostile one can stream forever,
                 // and this copy runs before anything has decided the input is even a zip. Bounding
@@ -92,6 +93,38 @@ class AppAnalyzerImpl(
                     )
                 } else {
                     readMetadata(bundleFile, apkFile, displayName)
+                }
+            } else {
+                // If content resolver cannot open the file directly (e.g. Scoped Storage non-owned file://),
+                // stage via /data/local/tmp (writable by Shizuku/shell, readable by Thor after chmod 666)
+                val path = uri.path
+                if (!path.isNullOrBlank()) {
+                    val tempToken = UUID.randomUUID().toString()
+                    val tmpPath = "/data/local/tmp/thor_staged_$tempToken"
+                    val cmd = "cat '$path' > '$tmpPath' 2>/dev/null && chmod 666 '$tmpPath' 2>/dev/null"
+                    val res = systemRepository.executeShellCommand(cmd).getOrNull()
+                    if (res != null && res.first == 0) {
+                        val tmpFile = File(tmpPath)
+                        if (tmpFile.exists() && tmpFile.length() > 0) {
+                            try {
+                                tmpFile.inputStream().use { input ->
+                                    FileOutputStream(bundleFile).use { output ->
+                                        input.copyTo(output)
+                                    }
+                                }
+                                readMetadata(bundleFile, apkFile, displayName)
+                            } finally {
+                                systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                            }
+                        } else {
+                            systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                            Result.failure(Exception("Could not open the selected file."))
+                        }
+                    } else {
+                        Result.failure(Exception("Could not open the selected file."))
+                    }
+                } else {
+                    Result.failure(Exception("Could not open the selected file."))
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppArchiveInstallerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppArchiveInstallerImpl.kt
@@ -195,11 +195,13 @@ class AppArchiveInstallerImpl(
         }
 
         val stampAfter = installStamp(packageName)
-        return archiveInstallOutcome(
+        val outcome = archiveInstallOutcome(
             settled = settled,
             landed = installLanded(before = stampBefore, after = stampAfter),
             reason = (settled as? InstallState.Error)?.message?.asString(context),
         )
+        Logger.i(TAG, "installAndAwait finished for $packageName: mode=$mode, settled=$settled, stampBefore=$stampBefore, stampAfter=$stampAfter, outcome=$outcome")
+        return outcome
     }
 
     /**

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
@@ -24,6 +24,7 @@ import com.valhalla.thor.domain.model.swapStagedEntriesCommand
 import com.valhalla.thor.domain.model.tarCreateCommand
 import com.valhalla.thor.domain.model.verifyEntriesCommand
 import com.valhalla.thor.domain.repository.AppDataArchiveGateway
+import com.valhalla.thor.domain.repository.AppDataProbe
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.Logger
 import java.io.File
@@ -68,6 +69,7 @@ internal class AppDataArchiveGatewayImpl(
     private val context: Context,
     private val packageManager: PackageManager,
     private val systemRepository: SystemRepository,
+    private val probe: AppDataProbe,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : AppDataArchiveGateway {
 
@@ -89,7 +91,11 @@ internal class AppDataArchiveGatewayImpl(
      * silently downgrade to a less secure location.
      */
     private suspend fun stagingRoot(): File = withContext(ioDispatcher) {
-        val rootDir = context.externalCacheDir ?: context.cacheDir
+        val rootDir = if (probe.probePrivateDataCapability()) {
+            context.cacheDir
+        } else {
+            context.externalCacheDir ?: context.cacheDir
+        }
         File(rootDir, AppDataArchiveStagingDir.NAME).also { it.mkdirs() }
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
@@ -315,16 +315,24 @@ internal class AppDataArchiveGatewayImpl(
         what: String,
         build: (String) -> String?,
     ): Boolean = withContext(ioDispatcher) {
-        val root = classRootOf(packageName, dataClass) ?: return@withContext false
-        val command = build(root) ?: run {
-            Logger.e(TAG, "$what refused for ${dataClass.id} of $packageName")
+        val root = classRootOf(packageName, dataClass) ?: run {
+            Logger.e(TAG, "$what failed: could not resolve class root for ${dataClass.id} of $packageName")
             return@withContext false
         }
+        val command = build(root) ?: run {
+            Logger.e(TAG, "$what refused for ${dataClass.id} of $packageName (root=$root)")
+            return@withContext false
+        }
+        Logger.d(TAG, "Executing $what command for ${dataClass.id}: $command")
         val result = systemRepository.executeShellCommand(command).getOrNull()
         if (result == null || result.first != 0) {
-            Logger.e(TAG, "$what of ${dataClass.id} for $packageName exited ${result?.first}")
+            Logger.e(
+                TAG,
+                "$what of ${dataClass.id} for $packageName failed. Exit code: ${result?.first}, output: '${result?.second}', command: $command"
+            )
             return@withContext false
         }
+        Logger.d(TAG, "$what of ${dataClass.id} for $packageName succeeded with exit 0")
         true
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
@@ -89,10 +89,8 @@ internal class AppDataArchiveGatewayImpl(
      * silently downgrade to a less secure location.
      */
     private suspend fun stagingRoot(): File = withContext(ioDispatcher) {
-        // The name comes from AppDataArchiveStagingDir, not a private constant: ArchiveOrphanSweeper
-        // empties this directory at launch and a second copy of the name is a sweep pointed at the
-        // wrong place.
-        File(context.cacheDir, AppDataArchiveStagingDir.NAME).also { it.mkdirs() }
+        val rootDir = context.externalCacheDir ?: context.cacheDir
+        File(rootDir, AppDataArchiveStagingDir.NAME).also { it.mkdirs() }
     }
 
     override suspend fun stagingFile(name: String): File = withContext(ioDispatcher) {
@@ -224,31 +222,12 @@ internal class AppDataArchiveGatewayImpl(
                 return outcome
             }
 
-            // The shell created the file as its own uid, so Thor cannot open it yet. 600, because the
-            // contents are plaintext app data.
+            // The shell created the file as its own uid. Attempt chown to Thor's uid if possible.
             val chown = chownFileCommand(out.absolutePath, android.os.Process.myUid())
-            if (chown == null) {
-                // The chown builder refused. `out` exists at this point with plaintext data — delete it
-                // before returning, or this becomes the one exit path that silently leaves a staged tar.
-                withContext(ioDispatcher) { out.delete() }
-                return TarOutcome.Failed("refused to build a chown command for ${out.name}")
+            if (chown != null) {
+                systemRepository.executeShellCommand(chown)
             }
 
-            // Both the exit code and `canRead()` are checked, and neither subsumes the other.
-            // `canRead()` is `access(2)`, which goes through `inode_permission` and so through the
-            // SELinux hook as well as the DAC check — it is not blind to policy, and an earlier comment
-            // here claiming that was simply wrong. What it *is* blind to is a `chown` that never ran:
-            // the file is Thor-readable in the (impossible-today, cheap-to-keep) case where it was
-            // already ours, so a silent failure of the ownership transfer would pass. Hence both.
-            val (chownExit, _) = systemRepository.executeShellCommand(chown).getOrElse {
-                Logger.e(TAG, "chown of ${out.name} failed", it)
-                withContext(ioDispatcher) { out.delete() }
-                return TarOutcome.Failed("chown for ${dataClass.id} failed: ${it.message}")
-            }
-            if (chownExit != 0) {
-                withContext(ioDispatcher) { out.delete() }
-                return TarOutcome.Failed("chown exited $chownExit for ${dataClass.id}")
-            }
             return if (withContext(ioDispatcher) { out.canRead() }) {
                 committed = true
                 outcome

--- a/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
@@ -17,6 +17,8 @@ import com.valhalla.thor.domain.repository.BackupArchiveItem
 import com.valhalla.thor.domain.repository.BackupArchiveKind
 import com.valhalla.thor.domain.repository.BackupArchiveScanner
 import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.Logger
 import java.io.File
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -31,28 +33,57 @@ import org.koin.core.annotation.Single
 class BackupArchiveScannerImpl(
     private val context: Context,
     private val preferences: PreferenceRepository,
+    private val systemRepository: SystemRepository,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : BackupArchiveScanner {
 
     override fun scanBackups(): Flow<List<BackupArchiveItem>> = flow {
         val items = mutableListOf<BackupArchiveItem>()
         val seenUris = mutableSetOf<String>()
+        val seenKeys = mutableSetOf<String>()
 
-        // 1. Scan default Downloads/Thor directory
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            items.addAll(queryMediaStoreDownloads(seenUris))
+        // 0. Ensure directory exists and permissions across Downloads/Thor
+        val extPath = Environment.getExternalStorageDirectory().absolutePath
+        runCatching {
+            File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                THOR_DOWNLOADS_SUBDIR
+            ).mkdirs()
+        }
+        systemRepository.executeShellCommand(
+            "mkdir -p '$extPath/Download/$THOR_DOWNLOADS_SUBDIR' && chmod -R 777 '$extPath/Download/$THOR_DOWNLOADS_SUBDIR' 2>/dev/null"
+        )
+
+        // 1. Direct filesystem scan for Downloads/Thor
+        val fsItems = queryFilesystemDownloads(seenUris, seenKeys)
+        items.addAll(fsItems)
+
+        // 2. Privileged shell scan (Shizuku / Root) to discover non-owned files across Downloads/Thor
+        val shellItems = queryShellDownloads(seenUris, seenKeys)
+        items.addAll(shellItems)
+
+        // 3. MediaStore query (Downloads and Files tables) on Q+
+        val msItems = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            queryMediaStoreDownloads(seenUris, seenKeys)
         } else {
-            items.addAll(queryLegacyDownloads(seenUris))
+            emptyList()
         }
+        items.addAll(msItems)
 
-        // 2. Scan custom SAF folder if user configured one
+        // 4. Custom SAF tree if configured
         val customTreeUri = preferences.userPreferences.first().exportDirUri
-        if (!customTreeUri.isNullOrBlank()) {
-            items.addAll(queryCustomTree(customTreeUri, seenUris))
+        val treeItems = if (!customTreeUri.isNullOrBlank()) {
+            queryCustomTree(customTreeUri, seenUris, seenKeys)
+        } else {
+            emptyList()
         }
+        items.addAll(treeItems)
 
-        // Sort descending by date modified
         items.sortByDescending { it.dateModifiedEpochSec }
+        Logger.i(
+            "BackupArchiveScanner",
+            "Discovered ${items.size} items (filesystem=${fsItems.size}, shell=${shellItems.size}, mediaStore=${msItems.size}, customTree=${treeItems.size}): ${items.map { it.displayName }}"
+        )
         emit(items)
     }.flowOn(ioDispatcher)
 
@@ -68,8 +99,13 @@ class BackupArchiveScannerImpl(
                         context.contentResolver.delete(uri, null, null) > 0
                     }
                 } else if (uri.scheme == "file") {
-                    val f = File(uri.path ?: return@withContext false)
-                    f.delete()
+                    val path = uri.path ?: return@withContext false
+                    val f = File(path)
+                    if (!f.delete()) {
+                        systemRepository.executeShellCommand("rm -f '$path'").getOrNull()?.first == 0
+                    } else {
+                        true
+                    }
                 } else {
                     false
                 }
@@ -78,19 +114,73 @@ class BackupArchiveScannerImpl(
             }
         }
 
-    @RequiresApi(Build.VERSION_CODES.Q)
-    private fun queryMediaStoreDownloads(seenUris: MutableSet<String>): List<BackupArchiveItem> {
+    private suspend fun queryShellDownloads(
+        seenUris: MutableSet<String>,
+        seenKeys: MutableSet<String>,
+    ): List<BackupArchiveItem> {
         val results = mutableListOf<BackupArchiveItem>()
+        val extPath = Environment.getExternalStorageDirectory().absolutePath
+        val candidateDirs = listOf(
+            "$extPath/Download/$THOR_DOWNLOADS_SUBDIR",
+            "$extPath/Downloads/$THOR_DOWNLOADS_SUBDIR",
+            "/storage/emulated/0/Download/$THOR_DOWNLOADS_SUBDIR",
+            "/storage/emulated/0/Downloads/$THOR_DOWNLOADS_SUBDIR",
+        ).distinct()
+
+        for (dir in candidateDirs) {
+            val cmd = "stat -c '%s %Y %n' '$dir/'* 2>/dev/null"
+            val res = systemRepository.executeShellCommand(cmd).getOrNull()
+            if (res != null && res.first == 0 && !res.second.isNullOrBlank()) {
+                val lines = res.second!!.lines()
+                for (line in lines) {
+                    val trimmed = line.trim()
+                    if (trimmed.isBlank()) continue
+                    val parts = trimmed.split(Regex("\\s+"), limit = 3)
+                    if (parts.size < 3) continue
+                    val size = parts[0].toLongOrNull() ?: continue
+                    val mtime = parts[1].toLongOrNull() ?: (System.currentTimeMillis() / 1000)
+                    val fullPath = parts[2]
+                    val file = File(fullPath)
+                    val name = file.name
+                    val lower = name.lowercase()
+                    if (lower.endsWith(".part")) continue
+                    if (lower.endsWith(".thorbak") || lower.endsWith(".xapk") || lower.endsWith(".apks") || lower.endsWith(".apk")) {
+                        android.media.MediaScannerConnection.scanFile(context, arrayOf(fullPath), null, null)
+                        val uri = file.toUri()
+                        val key = "${lower}:$size"
+                        if (!seenUris.add(uri.toString()) || !seenKeys.add(key)) continue
+                        parseArchiveItem(file.hashCode().toLong(), uri, name, size, mtime)?.let {
+                            results.add(it)
+                        }
+                    }
+                }
+            }
+        }
+        return results
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun queryMediaStoreDownloads(
+        seenUris: MutableSet<String>,
+        seenKeys: MutableSet<String>,
+    ): List<BackupArchiveItem> {
+        val results = mutableListOf<BackupArchiveItem>()
+        val contentUris = listOf(
+            MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+            MediaStore.Files.getContentUri("external"),
+        )
         val projection = arrayOf(
-            MediaStore.Downloads._ID,
-            MediaStore.Downloads.DISPLAY_NAME,
-            MediaStore.Downloads.SIZE,
-            MediaStore.Downloads.DATE_MODIFIED,
-            MediaStore.Downloads.RELATIVE_PATH,
+            MediaStore.MediaColumns._ID,
+            MediaStore.MediaColumns.DISPLAY_NAME,
+            MediaStore.MediaColumns.SIZE,
+            MediaStore.MediaColumns.DATE_MODIFIED,
+            MediaStore.MediaColumns.RELATIVE_PATH,
         )
 
-        val selection = "(${MediaStore.Downloads.RELATIVE_PATH} LIKE ? OR ${MediaStore.Downloads.RELATIVE_PATH} LIKE ?) AND (${MediaStore.Downloads.DISPLAY_NAME} LIKE ? OR ${MediaStore.Downloads.DISPLAY_NAME} LIKE ? OR ${MediaStore.Downloads.DISPLAY_NAME} LIKE ? OR ${MediaStore.Downloads.DISPLAY_NAME} LIKE ?)"
+        val selection = "(${MediaStore.MediaColumns.DATA} LIKE ? OR ${MediaStore.MediaColumns.DATA} LIKE ? OR ${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ? OR ${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ?) AND (${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ? OR ${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ? OR ${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ? OR ${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ?)"
         val selectionArgs = arrayOf(
+            "%/Download/Thor/%",
+            "%/Downloads/Thor/%",
             "%Download/Thor%",
             "%Downloads/Thor%",
             "%.thorbak",
@@ -99,56 +189,73 @@ class BackupArchiveScannerImpl(
             "%.apk",
         )
 
-        try {
-            context.contentResolver.query(
-                MediaStore.Downloads.EXTERNAL_CONTENT_URI,
-                projection,
-                selection,
-                selectionArgs,
-                "${MediaStore.Downloads.DATE_MODIFIED} DESC",
-            )?.use { cursor ->
-                val idCol = cursor.getColumnIndexOrThrow(MediaStore.Downloads._ID)
-                val nameCol = cursor.getColumnIndexOrThrow(MediaStore.Downloads.DISPLAY_NAME)
-                val sizeCol = cursor.getColumnIndexOrThrow(MediaStore.Downloads.SIZE)
-                val dateCol = cursor.getColumnIndexOrThrow(MediaStore.Downloads.DATE_MODIFIED)
+        for (contentUri in contentUris) {
+            try {
+                context.contentResolver.query(
+                    contentUri,
+                    projection,
+                    selection,
+                    selectionArgs,
+                    "${MediaStore.MediaColumns.DATE_MODIFIED} DESC",
+                )?.use { cursor ->
+                    val idCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
+                    val nameCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+                    val sizeCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE)
+                    val dateCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_MODIFIED)
 
-                while (cursor.moveToNext()) {
-                    val id = cursor.getLong(idCol)
-                    val name = cursor.getString(nameCol) ?: continue
-                    if (name.endsWith(".part")) continue
+                    while (cursor.moveToNext()) {
+                        val id = cursor.getLong(idCol)
+                        val name = cursor.getString(nameCol) ?: continue
+                        if (name.endsWith(".part")) continue
 
-                    val size = cursor.getLong(sizeCol)
-                    val date = cursor.getLong(dateCol)
-                    val uri = ContentUris.withAppendedId(MediaStore.Downloads.EXTERNAL_CONTENT_URI, id)
-                    if (!seenUris.add(uri.toString())) continue
+                        val size = cursor.getLong(sizeCol)
+                        val date = cursor.getLong(dateCol)
+                        val uri = ContentUris.withAppendedId(contentUri, id)
+                        val key = "${name.lowercase()}:$size"
+                        if (!seenUris.add(uri.toString()) || !seenKeys.add(key)) continue
 
-                    parseArchiveItem(id, uri, name, size, date)?.let { results.add(it) }
+                        parseArchiveItem(id, uri, name, size, date)?.let { results.add(it) }
+                    }
                 }
+            } catch (_: Exception) {
+                // Ignore individual table query failures
             }
-        } catch (_: Exception) {
-            // Permission or resolver failure gracefully produces whatever else resolved
         }
         return results
     }
 
-    private fun queryLegacyDownloads(seenUris: MutableSet<String>): List<BackupArchiveItem> {
+    private fun queryFilesystemDownloads(
+        seenUris: MutableSet<String>,
+        seenKeys: MutableSet<String>,
+    ): List<BackupArchiveItem> {
         val results = mutableListOf<BackupArchiveItem>()
-        val dir = File(
-            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
-            THOR_DOWNLOADS_SUBDIR,
-        )
-        if (!dir.exists() || !dir.isDirectory) return results
+        val candidateDirs = listOfNotNull(
+            File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                THOR_DOWNLOADS_SUBDIR,
+            ),
+            File(Environment.getExternalStorageDirectory(), "Download/$THOR_DOWNLOADS_SUBDIR"),
+            File(Environment.getExternalStorageDirectory(), "Downloads/$THOR_DOWNLOADS_SUBDIR"),
+        ).distinctBy { it.absolutePath }
 
-        val files = dir.listFiles { f ->
-            val n = f.name.lowercase()
-            !n.endsWith(".part") && (n.endsWith(".thorbak") || n.endsWith(".xapk") || n.endsWith(".apks") || n.endsWith(".apk"))
-        } ?: return results
+        for (dir in candidateDirs) {
+            try {
+                if (!dir.exists() || !dir.isDirectory) continue
+                val files = dir.listFiles { f ->
+                    val n = f.name.lowercase()
+                    !n.endsWith(".part") && (n.endsWith(".thorbak") || n.endsWith(".xapk") || n.endsWith(".apks") || n.endsWith(".apk"))
+                } ?: continue
 
-        for (f in files) {
-            val uri = f.toUri()
-            if (!seenUris.add(uri.toString())) continue
-            parseArchiveItem(f.hashCode().toLong(), uri, f.name, f.length(), f.lastModified() / 1000)
-                ?.let { results.add(it) }
+                for (f in files) {
+                    val uri = f.toUri()
+                    val key = "${f.name.lowercase()}:${f.length()}"
+                    if (!seenUris.add(uri.toString()) || !seenKeys.add(key)) continue
+                    parseArchiveItem(f.hashCode().toLong(), uri, f.name, f.length(), f.lastModified() / 1000)
+                        ?.let { results.add(it) }
+                }
+            } catch (_: Exception) {
+                // Ignore filesystem scan errors
+            }
         }
         return results
     }
@@ -156,6 +263,7 @@ class BackupArchiveScannerImpl(
     private fun queryCustomTree(
         treeUriString: String,
         seenUris: MutableSet<String>,
+        seenKeys: MutableSet<String>,
     ): List<BackupArchiveItem> {
         val results = mutableListOf<BackupArchiveItem>()
         try {
@@ -167,7 +275,8 @@ class BackupArchiveScannerImpl(
                 val lower = name.lowercase()
                 if (lower.endsWith(".part")) continue
                 if (lower.endsWith(".thorbak") || lower.endsWith(".xapk") || lower.endsWith(".apks") || lower.endsWith(".apk")) {
-                    if (!seenUris.add(doc.uri.toString())) continue
+                    val key = "${name.lowercase()}:${doc.length()}"
+                    if (!seenUris.add(doc.uri.toString()) || !seenKeys.add(key)) continue
                     parseArchiveItem(
                         doc.uri.hashCode().toLong(),
                         doc.uri,

--- a/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
@@ -5,6 +5,7 @@ package com.valhalla.thor.data.repository
 
 import android.content.ContentUris
 import android.content.Context
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -325,10 +326,28 @@ class BackupArchiveScannerImpl(
         val possiblePkg = nameWithoutExt.substringBefore('-')
         val packageName = if (possiblePkg.contains('.') && possiblePkg.length > 3) possiblePkg else null
 
+        val appName = if (!packageName.isNullOrBlank()) {
+            try {
+                val flags = PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
+                val ai = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    context.packageManager.getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(flags))
+                } else {
+                    context.packageManager.getApplicationInfo(packageName, PackageManager.MATCH_UNINSTALLED_PACKAGES)
+                }
+                context.packageManager.getApplicationLabel(ai).toString()
+            } catch (_: Exception) {
+                null
+            }
+        } else {
+            val cleaned = nameWithoutExt.replace(Regex("_[0-9]+(\\.[0-9]+)*.*$"), "").replace('_', ' ').trim()
+            cleaned.ifBlank { null }
+        }
+
         return BackupArchiveItem(
             id = id,
             uriString = uri.toString(),
             displayName = displayName,
+            appName = appName,
             packageName = packageName,
             sizeBytes = sizeBytes,
             dateModifiedEpochSec = dateModifiedEpochSec,

--- a/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
@@ -13,6 +13,7 @@ import android.provider.MediaStore
 import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
+import com.valhalla.thor.domain.model.escapeShellArg
 import com.valhalla.thor.domain.repository.BackupArchiveItem
 import com.valhalla.thor.domain.repository.BackupArchiveKind
 import com.valhalla.thor.domain.repository.BackupArchiveScanner
@@ -44,14 +45,16 @@ class BackupArchiveScannerImpl(
 
         // 0. Ensure directory exists and permissions across Downloads/Thor
         val extPath = Environment.getExternalStorageDirectory().absolutePath
+        val thorDir = "$extPath/Download/$THOR_DOWNLOADS_SUBDIR"
         runCatching {
             File(
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
                 THOR_DOWNLOADS_SUBDIR
             ).mkdirs()
         }
+        val safeThorDir = thorDir.escapeShellArg()
         systemRepository.executeShellCommand(
-            "mkdir -p '$extPath/Download/$THOR_DOWNLOADS_SUBDIR' && chmod -R 777 '$extPath/Download/$THOR_DOWNLOADS_SUBDIR' 2>/dev/null"
+            "mkdir -p $safeThorDir && chmod 755 $safeThorDir 2>/dev/null"
         )
 
         // 1. Direct filesystem scan for Downloads/Thor
@@ -102,7 +105,8 @@ class BackupArchiveScannerImpl(
                     val path = uri.path ?: return@withContext false
                     val f = File(path)
                     if (!f.delete()) {
-                        systemRepository.executeShellCommand("rm -f '$path'").getOrNull()?.first == 0
+                        val safePath = path.escapeShellArg()
+                        systemRepository.executeShellCommand("rm -f $safePath").getOrNull()?.first == 0
                     } else {
                         true
                     }
@@ -128,14 +132,15 @@ class BackupArchiveScannerImpl(
         ).distinct()
 
         for (dir in candidateDirs) {
-            val cmd = "stat -c '%s %Y %n' '$dir/'* 2>/dev/null"
+            val safeDir = dir.escapeShellArg()
+            val cmd = "stat -c '%s\t%Y\t%n' $safeDir/* 2>/dev/null"
             val res = systemRepository.executeShellCommand(cmd).getOrNull()
             if (res != null && res.first == 0 && !res.second.isNullOrBlank()) {
                 val lines = res.second!!.lines()
                 for (line in lines) {
                     val trimmed = line.trim()
                     if (trimmed.isBlank()) continue
-                    val parts = trimmed.split(Regex("\\s+"), limit = 3)
+                    val parts = trimmed.split('\t', limit = 3)
                     if (parts.size < 3) continue
                     val size = parts[0].toLongOrNull() ?: continue
                     val mtime = parts[1].toLongOrNull() ?: (System.currentTimeMillis() / 1000)
@@ -149,7 +154,8 @@ class BackupArchiveScannerImpl(
                         val uri = file.toUri()
                         val key = "${lower}:$size"
                         if (!seenUris.add(uri.toString()) || !seenKeys.add(key)) continue
-                        parseArchiveItem(file.hashCode().toLong(), uri, name, size, mtime)?.let {
+                        val id = (fullPath.hashCode().toLong() shl 32) xor (size xor (mtime shl 16))
+                        parseArchiveItem(id, uri, name, size, mtime)?.let {
                             results.add(it)
                         }
                     }
@@ -174,7 +180,6 @@ class BackupArchiveScannerImpl(
             MediaStore.MediaColumns.DISPLAY_NAME,
             MediaStore.MediaColumns.SIZE,
             MediaStore.MediaColumns.DATE_MODIFIED,
-            MediaStore.MediaColumns.RELATIVE_PATH,
         )
 
         val selection = "(${MediaStore.MediaColumns.DATA} LIKE ? OR ${MediaStore.MediaColumns.DATA} LIKE ? OR ${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ? OR ${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ?) AND (${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ? OR ${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ? OR ${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ? OR ${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ?)"
@@ -250,7 +255,8 @@ class BackupArchiveScannerImpl(
                     val uri = f.toUri()
                     val key = "${f.name.lowercase()}:${f.length()}"
                     if (!seenUris.add(uri.toString()) || !seenKeys.add(key)) continue
-                    parseArchiveItem(f.hashCode().toLong(), uri, f.name, f.length(), f.lastModified() / 1000)
+                    val id = (f.absolutePath.hashCode().toLong() shl 32) xor (f.length() xor (f.lastModified()))
+                    parseArchiveItem(id, uri, f.name, f.length(), f.lastModified() / 1000)
                         ?.let { results.add(it) }
                 }
             } catch (_: Exception) {

--- a/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BackupArchiveScannerImpl.kt
@@ -207,7 +207,7 @@ class BackupArchiveScannerImpl(
 
         // Package name extraction heuristic: "com.example.app-100.thorbak" -> "com.example.app"
         val nameWithoutExt = displayName.substringBeforeLast('.')
-        val possiblePkg = nameWithoutExt.substringBefore('-').substringBefore('_')
+        val possiblePkg = nameWithoutExt.substringBefore('-')
         val packageName = if (possiblePkg.contains('.') && possiblePkg.length > 3) possiblePkg else null
 
         return BackupArchiveItem(

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -21,6 +21,7 @@ import com.valhalla.thor.domain.model.dataClassRoot
 import com.valhalla.thor.domain.model.measuredExclusions
 import com.valhalla.thor.domain.model.parseCapabilityProbe
 import com.valhalla.thor.domain.model.parseClassSize
+import com.valhalla.thor.domain.model.sharedDataCapabilityProbeCommand
 import com.valhalla.thor.domain.repository.AppDataProbe
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.StorageStatsProvider
@@ -346,15 +347,18 @@ class SystemRepositoryImpl(
         return verdict
     }
 
-    /**
-     * Built on [executeShellCommand] for the reason [probeObb] gives: the probe and the capture that
-     * follows it must cross the *same* privileged surface, or a pass here stops being evidence.
-     */
-    override suspend fun probeDataArchiveCapability(): Boolean {
-        // BuildConfig.APPLICATION_ID, not the namespace: `debug` carries an applicationIdSuffix, and
-        // the data directory is named after the application id. The namespace would name a path that
-        // exists in no build — the same trap `ComponentName`'s two halves set.
+    override suspend fun probePrivateDataCapability(): Boolean {
         val command = capabilityProbeCommand(BuildConfig.APPLICATION_ID, thorUserId) ?: return false
+        return executeShellCommand(command).fold(
+            onSuccess = { (exitCode, output) -> parseCapabilityProbe(exitCode, output) },
+            onFailure = { false }
+        )
+    }
+
+    override suspend fun probeDataArchiveCapability(): Boolean {
+        if (probePrivateDataCapability()) return true
+        val externalRoot = Environment.getExternalStorageDirectory()?.absolutePath.orEmpty()
+        val command = sharedDataCapabilityProbeCommand(externalRoot) ?: return false
         return executeShellCommand(command).fold(
             onSuccess = { (exitCode, output) -> parseCapabilityProbe(exitCode, output) },
             onFailure = { false }

--- a/app/src/main/java/com/valhalla/thor/data/repository/UriArchiveSourceFactory.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/UriArchiveSourceFactory.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
 import androidx.core.net.toUri
+import com.valhalla.thor.domain.model.escapeShellArg
 import com.valhalla.thor.domain.repository.ArchiveOpenOutcome
 import com.valhalla.thor.domain.repository.ArchiveSourceFactory
 import com.valhalla.thor.util.Logger
@@ -132,7 +133,9 @@ class UriArchiveSourceFactory(
                 if (!path.isNullOrBlank()) {
                     val tempToken = java.util.UUID.randomUUID().toString()
                     val tmpPath = "/data/local/tmp/thor_read_$tempToken"
-                    val cmd = "cat '$path' > '$tmpPath' 2>/dev/null && chmod 666 '$tmpPath' 2>/dev/null"
+                    val src = path.escapeShellArg()
+                    val dst = tmpPath.escapeShellArg()
+                    val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
                     val res = systemRepository.executeShellCommand(cmd).getOrNull()
                     if (res != null && res.first == 0) {
                         val tmpFile = File(tmpPath)
@@ -142,10 +145,10 @@ class UriArchiveSourceFactory(
                                     copy.outputStream().use(input::copyTo)
                                 }
                             } finally {
-                                systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                                systemRepository.executeShellCommand("rm -f $dst")
                             }
                         } else {
-                            systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                            systemRepository.executeShellCommand("rm -f $dst")
                         }
                     }
                 }

--- a/app/src/main/java/com/valhalla/thor/data/repository/UriArchiveSourceFactory.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/UriArchiveSourceFactory.kt
@@ -36,9 +36,12 @@ import java.util.zip.ZipException
  * A [ZipException] from the fd path means the bytes were readable but are not a zip; the copy
  * fallback would fail identically, so that case gives up immediately.
  */
+import com.valhalla.thor.domain.repository.SystemRepository
+
 @Single(binds = [ArchiveSourceFactory::class])
 class UriArchiveSourceFactory(
     private val context: Context,
+    private val systemRepository: SystemRepository,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : ArchiveSourceFactory {
 
@@ -49,7 +52,10 @@ class UriArchiveSourceFactory(
 
         val descriptor = runCatching { context.contentResolver.openFileDescriptor(uri, "r") }
             .getOrNull()
-            ?: return@withContext ArchiveOpenOutcome.Unreadable
+
+        if (descriptor == null) {
+            return@withContext copyThenOpen(uri, name)
+        }
 
         openOrRelease(
             build = {
@@ -110,7 +116,7 @@ class UriArchiveSourceFactory(
      * bargain: prefix-and-suffix instead of equality, which the staging sweep already does for `.part`
      * names. The name is only ever produced and consumed here, so nothing has to parse it.
      */
-    private fun copyThenOpen(uri: Uri, name: String): ArchiveOpenOutcome {
+    private suspend fun copyThenOpen(uri: Uri, name: String): ArchiveOpenOutcome {
         val copy = runCatching {
             File.createTempFile(COPY_FILE_PREFIX, COPY_FILE_SUFFIX, context.cacheDir)
         }.getOrElse {
@@ -118,8 +124,35 @@ class UriArchiveSourceFactory(
             return ArchiveOpenOutcome.Unreadable
         }
         return runCatching {
-            context.contentResolver.openInputStream(uri)!!.use { input ->
-                copy.outputStream().use(input::copyTo)
+            val input = runCatching { context.contentResolver.openInputStream(uri) }.getOrNull()
+            if (input != null) {
+                input.use { src -> copy.outputStream().use(src::copyTo) }
+            } else {
+                val path = uri.path
+                if (!path.isNullOrBlank()) {
+                    val tempToken = java.util.UUID.randomUUID().toString()
+                    val tmpPath = "/data/local/tmp/thor_read_$tempToken"
+                    val cmd = "cat '$path' > '$tmpPath' 2>/dev/null && chmod 666 '$tmpPath' 2>/dev/null"
+                    val res = systemRepository.executeShellCommand(cmd).getOrNull()
+                    if (res != null && res.first == 0) {
+                        val tmpFile = File(tmpPath)
+                        if (tmpFile.exists() && tmpFile.length() > 0) {
+                            try {
+                                tmpFile.inputStream().use { input ->
+                                    copy.outputStream().use(input::copyTo)
+                                }
+                            } finally {
+                                systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                            }
+                        } else {
+                            systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                        }
+                    }
+                }
+            }
+            if (!copy.exists() || copy.length() == 0L) {
+                copy.delete()
+                return ArchiveOpenOutcome.Unreadable
             }
             // Deletes *this* copy, by identity — the whole point of the unique name.
             ArchiveOpenOutcome.Opened(ZipArchiveSource(copy, name, onClose = { copy.delete() }))
@@ -198,7 +231,7 @@ class UriArchiveSourceFactory(
  * classpath.
  */
 internal suspend fun <T> openOrRelease(
-    build: () -> T,
+    build: suspend () -> T,
     release: (T?) -> Unit,
 ): T {
     var committed = false

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppDataCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppDataCommands.kt
@@ -177,10 +177,10 @@ internal fun capabilityProbeCommand(thorPackageName: String, userId: Int): Strin
     return "ls -1 '/data/user/$userId/$thorPackageName' >/dev/null 2>&1 && echo $THOR_OK"
 }
 
-/** Probe whether shell can access external shared storage (/sdcard/Android). */
+/** Probe whether shell can read and traverse external shared storage ($externalStorageDir/Android). */
 internal fun sharedDataCapabilityProbeCommand(externalStorageDir: String): String? {
     if (!isQuotableAbsolutePath(externalStorageDir)) return null
-    return "( [ -d '$externalStorageDir/Android' ] || [ -d '$externalStorageDir' ] ) && echo $THOR_OK"
+    return "ls -1 '$externalStorageDir/Android' >/dev/null 2>&1 && echo $THOR_OK"
 }
 
 /**

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppDataCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppDataCommands.kt
@@ -631,7 +631,7 @@ internal fun extractCommand(root: String, tarPath: String, compressed: Boolean):
     val staging = stagingDirPath(root) ?: return null
     if (!isQuotableAbsolutePath(tarPath)) return null
     val listFlags = if (compressed) "-tvzf" else "-tvf"
-    val extractFlags = if (compressed) "-xzf" else "-xf"
+    val extractFlags = if (compressed) "-mxzf" else "-mxf"
     return "rm -rf '$staging' && mkdir -p '$staging' && [ ! -L '$staging' ] && " +
         "( ( tar $listFlags '$tarPath' || echo $THOR_LIST_FAILED ) | " +
         "grep -qE '$ARCHIVE_MEMBER_REFUSAL_PATTERN' ; [ \$? -eq 1 ] ) && " +

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppDataCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppDataCommands.kt
@@ -697,3 +697,9 @@ internal fun restoreconCommand(root: String): String? {
     if (!isNormalisedRoot(root)) return null
     return "restorecon -RF '$root'"
 }
+
+/**
+ * Wraps [this] in single quotes and escapes embedded single quotes for POSIX shell argument safety.
+ */
+fun String.escapeShellArg(): String = "'" + replace("'", "'\\''") + "'"
+

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppDataCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppDataCommands.kt
@@ -177,6 +177,12 @@ internal fun capabilityProbeCommand(thorPackageName: String, userId: Int): Strin
     return "ls -1 '/data/user/$userId/$thorPackageName' >/dev/null 2>&1 && echo $THOR_OK"
 }
 
+/** Probe whether shell can access external shared storage (/sdcard/Android). */
+internal fun sharedDataCapabilityProbeCommand(externalStorageDir: String): String? {
+    if (!isQuotableAbsolutePath(externalStorageDir)) return null
+    return "( [ -d '$externalStorageDir/Android' ] || [ -d '$externalStorageDir' ] ) && echo $THOR_OK"
+}
+
 /**
  * Believed only on a zero exit **and** the marker.
  *

--- a/app/src/main/java/com/valhalla/thor/domain/model/ArchiveRestoreGate.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ArchiveRestoreGate.kt
@@ -114,9 +114,6 @@ fun evaluateArchiveRestoreGate(
     if (header.userId < 0) {
         return ArchiveRestoreDecision.Refused(ArchiveRestoreRefusal.INVALID_USER_ID)
     }
-    if (selectedClasses.isEmpty()) {
-        return ArchiveRestoreDecision.Refused(ArchiveRestoreRefusal.NOTHING_SELECTED)
-    }
     val held = header.heldClasses()
     if (selectedClasses.any { it !in held }) {
         return ArchiveRestoreDecision.Refused(ArchiveRestoreRefusal.CLASS_NOT_IN_ARCHIVE)
@@ -138,6 +135,10 @@ fun evaluateArchiveRestoreGate(
             // No version warning: the version about to be installed *is* the archive's.
             ArchiveRestoreDecision.Allowed(installFirst = true, warnings = warnings)
         }
+    }
+
+    if (selectedClasses.isEmpty()) {
+        return ArchiveRestoreDecision.Refused(ArchiveRestoreRefusal.NOTHING_SELECTED)
     }
 
     if (installed.signerSha256 == null) {

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppDataProbe.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppDataProbe.kt
@@ -20,10 +20,14 @@ interface AppDataProbe {
     /**
      * Can the active privileged surface read *another* app's private data directory?
      *
-     * Deliberately a probe and not a privilege check. Root-started Shizuku can do this and plain
-     * Shizuku (`shell` uid) cannot, so "requires Root" would be a lie on the first device and
-     * `isRootAvailable()` would be the wrong question on both. Never throws — every failure is
-     * `false`, because a maybe here has to read as "do not offer the feature".
+     * True for Root or root-started Shizuku. Plain Shizuku (shell UID 2000) returns false.
+     */
+    suspend fun probePrivateDataCapability(): Boolean
+
+    /**
+     * Can the active privileged surface back up app data at all?
+     *
+     * True for Root, root-started Shizuku, or plain Shizuku with shell access.
      */
     suspend fun probeDataArchiveCapability(): Boolean
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/BackupArchiveScanner.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/BackupArchiveScanner.kt
@@ -20,6 +20,7 @@ data class BackupArchiveItem(
     val id: Long,
     val uriString: String,
     val displayName: String,
+    val appName: String? = null,
     val packageName: String?,
     val sizeBytes: Long,
     val dateModifiedEpochSec: Long,

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/MeasureAppDataUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/MeasureAppDataUseCase.kt
@@ -20,6 +20,7 @@ import org.koin.core.annotation.Factory
 data class AppDataMeasurement(
     val supported: Boolean,
     val sizes: Map<DataClass, DataClassSize>,
+    val supportedClasses: Set<DataClass> = DataClass.entries.toSet(),
 )
 
 /**
@@ -40,18 +41,23 @@ class MeasureAppDataUseCase(
         // would each cost a round trip to say so; and a package name this shape means the caller is
         // confused, not that one class is unreadable.
         if (!isUsablePackageName(packageName)) {
-            return AppDataMeasurement(supported = false, sizes = emptyMap())
+            return AppDataMeasurement(supported = false, sizes = emptyMap(), supportedClasses = emptySet())
         }
         if (!cache.isSupported()) {
             // Deliberately no measurements: four shell round trips that will each fail, rendered as
             // four "unknown" rows, is a worse answer than one honest refusal.
-            return AppDataMeasurement(supported = false, sizes = emptyMap())
+            return AppDataMeasurement(supported = false, sizes = emptyMap(), supportedClasses = emptySet())
         }
+        val supportedClasses = cache.supportedClasses()
         // Sequential, not parallel. These are `du -s -k` walks over potentially gigabytes; four at
         // once on one privileged shell queue is slower, not faster, and the shell serialises anyway.
-        val sizes = DataClass.entries.associateWith { dataClass ->
+        val sizes = supportedClasses.associateWith { dataClass ->
             probe.measureDataClass(packageName, dataClass)
         }
-        return AppDataMeasurement(supported = true, sizes = sizes)
+        return AppDataMeasurement(
+            supported = true,
+            sizes = sizes,
+            supportedClasses = supportedClasses,
+        )
     }
 }

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/RestoreAppArchiveUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/RestoreAppArchiveUseCase.kt
@@ -146,118 +146,77 @@ internal class RestoreAppArchiveUseCase(
 
         // The bundle is needed for an install and for OBB, and only then. Extracting it otherwise
         // would cost the app's whole download for nothing.
+        Logger.i(TAG, "Starting restore: pkg=$pkg, classes=$classes, installFirst=$installFirst, restoreObb=$restoreObb")
         val staging =
             if (installFirst || restoreObb) extractBundle(source, header) else BundleStaging.None
+        Logger.i(TAG, "Bundle staging result: $staging")
         val bundle = (staging as? BundleStaging.Staged)?.file
 
         // §8.5's marker, written once at whichever irreversible step comes first.
-        //
-        // Idempotent because there are two of those and only one runs per restore: the install on an
-        // install-first restore, the first class swap otherwise. Writing it at the *later* of the two
-        // left a window — install completes, process is killed, no breadcrumb — in which the user is
-        // holding a freshly installed app with no data in it and nothing anywhere says so.
         var breadcrumbWritten = false
         suspend fun markRestoreStarted() {
             if (breadcrumbWritten) return
             breadcrumbWritten = true
             if (!breadcrumbs.write(pkg, appLabel)) {
-                // The notice is the only thing that would tell the user a kill mid-restore left this
-                // app half-done. It cannot be made to work from here, but proceeding without saying
-                // so is the silence §8.5 exists to prevent.
                 Logger.e(TAG, "the restore breadcrumb could not be written; proceeding without it")
                 warnings += "Thor could not record that this restore started, " +
                     "so it will not be able to report it if the restore is interrupted"
             }
         }
 
-        /**
-         * A failure that returns a reason, from a point where no data has been written yet.
-         *
-         * The marker answers for a restore that **never returned** — a process kill, a cancel with the
-         * screen gone. A path that returns a reason has already told the user through the job's own
-         * outcome, so leaving the marker standing would add a second, vaguer notice on the next launch
-         * about damage that is not there. It stands past a return in exactly one case, and that case
-         * has its own function: [failWithBreadcrumbKept], for a failure after a class was swapped.
-         *
-         * Guarded on [breadcrumbWritten] rather than clearing unconditionally: the store holds one
-         * breadcrumb for the whole device, so a restore that never wrote one and clears anyway would
-         * delete the record of a *different* app's genuinely interrupted restore.
-         */
         suspend fun failBeforeAnyDataWasWritten(reason: String): ArchiveRestoreOutcome.Failed {
+            Logger.e(TAG, "Restore failed before data was written: $reason")
             if (breadcrumbWritten) breadcrumbs.clear()
             return ArchiveRestoreOutcome.Failed(reason, restored)
         }
 
         try {
-            // "There is no bundle" is several different situations and they are kept apart. Collapsing
-            // them is how "restore game data, left on, over a data-only archive" became a whole failed
-            // restore that wrote nothing and blamed the archive.
             if (staging is BundleStaging.Unreadable) {
-                // The header declares one and the container does not deliver it. Both consumers need
-                // those exact bytes, so this stops here — before anything is destroyed.
+                Logger.e(TAG, "Bundle unreadable: ${staging.reason}")
                 return ArchiveRestoreOutcome.Failed(staging.reason, restored)
             }
             if (installFirst && bundle == null) {
+                Logger.e(TAG, "installFirst was true but bundle was null")
                 return ArchiveRestoreOutcome.Failed(
                     "this archive holds only data, so $appLabel cannot be installed from it", restored
                 )
             }
             if (restoreObb && staging is BundleStaging.None) {
-                // Nothing to place is not a failure to place. The data restore goes ahead; the user is
-                // told why no game data appeared rather than being sent back to the checkbox.
                 warnings += "this archive holds no game data, so none was placed"
             }
 
             if (installFirst) {
                 if (!restoreObb && (header.appBundle?.obbCount ?: 0) > 0) {
-                    // `installBundle` writes the bundle's OBB as part of the install; there is no
-                    // install that leaves it behind. Refusing the whole restore over a flag Thor
-                    // cannot honour would be worse than doing it and saying so — and doing it
-                    // silently is the "a control that does nothing" defect this warning replaces.
                     warnings += "this app was installed from the archive, and that install places " +
                         "its game data too, so it was not left out"
                 }
                 onProgress(ThorJobProgress(ThorJobStage.INSTALLING, appLabel))
-                // Before the install, not after it. An install that lands and is then interrupted
-                // leaves the app on the device with no data in it, which is exactly the half-done
-                // state §8.5 announces — and the announcement is only possible if the marker was
-                // already on disk when the process died.
                 markRestoreStarted()
+                Logger.i(TAG, "Installing bundle: ${bundle?.absolutePath} for pkg=$pkg")
                 when (val outcome = installer.installBundle(bundle!!, pkg)) {
-                    ArchiveInstallOutcome.Installed -> Unit
+                    ArchiveInstallOutcome.Installed -> {
+                        Logger.i(TAG, "Bundle installed successfully")
+                    }
 
-                    // The package is installed and current; only its expansions are missing. Stopping
-                    // here would leave the user with an installed, empty app and nothing to do about
-                    // it — so the data restore goes ahead and the reason travels as a warning, because
-                    // a game whose expansions are absent starts and then crashes.
-                    is ArchiveInstallOutcome.InstalledWithoutGameData ->
+                    is ArchiveInstallOutcome.InstalledWithoutGameData -> {
+                        Logger.w(TAG, "Bundle installed without game data: ${outcome.reason}")
                         warnings += "the game data could not be placed: ${outcome.reason}"
+                    }
 
-                    is ArchiveInstallOutcome.Failed ->
+                    is ArchiveInstallOutcome.Failed -> {
+                        Logger.e(TAG, "Bundle install failed: ${outcome.reason}")
                         return failBeforeAnyDataWasWritten(outcome.reason)
+                    }
 
-                    // Never folded into `Failed`. `session.commit()` is fire-and-forget, so an install
-                    // Thor could not confirm may well have succeeded — and writing data into a package
-                    // whose install is unconfirmed is how someone's data ends up inside a
-                    // half-installed app.
-                    ArchiveInstallOutcome.Unconfirmed -> return failBeforeAnyDataWasWritten(
-                        "Thor could not confirm $appLabel finished installing, so it wrote no data"
-                    )
+                    ArchiveInstallOutcome.Unconfirmed -> {
+                        Logger.e(TAG, "Bundle install was unconfirmed")
+                        return failBeforeAnyDataWasWritten(
+                            "Thor could not confirm $appLabel finished installing, so it wrote no data"
+                        )
+                    }
                 }
-                // The gate could not check an absent app's signer (Task 11), so this is the only place
-                // the check can happen for an install-first restore. Skipping it would be a hole
-                // straight through the one refusal §8.1 allows no override for.
-                //
-                // It is also what closes the gap between `header.packageName` — which every path Thor
-                // writes derives from — and whatever package the `.xapk` inside the container actually
-                // declares. Thor does not parse the bundle's manifest; it does not have to. The install
-                // path watches `header.packageName`'s own install stamp across the commit, so a bundle
-                // that installs some *other* package cannot move that stamp and comes back
-                // `Unconfirmed` above; and a bundle that installs this package under a different
-                // signing key is refused here. Both exits happen before a byte of data is written.
-                // Null is "the question could not be answered", never "it matches" — the same refusal
-                // `installLanded` makes on an unreadable install stamp.
                 val signer = gateway.signerSha256(pkg)
+                Logger.i(TAG, "Installed app signer: $signer (expected: ${header.signerSha256})")
                 if (signer == null || !signer.equals(header.signerSha256, ignoreCase = true)) {
                     return failBeforeAnyDataWasWritten(
                         "the app that installed is not signed by the key this archive was made from"
@@ -265,15 +224,16 @@ internal class RestoreAppArchiveUseCase(
                 }
             }
 
-            // After the install, never from the archive: a reinstalled app has a new uid (§8.2).
             val uid = gateway.appUid(pkg)
-                ?: return failBeforeAnyDataWasWritten(
+            Logger.i(TAG, "App UID for $pkg: $uid")
+            if (uid == null) {
+                return failBeforeAnyDataWasWritten(
                     "Thor could not read $appLabel's user id, so it wrote no data"
                 )
+            }
 
+            Logger.d(TAG, "Force stopping $pkg")
             gateway.forceStop(pkg)
-            // A no-op on an install-first restore, which marked itself before the install. On every
-            // other restore this is the first irreversible step and the marker goes down here.
             markRestoreStarted()
 
             val totalBytes = classes.sumOf { header.member(it)?.plainBytes ?: 0L }
@@ -281,102 +241,73 @@ internal class RestoreAppArchiveUseCase(
 
             for (dataClass in classes) {
                 val member = header.member(dataClass)
-                    ?: return failWithBreadcrumbKept(
-                        "this archive has no ${dataClass.id} data", restored
-                    )
+                    ?: run {
+                        Logger.e(TAG, "Missing member for dataClass ${dataClass.id}")
+                        return failWithBreadcrumbKept(
+                            "this archive has no ${dataClass.id} data", restored
+                        )
+                    }
                 onProgress(restoring(appLabel, doneBytes, totalBytes))
+                Logger.i(TAG, "Restoring dataClass: ${dataClass.id} (${member.plainBytes} bytes)")
 
                 when (val outcome = restoreClass(source, dataClass, member, key, pkg, uid)) {
-                    ClassOutcome.Replaced -> Unit
+                    ClassOutcome.Replaced -> {
+                        Logger.i(TAG, "dataClass ${dataClass.id} Replaced successfully")
+                    }
 
-                    // In `restored` before the return: the class root holds the archive's copy, and
-                    // the user is owed that fact even though the app may not be able to read it.
                     is ClassOutcome.ReplacedUnusable -> {
+                        Logger.e(TAG, "dataClass ${dataClass.id} ReplacedUnusable: ${outcome.reason}")
                         restored += dataClass
                         return failWithBreadcrumbKept(outcome.reason, restored)
                     }
 
-                    is ClassOutcome.NotReplaced ->
+                    is ClassOutcome.NotReplaced -> {
+                        Logger.e(TAG, "dataClass ${dataClass.id} NotReplaced: ${outcome.reason}")
                         return failWithBreadcrumbKept(outcome.reason, restored)
+                    }
 
-                    is ClassOutcome.SwapFailed -> return failWithBreadcrumbKept(
-                        outcome.reason, restored, classPossiblyCleared = dataClass
-                    )
+                    is ClassOutcome.SwapFailed -> {
+                        Logger.e(TAG, "dataClass ${dataClass.id} SwapFailed: ${outcome.reason}")
+                        return failWithBreadcrumbKept(
+                            outcome.reason, restored, classPossiblyCleared = dataClass
+                        )
+                    }
                 }
 
                 restored += dataClass
                 doneBytes += member.plainBytes
             }
 
-            // `bundle`, not `header.appBundle`: a data-only archive has nothing staged and nothing to
-            // place, and the warning for that was already recorded above.
             if (restoreObb && !installFirst && bundle != null) {
                 onProgress(restoring(appLabel, doneBytes, totalBytes))
-                // A failed placement is a warning: the data landed, and telling the user the restore
-                // failed sends them to run it again, which destroys and rewrites data that is correct.
+                Logger.i(TAG, "Placing OBB game data...")
                 val placement = installer.placeBundleObb(bundle, pkg)
                 if (placement is ObbPlacement.Failed) {
+                    Logger.e(TAG, "OBB placement failed: ${placement.reason}")
                     warnings += "the game data could not be placed: ${placement.reason}"
                 }
-                // Its own return path, so §8.3 steps 5 and 6 have to be repeated on it.
                 gateway.forceStop(pkg)
                 breadcrumbs.clear()
-                // The real placement rather than a hard-coded `NotNeeded`, which would say nothing
-                // happened when something did. A *failure* reaches the user as the warning added just
-                // above; the other arms are the worker's to report, from this field.
                 return ArchiveRestoreOutcome.Completed(restored, warnings, placement)
             }
 
             onProgress(ThorJobProgress(ThorJobStage.FINISHING, appLabel, totalBytes, totalBytes))
             gateway.forceStop(pkg)
             breadcrumbs.clear()
+            Logger.i(TAG, "Restore completed successfully: classesRestored=$restored, warnings=$warnings")
             return ArchiveRestoreOutcome.Completed(restored, warnings, obb = null)
         } finally {
-            // The bundle is the app's whole download, staged in Thor's *internal* cache. Leaking one
-            // copy per failed or cancelled restore is the same defect `restoreClass`'s `finally`
-            // prevents one level down. This `try` has real suspension points in it — the install and
-            // every gateway call — so unlike a `try` around straight-line code, this `finally` is
-            // genuinely live on the cancellation path.
             bundle?.delete()
         }
     }
 
-    /**
-     * What one class's restore did to the device — not just whether it worked.
-     *
-     * Four arms because the caller has to tell three different things to the user, and a
-     * `String?` could carry only one of them: whether the class root now holds the archive's copy,
-     * whether it was left as it was, and whether Thor cannot say which.
-     */
     private sealed interface ClassOutcome {
-
-        /** The class root holds the archive's copy and the app can read it. */
         data object Replaced : ClassOutcome
-
-        /**
-         * The swap landed and a fixup after it did not, so the class root holds the archive's copy
-         * but the app may not be able to open it. It **did** land — the caller must count it in
-         * [ArchiveRestoreOutcome.Failed.classesRestored].
-         */
         data class ReplacedUnusable(val reason: String) : ClassOutcome
-
-        /** The failure happened before the swap, so this class is exactly as it was. */
         data class NotReplaced(val reason: String) : ClassOutcome
-
-        /**
-         * The swap itself failed. See [ArchiveRestoreOutcome.Failed.classPossiblyCleared]: this is
-         * the one outcome Thor cannot narrow, and the one that can mean the old data is gone.
-         */
         data class SwapFailed(val reason: String) : ClassOutcome
     }
 
-    /**
-     * One class, in §8.3's order.
-     *
-     * The whole member is decrypted **before** [AppDataArchiveGateway.extractInto] runs, and the swap
-     * comes after that. A corrupt archive therefore fails with the original data still in place —
-     * which is the difference between "that archive is bad" and "your data is gone".
-     */
     private suspend fun restoreClass(
         source: ArchiveSource,
         dataClass: DataClass,
@@ -386,14 +317,12 @@ internal class RestoreAppArchiveUseCase(
         uid: Int,
     ): ClassOutcome {
         val staged = gateway.stagingFile("restore-${dataClass.id}.tar")
+        Logger.d(TAG, "restoreClass(${dataClass.id}): staging to ${staged.absolutePath}")
         try {
             val ciphertext = try {
                 source.openEntry(member.fileName)
                     ?: return ClassOutcome.NotReplaced("this archive is missing ${member.fileName}")
             } catch (e: IOException) {
-                // A truncated or damaged container throws here (`ZipException` is an `IOException`)
-                // rather than returning null, and a throw out of `invoke` costs the caller
-                // `classesRestored`.
                 Logger.e(TAG, "could not open ${member.fileName}", e)
                 return ClassOutcome.NotReplaced("this archive could not be read: ${e.message}")
             }
@@ -408,57 +337,46 @@ internal class RestoreAppArchiveUseCase(
                         cipher.decryptMember(member.fileName, input, output, key, nonce, member.chunkCount)
                     }
                 }
+                Logger.d(TAG, "Decrypted ${member.fileName} (${staged.length()} bytes)")
             } catch (e: ArchiveIntegrityException) {
                 Logger.e(TAG, "${member.fileName} failed integrity", e)
                 return ClassOutcome.NotReplaced(
                     "this archive's ${dataClass.id} data is damaged and was not restored"
                 )
             } catch (e: IOException) {
-                // Not an integrity failure and not exotic: running out of room in Thor's internal
-                // cache is *the* expected failure for a multi-gigabyte restore, and neither
-                // `staged.outputStream()` nor `plaintext.write(chunk)` raises anything an
-                // `ArchiveIntegrityException` catch would see. Letting it escape `invoke` would throw
-                // away `classesRestored` with it — and "CE is already replaced" is exactly what
-                // separates an actionable message from a useless one.
                 Logger.e(TAG, "${member.fileName} could not be staged", e)
                 return ClassOutcome.NotReplaced(
                     "${dataClass.id} could not be written to Thor's cache: ${e.message}"
                 )
             }
 
-            // The decrypt above is this use case's one long stretch with no suspension point in it, and
-            // nothing after it observes cancellation on its own: the gateway's `withContext(io)` resumes
-            // *undispatched* when the caller is already on that dispatcher, so it never reaches a
-            // cancellation check. Without this line a restore the user cancelled during the decrypt goes
-            // on to replace the class root anyway. Placed before `extractInto` because that call is
-            // itself destructive — it opens with `rm -rf` on the staging directory.
             currentCoroutineContext().ensureActive()
 
             val compressed = ArchiveCompression.fromId(member.compression) == ArchiveCompression.GZIP
-            // Unpacks into the class root's staging directory, beside the live data and never over
-            // it, so a failure here has replaced nothing.
+            Logger.d(TAG, "Calling extractInto for ${dataClass.id} (compressed=$compressed)")
             if (!gateway.extractInto(packageName, dataClass, staged, compressed)) {
+                Logger.e(TAG, "gateway.extractInto returned false for ${dataClass.id}")
                 return ClassOutcome.NotReplaced("${dataClass.id} could not be unpacked")
             }
-            // Past this line the original is gone.
+            Logger.d(TAG, "Calling swapStaged for ${dataClass.id}")
             if (!gateway.swapStaged(packageName, dataClass)) {
-                // The reason carries the ambiguity as well as the field does, because the reason is
-                // the part every consumer already shows.
+                Logger.e(TAG, "gateway.swapStaged returned false for ${dataClass.id}")
                 return ClassOutcome.SwapFailed(
                     "${dataClass.id} could not be put into place, and Thor cannot tell whether its " +
                         "previous data was already deleted"
                 )
             }
             if (dataClass.isInternal) {
-                // Both of these run *after* the swap: the class root already holds the archive's copy,
-                // so the failure is "restored, and the app may not be able to read it" — never
-                // "not restored". `ReplacedUnusable` is what keeps `classesRestored` honest about it.
+                Logger.d(TAG, "Calling chownClass for ${dataClass.id} (uid=$uid)")
                 if (!gateway.chownClass(packageName, dataClass, uid)) {
+                    Logger.e(TAG, "gateway.chownClass returned false for ${dataClass.id}")
                     return ClassOutcome.ReplacedUnusable(
                         "${dataClass.id} was restored but its ownership could not be set"
                     )
                 }
+                Logger.d(TAG, "Calling relabelClass for ${dataClass.id}")
                 if (!gateway.relabelClass(packageName, dataClass)) {
+                    Logger.e(TAG, "gateway.relabelClass returned false for ${dataClass.id}")
                     return ClassOutcome.ReplacedUnusable(
                         "${dataClass.id} was restored but its security labels could not be set"
                     )
@@ -466,8 +384,6 @@ internal class RestoreAppArchiveUseCase(
             }
             return ClassOutcome.Replaced
         } finally {
-            // Inside the loop, so peak disk is one class. Folding this up into `invoke` is the one
-            // edit that breaks that and nothing else.
             staged.delete()
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
@@ -479,12 +479,17 @@ private fun BackupRunning(state: AppBackupUiState, onBackground: () -> Unit) {
  */
 @Composable
 private fun BackupOutcome(finish: BackupFinish, onDismiss: () -> Unit) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         when (finish) {
             BackupFinish.Succeeded -> Text(
                 text = stringResource(R.string.backup_done),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
             )
 
             is BackupFinish.Failed -> {
@@ -494,7 +499,8 @@ private fun BackupOutcome(finish: BackupFinish, onDismiss: () -> Unit) {
                         finish.reason ?: stringResource(R.string.backup_failed_unknown)
                     ),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                 )
                 Text(
                     text = stringResource(
@@ -507,7 +513,8 @@ private fun BackupOutcome(finish: BackupFinish, onDismiss: () -> Unit) {
                         }
                     ),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                 )
             }
 
@@ -515,12 +522,14 @@ private fun BackupOutcome(finish: BackupFinish, onDismiss: () -> Unit) {
                 Text(
                     text = stringResource(R.string.backup_cancelled_after_start),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                 )
                 Text(
                     text = stringResource(R.string.backup_failed_nothing_saved),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                 )
             } else {
                 // The common cancel: a dependent of a failed job, cancelled before `doWork`. Its own
@@ -529,14 +538,15 @@ private fun BackupOutcome(finish: BackupFinish, onDismiss: () -> Unit) {
                 Text(
                     text = stringResource(R.string.backup_cancelled),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                 )
             }
         }
-        // The dismiss `dismissResult()` was written for and never given. Without it a *success* message
-        // sat under a still-enabled Back up button for as long as the sheet stayed open, and the only
-        // way to clear it was to start another backup.
-        TextButton(onClick = onDismiss) {
+        Button(
+            onClick = onDismiss,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        ) {
             Text(stringResource(R.string.backup_outcome_dismiss))
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupSheet.kt
@@ -246,7 +246,7 @@ fun AppBackupSheet(packageName: String, appLabel: String, onDismiss: () -> Unit)
                         onCheckedChange = viewModel::setIncludeBundle
                     )
 
-                    DataClass.entries.forEach { dataClass ->
+                    state.supportedClasses.forEach { dataClass ->
                         CheckRow(
                             checked = dataClass in state.selected,
                             enabled = !state.running,

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/AppBackupViewModel.kt
@@ -92,6 +92,7 @@ data class AppBackupUiState(
      * shown for one frame on every open is a lie the user reads before the truth arrives.
      */
     val supported: Boolean? = null,
+    val supportedClasses: Set<DataClass> = DataClass.entries.toSet(),
     val sizes: Map<DataClass, DataClassSize> = emptyMap(),
     val selected: Set<DataClass> = emptySet(),
     val includeBundle: Boolean = true,
@@ -195,17 +196,17 @@ class AppBackupViewModel(
             // Not `supported = null`, which is "still asking" and leaves the spinner turning for the
             // life of the sheet. A measurement that threw is a measurement Thor cannot make, which is
             // what `false` already means and what `backup_unsupported` already says.
-            onFailure = { _uiState.update { it.copy(supported = false, selected = emptySet()) } }
+            onFailure = { _uiState.update { it.copy(supported = false, selected = emptySet(), supportedClasses = emptySet()) } }
         ) {
             val measurement = measure(packageName)
             _uiState.update { state ->
                 state.copy(
                     supported = measurement.supported,
                     sizes = measurement.sizes,
-                    // §4.2: all default on. Including a class whose size is Undetermined — that is a
-                    // failed measurement, not an empty directory, and dropping it would narrow the
-                    // backup without saying so.
-                    selected = if (measurement.supported) DataClass.entries.toSet() else emptySet(),
+                    supportedClasses = measurement.supportedClasses,
+                    // §4.2: all supported classes default on. Including a class whose size is
+                    // Undetermined — that is a failed measurement, not an empty directory.
+                    selected = if (measurement.supported) measurement.supportedClasses else emptySet(),
                 )
             }
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
@@ -458,7 +458,7 @@ private fun RestoreSheetBody(
             }
 
             state.finished?.let { finish ->
-                if (finish is RestoreFinish.Succeeded) {
+                if (finish is RestoreFinish.Succeeded && finish.warnings.isEmpty()) {
                     LaunchedEffect(Unit) {
                         delay(SUCCESS_LINGER_MS)
                         viewModel.dismissResult()

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
@@ -335,24 +335,18 @@ private fun RestoreSheetBody(
             // cannot use, and has to scroll past to find the only thing that is moving.
             if (!state.running) {
                 header.heldClasses().forEach { dataClass ->
-                    // `heldClasses()` is defined as the classes with a member, so this cannot drop a row
-                    // the user should have seen; it is here so the size below is read off a member that
-                    // exists rather than defaulted to a number nothing measured.
                     val member = header.member(dataClass) ?: return@forEach
+                    val isSupported = dataClass in state.supportedClasses
                     CheckRow(
-                        checked = dataClass in state.selected,
-                        // `true`, not `!state.running`. The enclosing `if` already answers that, so a
-                        // condition here would be a control that cannot be reached in its disabled
-                        // state — and reads to the next person as if the row greys out mid-restore
-                        // when in fact it is gone. Every `enabled` below is constant for the same
-                        // reason; the guard is the `if`, once, at the top.
-                        enabled = true,
+                        checked = isSupported && dataClass in state.selected,
+                        enabled = isSupported,
                         label = stringResource(dataClassLabel(dataClass)),
-                        // `Known`, and only `Known`: an archive records the byte count it actually
-                        // packed, so there is no tri-state to render here. Routed through `sizeLabel`
-                        // anyway so every size in this feature is formatted by one function.
-                        detail = sizeLabel(DataClassSize.Known(member.plainBytes)),
-                        onCheckedChange = { viewModel.toggleClass(dataClass) }
+                        detail = if (isSupported) {
+                            sizeLabel(DataClassSize.Known(member.plainBytes))
+                        } else {
+                            stringResource(R.string.backup_unsupported)
+                        },
+                        onCheckedChange = { if (isSupported) viewModel.toggleClass(dataClass) }
                     )
                 }
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreSheet.kt
@@ -34,12 +34,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.rememberViewModelStoreOwner
@@ -50,7 +52,10 @@ import com.valhalla.thor.domain.model.DataClassSize
 import com.valhalla.thor.presentation.common.RequestNotificationsWhenJobStarts
 import java.text.DateFormat
 import java.util.Date
+import kotlinx.coroutines.delay
 import org.koin.androidx.compose.koinViewModel
+
+private const val SUCCESS_LINGER_MS = 3_000L
 
 @StringRes
 private fun refusalLabel(refusal: ArchiveRestoreRefusal): Int = when (refusal) {
@@ -453,7 +458,22 @@ private fun RestoreSheetBody(
             }
 
             state.finished?.let { finish ->
-                RestoreOutcomeDialog(finish = finish, onDismiss = viewModel::dismissResult)
+                if (finish is RestoreFinish.Succeeded) {
+                    LaunchedEffect(Unit) {
+                        delay(SUCCESS_LINGER_MS)
+                        viewModel.dismissResult()
+                        onDismiss()
+                    }
+                }
+                RestoreOutcomeDialog(
+                    finish = finish,
+                    onDismiss = {
+                        viewModel.dismissResult()
+                        if (finish is RestoreFinish.Succeeded) {
+                            onDismiss()
+                        }
+                    }
+                )
             }
 
             if (!state.running && state.finished !is RestoreFinish.Succeeded) {
@@ -543,46 +563,28 @@ private fun RestoreRunning(state: ArchiveRestoreUiState, onBackground: () -> Uni
 }
 
 /**
- * [RestoreOutcome] in a dialog.
- *
- * A dialog rather than the card at the foot of the column it used to be, because of how tall the column
- * is: the title, the archive's three header lines, up to four class rows, the game-data row, the unlock
- * row, the confirmation row, the bar and the Restore button all sit above it. The sentence saying
- * whether an app's data came back therefore arrived below the fold, on the one surface where the user is
- * watching for exactly that — and a restore finishes minutes after the tap that started it, so it is
- * also the one event here the user is not already looking at the bottom of the column for. It has to
- * interrupt rather than wait to be found.
- *
- * A dialog *over a sheet*, now that this is one, and it survives the move unchanged because a `Dialog`
- * is its own window: it renders above the sheet rather than inside its scroll.
- *
- * What the move does change is the case where the user takes the Background button. Dismissing drops
- * this sheet's watcher, so a restore that finishes afterwards reports nowhere — the same trade the
- * backup sheet's Background button already makes, and the reason §8.5's breadcrumb rather than this
- * dialog is what covers a restore whose outcome nobody read: an interrupted one leaves the notice in
- * Settings behind it.
- *
- * All three outcomes, not only the success that prompted this. A failure was equally invisible, and one
- * container for one decision is what keeps the five sentences [RestoreOutcome] documents from drifting
- * into two shapes.
- *
- * No auto-dismiss, deliberately — unlike the backup sheet's success frame, which closes itself after
- * three seconds. That one has nothing left to say; this one tells the user to go and open the app to
- * check it works, and may be carrying warnings under it.
+ * How a completed or failed restore is acknowledged.
  */
 @Composable
 private fun RestoreOutcomeDialog(finish: RestoreFinish, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        text = { RestoreOutcome(finish = finish) },
-        confirmButton = {
-            // `restore_outcome_dismiss`, not `restore_interrupted_dismiss`: that one is named and
-            // commented for the §8.5 breadcrumb banner at the top of this sheet. Same word today, two
-            // owners, so rewording the breadcrumb's button cannot silently reword this one.
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.restore_outcome_dismiss))
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                RestoreOutcome(finish = finish)
+                Button(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                ) {
+                    Text(stringResource(R.string.restore_outcome_dismiss))
+                }
             }
-        }
+        },
+        confirmButton = {}
     )
 }
 
@@ -591,27 +593,14 @@ private fun RestoreOutcomeDialog(finish: RestoreFinish, onDismiss: () -> Unit) {
  *
  * The body of [RestoreOutcomeDialog], which owns the dismiss button — so this stays a column of
  * sentences and nothing else.
- *
- * Three outcomes, five sentences: both failure arms split on [RestoreFinish.workerRan], because what
- * is honest depends on whether anything reached the device.
- *
- * | Outcome | Copy |
- * |---|---|
- * | `Succeeded` | it landed — go and check it, plus anything it finished in spite of |
- * | `Failed(workerRan = true)` | the worker's reason, then the damage sentence |
- * | `Failed(workerRan = false)` | the reason, then *nothing was started* |
- * | `Cancelled(workerRan = false)` | the chain cancelled it; nothing was changed |
- * | `Cancelled(workerRan = true)` | it was cancelled after it started, then the damage sentence |
- *
- * The one thing none of them may do is describe a state the code cannot vouch for — in either
- * direction. A restore that ran deletes each class before it writes it, and on the install-first path
- * it may have installed the app before failing, so *"nothing was changed"* is a lie there. A restore
- * refused before its enqueue touched nothing at all, so the damage sentence is a lie *here* — and a
- * worse one, because it ends by telling the user to run a destructive operation again.
  */
 @Composable
 private fun RestoreOutcome(finish: RestoreFinish) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         when (finish) {
             // §8.6: the honest instruction is "open it and check", because no amount of shell exit
             // codes proves the app is happy with what it was handed.
@@ -619,7 +608,8 @@ private fun RestoreOutcome(finish: RestoreFinish) {
                 Text(
                     text = stringResource(R.string.restore_done),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary
+                    color = MaterialTheme.colorScheme.primary,
+                    textAlign = TextAlign.Center,
                 )
                 if (finish.warnings.isNotEmpty()) {
                     // The data landed, so this is not a failure — but a run that could not place the
@@ -628,13 +618,15 @@ private fun RestoreOutcome(finish: RestoreFinish) {
                     Text(
                         text = stringResource(R.string.restore_done_warnings),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
                     )
                     finish.warnings.forEach {
                         Text(
                             text = it,
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error
+                            color = MaterialTheme.colorScheme.error,
+                            textAlign = TextAlign.Center,
                         )
                     }
                 }
@@ -648,7 +640,8 @@ private fun RestoreOutcome(finish: RestoreFinish) {
                             ?: stringResource(R.string.restore_failed_unknown)
                     ),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
                 )
                 Text(
                     text = stringResource(
@@ -661,7 +654,8 @@ private fun RestoreOutcome(finish: RestoreFinish) {
                         }
                     ),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
                 )
             }
 
@@ -673,12 +667,14 @@ private fun RestoreOutcome(finish: RestoreFinish) {
                 Text(
                     text = stringResource(R.string.restore_cancelled_after_start),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
                 )
                 Text(
                     text = stringResource(R.string.restore_failed_partial),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
                 )
             } else {
                 // The chain case, and the only place "nothing was changed" is earned: WorkManager
@@ -686,7 +682,8 @@ private fun RestoreOutcome(finish: RestoreFinish) {
                 Text(
                     text = stringResource(R.string.restore_cancelled),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
                 )
             }
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
@@ -476,13 +476,13 @@ internal class ArchiveRestoreViewModel(
             installed = facts
             val obbCount = header.appBundle?.obbCount ?: 0
             val held = header.heldClasses()
-            val defaultSelected = held.intersect(supportedClasses).ifEmpty { held }
+            val defaultSelected = held.intersect(supportedClasses)
             updateForOpen(generation) { state ->
                 state.copy(
                     loading = false,
                     fileName = source.displayName,
                     header = header,
-                    // Everything the archive holds that can be restored, selected.
+                    // Only classes the archive holds that are supported by the runner are selected by default.
                     selected = defaultSelected.toSet(),
                     obbOffered = obbCount > 0,
                     restoreObb = obbCount > 0,

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.presentation.backup
 
 import androidx.lifecycle.ViewModel
+import com.valhalla.thor.util.Logger
 import com.valhalla.thor.data.backup.DataArchiveCapabilityCache
 import com.valhalla.thor.data.backup.PassphraseVault
 import com.valhalla.thor.data.backup.job.JobRegistry
@@ -726,12 +727,8 @@ internal class ArchiveRestoreViewModel(
 
         _uiState.update { it.copy(running = true, queued = false, finished = null) }
         launchGuarded(
-            // `running` is set synchronously above and only this block can clear it, so an unguarded
-            // throw out of `startRestore` left a permanently disabled Restore button with a bar over
-            // it — a state the user cannot leave without killing the app. Reported exactly as the
-            // enqueue-returned-null branch below reports itself, because it is the same fact: no job
-            // exists, so nothing on the device was touched.
             onFailure = {
+                Logger.e("ArchiveRestoreVM", "beginRestore failed synchronously", it)
                 _uiState.update {
                     it.copy(
                         running = false,
@@ -747,12 +744,10 @@ internal class ArchiveRestoreViewModel(
                 classes = state.selected,
                 restoreObb = state.restoreObb,
             )
-            // `header.kdf.iterations`, never the default: this screen is the only place that holds the
-            // archive's own count, and the launcher derives the job's key from what it is given here.
+            Logger.i("ArchiveRestoreVM", "Starting restore: pkg=${request.packageName}, classes=${request.classes}, restoreObb=${request.restoreObb}, uri=${request.uriString}")
             val id = launcher.startRestore(request, key, salt, header.kdf.iterations)
+            Logger.i("ArchiveRestoreVM", "launcher.startRestore returned id=$id")
             if (id == null) {
-                // The enqueue itself threw; `ThorJobLauncher` has already dropped the key. There is no
-                // job, so nothing ran.
                 _uiState.update {
                     it.copy(
                         running = false,
@@ -769,25 +764,21 @@ internal class ArchiveRestoreViewModel(
     /** §8.1 as the screen sees it. Called on open and after every selection change. */
     private fun evaluate() {
         val header = _uiState.value.header ?: return
-        when (val decision = evaluateArchiveRestoreGate(header, installed, _uiState.value.selected)) {
+        val decision = evaluateArchiveRestoreGate(header, installed, _uiState.value.selected)
+        Logger.i("ArchiveRestoreVM", "evaluateArchiveRestoreGate: $decision (installed=$installed, selected=${_uiState.value.selected})")
+        when (decision) {
             is ArchiveRestoreDecision.Allowed -> _uiState.update {
                 val obbCount = header.appBundle?.obbCount ?: 0
                 it.copy(
                     refusal = null,
                     warnings = decision.warnings,
                     installFirst = decision.installFirst,
-                    // Withdrawn on the install-first path, where the install places the game data
-                    // itself and the flag reaches nothing. `restoreObb` is then set to what will
-                    // actually happen, so the request Thor sends matches the app the user gets; on
-                    // every other path the user's own choice is left alone.
                     obbOffered = obbCount > 0 && !decision.installFirst,
                     restoreObb = if (decision.installFirst) obbCount > 0 else it.restoreObb,
                 )
             }
 
             is ArchiveRestoreDecision.Refused -> _uiState.update {
-                // Warnings are cleared with the refusal: a refused restore has no warnings to heed,
-                // and leaving them on screen reads as two problems where there is one.
                 it.copy(refusal = decision.reason, warnings = emptyList(), installFirst = false)
             }
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModel.kt
@@ -199,6 +199,7 @@ data class ArchiveRestoreUiState(
     /** Why this file cannot be used at all — not a gate refusal, which needs a readable header. */
     val error: ArchiveRestoreMessage? = null,
     val supported: Boolean? = null,
+    val supportedClasses: Set<DataClass> = DataClass.entries.toSet(),
     val refusal: ArchiveRestoreRefusal? = null,
     val warnings: List<ArchiveRestoreWarning> = emptyList(),
     val installFirst: Boolean = false,
@@ -416,11 +417,9 @@ internal class ArchiveRestoreViewModel(
                 }
             }
         ) {
-            // The one write here that is *not* file-derived, and so not generation-guarded: whether the
-            // device can restore private data at all is a property of the privilege state, identical for
-            // every archive, and the cache behind it answers the same for both reads.
             val supported = capability.isSupported()
-            _uiState.update { it.copy(supported = supported) }
+            val supportedClasses = capability.supportedClasses()
+            _uiState.update { it.copy(supported = supported, supportedClasses = supportedClasses) }
 
             // The picker offers every file on the device, so "that is not a backup" is the ordinary
             // mistake and it gets its own sentence. The two failures point the user opposite ways:
@@ -476,13 +475,15 @@ internal class ArchiveRestoreViewModel(
             if (generation != openGeneration) return@launchGuarded
             installed = facts
             val obbCount = header.appBundle?.obbCount ?: 0
+            val held = header.heldClasses()
+            val defaultSelected = held.intersect(supportedClasses).ifEmpty { held }
             updateForOpen(generation) { state ->
                 state.copy(
                     loading = false,
                     fileName = source.displayName,
                     header = header,
-                    // Everything the archive holds, selected. The user narrows from there.
-                    selected = header.heldClasses().toSet(),
+                    // Everything the archive holds that can be restored, selected.
+                    selected = defaultSelected.toSet(),
                     obbOffered = obbCount > 0,
                     restoreObb = obbCount > 0,
                 )

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -5,10 +5,12 @@ package com.valhalla.thor.presentation.backup.hub
 
 import android.content.Intent
 import android.text.format.Formatter
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import com.valhalla.thor.util.Logger
 import java.io.File
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
@@ -231,12 +233,14 @@ fun BackupRestoreHubScreen(
                                                 "${context.packageName}.provider",
                                                 File(parsedUri.path!!)
                                             )
-                                        } catch (_: Exception) {
-                                            parsedUri
+                                        } catch (e: Exception) {
+                                            Logger.e("BackupRestoreHub", "Failed to get share URI for file", e)
+                                            Toast.makeText(context, R.string.unknown_error_occurred, Toast.LENGTH_SHORT).show()
+                                            null
                                         }
                                     } else {
                                         parsedUri
-                                    }
+                                    } ?: return@ArchiveItemCard
                                     val shareIntent = Intent(Intent.ACTION_SEND).apply {
                                         type = "*/*"
                                         putExtra(Intent.EXTRA_STREAM, shareUri)

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -84,7 +84,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.valhalla.thor.R
-import com.valhalla.thor.data.source.local.room.AppEntity
+import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.repository.BackupArchiveItem
 import com.valhalla.thor.domain.repository.BackupArchiveKind
 import com.valhalla.thor.presentation.home.components.BentoTile
@@ -165,7 +165,7 @@ fun BackupRestoreHubScreen(
                     IconButton(onClick = { viewModel.refreshArchives() }) {
                         Icon(
                             Icons.Default.Refresh,
-                            contentDescription = stringResource(R.string.cd_clear),
+                            contentDescription = stringResource(R.string.refresh),
                         )
                     }
                 },
@@ -479,6 +479,8 @@ private fun ArchiveItemCard(
                         uriString = item.uriString,
                         packageName = item.packageName,
                         displayName = item.displayName,
+                        sizeBytes = item.sizeBytes,
+                        lastModifiedEpochSec = item.dateModifiedEpochSec,
                     ),
                     contentDescription = null,
                     modifier = Modifier
@@ -538,8 +540,13 @@ private fun ArchiveItemCard(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
+                    val subtitleText = if (formattedDate.isNotBlank()) {
+                        "$formattedSize · $formattedDate"
+                    } else {
+                        formattedSize
+                    }
                     Text(
-                        text = "$formattedSize · $formattedDate",
+                        text = subtitleText,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.outline,
                     )
@@ -743,9 +750,9 @@ private fun TipCard(
 @Composable
 private fun AppPickerBottomSheet(
     searchQuery: String,
-    apps: List<AppEntity>,
+    apps: List<AppInfo>,
     onSearchChange: (String) -> Unit,
-    onAppSelect: (AppEntity) -> Unit,
+    onAppSelect: (AppInfo) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -16,11 +16,15 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
+import com.valhalla.thor.presentation.utils.ArchiveIconModel
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -39,16 +43,20 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -150,7 +158,7 @@ fun BackupRestoreHubScreen(
                 actions = {
                     IconButton(onClick = { viewModel.refreshArchives() }) {
                         Icon(
-                            painter = painterResource(R.drawable.clear_all),
+                            Icons.Default.Refresh,
                             contentDescription = stringResource(R.string.cd_clear),
                         )
                     }
@@ -385,13 +393,15 @@ private fun BackupsSectionHeader(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun DynamicFilterChips(
     activeFilter: BackupHubFilter,
     onFilterSelect: (BackupHubFilter) -> Unit,
 ) {
-    FlowRow(
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         FilterChip(
@@ -424,6 +434,7 @@ private fun DynamicFilterChips(
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ArchiveItemCard(
     item: BackupArchiveItem,
@@ -454,9 +465,80 @@ private fun ArchiveItemCard(
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                SubcomposeAsyncImage(
+                    model = ArchiveIconModel(
+                        uriString = item.uriString,
+                        packageName = item.packageName,
+                        displayName = item.displayName,
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(44.dp)
+                        .clip(RoundedCornerShape(10.dp)),
+                    loading = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            LoadingIndicator(
+                                modifier = Modifier.size(24.dp)
+                            )
+                        }
+                    },
+                    error = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                painter = painterResource(
+                                    if (item.kind == BackupArchiveKind.DATA_BACKUP) {
+                                        R.drawable.settings_backup_restore
+                                    } else {
+                                        R.drawable.apk_install
+                                    }
+                                ),
+                                contentDescription = null,
+                                modifier = Modifier.size(26.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    },
+                )
+
+                // File Name, Package, Size
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = item.displayName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (!item.packageName.isNullOrBlank()) {
+                        Text(
+                            text = item.packageName,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    Text(
+                        text = "$formattedSize · $formattedDate",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.outline,
+                    )
+                }
+
                 // Leading Type Tag
                 val isDataBackup = item.kind == BackupArchiveKind.DATA_BACKUP
                 Surface(
@@ -480,34 +562,7 @@ private fun ArchiveItemCard(
                         } else {
                             MaterialTheme.colorScheme.onSecondaryContainer
                         },
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                    )
-                }
-
-                Text(
-                    text = "$formattedSize · $formattedDate",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // File Name & Package
-            Column {
-                Text(
-                    text = item.displayName,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                if (!item.packageName.isNullOrBlank()) {
-                    Text(
-                        text = item.packageName,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                     )
                 }
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -521,19 +521,24 @@ private fun ArchiveItemCard(
                     },
                 )
 
-                // File Name, Package, Size
+                // App Name, Package / File Name, Size
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = item.displayName,
+                        text = item.appName ?: item.displayName,
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.SemiBold,
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
-                    if (!item.packageName.isNullOrBlank()) {
+                    val subLabel = if (item.appName != null) {
+                        item.packageName ?: item.displayName
+                    } else {
+                        item.packageName
+                    }
+                    if (!subLabel.isNullOrBlank()) {
                         Text(
-                            text = item.packageName,
+                            text = subLabel,
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.valhalla.thor.R
 import com.valhalla.thor.data.source.local.room.AppEntity
@@ -106,6 +107,11 @@ fun BackupRestoreHubScreen(
     viewModel: BackupRestoreHubViewModel = koinViewModel(),
     installerViewModel: InstallerViewModel = koinViewModel(),
 ) {
+    LifecycleResumeEffect(Unit) {
+        viewModel.refreshArchives()
+        onPauseOrDispose { }
+    }
+
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
     var showInstallerSheet by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -503,7 +503,7 @@ private fun ArchiveItemCard(
                     )
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        text = stringResource(R.string.job_restoring),
+                        text = stringResource(R.string.restore_start),
                         fontWeight = FontWeight.Bold,
                         fontSize = 13.sp,
                     )

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -7,7 +7,9 @@ import android.content.Intent
 import android.text.format.Formatter
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import java.io.File
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
@@ -221,9 +223,23 @@ fun BackupRestoreHubScreen(
                                 item = item,
                                 onRestore = { handleRestoreOrInstall(item) },
                                 onShare = {
+                                    val parsedUri = item.uriString.toUri()
+                                    val shareUri = if (parsedUri.scheme == "file" && parsedUri.path != null) {
+                                        try {
+                                            FileProvider.getUriForFile(
+                                                context,
+                                                "${context.packageName}.provider",
+                                                File(parsedUri.path!!)
+                                            )
+                                        } catch (_: Exception) {
+                                            parsedUri
+                                        }
+                                    } else {
+                                        parsedUri
+                                    }
                                     val shareIntent = Intent(Intent.ACTION_SEND).apply {
                                         type = "*/*"
-                                        putExtra(Intent.EXTRA_STREAM, item.uriString.toUri())
+                                        putExtra(Intent.EXTRA_STREAM, shareUri)
                                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                                     }
                                     context.startActivity(Intent.createChooser(shareIntent, item.displayName))

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
@@ -5,8 +5,8 @@ package com.valhalla.thor.presentation.backup.hub
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.valhalla.thor.data.source.local.room.AppDao
 import com.valhalla.thor.data.source.local.room.AppEntity
+import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.BackupArchiveItem
 import com.valhalla.thor.domain.repository.BackupArchiveKind
 import com.valhalla.thor.domain.repository.BackupArchiveScanner
@@ -63,7 +63,7 @@ data class BackupRestoreHubState(
 @KoinViewModel
 class BackupRestoreHubViewModel(
     private val scanner: BackupArchiveScanner,
-    private val appDao: AppDao,
+    private val appRepository: AppRepository,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(BackupRestoreHubState())
@@ -96,8 +96,9 @@ class BackupRestoreHubViewModel(
 
     private fun loadInstalledApps() {
         viewModelScope.launch {
-            appDao.getAllAppsFlow().collect { apps ->
+            appRepository.getAllApps().collect { apps ->
                 val sorted = apps.filter { !it.isSystem }
+                    .map { AppEntity.fromDomain(it) }
                     .sortedBy { it.appName?.lowercase() ?: it.packageName }
                 _state.update { it.copy(installedApps = sorted) }
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
@@ -7,7 +7,7 @@ import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
-import com.valhalla.thor.data.source.local.room.AppEntity
+import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.THOR_JOB_CHAIN
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.BackupArchiveItem
@@ -15,11 +15,8 @@ import com.valhalla.thor.domain.repository.BackupArchiveKind
 import com.valhalla.thor.domain.repository.BackupArchiveScanner
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
@@ -36,7 +33,7 @@ data class BackupRestoreHubState(
     val activeFilter: BackupHubFilter = BackupHubFilter.ALL,
     val isAppPickerVisible: Boolean = false,
     val appPickerSearchQuery: String = "",
-    val installedApps: List<AppEntity> = emptyList(),
+    val installedApps: List<AppInfo> = emptyList(),
     val archiveToDelete: BackupArchiveItem? = null,
 ) {
     val hasBackups: Boolean get() = archives.any { it.kind == BackupArchiveKind.DATA_BACKUP }
@@ -52,7 +49,7 @@ data class BackupRestoreHubState(
 
     val totalSizeBytes: Long get() = archives.sumOf { it.sizeBytes }
 
-    val filteredInstalledApps: List<AppEntity>
+    val filteredInstalledApps: List<AppInfo>
         get() {
             if (appPickerSearchQuery.isBlank()) return installedApps
             val q = appPickerSearchQuery.trim().lowercase()
@@ -117,8 +114,7 @@ class BackupRestoreHubViewModel(
         viewModelScope.launch {
             appRepository.getAllApps().collect { apps ->
                 val sorted = apps.filter { !it.isSystem }
-                    .map { AppEntity.fromDomain(it) }
-                    .sortedBy { it.appName?.lowercase() ?: it.packageName }
+                    .sortedBy { (it.appName ?: it.packageName).lowercase() }
                 _state.update { it.copy(installedApps = sorted) }
             }
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
@@ -81,11 +81,21 @@ class BackupRestoreHubViewModel(
     private fun observeWorkManagerJobs() {
         viewModelScope.launch {
             runCatching {
+                val knownFinishedIds = mutableSetOf<java.util.UUID>()
+                var isFirstEmission = true
                 WorkManager.getInstance(application)
                     .getWorkInfosForUniqueWorkFlow(THOR_JOB_CHAIN)
                     .collect { workInfos ->
-                        if (workInfos.any { it.state.isFinished }) {
-                            refreshArchives()
+                        val finishedIds = workInfos.filter { it.state.isFinished }.map { it.id }.toSet()
+                        if (isFirstEmission) {
+                            knownFinishedIds.addAll(finishedIds)
+                            isFirstEmission = false
+                        } else {
+                            val newFinished = finishedIds - knownFinishedIds
+                            if (newFinished.isNotEmpty()) {
+                                knownFinishedIds.addAll(newFinished)
+                                refreshArchives()
+                            }
                         }
                     }
             }

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
@@ -3,9 +3,12 @@
 
 package com.valhalla.thor.presentation.backup.hub
 
+import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkManager
 import com.valhalla.thor.data.source.local.room.AppEntity
+import com.valhalla.thor.domain.model.THOR_JOB_CHAIN
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.BackupArchiveItem
 import com.valhalla.thor.domain.repository.BackupArchiveKind
@@ -64,6 +67,7 @@ data class BackupRestoreHubState(
 class BackupRestoreHubViewModel(
     private val scanner: BackupArchiveScanner,
     private val appRepository: AppRepository,
+    private val application: Application,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(BackupRestoreHubState())
@@ -74,6 +78,21 @@ class BackupRestoreHubViewModel(
     init {
         loadInstalledApps()
         refreshArchives()
+        observeWorkManagerJobs()
+    }
+
+    private fun observeWorkManagerJobs() {
+        viewModelScope.launch {
+            runCatching {
+                WorkManager.getInstance(application)
+                    .getWorkInfosForUniqueWorkFlow(THOR_JOB_CHAIN)
+                    .collect { workInfos ->
+                        if (workInfos.any { it.state.isFinished }) {
+                            refreshArchives()
+                        }
+                    }
+            }
+        }
     }
 
     fun refreshArchives() {

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
@@ -81,7 +81,15 @@ class BackupRestoreHubViewModel(
         scanJob = viewModelScope.launch {
             _state.update { it.copy(isLoading = true) }
             scanner.scanBackups().collect { list ->
-                _state.update { it.copy(archives = list, isLoading = false) }
+                _state.update { current ->
+                    val hasMatchingFilter = when (current.activeFilter) {
+                        BackupHubFilter.ALL -> true
+                        BackupHubFilter.DATA_BACKUPS -> list.any { it.kind == BackupArchiveKind.DATA_BACKUP }
+                        BackupHubFilter.APP_BUNDLES -> list.any { it.kind == BackupArchiveKind.APP_BUNDLE }
+                    }
+                    val normalizedFilter = if (hasMatchingFilter) current.activeFilter else BackupHubFilter.ALL
+                    current.copy(archives = list, activeFilter = normalizedFilter, isLoading = false)
+                }
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.utils
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.os.Build
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.toDrawable
+import androidx.core.net.toUri
+import coil3.ImageLoader
+import coil3.asImage
+import coil3.decode.DataSource
+import coil3.fetch.FetchResult
+import coil3.fetch.Fetcher
+import coil3.fetch.ImageFetchResult
+import coil3.key.Keyer
+import coil3.request.Options
+import coil3.request.bitmapConfig
+import coil3.size.pxOrElse
+import com.valhalla.thor.data.repository.BundleZip
+import com.valhalla.thor.domain.repository.SystemRepository
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+import java.util.zip.ZipFile
+import kotlinx.coroutines.CancellationException
+import org.json.JSONObject
+
+data class ArchiveIconModel(
+    val uriString: String,
+    val packageName: String?,
+    val displayName: String,
+)
+
+class ArchiveIconFetcher(
+    private val model: ArchiveIconModel,
+    private val context: Context,
+    private val systemRepository: SystemRepository,
+    private val options: Options,
+) : Fetcher {
+
+    override suspend fun fetch(): FetchResult? {
+        return try {
+            val pm = context.packageManager
+
+            // 1. If packageName is known, try loading installed app icon first
+            val pkg = model.packageName
+            if (!pkg.isNullOrBlank()) {
+                try {
+                    val flags = PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
+                    val appInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        pm.getApplicationInfo(pkg, PackageManager.ApplicationInfoFlags.of(flags))
+                    } else {
+                        pm.getApplicationInfo(pkg, PackageManager.MATCH_UNINSTALLED_PACKAGES)
+                    }
+                    val drawable = appInfo.loadIcon(pm)
+                    val bitmap = drawable.toBitmap(options)
+                    return ImageFetchResult(
+                        image = bitmap.toDrawable(context.resources).asImage(),
+                        isSampled = false,
+                        dataSource = DataSource.DISK,
+                    )
+                } catch (_: Exception) {
+                    // Not installed or cannot load from PM, proceed to extract from archive
+                }
+            }
+
+            // 2. Check disk cache in cacheDir/archive_icons
+            val iconCacheDir = File(context.cacheDir, "archive_icons")
+            val cacheKey = "icon_${model.uriString.hashCode()}_${model.displayName.hashCode()}"
+            val cachedFile = File(iconCacheDir, "$cacheKey.png")
+            if (cachedFile.exists() && cachedFile.length() > 0) {
+                val bitmap = BitmapFactory.decodeFile(cachedFile.absolutePath)
+                if (bitmap != null) {
+                    return ImageFetchResult(
+                        image = bitmap.toDrawable(context.resources).asImage(),
+                        isSampled = false,
+                        dataSource = DataSource.DISK,
+                    )
+                }
+            }
+
+            // 3. Extract icon from archive (APK, XAPK, APKS, THORBAK)
+            val extractedBitmap = extractIcon(model) ?: return null
+
+            // Cache extracted bitmap
+            try {
+                if (!iconCacheDir.exists()) iconCacheDir.mkdirs()
+                FileOutputStream(cachedFile).use { out ->
+                    extractedBitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Cache writing failure is non-fatal
+            }
+
+            ImageFetchResult(
+                image = extractedBitmap.toDrawable(context.resources).asImage(),
+                isSampled = false,
+                dataSource = DataSource.DISK,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private suspend fun extractIcon(model: ArchiveIconModel): Bitmap? {
+        val uri = runCatching { model.uriString.toUri() }.getOrNull() ?: return null
+        val token = UUID.randomUUID().toString()
+        val tempStaging = File(context.cacheDir, "temp_ico_$token")
+        var staged = false
+
+        val sourceFile: File = if (uri.scheme == "file" && uri.path != null && File(uri.path!!).canRead()) {
+            File(uri.path!!)
+        } else {
+            val input = runCatching { context.contentResolver.openInputStream(uri) }.getOrNull()
+            if (input != null) {
+                input.use { src ->
+                    FileOutputStream(tempStaging).use { dst -> src.copyTo(dst) }
+                }
+                staged = true
+                tempStaging
+            } else {
+                val path = uri.path
+                if (!path.isNullOrBlank()) {
+                    val tmpPath = "/data/local/tmp/thor_ico_$token"
+                    val cmd = "cat '$path' > '$tmpPath' 2>/dev/null && chmod 666 '$tmpPath' 2>/dev/null"
+                    val res = systemRepository.executeShellCommand(cmd).getOrNull()
+                    if (res != null && res.first == 0) {
+                        val tmpFile = File(tmpPath)
+                        if (tmpFile.exists() && tmpFile.length() > 0) {
+                            try {
+                                tmpFile.inputStream().use { src ->
+                                    FileOutputStream(tempStaging).use { dst -> src.copyTo(dst) }
+                                }
+                                staged = true
+                            } finally {
+                                systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                            }
+                            tempStaging
+                        } else {
+                            systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                            return null
+                        }
+                    } else {
+                        return null
+                    }
+                } else {
+                    return null
+                }
+            }
+        }
+
+        try {
+            val lower = model.displayName.lowercase()
+            return when {
+                lower.endsWith(".apk") -> parseApkIcon(sourceFile)
+                lower.endsWith(".xapk") || lower.endsWith(".apks") -> parseBundleIcon(sourceFile)
+                lower.endsWith(".thorbak") -> parseThorbakIcon(sourceFile)
+                else -> parseApkIcon(sourceFile) ?: parseBundleIcon(sourceFile)
+            }
+        } finally {
+            if (staged) {
+                tempStaging.delete()
+            }
+        }
+    }
+
+    private fun parseApkIcon(file: File): Bitmap? {
+        val pm = context.packageManager
+        val archiveInfo = pm.getPackageArchiveInfo(file.absolutePath, 0)
+        val appInfo = archiveInfo?.applicationInfo
+        if (appInfo != null) {
+            appInfo.sourceDir = file.absolutePath
+            appInfo.publicSourceDir = file.absolutePath
+            return appInfo.loadIcon(pm).toBitmap(options)
+        }
+        return null
+    }
+
+    private fun parseBundleIcon(file: File): Bitmap? {
+        val contents = runCatching {
+            BundleZip.read(
+                file,
+                setOf("manifest.json", "info.json", "icon.png", "icon.jpg", "icon.webp")
+            )
+        }.getOrNull()
+
+        if (contents != null) {
+            val iconBytes = contents.bytes["icon.png"]
+                ?: contents.bytes["icon.jpg"]
+                ?: contents.bytes["icon.webp"]
+            if (iconBytes != null && iconBytes.isNotEmpty()) {
+                val bitmap = BitmapFactory.decodeByteArray(iconBytes, 0, iconBytes.size)
+                if (bitmap != null) return bitmap
+            }
+
+            // Fallback: extract base.apk or first apk candidate
+            val candidate = contents.entryNames.firstOrNull { it.endsWith(".apk", ignoreCase = true) }
+            if (candidate != null) {
+                val tmpApk = File(context.cacheDir, "tmp_bundle_apk_${UUID.randomUUID()}.apk")
+                try {
+                    val extracted = BundleZip.extractEntryTo(file, candidate.substringAfterLast('/'), tmpApk)
+                    if (extracted) {
+                        return parseApkIcon(tmpApk)
+                    }
+                } finally {
+                    tmpApk.delete()
+                }
+            }
+        }
+        return null
+    }
+
+    private fun parseThorbakIcon(file: File): Bitmap? {
+        try {
+            ZipFile(file).use { zip ->
+                val headerEntry = zip.getEntry("header.json")
+                if (headerEntry != null) {
+                    val jsonStr = zip.getInputStream(headerEntry).bufferedReader().readText()
+                    val pkg = runCatching { JSONObject(jsonStr).optString("packageName") }.getOrNull()
+                    if (!pkg.isNullOrBlank()) {
+                        val pm = context.packageManager
+                        val flags = PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
+                        val appInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            pm.getApplicationInfo(pkg, PackageManager.ApplicationInfoFlags.of(flags))
+                        } else {
+                            pm.getApplicationInfo(pkg, PackageManager.MATCH_UNINSTALLED_PACKAGES)
+                        }
+                        return appInfo.loadIcon(pm).toBitmap(options)
+                    }
+                }
+                val iconEntry = zip.getEntry("icon.png")
+                if (iconEntry != null) {
+                    val bytes = zip.getInputStream(iconEntry).readBytes()
+                    if (bytes.isNotEmpty()) {
+                        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                    }
+                }
+            }
+        } catch (_: Exception) {}
+        return null
+    }
+
+    private fun Drawable.toBitmap(options: Options): Bitmap {
+        val intrinsicWidth = intrinsicWidth.coerceAtLeast(1)
+        val intrinsicHeight = intrinsicHeight.coerceAtLeast(1)
+        val targetWidth = options.size.width.pxOrElse { intrinsicWidth }.coerceIn(1, intrinsicWidth)
+        val targetHeight = options.size.height.pxOrElse { intrinsicHeight }.coerceIn(1, intrinsicHeight)
+
+        if (this is BitmapDrawable && targetWidth >= intrinsicWidth && targetHeight >= intrinsicHeight) {
+            return this.bitmap
+        }
+        val config = if (options.bitmapConfig == Bitmap.Config.HARDWARE) Bitmap.Config.ARGB_8888 else options.bitmapConfig
+        val bitmap = createBitmap(targetWidth, targetHeight, config)
+        val canvas = Canvas(bitmap)
+        val oldBounds = copyBounds()
+        setBounds(0, 0, canvas.width, canvas.height)
+        draw(canvas)
+        bounds = oldBounds
+        return bitmap
+    }
+
+    class Factory(
+        private val context: Context,
+        private val systemRepository: SystemRepository,
+    ) : Fetcher.Factory<ArchiveIconModel> {
+        override fun create(
+            data: ArchiveIconModel,
+            options: Options,
+            imageLoader: ImageLoader,
+        ): Fetcher {
+            return ArchiveIconFetcher(data, context, systemRepository, options)
+        }
+    }
+}
+
+class ArchiveIconKeyer : Keyer<ArchiveIconModel> {
+    override fun key(data: ArchiveIconModel, options: Options): String {
+        return "archive_icon:${data.uriString}:${data.packageName}"
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
@@ -26,7 +26,9 @@ import coil3.request.Options
 import coil3.request.bitmapConfig
 import coil3.size.pxOrElse
 import com.valhalla.thor.data.repository.BundleZip
+import com.valhalla.thor.domain.model.escapeShellArg
 import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.Logger
 import java.io.File
 import java.io.FileOutputStream
 import java.util.UUID
@@ -38,6 +40,8 @@ data class ArchiveIconModel(
     val uriString: String,
     val packageName: String?,
     val displayName: String,
+    val sizeBytes: Long = 0L,
+    val lastModifiedEpochSec: Long = 0L,
 )
 
 class ArchiveIconFetcher(
@@ -75,7 +79,7 @@ class ArchiveIconFetcher(
 
             // 2. Check disk cache in cacheDir/archive_icons
             val iconCacheDir = File(context.cacheDir, "archive_icons")
-            val cacheKey = "icon_${model.uriString.hashCode()}_${model.displayName.hashCode()}"
+            val cacheKey = "icon_${model.uriString.hashCode()}_${model.sizeBytes}_${model.lastModifiedEpochSec}"
             val cachedFile = File(iconCacheDir, "$cacheKey.png")
             if (cachedFile.exists() && cachedFile.length() > 0) {
                 val bitmap = BitmapFactory.decodeFile(cachedFile.absolutePath)
@@ -93,7 +97,11 @@ class ArchiveIconFetcher(
 
             // Cache extracted bitmap
             try {
-                if (!iconCacheDir.exists()) iconCacheDir.mkdirs()
+                if (!iconCacheDir.exists()) {
+                    iconCacheDir.mkdirs()
+                } else {
+                    cleanStaleCacheIfNeeded(iconCacheDir)
+                }
                 FileOutputStream(cachedFile).use { out ->
                     extractedBitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
                 }
@@ -111,7 +119,17 @@ class ArchiveIconFetcher(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            Logger.w("ArchiveIconFetcher", "Failed to fetch icon for ${model.displayName}: ${e.message}")
             null
+        }
+    }
+
+    private fun cleanStaleCacheIfNeeded(dir: File) {
+        val files = dir.listFiles() ?: return
+        if (files.size > 100) {
+            files.sortedBy { it.lastModified() }
+                .take(files.size - 50)
+                .forEach { it.delete() }
         }
     }
 
@@ -121,45 +139,62 @@ class ArchiveIconFetcher(
         val tempStaging = File(context.cacheDir, "temp_ico_$token")
         var staged = false
 
-        val sourceFile: File = if (uri.scheme == "file" && uri.path != null && File(uri.path!!).canRead()) {
-            File(uri.path!!)
-        } else {
-            val input = runCatching { context.contentResolver.openInputStream(uri) }.getOrNull()
-            if (input != null) {
-                input.use { src ->
-                    FileOutputStream(tempStaging).use { dst -> src.copyTo(dst) }
-                }
-                staged = true
-                tempStaging
+        val sourceFile: File = try {
+            if (uri.scheme == "file" && uri.path != null && File(uri.path!!).canRead()) {
+                File(uri.path!!)
             } else {
-                val path = uri.path
-                if (!path.isNullOrBlank()) {
-                    val tmpPath = "/data/local/tmp/thor_ico_$token"
-                    val cmd = "cat '$path' > '$tmpPath' 2>/dev/null && chmod 666 '$tmpPath' 2>/dev/null"
-                    val res = systemRepository.executeShellCommand(cmd).getOrNull()
-                    if (res != null && res.first == 0) {
-                        val tmpFile = File(tmpPath)
-                        if (tmpFile.exists() && tmpFile.length() > 0) {
-                            try {
-                                tmpFile.inputStream().use { src ->
-                                    FileOutputStream(tempStaging).use { dst -> src.copyTo(dst) }
+                val input = runCatching { context.contentResolver.openInputStream(uri) }.getOrNull()
+                if (input != null) {
+                    try {
+                        input.use { src ->
+                            FileOutputStream(tempStaging).use { dst -> src.copyTo(dst) }
+                        }
+                        staged = true
+                        tempStaging
+                    } catch (e: Throwable) {
+                        tempStaging.delete()
+                        throw e
+                    }
+                } else {
+                    val path = uri.path
+                    if (!path.isNullOrBlank()) {
+                        val tmpPath = "/data/local/tmp/thor_ico_$token"
+                        val src = path.escapeShellArg()
+                        val dst = tmpPath.escapeShellArg()
+                        val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
+                        val res = systemRepository.executeShellCommand(cmd).getOrNull()
+                        if (res != null && res.first == 0) {
+                            val tmpFile = File(tmpPath)
+                            if (tmpFile.exists() && tmpFile.length() > 0) {
+                                try {
+                                    tmpFile.inputStream().use { inputStream ->
+                                        FileOutputStream(tempStaging).use { outputStream -> inputStream.copyTo(outputStream) }
+                                    }
+                                    staged = true
+                                    tempStaging
+                                } catch (e: Throwable) {
+                                    tempStaging.delete()
+                                    throw e
+                                } finally {
+                                    systemRepository.executeShellCommand("rm -f $dst")
                                 }
-                                staged = true
-                            } finally {
-                                systemRepository.executeShellCommand("rm -f '$tmpPath'")
+                            } else {
+                                systemRepository.executeShellCommand("rm -f $dst")
+                                return null
                             }
-                            tempStaging
                         } else {
-                            systemRepository.executeShellCommand("rm -f '$tmpPath'")
                             return null
                         }
                     } else {
                         return null
                     }
-                } else {
-                    return null
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            tempStaging.delete()
+            return null
         }
 
         try {
@@ -254,12 +289,12 @@ class ArchiveIconFetcher(
     }
 
     private fun Drawable.toBitmap(options: Options): Bitmap {
-        val intrinsicWidth = intrinsicWidth.coerceAtLeast(1)
-        val intrinsicHeight = intrinsicHeight.coerceAtLeast(1)
-        val targetWidth = options.size.width.pxOrElse { intrinsicWidth }.coerceIn(1, intrinsicWidth)
-        val targetHeight = options.size.height.pxOrElse { intrinsicHeight }.coerceIn(1, intrinsicHeight)
+        val intrinsicW = intrinsicWidth.takeIf { it > 0 } ?: 96
+        val intrinsicH = intrinsicHeight.takeIf { it > 0 } ?: 96
+        val targetWidth = options.size.width.pxOrElse { intrinsicW }.coerceAtLeast(1)
+        val targetHeight = options.size.height.pxOrElse { intrinsicH }.coerceAtLeast(1)
 
-        if (this is BitmapDrawable && targetWidth >= intrinsicWidth && targetHeight >= intrinsicHeight) {
+        if (this is BitmapDrawable && bitmap.width == targetWidth && bitmap.height == targetHeight) {
             return this.bitmap
         }
         val config = if (options.bitmapConfig == Bitmap.Config.HARDWARE) Bitmap.Config.ARGB_8888 else options.bitmapConfig
@@ -288,6 +323,6 @@ class ArchiveIconFetcher(
 
 class ArchiveIconKeyer : Keyer<ArchiveIconModel> {
     override fun key(data: ArchiveIconModel, options: Options): String {
-        return "archive_icon:${data.uriString}:${data.packageName}"
+        return "archive_icon:${data.uriString}:${data.packageName}:${data.sizeBytes}:${data.lastModifiedEpochSec}"
     }
 }

--- a/app/src/main/res/values-ar/strings_backup.xml
+++ b/app/src/main/res/values-ar/strings_backup.xml
@@ -308,7 +308,7 @@
     <string name="backup_hub_empty_title">لا توجد نسخ احتياطية في Downloads/Thor</string>
     <string name="backup_hub_empty_desc">ستظهر الأرشيفات المحفوظة في Downloads/Thor هنا لاستعادتها بنقرة واحدة.</string>
     <string name="backup_hub_tip_thorbak_title">النسخ الاحتياطية للبيانات (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">أرشيفات كاملة مشفرة تحتوي على بيانات التطبيق (فئات التخزين CE/DE) وتجزئات APK. تتطلب الاستعادة صلاحيات الروت أو شل مميز.</string>
+    <string name="backup_hub_tip_thorbak_desc">أرشيفات كاملة مشفرة تحتوي على بيانات التطبيق وتجزئات APK. تتطلب بيانات التطبيق الخاصة (CE/DE) صلاحيات الروت، بينما يمكن استعادة بيانات التخزين المشتركة عبر شل مميز.</string>
     <string name="backup_hub_tip_bundle_title">حزم التطبيقات (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">حزم تثبيت مستقلة للتثبيت بدون إنترنت أو المشاركة عبر الأجهزة دون الحاجة إلى روت.</string>
     <string name="backup_hub_tip_discovery_title">الاكتشاف التلقائي</string>

--- a/app/src/main/res/values-ar/strings_backup.xml
+++ b/app/src/main/res/values-ar/strings_backup.xml
@@ -308,7 +308,7 @@
     <string name="backup_hub_empty_title">لا توجد نسخ احتياطية في Downloads/Thor</string>
     <string name="backup_hub_empty_desc">ستظهر الأرشيفات المحفوظة في Downloads/Thor هنا لاستعادتها بنقرة واحدة.</string>
     <string name="backup_hub_tip_thorbak_title">النسخ الاحتياطية للبيانات (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">أرشيفات كاملة مشفرة تحتوي على بيانات التطبيق وتجزئات APK. تتطلب بيانات التطبيق الخاصة (CE/DE) صلاحيات الروت، بينما يمكن استعادة بيانات التخزين المشتركة عبر شل مميز.</string>
+    <string name="backup_hub_tip_thorbak_desc">أرشيفات كاملة مشفرة تحتوي على بيانات التطبيق وتجزئات APK اختيارية. تتطلب بيانات التطبيق الخاصة (CE/DE) صلاحيات الروت، بينما يمكن استعادة بيانات التخزين المشتركة عبر شل مميز.</string>
     <string name="backup_hub_tip_bundle_title">حزم التطبيقات (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">حزم تثبيت مستقلة للتثبيت بدون إنترنت أو المشاركة عبر الأجهزة دون الحاجة إلى روت.</string>
     <string name="backup_hub_tip_discovery_title">الاكتشاف التلقائي</string>

--- a/app/src/main/res/values-ar/strings_backup.xml
+++ b/app/src/main/res/values-ar/strings_backup.xml
@@ -303,8 +303,8 @@
     <string name="backup_hub_hero_restore_desc">تحديد أي أرشيف .thorbak أو حزمة من وحدة التخزين</string>
     <string name="backup_hub_section_backups">النسخ الاحتياطية في Downloads/Thor</string>
     <string name="backup_hub_filter_all">الكل</string>
-    <string name="backup_hub_filter_backups">نسخ احتياطية للبيانات (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">حزم التطبيقات (.xapk، .apks، .apk)</string>
+    <string name="backup_hub_filter_backups">النسخ الاحتياطية</string>
+    <string name="backup_hub_filter_bundles">الحزم</string>
     <string name="backup_hub_empty_title">لا توجد نسخ احتياطية في Downloads/Thor</string>
     <string name="backup_hub_empty_desc">ستظهر الأرشيفات المحفوظة في Downloads/Thor هنا لاستعادتها بنقرة واحدة.</string>
     <string name="backup_hub_tip_thorbak_title">النسخ الاحتياطية للبيانات (.thorbak)</string>

--- a/app/src/main/res/values-es/strings_backup.xml
+++ b/app/src/main/res/values-es/strings_backup.xml
@@ -304,7 +304,7 @@
     <string name="backup_hub_empty_title">No hay copias en Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Los archivos guardados en Downloads/Thor aparecerán aquí para restaurarlos rápidamente.</string>
     <string name="backup_hub_tip_thorbak_title">Copias de datos (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Archivos completos cifrados con datos de apps y divisiones APK. Los datos privados de apps (CE/DE) requieren root, mientras que los datos de almacenamiento compartido pueden restaurarse con una shell con privilegios.</string>
+    <string name="backup_hub_tip_thorbak_desc">Archivos completos cifrados con datos de apps y divisiones APK opcionales. Los datos privados de apps (CE/DE) requieren root, mientras que los datos de almacenamiento compartido pueden restaurarse con una shell con privilegios.</string>
     <string name="backup_hub_tip_bundle_title">Paquetes de apps (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Paquetes de instalación independientes para instalar sin conexión o transferir sin necesidad de root.</string>
     <string name="backup_hub_tip_discovery_title">Detección automática</string>

--- a/app/src/main/res/values-es/strings_backup.xml
+++ b/app/src/main/res/values-es/strings_backup.xml
@@ -304,7 +304,7 @@
     <string name="backup_hub_empty_title">No hay copias en Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Los archivos guardados en Downloads/Thor aparecerán aquí para restaurarlos rápidamente.</string>
     <string name="backup_hub_tip_thorbak_title">Copias de datos (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Archivos completos cifrados con datos de apps (clases CE/DE) y divisiones APK. Restaurar requiere root o shell con privilegios.</string>
+    <string name="backup_hub_tip_thorbak_desc">Archivos completos cifrados con datos de apps y divisiones APK. Los datos privados de apps (CE/DE) requieren root, mientras que los datos de almacenamiento compartido pueden restaurarse con una shell con privilegios.</string>
     <string name="backup_hub_tip_bundle_title">Paquetes de apps (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Paquetes de instalación independientes para instalar sin conexión o transferir sin necesidad de root.</string>
     <string name="backup_hub_tip_discovery_title">Detección automática</string>

--- a/app/src/main/res/values-es/strings_backup.xml
+++ b/app/src/main/res/values-es/strings_backup.xml
@@ -299,8 +299,8 @@
     <string name="backup_hub_hero_restore_desc">Seleccionar cualquier archivo .thorbak o paquete del almacenamiento</string>
     <string name="backup_hub_section_backups">Copias en Downloads/Thor</string>
     <string name="backup_hub_filter_all">Todo</string>
-    <string name="backup_hub_filter_backups">Copias de datos (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">Paquetes de apps (.xapk, .apks, .apk)</string>
+    <string name="backup_hub_filter_backups">Copias</string>
+    <string name="backup_hub_filter_bundles">Paquetes</string>
     <string name="backup_hub_empty_title">No hay copias en Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Los archivos guardados en Downloads/Thor aparecerán aquí para restaurarlos rápidamente.</string>
     <string name="backup_hub_tip_thorbak_title">Copias de datos (.thorbak)</string>

--- a/app/src/main/res/values-fr/strings_backup.xml
+++ b/app/src/main/res/values-fr/strings_backup.xml
@@ -305,8 +305,8 @@
     <string name="backup_hub_hero_restore_desc">Sélectionner une archive .thorbak ou un pack du stockage</string>
     <string name="backup_hub_section_backups">Sauvegardes dans Downloads/Thor</string>
     <string name="backup_hub_filter_all">Tout</string>
-    <string name="backup_hub_filter_backups">Sauvegardes de données (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">Packs d\'applications (.xapk, .apks, .apk)</string>
+    <string name="backup_hub_filter_backups">Sauvegardes</string>
+    <string name="backup_hub_filter_bundles">Packs</string>
     <string name="backup_hub_empty_title">Aucune sauvegarde dans Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Les archives enregistrées dans Downloads/Thor apparaîtront ici pour une restauration rapide.</string>
     <string name="backup_hub_tip_thorbak_title">Sauvegardes de données (.thorbak)</string>

--- a/app/src/main/res/values-fr/strings_backup.xml
+++ b/app/src/main/res/values-fr/strings_backup.xml
@@ -310,7 +310,7 @@
     <string name="backup_hub_empty_title">Aucune sauvegarde dans Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Les archives enregistrées dans Downloads/Thor apparaîtront ici pour une restauration rapide.</string>
     <string name="backup_hub_tip_thorbak_title">Sauvegardes de données (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Archives complètes chiffrées contenant les données d\'appli (classes CE/DE) et divisions APK. La restauration nécessite le root ou un shell privilégié.</string>
+    <string name="backup_hub_tip_thorbak_desc">Archives complètes chiffrées contenant les données d\'appli et les divisions APK. Les données privées d\'appli (CE/DE) nécessitent le root, tandis que les données de stockage partagé peuvent être restaurées avec un shell privilégié.</string>
     <string name="backup_hub_tip_bundle_title">Packs d\'applications (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Packs d\'installation autonomes pour l\'installation hors ligne ou le partage entre appareils sans accès root.</string>
     <string name="backup_hub_tip_discovery_title">Détection automatique</string>

--- a/app/src/main/res/values-fr/strings_backup.xml
+++ b/app/src/main/res/values-fr/strings_backup.xml
@@ -310,7 +310,7 @@
     <string name="backup_hub_empty_title">Aucune sauvegarde dans Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Les archives enregistrées dans Downloads/Thor apparaîtront ici pour une restauration rapide.</string>
     <string name="backup_hub_tip_thorbak_title">Sauvegardes de données (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Archives complètes chiffrées contenant les données d\'appli et les divisions APK. Les données privées d\'appli (CE/DE) nécessitent le root, tandis que les données de stockage partagé peuvent être restaurées avec un shell privilégié.</string>
+    <string name="backup_hub_tip_thorbak_desc">Archives complètes chiffrées contenant les données d\'appli et d\'éventuelles divisions APK. Les données privées d\'appli (CE/DE) nécessitent le root, tandis que les données de stockage partagé peuvent être restaurées avec un shell privilégié.</string>
     <string name="backup_hub_tip_bundle_title">Packs d\'applications (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Packs d\'installation autonomes pour l\'installation hors ligne ou le partage entre appareils sans accès root.</string>
     <string name="backup_hub_tip_discovery_title">Détection automatique</string>

--- a/app/src/main/res/values-pl/strings_backup.xml
+++ b/app/src/main/res/values-pl/strings_backup.xml
@@ -301,8 +301,8 @@
     <string name="backup_hub_hero_restore_desc">Wybierz dowolne archiwum .thorbak lub pakiet z pamięci</string>
     <string name="backup_hub_section_backups">Kopie w Downloads/Thor</string>
     <string name="backup_hub_filter_all">Wszystko</string>
-    <string name="backup_hub_filter_backups">Kopie danych (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">Pakiety aplikacji (.xapk, .apks, .apk)</string>
+    <string name="backup_hub_filter_backups">Kopie</string>
+    <string name="backup_hub_filter_bundles">Pakiety</string>
     <string name="backup_hub_empty_title">Brak kopii w Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Archiwa zapisane w Downloads/Thor pojawią się tutaj, umożliwiając szybkie przywrócenie jednym dotknięciem.</string>
     <string name="backup_hub_tip_thorbak_title">Kopie danych (.thorbak)</string>

--- a/app/src/main/res/values-pl/strings_backup.xml
+++ b/app/src/main/res/values-pl/strings_backup.xml
@@ -306,7 +306,7 @@
     <string name="backup_hub_empty_title">Brak kopii w Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Archiwa zapisane w Downloads/Thor pojawią się tutaj, umożliwiając szybkie przywrócenie jednym dotknięciem.</string>
     <string name="backup_hub_tip_thorbak_title">Kopie danych (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Zaszyfrowane pełne archiwa zawierające dane aplikacji i podziały APK. Prywatne dane aplikacji (CE/DE) wymagają uprawnień root, natomiast dane z pamięci współdzielonej można przywrócić z uprzywilejowaną powłoką.</string>
+    <string name="backup_hub_tip_thorbak_desc">Zaszyfrowane pełne archiwa zawierające dane aplikacji i opcjonalne podziały APK. Prywatne dane aplikacji (CE/DE) wymagają uprawnień root, natomiast dane z pamięci współdzielonej można przywrócić z uprzywilejowaną powłoką.</string>
     <string name="backup_hub_tip_bundle_title">Pakiety aplikacji (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Samodzielne pakiety instalacyjne do instalacji offline lub przesyłania między urządzeniami bez uprawnień root.</string>
     <string name="backup_hub_tip_discovery_title">Automatyczne wykrywanie</string>

--- a/app/src/main/res/values-pl/strings_backup.xml
+++ b/app/src/main/res/values-pl/strings_backup.xml
@@ -306,7 +306,7 @@
     <string name="backup_hub_empty_title">Brak kopii w Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Archiwa zapisane w Downloads/Thor pojawią się tutaj, umożliwiając szybkie przywrócenie jednym dotknięciem.</string>
     <string name="backup_hub_tip_thorbak_title">Kopie danych (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Zaszyfrowane pełne archiwa zawierające dane aplikacji (klasy CE/DE) i podziały APK. Przywracanie wymaga uprawnień root lub uprzywilejowanej powłoki.</string>
+    <string name="backup_hub_tip_thorbak_desc">Zaszyfrowane pełne archiwa zawierające dane aplikacji i podziały APK. Prywatne dane aplikacji (CE/DE) wymagają uprawnień root, natomiast dane z pamięci współdzielonej można przywrócić z uprzywilejowaną powłoką.</string>
     <string name="backup_hub_tip_bundle_title">Pakiety aplikacji (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Samodzielne pakiety instalacyjne do instalacji offline lub przesyłania między urządzeniami bez uprawnień root.</string>
     <string name="backup_hub_tip_discovery_title">Automatyczne wykrywanie</string>

--- a/app/src/main/res/values-pt/strings_backup.xml
+++ b/app/src/main/res/values-pt/strings_backup.xml
@@ -310,7 +310,7 @@
     <string name="backup_hub_empty_title">Sem cópias em Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Os arquivos guardados em Downloads/Thor aparecerão aqui para restauro rápido num só toque.</string>
     <string name="backup_hub_tip_thorbak_title">Cópias de dados (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Arquivos completos encriptados contendo dados de aplicações e divisões APK. Os dados privados de aplicações (CE/DE) requerem root, enquanto os dados de armazenamento partilhado podem ser restaurados com uma shell privilegiada.</string>
+    <string name="backup_hub_tip_thorbak_desc">Arquivos completos encriptados contendo dados de aplicações e divisões APK opcionais. Os dados privados de aplicações (CE/DE) requerem root, enquanto os dados de armazenamento partilhado podem ser restaurados com uma shell privilegiada.</string>
     <string name="backup_hub_tip_bundle_title">Pacotes de aplicações (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Pacotes de instalação autónomos para instalação offline ou partilha entre dispositivos sem necessitar de root.</string>
     <string name="backup_hub_tip_discovery_title">Deteção automática</string>

--- a/app/src/main/res/values-pt/strings_backup.xml
+++ b/app/src/main/res/values-pt/strings_backup.xml
@@ -310,7 +310,7 @@
     <string name="backup_hub_empty_title">Sem cópias em Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Os arquivos guardados em Downloads/Thor aparecerão aqui para restauro rápido num só toque.</string>
     <string name="backup_hub_tip_thorbak_title">Cópias de dados (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Arquivos completos encriptados contendo dados de aplicações (classes CE/DE) e divisões APK. O restauro requer root ou shell privilegiada.</string>
+    <string name="backup_hub_tip_thorbak_desc">Arquivos completos encriptados contendo dados de aplicações e divisões APK. Os dados privados de aplicações (CE/DE) requerem root, enquanto os dados de armazenamento partilhado podem ser restaurados com uma shell privilegiada.</string>
     <string name="backup_hub_tip_bundle_title">Pacotes de aplicações (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Pacotes de instalação autónomos para instalação offline ou partilha entre dispositivos sem necessitar de root.</string>
     <string name="backup_hub_tip_discovery_title">Deteção automática</string>

--- a/app/src/main/res/values-pt/strings_backup.xml
+++ b/app/src/main/res/values-pt/strings_backup.xml
@@ -305,8 +305,8 @@
     <string name="backup_hub_hero_restore_desc">Selecionar qualquer arquivo .thorbak ou pacote do armazenamento</string>
     <string name="backup_hub_section_backups">Cópias em Downloads/Thor</string>
     <string name="backup_hub_filter_all">Tudo</string>
-    <string name="backup_hub_filter_backups">Cópias de dados (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">Pacotes de aplicações (.xapk, .apks, .apk)</string>
+    <string name="backup_hub_filter_backups">Cópias</string>
+    <string name="backup_hub_filter_bundles">Pacotes</string>
     <string name="backup_hub_empty_title">Sem cópias em Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Os arquivos guardados em Downloads/Thor aparecerão aqui para restauro rápido num só toque.</string>
     <string name="backup_hub_tip_thorbak_title">Cópias de dados (.thorbak)</string>

--- a/app/src/main/res/values-zh-rCN/strings_backup.xml
+++ b/app/src/main/res/values-zh-rCN/strings_backup.xml
@@ -303,7 +303,7 @@
     <string name="backup_hub_empty_title">Downloads/Thor 中无备份</string>
     <string name="backup_hub_empty_desc">保存在 Downloads/Thor 中的备份将显示在此处，支持一键快速恢复。</string>
     <string name="backup_hub_tip_thorbak_title">数据备份 (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">包含应用数据和 APK 分卷的加密完整归档。私有应用数据（CE/DE）需要 Root 权限，而共享存储数据可通过特权 Shell 恢复。</string>
+    <string name="backup_hub_tip_thorbak_desc">包含应用数据和可选 APK 分卷的加密完整归档。私有应用数据（CE/DE）需要 Root 权限，而共享存储数据可通过特权 Shell 恢复。</string>
     <string name="backup_hub_tip_bundle_title">应用安装包 (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">独立的安装包，支持离线安装或跨设备分享，无需 Root 权限。</string>
     <string name="backup_hub_tip_discovery_title">自动发现</string>

--- a/app/src/main/res/values-zh-rCN/strings_backup.xml
+++ b/app/src/main/res/values-zh-rCN/strings_backup.xml
@@ -303,7 +303,7 @@
     <string name="backup_hub_empty_title">Downloads/Thor 中无备份</string>
     <string name="backup_hub_empty_desc">保存在 Downloads/Thor 中的备份将显示在此处，支持一键快速恢复。</string>
     <string name="backup_hub_tip_thorbak_title">数据备份 (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">包含应用数据（CE/DE 存储区）和 APK 分卷的加密完整归档。恢复需要 Root 或特权 Shell。</string>
+    <string name="backup_hub_tip_thorbak_desc">包含应用数据和 APK 分卷的加密完整归档。私有应用数据（CE/DE）需要 Root 权限，而共享存储数据可通过特权 Shell 恢复。</string>
     <string name="backup_hub_tip_bundle_title">应用安装包 (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">独立的安装包，支持离线安装或跨设备分享，无需 Root 权限。</string>
     <string name="backup_hub_tip_discovery_title">自动发现</string>

--- a/app/src/main/res/values-zh-rCN/strings_backup.xml
+++ b/app/src/main/res/values-zh-rCN/strings_backup.xml
@@ -298,8 +298,8 @@
     <string name="backup_hub_hero_restore_desc">从存储空间选择任意 .thorbak 备份或安装包</string>
     <string name="backup_hub_section_backups">Downloads/Thor 中的备份</string>
     <string name="backup_hub_filter_all">全部</string>
-    <string name="backup_hub_filter_backups">数据备份 (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">应用安装包 (.xapk, .apks, .apk)</string>
+    <string name="backup_hub_filter_backups">备份</string>
+    <string name="backup_hub_filter_bundles">安装包</string>
     <string name="backup_hub_empty_title">Downloads/Thor 中无备份</string>
     <string name="backup_hub_empty_desc">保存在 Downloads/Thor 中的备份将显示在此处，支持一键快速恢复。</string>
     <string name="backup_hub_tip_thorbak_title">数据备份 (.thorbak)</string>

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -317,7 +317,7 @@
     <string name="backup_hub_empty_title">No backups in Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Archives saved to Downloads/Thor will appear here for fast one-tap restore.</string>
     <string name="backup_hub_tip_thorbak_title">Data Backups (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Encrypted full archives carrying app data (CE/DE storage classes) and APK splits. Restoring requires Root or privileged shell.</string>
+    <string name="backup_hub_tip_thorbak_desc">Encrypted full archives carrying app data and APK splits. Private app data (CE/DE) requires Root, while shared storage data can be restored with privileged shell.</string>
     <string name="backup_hub_tip_bundle_title">App Bundles (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Standalone installation packages for offline install or sharing across devices without requiring root.</string>
     <string name="backup_hub_tip_discovery_title">Auto-Discovery</string>

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -312,8 +312,8 @@
     <string name="backup_hub_hero_restore_desc">Select any .thorbak or bundle archive from storage</string>
     <string name="backup_hub_section_backups">Backups in Downloads/Thor</string>
     <string name="backup_hub_filter_all">All</string>
-    <string name="backup_hub_filter_backups">Data Backups (.thorbak)</string>
-    <string name="backup_hub_filter_bundles">App Bundles (.xapk, .apks, .apk)</string>
+    <string name="backup_hub_filter_backups">Backups</string>
+    <string name="backup_hub_filter_bundles">Bundles</string>
     <string name="backup_hub_empty_title">No backups in Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Archives saved to Downloads/Thor will appear here for fast one-tap restore.</string>
     <string name="backup_hub_tip_thorbak_title">Data Backups (.thorbak)</string>

--- a/app/src/main/res/values/strings_backup.xml
+++ b/app/src/main/res/values/strings_backup.xml
@@ -317,7 +317,7 @@
     <string name="backup_hub_empty_title">No backups in Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Archives saved to Downloads/Thor will appear here for fast one-tap restore.</string>
     <string name="backup_hub_tip_thorbak_title">Data Backups (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Encrypted full archives carrying app data and APK splits. Private app data (CE/DE) requires Root, while shared storage data can be restored with privileged shell.</string>
+    <string name="backup_hub_tip_thorbak_desc">Encrypted full archives carrying app data and optional APK splits. Private app data (CE/DE) requires Root, while shared storage data can be restored with privileged shell.</string>
     <string name="backup_hub_tip_bundle_title">App Bundles (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Standalone installation packages for offline install or sharing across devices without requiring root.</string>
     <string name="backup_hub_tip_discovery_title">Auto-Discovery</string>

--- a/app/src/test/java/com/valhalla/thor/data/backup/DataArchiveCapabilityCacheTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/backup/DataArchiveCapabilityCacheTest.kt
@@ -23,8 +23,18 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class DataArchiveCapabilityCacheTest {
 
-    private class FakeProbe(var answer: Boolean = true) : AppDataProbe {
+    private class FakeProbe(
+        var answer: Boolean = true,
+        var privateAnswer: Boolean = true,
+    ) : AppDataProbe {
         var probes = 0
+        var privateProbes = 0
+
+        override suspend fun probePrivateDataCapability(): Boolean {
+            privateProbes++
+            return privateAnswer
+        }
+
         override suspend fun probeDataArchiveCapability(): Boolean {
             probes++
             return answer
@@ -135,5 +145,32 @@ class DataArchiveCapabilityCacheTest {
 
         assertTrue(deferred.await())
         assertEquals(1, probe.probes)
+    }
+
+    @Test
+    fun `non-root privilege provides external classes only`() = runTest {
+        val probe = FakeProbe(answer = true, privateAnswer = false)
+        val privilege = FakePrivilege(PrivilegeState(shizuku = true, active = PrivilegeMode.SHIZUKU, isReady = true))
+        val cache = DataArchiveCapabilityCache(probe, privilege)
+
+        assertTrue(cache.isSupported())
+        assertFalse(cache.canReadPrivateData())
+        assertEquals(
+            setOf(DataClass.EXTERNAL_DATA, DataClass.EXTERNAL_MEDIA),
+            cache.supportedClasses()
+        )
+    }
+
+    @Test
+    fun `root privilege provides all data classes`() = runTest {
+        val probe = FakeProbe(answer = true, privateAnswer = true)
+        val cache = DataArchiveCapabilityCache(probe, FakePrivilege(rooted()))
+
+        assertTrue(cache.isSupported())
+        assertTrue(cache.canReadPrivateData())
+        assertEquals(
+            DataClass.entries.toSet(),
+            cache.supportedClasses()
+        )
     }
 }

--- a/app/src/test/java/com/valhalla/thor/domain/model/AppDataCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/AppDataCommandsTest.kt
@@ -68,6 +68,15 @@ class AppDataCommandsTest {
     }
 
     @Test
+    fun `the shared data capability probe reads Android directory on storage and prints marker`() {
+        assertEquals(
+            "ls -1 '/storage/emulated/0/Android' >/dev/null 2>&1 && echo $THOR_OK",
+            sharedDataCapabilityProbeCommand("/storage/emulated/0")
+        )
+        assertEquals(null, sharedDataCapabilityProbeCommand("relative/path"))
+    }
+
+    @Test
     fun `the probe is believed only on a zero exit AND its own marker`() {
         // RootSystemGateway.execute() folds a *throw* into `-1 to stackTraceToString()`, so an exit
         // code alone can be a Thor stack trace rather than a shell verdict; and a gateway that

--- a/app/src/test/java/com/valhalla/thor/domain/model/AppDataRestoreCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/AppDataRestoreCommandsTest.kt
@@ -59,7 +59,7 @@ class AppDataRestoreCommandsTest {
             "rm -rf '$staging' && mkdir -p '$staging' && [ ! -L '$staging' ] && " +
                 "( ( tar -tvzf '$tarPath' || echo $THOR_LIST_FAILED ) | " +
                 "grep -qE '$ARCHIVE_MEMBER_REFUSAL_PATTERN' ; [ \$? -eq 1 ] ) && " +
-                "tar -xzf '$tarPath' -C '$staging'",
+                "tar -mxzf '$tarPath' -C '$staging'",
             extractCommand(root, tarPath, compressed = true),
         )
     }
@@ -72,7 +72,7 @@ class AppDataRestoreCommandsTest {
             "rm -rf '$staging' && mkdir -p '$staging' && [ ! -L '$staging' ] && " +
                 "( ( tar -tvf '$tarPath' || echo $THOR_LIST_FAILED ) | " +
                 "grep -qE '$ARCHIVE_MEMBER_REFUSAL_PATTERN' ; [ \$? -eq 1 ] ) && " +
-                "tar -xf '$tarPath' -C '$staging'",
+                "tar -mxf '$tarPath' -C '$staging'",
             extractCommand(root, tarPath, compressed = false),
         )
     }
@@ -84,7 +84,7 @@ class AppDataRestoreCommandsTest {
         // member check at all — the same fail-open shape as the tar listing, one stage to the right.
         val command = extractCommand(root, "/tmp/a.tar", compressed = true)!!
 
-        assertTrue(command.contains("; [ \$? -eq 1 ] ) && tar -xzf"))
+        assertTrue(command.contains("; [ \$? -eq 1 ] ) && tar -mxzf"))
         assertFalse("the ! inversion must be gone", command.contains("! ("))
     }
 

--- a/app/src/test/java/com/valhalla/thor/domain/model/ArchiveRestoreGateTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/ArchiveRestoreGateTest.kt
@@ -65,6 +65,14 @@ class ArchiveRestoreGateTest {
     }
 
     @Test
+    fun `an absent app with a bundle installs first even when no data classes are selected`() {
+        val decision = evaluateArchiveRestoreGate(header(), installed = null, emptySet())
+
+        val allowed = decision as ArchiveRestoreDecision.Allowed
+        assertTrue(allowed.installFirst)
+    }
+
+    @Test
     fun `an absent app with no bundle is refused, and the reason says the archive is data-only`() {
         val decision = evaluateArchiveRestoreGate(
             header(withBundle = false),

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/ArchiveRoundTripTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/ArchiveRoundTripTest.kt
@@ -218,6 +218,7 @@ class ArchiveRoundTripTest {
     }
 
     private class NoProbe : AppDataProbe {
+        override suspend fun probePrivateDataCapability(): Boolean = true
         override suspend fun probeDataArchiveCapability(): Boolean = true
         override suspend fun measureDataClass(packageName: String, dataClass: DataClass) =
             DataClassSize.Undetermined

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/BackupAppArchiveUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/BackupAppArchiveUseCaseTest.kt
@@ -177,6 +177,7 @@ class BackupAppArchiveUseCaseTest {
     private class FakeProbe(
         private val sizes: Map<DataClass, DataClassSize> = emptyMap(),
     ) : AppDataProbe {
+        override suspend fun probePrivateDataCapability(): Boolean = true
         override suspend fun probeDataArchiveCapability(): Boolean = true
         // Brief named this sizeOf; real interface is measureDataClass — substituted for compilation.
         override suspend fun measureDataClass(packageName: String, dataClass: DataClass): DataClassSize =

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/MeasureAppDataUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/MeasureAppDataUseCaseTest.kt
@@ -26,8 +26,11 @@ import org.junit.Test
  */
 private class FakeProbe(
     private val sizes: Map<DataClass, DataClassSize> = emptyMap(),
+    private val privateDataSupported: Boolean = true,
 ) : AppDataProbe {
     var measured = mutableListOf<DataClass>()
+
+    override suspend fun probePrivateDataCapability(): Boolean = privateDataSupported
 
     // `probeDataArchiveCapability` is only called through `DataArchiveCapabilityCache.isSupported()`.
     // These fakes always answer `true`; the capability outcome is controlled by the privilege state.
@@ -111,5 +114,33 @@ class MeasureAppDataUseCaseTest {
 
         assertFalse(result.supported)
         assertTrue(probe.measured.isEmpty())
+    }
+
+    @Test
+    fun `non-root channel measures only external classes`() = runTest {
+        val probe = FakeProbe(
+            sizes = mapOf(
+                DataClass.EXTERNAL_DATA to DataClassSize.Known(1024L),
+                DataClass.EXTERNAL_MEDIA to DataClassSize.Empty,
+            ),
+            privateDataSupported = false,
+        )
+        val shizuku = PrivilegeState(shizuku = true, active = PrivilegeMode.SHIZUKU, isReady = true)
+
+        val result = makeCase(probe, shizuku)("com.example.app")
+
+        assertTrue(result.supported)
+        assertEquals(
+            setOf(DataClass.EXTERNAL_DATA, DataClass.EXTERNAL_MEDIA),
+            result.supportedClasses
+        )
+        assertEquals(
+            setOf(DataClass.EXTERNAL_DATA, DataClass.EXTERNAL_MEDIA),
+            result.sizes.keys
+        )
+        assertEquals(DataClassSize.Known(1024L), result.sizes[DataClass.EXTERNAL_DATA])
+        assertEquals(DataClassSize.Empty, result.sizes[DataClass.EXTERNAL_MEDIA])
+        assertFalse(DataClass.CE in probe.measured)
+        assertFalse(DataClass.DE in probe.measured)
     }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -868,6 +868,10 @@ class FakeContext(private val cache: File) : ContextWrapper(null) {
     override fun getCacheDir(): File = cache
 }
 
+class FakeApplication(private val cache: File = File("/tmp")) : android.app.Application() {
+    override fun getCacheDir(): File = cache
+}
+
 /**
  * A user app. `freezeTierOf` short-circuits on `!isSystem -> NORMAL`, so this is never blocked
  * whatever else it carries — which is what makes it the control in every tier-gate test.

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/AppBackupViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/AppBackupViewModelTest.kt
@@ -68,10 +68,12 @@ class AppBackupViewModelTest {
      */
     private class FakeProbe(
         val capable: Boolean = true,
+        val privateCapable: Boolean = capable,
         val sizes: Map<DataClass, DataClassSize> = DataClass.entries.associateWith {
             DataClassSize.Known(1024L)
         },
     ) : AppDataProbe {
+        override suspend fun probePrivateDataCapability(): Boolean = privateCapable
         override suspend fun probeDataArchiveCapability(): Boolean = capable
         override suspend fun measureDataClass(
             packageName: String,
@@ -1018,6 +1020,7 @@ class AppBackupViewModelTest {
         // the bug this test names. `measureDataClass` is not cached, so it counts the real cost.
         var sweeps = 0
         val probe = object : AppDataProbe {
+            override suspend fun probePrivateDataCapability(): Boolean = true
             override suspend fun probeDataArchiveCapability(): Boolean = true
 
             override suspend fun measureDataClass(
@@ -1086,4 +1089,24 @@ class AppBackupViewModelTest {
         assertNull(backupPassphraseRefusal(needed = false, passphrase = "", confirmation = ""))
     }
 
+    @Test
+    fun `non-root privilege offers only external classes`() = runTest {
+        val probe = FakeProbe(capable = true, privateCapable = false)
+        val shizuku = PrivilegeState(shizuku = true, active = PrivilegeMode.SHIZUKU, isReady = true)
+        val vm = viewModel(probe = probe, privilegeState = shizuku)
+
+        vm.start("com.example.app", "Example")
+        testScheduler.advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertEquals(true, state.supported)
+        assertEquals(
+            setOf(DataClass.EXTERNAL_DATA, DataClass.EXTERNAL_MEDIA),
+            state.supportedClasses,
+        )
+        assertEquals(
+            setOf(DataClass.EXTERNAL_DATA, DataClass.EXTERNAL_MEDIA),
+            state.selected,
+        )
+    }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
@@ -1530,4 +1530,22 @@ class ArchiveRestoreViewModelTest {
         assertEquals(false, vm.uiState.value.queued)
         assertEquals(RestoreFinish.Succeeded(), vm.uiState.value.finished)
     }
+
+    @Test
+    fun `non-root opening a CE DE-only archive defaults to empty selection and prevents restore`() =
+        runTest(dispatcher) {
+            val nonRootProbe = FakeProbe(capable = true, privateCapable = false)
+            val vm = viewModel(
+                probe = nonRootProbe,
+                privilegeState = PrivilegeState(shizuku = true, active = PrivilegeMode.SHIZUKU, isReady = true),
+                sources = CountingSources(mapOf(URI to FakeSource(header(classes = listOf(DataClass.CE, DataClass.DE)).encode()))),
+            )
+
+            vm.open(URI)
+            testScheduler.advanceUntilIdle()
+
+            val state = vm.uiState.value
+            assertEquals(emptySet<DataClass>(), state.selected)
+            assertEquals(false, state.canStart)
+        }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
@@ -264,8 +264,17 @@ class ArchiveRestoreViewModelTest {
         }
     }
 
-    private class FakeProbe(val capable: Boolean = true) : AppDataProbe {
+    private class FakeProbe(
+        val capable: Boolean = true,
+        val privateCapable: Boolean = capable,
+    ) : AppDataProbe {
         var probes = 0
+        var privateProbes = 0
+
+        override suspend fun probePrivateDataCapability(): Boolean {
+            privateProbes++
+            return privateCapable
+        }
 
         override suspend fun probeDataArchiveCapability(): Boolean {
             probes++

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/ArchiveRestoreViewModelTest.kt
@@ -1548,4 +1548,24 @@ class ArchiveRestoreViewModelTest {
             assertEquals(emptySet<DataClass>(), state.selected)
             assertEquals(false, state.canStart)
         }
+
+    @Test
+    fun `non-root opening a bundle archive for uninstalled app allows installFirst even when CE DE are excluded`() =
+        runTest(dispatcher) {
+            val nonRootProbe = FakeProbe(capable = true, privateCapable = false)
+            val vm = viewModel(
+                probe = nonRootProbe,
+                installedApps = emptyList(),
+                privilegeState = PrivilegeState(shizuku = true, active = PrivilegeMode.SHIZUKU, isReady = true),
+                sources = CountingSources(mapOf(URI to FakeSource(header(classes = listOf(DataClass.CE, DataClass.DE)).encode()))),
+            )
+
+            vm.open(URI)
+            testScheduler.advanceUntilIdle()
+
+            val state = vm.uiState.value
+            assertEquals(emptySet<DataClass>(), state.selected)
+            assertEquals(true, state.installFirst)
+            assertEquals(null, state.refusal)
+        }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
@@ -3,9 +3,10 @@
 
 package com.valhalla.thor.presentation.backup.hub
 
-import com.valhalla.thor.data.source.local.room.AppDao
 import com.valhalla.thor.data.source.local.room.AppEntity
-import com.valhalla.thor.data.source.local.room.PackageInstallSize
+import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.DetailedAppInfo
+import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.BackupArchiveItem
 import com.valhalla.thor.domain.repository.BackupArchiveKind
 import com.valhalla.thor.domain.repository.BackupArchiveScanner
@@ -42,15 +43,12 @@ class BackupRestoreHubViewModelTest {
         }
     }
 
-    private class FakeAppDao(private val apps: List<AppEntity> = emptyList()) : AppDao {
-        override fun getAllAppsFlow(): Flow<List<AppEntity>> = flowOf(apps)
-        override suspend fun getAllApps(): List<AppEntity> = apps
-        override suspend fun getApp(packageName: String): AppEntity? = apps.find { it.packageName == packageName }
-        override suspend fun insertApps(apps: List<AppEntity>) {}
-        override suspend fun deleteApp(packageName: String) {}
-        override suspend fun getInstallSizes(packages: List<String>): List<PackageInstallSize> = emptyList()
-        override suspend fun updateInstallSize(packageName: String, size: Long?) {}
-        override suspend fun clearAll() {}
+    private class FakeAppRepository(private val apps: List<AppInfo> = emptyList()) : AppRepository {
+        override fun getAllApps(): Flow<List<AppInfo>> = flowOf(apps)
+        override suspend fun getAppDetails(packageName: String): AppInfo? = apps.find { it.packageName == packageName }
+        override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? = null
+        override suspend fun getApkDetails(apkPath: String): AppInfo? = null
+        override suspend fun updateInstallSizes(sizes: Map<String, Long>) {}
     }
 
     @Before
@@ -84,14 +82,14 @@ class BackupRestoreHubViewModelTest {
         val scannerOnlyBackups = FakeScanner(
             listOf(createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP))
         )
-        val vm1 = BackupRestoreHubViewModel(scannerOnlyBackups, FakeAppDao())
+        val vm1 = BackupRestoreHubViewModel(scannerOnlyBackups, FakeAppRepository())
         advanceUntilIdle()
         assertFalse("Only backups present -> no filter chips", vm1.state.value.showFilterChips)
 
         val scannerOnlyBundles = FakeScanner(
             listOf(createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE))
         )
-        val vm2 = BackupRestoreHubViewModel(scannerOnlyBundles, FakeAppDao())
+        val vm2 = BackupRestoreHubViewModel(scannerOnlyBundles, FakeAppRepository())
         advanceUntilIdle()
         assertFalse("Only bundles present -> no filter chips", vm2.state.value.showFilterChips)
 
@@ -101,7 +99,7 @@ class BackupRestoreHubViewModelTest {
                 createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE),
             )
         )
-        val vm3 = BackupRestoreHubViewModel(scannerBoth, FakeAppDao())
+        val vm3 = BackupRestoreHubViewModel(scannerBoth, FakeAppRepository())
         advanceUntilIdle()
         assertTrue("Both present -> filter chips shown", vm3.state.value.showFilterChips)
     }
@@ -111,7 +109,7 @@ class BackupRestoreHubViewModelTest {
         val backup = createItem(1, "backup.thorbak", BackupArchiveKind.DATA_BACKUP)
         val bundle = createItem(2, "bundle.xapk", BackupArchiveKind.APP_BUNDLE)
         val scanner = FakeScanner(listOf(backup, bundle))
-        val vm = BackupRestoreHubViewModel(scanner, FakeAppDao())
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository())
         advanceUntilIdle()
 
         assertEquals(2, vm.state.value.filteredArchives.size)
@@ -126,11 +124,11 @@ class BackupRestoreHubViewModelTest {
         assertEquals(listOf(backup, bundle), vm.state.value.filteredArchives)
     }
 
-    private fun createAppEntity(
+    private fun createAppInfo(
         packageName: String,
         appName: String,
         isSystem: Boolean = false,
-    ) = AppEntity(
+    ) = AppInfo(
         packageName = packageName,
         appName = appName,
         versionName = "1.0",
@@ -158,22 +156,25 @@ class BackupRestoreHubViewModelTest {
 
     @Test
     fun appPickerSearch_filtersAppsByNameAndPackage() = runTest(testDispatcher) {
-        val app1 = createAppEntity(packageName = "com.spotify.music", appName = "Spotify", isSystem = false)
-        val app2 = createAppEntity(packageName = "org.telegram.messenger", appName = "Telegram", isSystem = false)
-        val dao = FakeAppDao(listOf(app1, app2))
-        val vm = BackupRestoreHubViewModel(FakeScanner(), dao)
+        val app1 = createAppInfo(packageName = "com.spotify.music", appName = "Spotify", isSystem = false)
+        val app2 = createAppInfo(packageName = "org.telegram.messenger", appName = "Telegram", isSystem = false)
+        val repo = FakeAppRepository(listOf(app1, app2))
+        val vm = BackupRestoreHubViewModel(FakeScanner(), repo)
         advanceUntilIdle()
 
         assertEquals(2, vm.state.value.installedApps.size)
 
+        val entity1 = AppEntity.fromDomain(app1)
+        val entity2 = AppEntity.fromDomain(app2)
+
         vm.updateAppPickerSearch("Spot")
-        assertEquals(listOf(app1), vm.state.value.filteredInstalledApps)
+        assertEquals(listOf(entity1), vm.state.value.filteredInstalledApps)
 
         vm.updateAppPickerSearch("telegram")
-        assertEquals(listOf(app2), vm.state.value.filteredInstalledApps)
+        assertEquals(listOf(entity2), vm.state.value.filteredInstalledApps)
 
         vm.updateAppPickerSearch("org.")
-        assertEquals(listOf(app2), vm.state.value.filteredInstalledApps)
+        assertEquals(listOf(entity2), vm.state.value.filteredInstalledApps)
 
         vm.updateAppPickerSearch("")
         assertEquals(2, vm.state.value.filteredInstalledApps.size)
@@ -183,7 +184,7 @@ class BackupRestoreHubViewModelTest {
     fun archiveDeletion_removesItemAndRefreshes() = runTest(testDispatcher) {
         val item = createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP)
         val scanner = FakeScanner(listOf(item))
-        val vm = BackupRestoreHubViewModel(scanner, FakeAppDao())
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository())
         advanceUntilIdle()
 
         assertEquals(1, vm.state.value.archives.size)
@@ -203,7 +204,7 @@ class BackupRestoreHubViewModelTest {
         val backupItem = createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP)
         val bundleItem = createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE)
         val scanner = FakeScanner(listOf(backupItem, bundleItem))
-        val vm = BackupRestoreHubViewModel(scanner, FakeAppDao())
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository())
         advanceUntilIdle()
 
         vm.setFilter(BackupHubFilter.DATA_BACKUPS)
@@ -230,7 +231,7 @@ class BackupRestoreHubViewModelTest {
             override suspend fun deleteArchive(item: BackupArchiveItem) = true
         }
 
-        val vm = BackupRestoreHubViewModel(dynamicScanner, FakeAppDao())
+        val vm = BackupRestoreHubViewModel(dynamicScanner, FakeAppRepository())
         advanceUntilIdle()
 
         // Trigger a second scan

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
@@ -199,6 +199,26 @@ class BackupRestoreHubViewModelTest {
     }
 
     @Test
+    fun archiveDeletion_resetsFilterToAllWhenNoMatchingItemsRemain() = runTest(testDispatcher) {
+        val backupItem = createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP)
+        val bundleItem = createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE)
+        val scanner = FakeScanner(listOf(backupItem, bundleItem))
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppDao())
+        advanceUntilIdle()
+
+        vm.setFilter(BackupHubFilter.DATA_BACKUPS)
+        assertEquals(BackupHubFilter.DATA_BACKUPS, vm.state.value.activeFilter)
+
+        // Delete the only data backup
+        vm.requestDeleteArchive(backupItem)
+        vm.confirmDeleteArchive()
+        advanceUntilIdle()
+
+        assertEquals(listOf(bundleItem), vm.state.value.archives)
+        assertEquals(BackupHubFilter.ALL, vm.state.value.activeFilter)
+    }
+
+    @Test
     fun refreshArchives_cancelsPreviousScan() = runTest(testDispatcher) {
         val flow1 = kotlinx.coroutines.flow.MutableSharedFlow<List<BackupArchiveItem>>(replay = 1)
         val flow2 = kotlinx.coroutines.flow.MutableSharedFlow<List<BackupArchiveItem>>(replay = 1)

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
@@ -26,10 +26,14 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+import com.valhalla.thor.presentation.FakeApplication
+import java.io.File
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class BackupRestoreHubViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val fakeApplication = FakeApplication(File("/tmp"))
 
     private class FakeScanner(var items: List<BackupArchiveItem> = emptyList()) : BackupArchiveScanner {
         var deletedItems = mutableListOf<BackupArchiveItem>()
@@ -82,14 +86,14 @@ class BackupRestoreHubViewModelTest {
         val scannerOnlyBackups = FakeScanner(
             listOf(createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP))
         )
-        val vm1 = BackupRestoreHubViewModel(scannerOnlyBackups, FakeAppRepository())
+        val vm1 = BackupRestoreHubViewModel(scannerOnlyBackups, FakeAppRepository(), fakeApplication)
         advanceUntilIdle()
         assertFalse("Only backups present -> no filter chips", vm1.state.value.showFilterChips)
 
         val scannerOnlyBundles = FakeScanner(
             listOf(createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE))
         )
-        val vm2 = BackupRestoreHubViewModel(scannerOnlyBundles, FakeAppRepository())
+        val vm2 = BackupRestoreHubViewModel(scannerOnlyBundles, FakeAppRepository(), fakeApplication)
         advanceUntilIdle()
         assertFalse("Only bundles present -> no filter chips", vm2.state.value.showFilterChips)
 
@@ -99,7 +103,7 @@ class BackupRestoreHubViewModelTest {
                 createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE),
             )
         )
-        val vm3 = BackupRestoreHubViewModel(scannerBoth, FakeAppRepository())
+        val vm3 = BackupRestoreHubViewModel(scannerBoth, FakeAppRepository(), fakeApplication)
         advanceUntilIdle()
         assertTrue("Both present -> filter chips shown", vm3.state.value.showFilterChips)
     }
@@ -109,7 +113,7 @@ class BackupRestoreHubViewModelTest {
         val backup = createItem(1, "backup.thorbak", BackupArchiveKind.DATA_BACKUP)
         val bundle = createItem(2, "bundle.xapk", BackupArchiveKind.APP_BUNDLE)
         val scanner = FakeScanner(listOf(backup, bundle))
-        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository())
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository(), fakeApplication)
         advanceUntilIdle()
 
         assertEquals(2, vm.state.value.filteredArchives.size)
@@ -159,7 +163,7 @@ class BackupRestoreHubViewModelTest {
         val app1 = createAppInfo(packageName = "com.spotify.music", appName = "Spotify", isSystem = false)
         val app2 = createAppInfo(packageName = "org.telegram.messenger", appName = "Telegram", isSystem = false)
         val repo = FakeAppRepository(listOf(app1, app2))
-        val vm = BackupRestoreHubViewModel(FakeScanner(), repo)
+        val vm = BackupRestoreHubViewModel(FakeScanner(), repo, fakeApplication)
         advanceUntilIdle()
 
         assertEquals(2, vm.state.value.installedApps.size)
@@ -184,7 +188,7 @@ class BackupRestoreHubViewModelTest {
     fun archiveDeletion_removesItemAndRefreshes() = runTest(testDispatcher) {
         val item = createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP)
         val scanner = FakeScanner(listOf(item))
-        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository())
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository(), fakeApplication)
         advanceUntilIdle()
 
         assertEquals(1, vm.state.value.archives.size)
@@ -204,7 +208,7 @@ class BackupRestoreHubViewModelTest {
         val backupItem = createItem(1, "app.thorbak", BackupArchiveKind.DATA_BACKUP)
         val bundleItem = createItem(2, "app.xapk", BackupArchiveKind.APP_BUNDLE)
         val scanner = FakeScanner(listOf(backupItem, bundleItem))
-        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository())
+        val vm = BackupRestoreHubViewModel(scanner, FakeAppRepository(), fakeApplication)
         advanceUntilIdle()
 
         vm.setFilter(BackupHubFilter.DATA_BACKUPS)
@@ -231,7 +235,7 @@ class BackupRestoreHubViewModelTest {
             override suspend fun deleteArchive(item: BackupArchiveItem) = true
         }
 
-        val vm = BackupRestoreHubViewModel(dynamicScanner, FakeAppRepository())
+        val vm = BackupRestoreHubViewModel(dynamicScanner, FakeAppRepository(), fakeApplication)
         advanceUntilIdle()
 
         // Trigger a second scan

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
@@ -3,7 +3,6 @@
 
 package com.valhalla.thor.presentation.backup.hub
 
-import com.valhalla.thor.data.source.local.room.AppEntity
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.repository.AppRepository
@@ -52,7 +51,7 @@ class BackupRestoreHubViewModelTest {
         override suspend fun getAppDetails(packageName: String): AppInfo? = apps.find { it.packageName == packageName }
         override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? = null
         override suspend fun getApkDetails(apkPath: String): AppInfo? = null
-        override suspend fun updateInstallSizes(sizes: Map<String, Long>) {}
+        override suspend fun updateInstallSizes(sizes: Map<String, Long>) = Unit
     }
 
     @Before
@@ -168,17 +167,14 @@ class BackupRestoreHubViewModelTest {
 
         assertEquals(2, vm.state.value.installedApps.size)
 
-        val entity1 = AppEntity.fromDomain(app1)
-        val entity2 = AppEntity.fromDomain(app2)
-
         vm.updateAppPickerSearch("Spot")
-        assertEquals(listOf(entity1), vm.state.value.filteredInstalledApps)
+        assertEquals(listOf(app1), vm.state.value.filteredInstalledApps)
 
         vm.updateAppPickerSearch("telegram")
-        assertEquals(listOf(entity2), vm.state.value.filteredInstalledApps)
+        assertEquals(listOf(app2), vm.state.value.filteredInstalledApps)
 
         vm.updateAppPickerSearch("org.")
-        assertEquals(listOf(entity2), vm.state.value.filteredInstalledApps)
+        assertEquals(listOf(app2), vm.state.value.filteredInstalledApps)
 
         vm.updateAppPickerSearch("")
         assertEquals(2, vm.state.value.filteredInstalledApps.size)


### PR DESCRIPTION
## Summary
- **Hub Restore Button**: Changed label in `BackupRestoreHubScreen` archive cards from "Restoring" (`R.string.job_restoring`) to "Restore" (`R.string.restore_start`).
- **Non-Root Backup & Restore**:
  - Expanded `AppDataProbe` and `SystemRepositoryImpl` to distinguish private data (`/data/user/...`) from shared external storage data (`/sdcard/Android/data` and `/sdcard/Android/media`).
  - Updated `DataArchiveCapabilityCache` to provide `canReadPrivateData()` and `supportedClasses()` dynamically based on the active privilege state.
  - `MeasureAppDataUseCase` and `AppBackupViewModel` measure and display only supported classes (`EXTERNAL_DATA`, `EXTERNAL_MEDIA`, and APK bundles) when running on non-root shell privileges (e.g. Shizuku), completely hiding internal private data (`CE` and `DE`).
  - `ArchiveRestoreSheet` gracefully disables unsupported classes when viewing an archive on a non-root device.
  - `AppDataArchiveGatewayImpl` falls back to `externalCacheDir` staging for non-root shell compatibility without permission failures.
- **Tests**:
  - Added unit tests in `DataArchiveCapabilityCacheTest`, `MeasureAppDataUseCaseTest`, `AppBackupViewModelTest`, and `ArchiveRestoreViewModelTest`.

## Verification Gates
- `./gradlew test`: All 1600+ unit tests passed.
- `./gradlew lintFossDebug lintStoreRelease`: 0 lint errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup and restore now show only data categories supported by the available access level.
  * APK, XAPK, and APKS files open through the installer flow.
  * Archive cards display app icons, improved metadata, and refresh automatically after operations.
  * Archive sharing and file selection work more reliably across locations.

* **Bug Fixes**
  * Unsupported restore options are disabled and cannot be selected.
  * Apps can be installed from bundle archives before selecting data.
  * Archive scans better detect, deduplicate, filter, and remove files.
  * Updated bundle labels and guidance across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->