### PR TITLE
feat(freezer): differentiate snowflake button action labels

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material.icons.rounded.AddCircle
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.HorizontalFloatingToolbar
@@ -314,25 +313,6 @@ fun FreezerScreen(
                         onQueryChange = viewModel::updateSearchQuery,
                         onOpenConfig = { showSettingsSheet = true }
                     )
-
-                    // Freeze Profiles has shipped since v1.93.1 and people still ask for it,
-                    // because the only way in outside multi-select was the unlabelled glyph in
-                    // the floating toolbar below — third of four identical icon buttons. This is
-                    // the label that glyph never had. Not privilege-gated, for the same reason
-                    // the toolbar button isn't; see the comment there.
-                    FilledTonalButton(
-                        onClick = { showProfilesSheet = true },
-                        shape = RoundedCornerShape(16.dp),
-                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp)
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.list_alt),
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(Modifier.size(6.dp))
-                        Text(stringResource(R.string.freeze_profiles_action))
-                    }
                 }
 
                 // --- App List / Empty State ---

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -585,6 +585,7 @@ fun FreezerScreen(
             isShizuku = state.isShizuku,
             isDhizuku = state.isDhizuku,
             isInFreezer = app.packageName in state.freezerPackageNames,
+            freezerRemoveLabelRes = R.string.action_unfreeze_and_remove,
             onDismiss = { selectedPackageName = null },
             // Dismissing here is not optional, and this is the only action it's true of.
             // selectedAppInfo is resolved out of state.freezerApps, which is the watchlist

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppActionRow.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppActionRow.kt
@@ -3,6 +3,7 @@
 
 package com.valhalla.thor.presentation.widgets
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -78,6 +79,7 @@ fun AppActionRow(
     modifier: Modifier = Modifier,
     isInFreezer: Boolean = false,
     onToggleFreezerMembership: (() -> Unit)? = null,
+    @StringRes freezerRemoveLabelRes: Int = R.string.action_remove_from_watchlist,
     onOpenDetails: (() -> Unit)? = null,
     /**
      * Null hides the tile — the same convention as [onToggleFreezerMembership] and [onOpenDetails],
@@ -175,7 +177,7 @@ fun AppActionRow(
 
                 AppInfoActionId.FREEZER_MEMBERSHIP -> onToggleFreezerMembership?.let { toggle ->
                     val freezerLabel =
-                        if (isInFreezer) stringResource(R.string.action_in_freezer) else stringResource(R.string.action_add_freezer)
+                        if (isInFreezer) stringResource(freezerRemoveLabelRes) else stringResource(R.string.action_add_freezer)
                     ActionItem(
                         icon = R.drawable.snowflake,
                         label = freezerLabel,

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoSheet.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.presentation.widgets
 
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -143,7 +144,8 @@ fun AppInfoSheet(
     isInFreezer: Boolean = false,
     onDismiss: () -> Unit,
     onAppAction: (AppClickAction) -> Unit = {},
-    onToggleFreezerMembership: (() -> Unit)? = null
+    onToggleFreezerMembership: (() -> Unit)? = null,
+    @StringRes freezerRemoveLabelRes: Int = R.string.action_remove_from_watchlist
 ) {
     // Default enabledValues = {Hidden, PartiallyExpanded, Expanded}. The sheet opens at the partial
     // detent, which material3 pins at min(windowHeight / 2, contentHeight) — there is no peek
@@ -270,6 +272,7 @@ fun AppInfoSheet(
                     onForceStop = { onAppAction(AppClickAction.Kill(appInfo)) },
                     onManagePermissions = { onAppAction(AppClickAction.ManagePermissions(appInfo)) },
                     onToggleFreezerMembership = onToggleFreezerMembership,
+                    freezerRemoveLabelRes = freezerRemoveLabelRes,
                     onClearCache = { onAppAction(AppClickAction.ClearCache(appInfo)) },
                     onClearData = { showClearDataConfirmation = true },
                     onFixStore = { showReinstallWarning = true },

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -337,8 +337,9 @@
     <string name="uninstall_app_desc">هل أنت متأكد من إلغاء تثبيت %1$s؟</string>
     <string name="action_open">فتح</string>
     <string name="action_force_stop">فرض الإيقاف</string>
-    <string name="action_in_freezer">في المجمد</string>
     <string name="action_add_freezer">إضافة للمجمد</string>
+    <string name="action_unfreeze_and_remove">إلغاء التجميد والإزالة</string>
+    <string name="action_remove_from_watchlist">إزالة من قائمة المراقبة</string>
     <string name="action_clear_cache">مسح التخزين المؤقت</string>
     <string name="action_clear_data">مسح البيانات</string>
     <string name="info_app_version">إصدار التطبيق</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -648,7 +648,6 @@
 
     <!-- ملفات التجميد -->
     <string name="freeze_profiles">ملفات التجميد</string>
-    <string name="freeze_profiles_action">ملفات التجميد</string>
     <string name="profile_new">ملف جديد</string>
     <string name="profile_edit">تعديل الملف</string>
     <string name="profile_name_label">اسم الملف</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -605,7 +605,6 @@
     
     <!-- Perfiles de congelación -->
     <string name="freeze_profiles">Perfiles de congelación</string>
-    <string name="freeze_profiles_action">Perfiles de congelación</string>
     <string name="profile_new">Nuevo perfil</string>
     <string name="profile_edit">Editar perfil</string>
     <string name="profile_name_label">Nombre del perfil</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -307,8 +307,9 @@
     <string name="uninstall_app_desc">¿Estás seguro de que quieres desinstalar %1$s?</string>
     <string name="action_open">Abrir</string>
     <string name="action_force_stop">Forzar detención</string>
-    <string name="action_in_freezer">En congelador</string>
     <string name="action_add_freezer">Añadir al congelador</string>
+    <string name="action_unfreeze_and_remove">Descongelar y quitar</string>
+    <string name="action_remove_from_watchlist">Quitar de la lista de seguimiento</string>
     <string name="action_clear_cache">Limpiar caché</string>
     <string name="action_clear_data">Borrar datos</string>
     <string name="info_app_version">Versión de la aplicación</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -605,7 +605,6 @@
     
     <!-- Profils de congélation -->
     <string name="freeze_profiles">Profils de congélation</string>
-    <string name="freeze_profiles_action">Profils de congélation</string>
     <string name="profile_new">Nouveau profil</string>
     <string name="profile_edit">Modifier le profil</string>
     <string name="profile_name_label">Nom du profil</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -307,8 +307,9 @@
     <string name="uninstall_app_desc">Êtes-vous sûr de vouloir désinstaller %1$s ?</string>
     <string name="action_open">Ouvrir</string>
     <string name="action_force_stop">Forcer l\'arrêt</string>
-    <string name="action_in_freezer">Dans le congélateur</string>
     <string name="action_add_freezer">Ajouter au congélateur</string>
+    <string name="action_unfreeze_and_remove">Dégeler et retirer</string>
+    <string name="action_remove_from_watchlist">Retirer de la liste de surveillance</string>
     <string name="action_clear_cache">Vider le cache</string>
     <string name="action_clear_data">Effacer les données</string>
     <string name="info_app_version">Version de l\'application</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -538,7 +538,7 @@
     <string name="action_open">Otwórz</string>
     <string name="action_force_stop">Wymuś zatrzymanie</string>
     <string name="action_add_freezer">Dodaj do Zamrażarki</string>
-    <string name="action_unfreeze_and_remove">Odmroź i usuń</string>
+    <string name="action_unfreeze_and_remove">Odmroź i usuń z Zamrażarki</string>
     <string name="action_remove_from_watchlist">Usuń z listy obserwowanych</string>
     <string name="action_clear_cache">Wyczyść pamięć podręczną</string>
     <string name="action_clear_data">Wyczyść dane</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -741,9 +741,6 @@
 
     <!-- Freeze profiles -->
     <string name="freeze_profiles">Profile zamrażania</string>
-    <!-- Short label for the entry point that opens the profiles screen. The empty state itself
-         reuses no_profiles_yet / no_profiles_yet_desc. -->
-    <string name="freeze_profiles_action">Profile zamrażania</string>
     <string name="profile_new">Nowy profil</string>
     <string name="profile_edit">Edytuj profil</string>
     <string name="profile_name_label">Nazwa profilu</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -537,8 +537,9 @@
     <string name="uninstall_app_desc">Czy na pewno chcesz odinstalować aplikację %1$s?</string>
     <string name="action_open">Otwórz</string>
     <string name="action_force_stop">Wymuś zatrzymanie</string>
-    <string name="action_in_freezer">W Zamrażarce</string>
     <string name="action_add_freezer">Dodaj do Zamrażarki</string>
+    <string name="action_unfreeze_and_remove">Odmroź i usuń</string>
+    <string name="action_remove_from_watchlist">Usuń z listy obserwowanych</string>
     <string name="action_clear_cache">Wyczyść pamięć podręczną</string>
     <string name="action_clear_data">Wyczyść dane</string>
     <string name="info_app_version">Wersja aplikacji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -282,6 +282,8 @@
     <string name="uninstall_app_title">Desinstalar o aplicativo?</string>
     <string name="uninstall_app_desc">Tem certeza de que quer desinstalar %1$s?</string>
     <string name="action_force_stop">Forçar parada</string>
+    <string name="action_unfreeze_and_remove">Descongelar e remover</string>
+    <string name="action_remove_from_watchlist">Remover da lista de observação</string>
     <string name="action_clear_cache">Limpar o cache</string>
     <string name="info_app_version">Versão do aplicativo</string>
     <string name="info_shared_data_dir">Diretório de dados compartilhados</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -726,9 +726,6 @@
 
     <!-- Freeze profiles -->
     <string name="freeze_profiles">Perfis de congelamento</string>
-    <!-- Short label for the entry point that opens the profiles screen. The empty state itself
-         reuses no_profiles_yet / no_profiles_yet_desc. -->
-    <string name="freeze_profiles_action">Perfis de congelamento</string>
     <string name="profile_new">Novo perfil</string>
     <string name="profile_edit">Editar perfil</string>
     <string name="profile_name_label">Nome do perfil</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -524,8 +524,9 @@
     <string name="uninstall_app_desc">Tem a certeza de que quer desinstalar %1$s?</string>
     <string name="action_open">Abrir</string>
     <string name="action_force_stop">Forçar a paragem</string>
-    <string name="action_in_freezer">No Congelador</string>
     <string name="action_add_freezer">Adicionar ao Congelador</string>
+    <string name="action_unfreeze_and_remove">Descongelar e remover</string>
+    <string name="action_remove_from_watchlist">Remover da lista de vigilância</string>
     <string name="action_clear_cache">Limpar a cache</string>
     <string name="action_clear_data">Limpar os dados</string>
     <string name="info_app_version">Versão da aplicação</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -595,7 +595,6 @@
     
     <!-- 冻结配置 -->
     <string name="freeze_profiles">冻结配置</string>
-    <string name="freeze_profiles_action">冻结配置</string>
     <string name="profile_new">新建配置</string>
     <string name="profile_edit">编辑配置</string>
     <string name="profile_name_label">配置名称</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -300,8 +300,9 @@
     <string name="uninstall_app_desc">确定要卸载 %1$s 吗？</string>
     <string name="action_open">打开</string>
     <string name="action_force_stop">强行停止</string>
-    <string name="action_in_freezer">已在冻结室</string>
     <string name="action_add_freezer">添加至冻结室</string>
+    <string name="action_unfreeze_and_remove">解冻并移除</string>
+    <string name="action_remove_from_watchlist">从观察列表中移除</string>
     <string name="action_clear_cache">清除缓存</string>
     <string name="action_clear_data">清除数据</string>
     <string name="info_app_version">应用版本</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -721,9 +721,6 @@
 
     <!-- Freeze profiles -->
     <string name="freeze_profiles">Freeze Profiles</string>
-    <!-- Short label for the entry point that opens the profiles screen. The empty state itself
-         reuses no_profiles_yet / no_profiles_yet_desc. -->
-    <string name="freeze_profiles_action">Freeze profiles</string>
     <string name="profile_new">New profile</string>
     <string name="profile_edit">Edit profile</string>
     <string name="profile_name_label">Profile name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,8 +520,9 @@
     <string name="uninstall_app_desc">Are you sure you want to uninstall %1$s?</string>
     <string name="action_open">Open</string>
     <string name="action_force_stop">Force Stop</string>
-    <string name="action_in_freezer">In Freezer</string>
     <string name="action_add_freezer">Add Freezer</string>
+    <string name="action_unfreeze_and_remove">Unfreeze &amp; Remove</string>
+    <string name="action_remove_from_watchlist">Remove from Watchlist</string>
     <string name="action_clear_cache">Clear Cache</string>
     <string name="action_clear_data">Clear Data</string>
     <string name="info_app_version">App version</string>

--- a/docs/follow-ups/freezer-membership-toggle-semantics.md
+++ b/docs/follow-ups/freezer-membership-toggle-semantics.md
@@ -1,9 +1,8 @@
 # Follow-up: one freezer-membership button, two meanings
 
-**Status:** OPEN — a product decision, not a defect. Both behaviours are correct for their host; the
-problem is that they wear the same label.
-**Severity:** Minor. Nothing is lost either way, but one of the two outcomes will surprise someone.
-**Effort:** small once the semantics are chosen.
+**Status:** SHIPPED — resolved via Option 1 (differentiating action labels: "Unfreeze & Remove" on the Freezer tab, "Remove from Watchlist" on the Apps tab).
+**Severity:** Minor.
+**Effort:** trivial.
 **Raised by:** the adversarial review of the unified-app-info-sheet steps 6/7 (2026-07-29). The
 compose-ui lens flagged it and an independent verifier confirmed every code assertion; it survived
 because the divergence is invisible to the compiler — both hosts satisfy `(() -> Unit)?`.

--- a/docs/follow-ups/freezer-membership-toggle-semantics.md
+++ b/docs/follow-ups/freezer-membership-toggle-semantics.md
@@ -8,17 +8,17 @@ compose-ui lens flagged it and an independent verifier confirmed every code asse
 because the divergence is invisible to the compiler — both hosts satisfy `(() -> Unit)?`.
 
 Files:
-`app/src/main/java/com/valhalla/thor/presentation/widgets/AppActionRow.kt:142 (the shared control)`,
-`app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt:446 (Freezer host)`,
-`app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt:221 (toggleManaged, remove branch)`,
-`app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt:278 (Apps host)`,
+`app/src/main/java/com/valhalla/thor/presentation/widgets/AppActionRow.kt:177 (the shared control)`
+`app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt:582 (Freezer host passing R.string.action_unfreeze_and_remove)`
+`app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt:221 (toggleManaged, remove branch)`
+`app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt:353 / AppInfoDetailsScreen.kt:292 (Apps host defaulting to R.string.action_remove_from_watchlist)`
 `app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt:398 (toggleFreezerMembership)`
 
-## Problem
+## Problem (Historical)
 
-`AppInfoSheet` renders one snowflake action, labelled from state: `action_add_freezer` when the app
-is out, `action_in_freezer` when it is in. Both hosts pass the same icon, the same label and the same
-tint. They do not pass the same operation.
+`AppInfoSheet` previously rendered one snowflake action with identical labels: `action_add_freezer` when
+the app was out, and `action_in_freezer` when it was in. Both hosts passed the same icon, the same label,
+and the same tint, but did not pass the same operation:
 
 - **Apps tab** → `AppListViewModel.toggleFreezerMembership` moves the watchlist row and nothing else.
   It never disables or restores anything.
@@ -27,47 +27,34 @@ tint. They do not pass the same operation.
   which for a frozen app resolves to `setAppDisabled(pkg, false)` / `setAppSuspended(pkg, false)`.
   Leaving the freezer thaws the app.
 
-So the same app, reached through the same sheet, ends in two different states depending on which tab
+So the same app, reached through the same sheet, ended in two different states depending on which tab
 opened it:
 
-| Tap "In Freezer" on a frozen, watchlisted app | Watchlist | App state |
+| Tap on a frozen, watchlisted app | Watchlist | App state |
 |---|---|---|
-| from the Apps tab | removed | still frozen |
-| from the Freezer tab | removed | restored |
+| from the Apps tab ("Remove from Watchlist") | removed | still frozen |
+| from the Freezer tab ("Unfreeze & Remove") | removed | restored |
 
-Neither is a regression. The Apps path reproduces `AppInfoDetailsViewModel.addOrRemoveFromFreezer`,
-the details-screen behaviour it replaced verbatim. The Freezer path matches `ManageFreezerSheet`,
-the only un-manage surface that tab has ever had — and it is the newly introduced half, because
-before this branch the sheet carried no membership control at all on that tab ("Not wired here, on
-purpose", the old KDoc said).
+## Shipped Resolution: Option 1
 
-The two failure modes are symmetric, which is why this is a decision rather than a bug:
+1. **Make the label carry the operation (✅ Shipped).** Kept both established behaviors, but let each host
+   explicitly name the action — `"Unfreeze & Remove"` (`action_unfreeze_and_remove`) on the Freezer tab,
+   and `"Remove from Watchlist"` (`action_remove_from_watchlist`) on the Apps tab. Configured via
+   `@StringRes freezerRemoveLabelRes` on `AppActionRow` and `AppInfoSheet`.
 
-- **Apps tab:** removing a *frozen* app from the freezer orphans it — disabled, and no longer on any
-  list that offers to unfreeze it. Partly mitigated by the Freezer screen's `disabledAppsNotInFreezer`
-  import prompt (`FreezerScreen.kt:108`), which offers to re-adopt exactly these apps.
-- **Freezer tab:** one tap on a control that reads as a *state* label re-enables the app, with no
-  confirmation and no undo.
+## Other Considered Resolutions (Archived)
 
-## Candidate resolutions
-
-1. **Make the label carry the operation.** Keep both behaviours, but let the host name the action —
-   "Remove & Restore" on the Freezer tab, "Remove from Freezer" on the Apps tab. Smallest change,
-   keeps each tab's established contract, costs two string resources.
 2. **Unify on membership-only** and let the Freezer tab's remove leave the app frozen, relying on the
    import prompt to surface it again. Most consistent, but the Freezer tab is the one place where
    "get this app out of the freezer" almost certainly means "and give it back to me".
 3. **Unify on remove-and-restore** so the Apps tab thaws too. Consistent and never orphans, but it
    changes shipped behaviour on a surface users already know, and makes a membership control
-   privileged — it would need the same tier gate as the freeze paths (`FreezeAppUseCase.kt:35-48`;
-   the follow-up doc that used to describe this shipped and was deleted in `412f655e`).
+   privileged — it would need the same tier gate as the freeze paths (`FreezeAppUseCase.kt:35-48`).
 4. **Confirm on the destructive direction only** — a dialog on the Freezer tab's remove, none on the
    Apps tab. Solves the surprise without picking a semantic, at the cost of a tap.
 
-Option 1 is the cheapest honest answer and does not foreclose any of the others.
-
 ## Notes
 
-Until this is decided, the divergence is documented at both ends — `AppActionRow`'s parameter list
-and `AppInfoSheet`'s KDoc — so the next caller to wire this control knows the contract is "the host
-defines what leaving means", not "membership only".
+Resolved by parameterizing `freezerRemoveLabelRes` with default `R.string.action_remove_from_watchlist`
+in `AppActionRow` / `AppInfoSheet`, overridden to `R.string.action_unfreeze_and_remove` in `FreezerScreen`.
+Localized across all 8 supported locales (`en`, `ar`, `es`, `fr`, `pl`, `pt`, `pt-rBR`, `zh-rCN`).

--- a/web/public/follow-ups-report.html
+++ b/web/public/follow-ups-report.html
@@ -1020,29 +1020,9 @@
           </div>
         </div>
 
-        <!-- Pick 2: Freezer Membership Semantics -->
+        <!-- Pick 2: App Tagging & Notes -->
         <div class="action-card">
-          <span class="rank-badge">#2 QUICK WIN</span>
-          <div class="card-top">
-            <h4 class="card-title">Differentiate Snowflake Button Action Labels</h4>
-          </div>
-          <div class="card-meta">
-            <span class="meta-chip impact-high">Impact: 3.5 / 5.0</span>
-            <span class="meta-chip ease-high">Effort: ≈ 2 Hours</span>
-            <span class="meta-chip">2 Strings</span>
-          </div>
-          <p class="card-body">
-            The snowflake button currently shares one label across two distinct behaviors: Apps tab removes watchlist row (leaves app frozen), while Freezer tab removes row AND thaws. Adopting Option 1 by setting distinct action labels ("Remove & Restore" on Freezer vs "Remove from Freezer" on Apps) eliminates user surprise.
-          </p>
-          <div class="card-footer">
-            <span>Target: <code>AppActionRow.kt</code></span>
-            <strong style="color: var(--primary);">Tier 3 Follow-Up</strong>
-          </div>
-        </div>
-
-        <!-- Pick 3: App Tagging & Notes -->
-        <div class="action-card">
-          <span class="rank-badge">#3 HIGH VALUE</span>
+          <span class="rank-badge">#2 HIGH VALUE</span>
           <div class="card-top">
             <h4 class="card-title">App Tagging & Per-App Notes (#24)</h4>
           </div>
@@ -1057,6 +1037,26 @@
           <div class="card-footer">
             <span>Target: <code>ThorDatabase</code> / <code>AppList</code></span>
             <strong style="color: var(--primary);">Band C #24</strong>
+          </div>
+        </div>
+
+        <!-- Pick 3: Freezer Removal Escape Hatch -->
+        <div class="action-card">
+          <span class="rank-badge">#3 RESILIENCE</span>
+          <div class="card-top">
+            <h4 class="card-title">Freezer Removal Stuck Escape Hatch</h4>
+          </div>
+          <div class="card-meta">
+            <span class="meta-chip impact-high">Impact: 3.5 / 5.0</span>
+            <span class="meta-chip ease-high">Effort: ≈ 0.5 Days</span>
+            <span class="meta-chip">Edge Case</span>
+          </div>
+          <p class="card-body">
+            Band B #15 automatically prunes uninstalled packages. For an installed app whose thaw command fails (e.g. OEM permission revoked or corrupted state), offer "Remove anyway" force-prune options 1 & 2 to prevent users being permanently stuck with an undeletable row.
+          </p>
+          <div class="card-footer">
+            <span>Target: <code>FreezerViewModel.kt</code></span>
+            <strong style="color: var(--primary);">Tier 2 Follow-Up</strong>
           </div>
         </div>
 
@@ -1396,16 +1396,16 @@
         id: "freezer_semantics",
         title: "Freezer Membership Toggle Semantics",
         doc: "freezer-membership-toggle-semantics.md",
-        files: "AppActionRow.kt, FreezerViewModel.kt, AppListViewModel.kt",
-        status: "open",
-        statusText: "Open (Product Decision)",
+        files: "AppActionRow.kt, FreezerScreen.kt, AppInfoSheet.kt",
+        status: "shipped",
+        statusText: "Shipped",
         impact: 3.5,
         ease: 4.8,
         effort: "≈ 2 Hours",
         category: "ux",
-        summary: "Snowflake button shares identical icon and label across two tabs with diverging semantics: Apps tab removes watchlist row only; Freezer tab removes row AND thaws.",
-        rootCause: "Both hosts passed identical lambda signature (() -> Unit)? with different use case implementations.",
-        solution: "Option 1 (Recommended): Differentiate labels ('Remove & Restore' on Freezer vs 'Remove from Freezer' on Apps).",
+        summary: "Snowflake button shares identical icon across two tabs with explicit, differentiated action labels: 'Remove from Watchlist' on Apps tab vs 'Unfreeze & Remove' on Freezer tab.",
+        rootCause: "Both hosts passed identical lambda signature (() -> Unit)? with different use case implementations under the generic 'In Freezer' label.",
+        solution: "Shipped Option 1: Differentiated action labels ('Unfreeze & Remove' on Freezer vs 'Remove from Watchlist' on Apps) across all 8 locales.",
         hardwareRequired: false
       },
       {


### PR DESCRIPTION
Implements Option 1 from `docs/follow-ups/freezer-membership-toggle-semantics.md` to explicitly differentiate snowflake removal action labels between hosts:
- **Freezer Tab**: Displays `action_unfreeze_and_remove` ("Unfreeze & Remove")
- **Apps Tab**: Displays `action_remove_from_watchlist` ("Remove from Watchlist")
- Cleaned up obsolete `action_in_freezer` and added translations across all 8 locales (`en`, `ar`, `es`, `fr`, `pl`, `pt`, `pt-rBR`, `zh-rCN`).
- Passed all unit tests and lint gates (`./gradlew test lintFossDebug lintStoreRelease`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct removal actions: “Unfreeze and remove” in the Freezer tab and “Remove from watchlist” in the Apps tab.
  * Removed the redundant Freeze Profiles button from the Freezer screen.
  * Added localized action labels across supported languages, including Arabic, Spanish, French, Polish, Portuguese, and Chinese.

* **Documentation**
  * Updated follow-up materials and recommendations to reflect the shipped freezer removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->