### PR TITLE
fix: package visibility, dynamic privilege acquisition, and sort touch fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,10 +18,6 @@
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="PackageVisibilityPolicy,QueryAllPackagesPermission" />
 
-    <permission
-        android:name="android.permission.QUERY_ALL_PACKAGES"
-        tools:ignore="ReservedSystemPermission" />
-
     <!--
       Non-AOSP. Declared by Chinese-market ROMs (MIUI/HyperOS, ColorOS, OriginOS, MagicOS)
       per T/TAF 108-2022, where package visibility is a three-state runtime permission

--- a/app/src/main/java/com/valhalla/thor/HomeActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/HomeActivity.kt
@@ -329,6 +329,9 @@ class HomeActivity : ComponentActivity() {
         // unacknowledged for three days; coming back to the app is the first chance to catch it.
         // The store implementation does its work on a background scope and the foss one is a no-op.
         billingProcessor.refreshPurchases()
+        // Re-probe privileges (e.g. user went to KernelSU/Magisk/APatch manager to grant root,
+        // or authorized Shizuku/Dhizuku externally).
+        privilegeManager.refresh()
         if (hasRequestedShizuku) return
         lifecycleScope.launch {
             val privileges = privilegeManager.state.first { it.isReady }

--- a/app/src/main/java/com/valhalla/thor/HomeActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/HomeActivity.kt
@@ -43,6 +43,7 @@ import com.valhalla.thor.presentation.settings.BillingProcessor
 import com.valhalla.thor.presentation.theme.ThorTheme
 import com.valhalla.thor.presentation.utils.ObserveAsEvents
 import com.valhalla.thor.util.AppLocale
+import com.valhalla.thor.util.AppScanRevision
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -107,6 +108,7 @@ class HomeActivity : ComponentActivity() {
     private val shizukuHandler = ShizukuPermissionHandler(
         onPermissionGranted = {
             Logger.d("HomeActivity", "Shizuku Ready")
+            AppScanRevision.bump()
             homeViewModel.loadDashboardData()
         },
         onPermissionDenied = {

--- a/app/src/main/java/com/valhalla/thor/HomeActivity.kt
+++ b/app/src/main/java/com/valhalla/thor/HomeActivity.kt
@@ -331,7 +331,18 @@ class HomeActivity : ComponentActivity() {
         billingProcessor.refreshPurchases()
         // Re-probe privileges (e.g. user went to KernelSU/Magisk/APatch manager to grant root,
         // or authorized Shizuku/Dhizuku externally).
-        privilegeManager.refresh()
+        //
+        // Gated on isReady, which is the difference between "probe again" and "probe twice".
+        // PrivilegeManager starts its first probe from its own init, i.e. from
+        // ThorApplication.onCreate, so on a cold start that probe is still in flight when the
+        // first onResume lands — refreshing here would bump the trigger and buy a second full
+        // root/Shizuku/Dhizuku sweep for an answer already on its way. That is the duplicate
+        // c86aa565 ("perf(privilege): one root probe per cold start") removed. isReady latches
+        // true on the first emission and never goes back, so every *later* resume — the ones
+        // where the user actually did go and grant something — still re-probes.
+        if (privilegeManager.state.value.isReady) {
+            privilegeManager.refresh()
+        }
         if (hasRequestedShizuku) return
         lifecycleScope.launch {
             val privileges = privilegeManager.state.first { it.isReady }

--- a/app/src/main/java/com/valhalla/thor/core/ThorShellConfig.kt
+++ b/app/src/main/java/com/valhalla/thor/core/ThorShellConfig.kt
@@ -17,13 +17,11 @@ object ThorShellConfig {
         // Set logging based on build type
         Shell.enableVerboseLogging = BuildConfig.DEBUG
 
-        // Configure the default builder.
-        // FLAG_MOUNT_MASTER: Essential for global namespace operations (mounting, etc.)
+        // Configure the default builder. Do NOT set FLAG_MOUNT_MASTER as KernelSU / APatch su
+        // does not accept --mount-master and would block root acquisition.
         Shell.setDefaultBuilder(
             Shell.Builder.create()
-                .setFlags(Shell.FLAG_MOUNT_MASTER)
-            // If you have specific initializers, add them here
-            // .setInitializers(MyInitializer::class.java)
+                .setTimeout(10)
         )
     }
 }

--- a/app/src/main/java/com/valhalla/thor/core/ThorShellConfig.kt
+++ b/app/src/main/java/com/valhalla/thor/core/ThorShellConfig.kt
@@ -17,11 +17,32 @@ object ThorShellConfig {
         // Set logging based on build type
         Shell.enableVerboseLogging = BuildConfig.DEBUG
 
-        // Configure the default builder. Do NOT set FLAG_MOUNT_MASTER as KernelSU / APatch su
-        // does not accept --mount-master and would block root acquisition.
+        // Do NOT set FLAG_MOUNT_MASTER — but not for the reason it is tempting to write down. The
+        // flag cannot "block root acquisition" on its own: Odin's BuilderImpl.start() wraps the
+        // `su --mount-master` attempt in `catch (_: NoShellException)` and falls through to plain
+        // `su`, then to `sh`, so an su that rejects the argument is recoverable by construction.
+        //
+        // What the fallback is not is free, and that is the part that bit KernelSU/APatch users.
+        // An su that rejects --mount-master by *exiting* is cheap — ShellImpl's shell check calls
+        // process.exitValue() first, sees a dead process and throws immediately. An su that instead
+        // sits there is not: nothing gives up until the shell check times out, and only then does
+        // the plain-`su` attempt start, from zero, with its own superuser prompt. Which of the two
+        // KernelSU and APatch actually do has not been confirmed here — the field symptom (root
+        // never acquired within any reasonable wait) fits the second. Thor never needs the global
+        // mount namespace, so there is nothing on the other side of that bet worth holding.
+        //
+        // setTimeout aligns the builder's shell-check budget with Odin's own root probe, which gives
+        // up at RealShellRepository.SHELL_INIT_TIMEOUT_MS = 10s; the 20s BuilderImpl default would
+        // leave a `su` process and a blocked executor thread alive for ten seconds after the probe
+        // has already reported "no root". The budget covers the time the *user* spends answering the
+        // superuser dialog, so the trade is real: a grant given between 10s and 20s now has its
+        // shell destroyed instead of cached, and costs one more prompt on the next probe.
         Shell.setDefaultBuilder(
             Shell.Builder.create()
-                .setTimeout(10)
+                .setTimeout(SHELL_INIT_TIMEOUT_SECONDS)
         )
     }
+
+    /** Matches Odin's `RealShellRepository.SHELL_INIT_TIMEOUT_MS`; see [init]. */
+    private const val SHELL_INIT_TIMEOUT_SECONDS = 10L
 }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -12,9 +12,11 @@ import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
 import com.valhalla.thor.data.source.local.installCommand
+import com.valhalla.thor.data.source.local.installedAppsAppOpGrantCommands
 import com.valhalla.thor.data.source.local.pmPathCommand
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
+import com.valhalla.thor.domain.model.GET_INSTALLED_APPS_PERMISSION
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
 import kotlinx.coroutines.CoroutineDispatcher
@@ -464,6 +466,11 @@ class DhizukuSystemGateway(
         val escapedPermissionName = permissionName.escapeForShell()
         return try {
             val result = DhizukuHelper.execute("pm grant --user $userId $escapedPackageName $escapedPermissionName")
+            if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
+                installedAppsAppOpGrantCommands(escapedPackageName, userId).forEach { cmd ->
+                    DhizukuHelper.execute(cmd)
+                }
+            }
             if (result.first == 0) Result.success(Unit)
             else Result.failure(Exception("Dhizuku: pm grant failed with exit code ${result.first}: ${result.second}"))
         } catch (e: Exception) {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -466,13 +466,15 @@ class DhizukuSystemGateway(
         val escapedPermissionName = permissionName.escapeForShell()
         return try {
             val result = DhizukuHelper.execute("pm grant --user $userId $escapedPackageName $escapedPermissionName")
+            if (result.first != 0) {
+                return Result.failure(Exception("Dhizuku: pm grant failed with exit code ${result.first}: ${result.second}"))
+            }
             if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
                 installedAppsAppOpGrantCommands(escapedPackageName, userId).forEach { cmd ->
                     DhizukuHelper.execute(cmd)
                 }
             }
-            if (result.first == 0) Result.success(Unit)
-            else Result.failure(Exception("Dhizuku: pm grant failed with exit code ${result.first}: ${result.second}"))
+            Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
+import com.valhalla.superuser.Shell
 import com.valhalla.superuser.ipc.RootService
 import com.valhalla.superuser.utils.escapeForShell
 import com.valhalla.thor.rootservice.IThorRootService
@@ -253,8 +254,14 @@ class RootSystemGateway(
         }
     }
 
-    // A root check is strictly asynchronous. Blocking the thread for this is unacceptable.
+    // A root check is strictly asynchronous. Invalidate any cached non-root shell so fresh su grants are recognized.
     override suspend fun isRootAvailable(): Boolean {
+        try {
+            val cached = Shell.cachedShell
+            if (cached != null && !cached.isRoot) {
+                cached.close()
+            }
+        } catch (_: Throwable) {}
         return shellRepository.isRootGranted()
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1340,7 +1340,7 @@ class RootSystemGateway(
         val escapedPackage = packageName.escapeForShell()
         val escapedPerm = permissionName.escapeForShell()
         val res = runCommand("pm grant --user $userId $escapedPackage $escapedPerm")
-        if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
+        if (res.isSuccess && permissionName == GET_INSTALLED_APPS_PERMISSION) {
             installedAppsAppOpGrantCommands(escapedPackage, userId).forEach { cmd ->
                 runCommand(cmd)
             }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -19,12 +19,14 @@ import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
 import com.valhalla.thor.data.source.local.clearAppDataCommand
 import com.valhalla.thor.data.source.local.clearCachePaths
 import com.valhalla.thor.data.source.local.forceStopCommand
+import com.valhalla.thor.data.source.local.installedAppsAppOpGrantCommands
 import com.valhalla.thor.data.source.local.pmPathCommand
 import com.valhalla.thor.data.source.local.setAppEnabledCommand
 import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.data.source.local.uninstallCommand
 import com.valhalla.thor.domain.gateway.SystemGateway
+import com.valhalla.thor.domain.model.GET_INSTALLED_APPS_PERMISSION
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.parseSuspendingPackages
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
@@ -1330,7 +1332,13 @@ class RootSystemGateway(
             ?: return Result.failure(Exception("Cannot resolve the Android user for $packageName; refusing to grant on user 0."))
         val escapedPackage = packageName.escapeForShell()
         val escapedPerm = permissionName.escapeForShell()
-        return runCommand("pm grant --user $userId $escapedPackage $escapedPerm")
+        val res = runCommand("pm grant --user $userId $escapedPackage $escapedPerm")
+        if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
+            installedAppsAppOpGrantCommands(escapedPackage, userId).forEach { cmd ->
+                runCommand(cmd)
+            }
+        }
+        return res
     }
 
     override suspend fun revokePermission(

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -472,13 +472,15 @@ class ShizukuSystemGateway(
         val escapedPermissionName = permissionName.escapeForShell()
         return try {
             val result = ShizukuHelper.execute("pm grant --user $userId $escapedPackageName $escapedPermissionName")
+            if (result.first != 0) {
+                return Result.failure(Exception("Shizuku: pm grant failed with exit code ${result.first}: ${result.second}"))
+            }
             if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
                 installedAppsAppOpGrantCommands(escapedPackageName, userId).forEach { cmd ->
                     ShizukuHelper.execute(cmd)
                 }
             }
-            if (result.first == 0) Result.success(Unit)
-            else Result.failure(Exception("Shizuku: pm grant failed with exit code ${result.first}: ${result.second}"))
+            Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -14,9 +14,11 @@ import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
 import com.valhalla.thor.data.source.local.installCommand
+import com.valhalla.thor.data.source.local.installedAppsAppOpGrantCommands
 import com.valhalla.thor.data.source.local.pmPathCommand
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
+import com.valhalla.thor.domain.model.GET_INSTALLED_APPS_PERMISSION
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.uninstallFreezeFallbackAllowed
 import kotlinx.coroutines.CancellationException
@@ -470,6 +472,11 @@ class ShizukuSystemGateway(
         val escapedPermissionName = permissionName.escapeForShell()
         return try {
             val result = ShizukuHelper.execute("pm grant --user $userId $escapedPackageName $escapedPermissionName")
+            if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
+                installedAppsAppOpGrantCommands(escapedPackageName, userId).forEach { cmd ->
+                    ShizukuHelper.execute(cmd)
+                }
+            }
             if (result.first == 0) Result.success(Unit)
             else Result.failure(Exception("Shizuku: pm grant failed with exit code ${result.first}: ${result.second}"))
         } catch (e: Exception) {

--- a/app/src/main/java/com/valhalla/thor/data/permission/SelfPermissionGranter.kt
+++ b/app/src/main/java/com/valhalla/thor/data/permission/SelfPermissionGranter.kt
@@ -15,6 +15,7 @@ import com.valhalla.thor.domain.model.SelfPermissionDeclaration
 import com.valhalla.thor.domain.model.planSelfGrant
 import com.valhalla.thor.domain.repository.PrivilegeStateProvider
 import com.valhalla.thor.domain.repository.SystemRepository
+import com.valhalla.thor.util.AppScanRevision
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -183,6 +184,7 @@ class SelfPermissionGranter(
 
         if (granted.isNotEmpty()) {
             Logger.d("SelfPermissions", "Self-granted ${granted.size}: ${granted.joinToString()}")
+            AppScanRevision.bump()
         }
 
         return SelfGrantOutcome(

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppInfoMapper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppInfoMapper.kt
@@ -57,7 +57,7 @@ fun mapToAppInfo(
     // a leftover from the deprecated Int `packInfo.versionCode` this mapper used to read, and
     // keeping it would silently swallow the next real deprecation on one of these calls.
     return AppInfo(
-        appName = appInfo.loadLabel(pm).toString(),
+        appName = runCatching { appInfo.loadLabel(pm).toString() }.getOrElse { packInfo.packageName },
         packageName = packInfo.packageName,
         versionName = packInfo.versionName,
         // No .toInt(): longVersionCode is (versionCodeMajor shl 32) or versionCode, so truncating

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -24,6 +24,7 @@ import com.valhalla.thor.domain.model.scanVerdict
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.FreezerRepository
 import com.valhalla.thor.domain.repository.InstalledAppsPermissionGate
+import com.valhalla.thor.util.AppScanRevision
 import com.valhalla.thor.util.LocaleRevision
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
@@ -426,6 +427,11 @@ class AppRepositoryImpl(
             LocaleRevision.changes.collect { triggerChannel.trySend(Unit) }
         }
 
+        // Process-wide scan requests (e.g. self-permission auto-grant, privilege changes)
+        val scanWatcher = launch {
+            AppScanRevision.changes.collect { triggerChannel.trySend(Unit) }
+        }
+
         // Receiver for Package-specific changes (requires "package" data scheme)
         val packageReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
@@ -468,6 +474,7 @@ class AppRepositoryImpl(
             context.unregisterReceiver(packageReceiver)
             context.unregisterReceiver(generalReceiver)
             localeWatcher.cancel()
+            scanWatcher.cancel()
             worker.cancel()
         }
     }.flowOn(ioDispatcher)

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -254,6 +254,7 @@ class AppRepositoryImpl(
                             pm.getInstalledPackages(PackageManager.MATCH_UNINSTALLED_PACKAGES)
                         }
 
+                    val initialCachedCount = cachedMap.size
                     val currentList = ArrayList<AppInfo>(installedPackages.size)
                     val toUpdate = mutableListOf<AppEntity>()
 
@@ -332,7 +333,7 @@ class AppRepositoryImpl(
                     // the rules; nothing is decided here.
                     val verdict = scanVerdict(
                         scannedPackageNames = currentPackageNames,
-                        cachedCount = cachedMap.size,
+                        cachedCount = initialCachedCount,
                         consecutiveSuspectScans = consecutiveSuspectScans,
                         permission = installedAppsPermission.state()
                     )
@@ -344,7 +345,13 @@ class AppRepositoryImpl(
                         ScanVerdict.Accept -> {
                             consecutiveSuspectScans = 0
                             if (toUpdate.isNotEmpty() || toDelete.isNotEmpty()) {
-                                appDao.syncCache(toUpdate, toDelete)
+                                try {
+                                    appDao.syncCache(toUpdate, toDelete)
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    Logger.e("AppRepository", "syncCache failed during accepted scan", e)
+                                }
                                 toDelete.forEach { pkgName ->
                                     cachedMap.remove(pkgName)
                                     try {
@@ -362,14 +369,20 @@ class AppRepositoryImpl(
                                 "AppRepository",
                                 "not pruning against this scan (${verdict.reason}): saw " +
                                         "${currentPackageNames.size} package(s) against " +
-                                        "${cachedMap.size} cached, keeping ${toDelete.size} row(s)"
+                                        "$initialCachedCount cached, keeping ${toDelete.size} row(s)"
                             )
                             // Updates still land — they describe packages the scan *did* see, so
                             // they are no less trustworthy than on an accepted scan. Only the
                             // deletions are withheld, and the icon files with them: a retained Room
                             // row is repaired by the next good scan, a deleted PNG is not.
                             if (toUpdate.isNotEmpty()) {
-                                appDao.syncCache(toUpdate, emptyList())
+                                try {
+                                    appDao.syncCache(toUpdate, emptyList())
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    Logger.e("AppRepository", "syncCache failed during retained scan", e)
+                                }
                             }
                             toDelete.mapNotNull { cachedMap[it]?.toDomain() }
                         }
@@ -398,7 +411,7 @@ class AppRepositoryImpl(
                     // the channel — defeating ensureActive() above and the awaitClose teardown.
                     throw e
                 } catch (e: Exception) {
-                    if (BuildConfig.DEBUG) e.printStackTrace()
+                    Logger.e("AppRepository", "getAllApps scan failed", e)
                 }
             }
         }

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -248,12 +248,25 @@ class AppRepositoryImpl(
                     val watchlistBeforeScan = watchlistSnapshot()
 
                     val flags = PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
-                    val installedPackages =
+                    var installedPackages =
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                             pm.getInstalledPackages(PackageManager.PackageInfoFlags.of(flags))
                         } else {
                             pm.getInstalledPackages(PackageManager.MATCH_UNINSTALLED_PACKAGES)
                         }
+
+                    // On Chinese OEMs (HyperOS, MIUI, ColorOS), MATCH_UNINSTALLED_PACKAGES may trigger
+                    // OEM package-visibility filters and collapse to only the calling app. Fall back to standard flags.
+                    if (installedPackages.size <= 1) {
+                        val fallback = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            pm.getInstalledPackages(PackageManager.PackageInfoFlags.of(0L))
+                        } else {
+                            pm.getInstalledPackages(0)
+                        }
+                        if (fallback.size > installedPackages.size) {
+                            installedPackages = fallback
+                        }
+                    }
 
                     val initialCachedCount = cachedMap.size
                     val currentList = ArrayList<AppInfo>(installedPackages.size)

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -18,6 +18,7 @@ import com.valhalla.thor.data.source.local.room.AppEntity
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.PermissionDetail
+import com.valhalla.thor.domain.model.RetainReason
 import com.valhalla.thor.domain.model.ScanVerdict
 import com.valhalla.thor.domain.model.prunableWatchlistRows
 import com.valhalla.thor.domain.model.scanVerdict
@@ -257,6 +258,14 @@ class AppRepositoryImpl(
 
                     // On Chinese OEMs (HyperOS, MIUI, ColorOS), MATCH_UNINSTALLED_PACKAGES may trigger
                     // OEM package-visibility filters and collapse to only the calling app. Fall back to standard flags.
+                    //
+                    // The fallback recovers the *list*, never the *authority to prune against it*:
+                    // without MATCH_UNINSTALLED_PACKAGES the query cannot see a package whose per-user
+                    // FLAG_INSTALLED bit is clear, so an uninstall-frozen app reads as gone when it is
+                    // merely invisible. Believing that would delete its Room row, its cached icon PNG
+                    // and — the one that cannot be repaired by a later scan — its Freezer watchlist row,
+                    // which is what makes it thawable at all. Hence the flag, read at the verdict below.
+                    var usedVisibilityFallback = false
                     if (installedPackages.size <= 1) {
                         val fallback = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                             pm.getInstalledPackages(PackageManager.PackageInfoFlags.of(0L))
@@ -265,6 +274,7 @@ class AppRepositoryImpl(
                         }
                         if (fallback.size > installedPackages.size) {
                             installedPackages = fallback
+                            usedVisibilityFallback = true
                         }
                     }
 
@@ -345,12 +355,20 @@ class AppRepositoryImpl(
                     // return a near-empty list, and pruning against that wipes the Room rows *and*
                     // the cached icon PNGs for almost every app the user has. scanVerdict() holds
                     // the rules; nothing is decided here.
-                    val verdict = scanVerdict(
-                        scannedPackageNames = currentPackageNames,
-                        cachedCount = initialCachedCount,
-                        consecutiveSuspectScans = consecutiveSuspectScans,
-                        permission = installedAppsPermission.state()
-                    )
+                    //
+                    // A scan that needed the weaker-flags fallback skips the rules entirely: none of
+                    // them can see that MATCH_UNINSTALLED_PACKAGES was dropped, and every one of them
+                    // would happily Accept the 300 packages such a scan *does* return.
+                    val verdict = if (usedVisibilityFallback) {
+                        ScanVerdict.Retain(RetainReason.VisibilityFallback)
+                    } else {
+                        scanVerdict(
+                            scannedPackageNames = currentPackageNames,
+                            cachedCount = initialCachedCount,
+                            consecutiveSuspectScans = consecutiveSuspectScans,
+                            permission = installedAppsPermission.state()
+                        )
+                    }
 
                     // The cached rows this scan did not see and was not allowed to delete. Mapped
                     // through the same AppEntity.toDomain() the initial cache emission above uses,
@@ -382,7 +400,15 @@ class AppRepositoryImpl(
                         }
 
                         is ScanVerdict.Retain -> {
-                            consecutiveSuspectScans++
+                            // VisibilityFallback deliberately does not count. The tolerance exists
+                            // to let a *genuinely* shrinking device eventually be believed after
+                            // SUSPECT_SCAN_TOLERANCE agreeing scans; a fallback scan is not evidence
+                            // of shrinkage at all, and spending the budget on it would hand the
+                            // third truncated scan the Accept the guard was built to withhold. Not
+                            // reset either — this scan is no proof the device is healthy.
+                            if (verdict.reason != RetainReason.VisibilityFallback) {
+                                consecutiveSuspectScans++
+                            }
                             Logger.w(
                                 "AppRepository",
                                 "not pruning against this scan (${verdict.reason}): saw " +

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -355,6 +355,7 @@ class AppRepositoryImpl(
                     // The cached rows this scan did not see and was not allowed to delete. Mapped
                     // through the same AppEntity.toDomain() the initial cache emission above uses,
                     // so a retained row reaches the UI exactly as it did a moment earlier.
+                    var syncCacheSucceeded = true
                     val retained = when (verdict) {
                         ScanVerdict.Accept -> {
                             consecutiveSuspectScans = 0
@@ -364,13 +365,16 @@ class AppRepositoryImpl(
                                 } catch (e: CancellationException) {
                                     throw e
                                 } catch (e: Exception) {
+                                    syncCacheSucceeded = false
                                     Logger.e("AppRepository", "syncCache failed during accepted scan", e)
                                 }
-                                toDelete.forEach { pkgName ->
-                                    cachedMap.remove(pkgName)
-                                    try {
-                                        File(context.filesDir, "app_icons/$pkgName.png").delete()
-                                    } catch (_: Exception) {}
+                                if (syncCacheSucceeded) {
+                                    toDelete.forEach { pkgName ->
+                                        cachedMap.remove(pkgName)
+                                        try {
+                                            File(context.filesDir, "app_icons/$pkgName.png").delete()
+                                        } catch (_: Exception) {}
+                                    }
                                 }
                             }
                             pruneWatchlist(watchlistBeforeScan, currentPackageNames, verdict)
@@ -395,6 +399,7 @@ class AppRepositoryImpl(
                                 } catch (e: CancellationException) {
                                     throw e
                                 } catch (e: Exception) {
+                                    syncCacheSucceeded = false
                                     Logger.e("AppRepository", "syncCache failed during retained scan", e)
                                 }
                             }
@@ -408,13 +413,13 @@ class AppRepositoryImpl(
                     // nothing would strand isLoading forever on a fresh collection.
                     producer.send(currentList + retained)
 
-                    // Only now, and only on a scan that was trusted enough to prune against. Moving
-                    // the key up next to the `forceRefresh` read would let a scan that was cancelled
-                    // mid-loop, or one that ran while package visibility was truncated, record a
-                    // language for rows it never re-mapped — and nothing would ever force-refresh
-                    // them again. Re-mapping twice costs a rescan; recording too early costs the
-                    // stale labels this key exists to prevent.
-                    if (forceRefresh && verdict == ScanVerdict.Accept) {
+                    // Only now, and only on a scan that was trusted enough to prune against and whose
+                    // cache synchronization succeeded. Moving the key up next to the `forceRefresh`
+                    // read would let a scan that was cancelled mid-loop, or one that ran while package
+                    // visibility was truncated, record a language for rows it never re-mapped — and
+                    // nothing would ever force-refresh them again. Re-mapping twice costs a rescan;
+                    // recording too early costs the stale labels this key exists to prevent.
+                    if (forceRefresh && verdict == ScanVerdict.Accept && syncCacheSucceeded) {
                         lastLocale = currentLocale
                         recordLabelLocale(currentLocale)
                     }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/PerUserCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/PerUserCommands.kt
@@ -257,6 +257,12 @@ internal fun backgroundRestrictionCommand(
 internal fun usageStatsGrantCommand(escapedPackage: String, userId: Int): String =
     appOpsCommand(escapedPackage, userId, op = "GET_USAGE_STATS", mode = "allow")
 
+internal fun installedAppsAppOpGrantCommands(escapedPackage: String, userId: Int): List<String> = listOf(
+    appOpsCommand(escapedPackage, userId, op = "GET_INSTALLED_APPS", mode = "allow"),
+    appOpsCommand(escapedPackage, userId, op = "android:get_installed_apps", mode = "allow"),
+    appOpsCommand(escapedPackage, userId, op = "10022", mode = "allow"),
+)
+
 /**
  * The one place that knows how an `appops set` line is spelled.
  *

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -144,6 +144,29 @@ object DhizukuHelper {
         clientInitialised = initialised
     }
 
+    /**
+     * Requests authorization from Dhizuku if installed and bound.
+     */
+    fun requestPermission(context: Context, onResult: (Boolean) -> Unit) {
+        try {
+            if (!clientInitialised) {
+                clientInitialised = DhizukuAPI.init(context)
+            }
+            if (DhizukuAPI.isPermissionGranted()) {
+                onResult(true)
+                return
+            }
+            DhizukuAPI.requestPermission(object : com.rosan.dhizuku.api.DhizukuRequestPermissionListener() {
+                override fun onRequestPermission(grantResult: Int) {
+                    onResult(grantResult == PackageManager.PERMISSION_GRANTED)
+                }
+            })
+        } catch (e: Exception) {
+            Logger.e("DhizukuHelper", "requestPermission failed", e)
+            onResult(false)
+        }
+    }
+
     fun getSystemService(serviceName: String): IBinder? {
         return try {
             val binder = SystemServiceHelper.getSystemService(serviceName)

--- a/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/dhizuku/Dhizuku.kt
@@ -123,7 +123,7 @@ object DhizukuHelper {
     fun isDhizukuAvailable(context: Context): Boolean {
         val probe = probeDhizuku(
             alreadyInitialised = clientInitialised,
-            init = { DhizukuAPI.init(context) },
+            init = { DhizukuAPI.init(context.applicationContext) },
             isPermissionGranted = { DhizukuAPI.isPermissionGranted() },
         )
         clientInitialised = probe.initialised
@@ -146,11 +146,20 @@ object DhizukuHelper {
 
     /**
      * Requests authorization from Dhizuku if installed and bound.
+     *
+     * Synchronous binder IPC — `DhizukuAPI.init` binds a service and `isPermissionGranted` is a
+     * round-trip to another process — so callers must be off the main thread. The dialog itself is
+     * asynchronous: [onResult] arrives on whichever thread Dhizuku's listener fires on.
+     *
+     * [context] is normalised to the application context at both `init` sites in this object,
+     * because `DhizukuAPI` retains what it is handed in a static field for the life of the process.
+     * A caller passing `LocalContext.current` — which the Privilege Check dialog does — would
+     * otherwise pin an Activity there past every rotation.
      */
     fun requestPermission(context: Context, onResult: (Boolean) -> Unit) {
         try {
             if (!clientInitialised) {
-                clientInitialised = DhizukuAPI.init(context)
+                clientInitialised = DhizukuAPI.init(context.applicationContext)
             }
             if (DhizukuAPI.isPermissionGranted()) {
                 onResult(true)

--- a/app/src/main/java/com/valhalla/thor/domain/model/InstalledAppsVisibility.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/InstalledAppsVisibility.kt
@@ -98,7 +98,7 @@ fun installedAppsPermissionState(
     else -> InstalledAppsPermission.Denied
 }
 
-/** Why a scan was not believed, in the order [scanVerdict] tests for them. */
+/** Why a scan was not believed. The first three are the order [scanVerdict] tests for them. */
 enum class RetainReason {
     /** The scan came back with nothing at all. */
     EmptyScan,
@@ -108,6 +108,17 @@ enum class RetainReason {
 
     /** The scan lost more than half the cached rows in one go. */
     Collapsed,
+
+    /**
+     * The scan had to fall back to weaker `getInstalledPackages` flags to see anything at all.
+     *
+     * Not one of [scanVerdict]'s rules — the caller knows it dropped `MATCH_UNINSTALLED_PACKAGES`
+     * and says so, because no rule here could infer it. A flags-0 query is *by construction* blind
+     * to packages whose per-user `FLAG_INSTALLED` bit is clear, which is exactly what an
+     * uninstall-frozen app is, so "absent from this scan" carries no information about those rows
+     * however healthy the scan otherwise looks.
+     */
+    VisibilityFallback,
 }
 
 /** Whether a package scan is trustworthy enough to prune the cache against. */

--- a/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeManagerApp.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeManagerApp.kt
@@ -16,16 +16,11 @@ enum class PrivilegeManagerApp(
     val mode: PrivilegeMode,
     val packageNames: Set<String>
 ) {
-    // Shizuku & Sui
+    // Shizuku
     SHIZUKU(
         displayName = "Shizuku",
         mode = PrivilegeMode.SHIZUKU,
         packageNames = setOf("moe.shizuku.privileged.api")
-    ),
-    SUI(
-        displayName = "Sui",
-        mode = PrivilegeMode.SHIZUKU,
-        packageNames = setOf("rikka.safemode")
     ),
 
     // Dhizuku

--- a/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeManagerApp.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/PrivilegeManagerApp.kt
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import android.content.pm.PackageManager
+
+/**
+ * Registry of known Android privilege manager applications (Root, Shizuku, Dhizuku).
+ *
+ * Used to detect installed management apps, deep-link to them so users can grant permissions
+ * directly without searching their app drawer, and display tailored privilege dialog states.
+ */
+enum class PrivilegeManagerApp(
+    val displayName: String,
+    val mode: PrivilegeMode,
+    val packageNames: Set<String>
+) {
+    // Shizuku & Sui
+    SHIZUKU(
+        displayName = "Shizuku",
+        mode = PrivilegeMode.SHIZUKU,
+        packageNames = setOf("moe.shizuku.privileged.api")
+    ),
+    SUI(
+        displayName = "Sui",
+        mode = PrivilegeMode.SHIZUKU,
+        packageNames = setOf("rikka.safemode")
+    ),
+
+    // Dhizuku
+    DHIZUKU(
+        displayName = "Dhizuku",
+        mode = PrivilegeMode.DHIZUKU,
+        packageNames = setOf("com.rosan.dhizuku")
+    ),
+
+    // Kernel-level Root Managers
+    KERNEL_SU(
+        displayName = "KernelSU",
+        mode = PrivilegeMode.ROOT,
+        packageNames = setOf("me.weishu.kernelsu")
+    ),
+    KERNEL_SU_NEXT(
+        displayName = "KernelSU Next",
+        mode = PrivilegeMode.ROOT,
+        packageNames = setOf("com.rifsxd.ksunext")
+    ),
+    WILD_KSU(
+        displayName = "Wild KSU",
+        mode = PrivilegeMode.ROOT,
+        packageNames = setOf("com.wild.ksu")
+    ),
+    APATCH(
+        displayName = "APatch",
+        mode = PrivilegeMode.ROOT,
+        packageNames = setOf("me.bmax.apatch")
+    ),
+
+    // Userspace Root Managers
+    MAGISK(
+        displayName = "Magisk",
+        mode = PrivilegeMode.ROOT,
+        packageNames = setOf("com.topjohnwu.magisk")
+    ),
+    MAGISK_ALPHA(
+        displayName = "Magisk Alpha",
+        mode = PrivilegeMode.ROOT,
+        packageNames = setOf("io.github.vvb2060.magisk", "io.github.vvb2060.magisk.lite")
+    ),
+    KITSUNE_MASK(
+        displayName = "Kitsune Mask",
+        mode = PrivilegeMode.ROOT,
+        packageNames = setOf("io.github.huskydg.magisk")
+    ),
+    SUPERSU(
+        displayName = "SuperSU",
+        mode = PrivilegeMode.ROOT,
+        packageNames = setOf("eu.chainfire.supersu")
+    );
+
+    companion object {
+        /**
+         * Pure functional resolver that identifies which managers match the given package lookup function.
+         */
+        fun findInstalledManagers(
+            isPackageInstalled: (String) -> Boolean
+        ): List<InstalledManagerInfo> {
+            val installed = mutableListOf<InstalledManagerInfo>()
+            for (app in entries) {
+                for (pkg in app.packageNames) {
+                    if (isPackageInstalled(pkg)) {
+                        installed.add(
+                            InstalledManagerInfo(
+                                app = app,
+                                installedPackageName = pkg
+                            )
+                        )
+                        break // one package match per manager entry
+                    }
+                }
+            }
+            return installed
+        }
+
+        /**
+         * Detects all known privilege manager applications currently installed on the device via PackageManager.
+         */
+        fun findInstalledManagers(pm: PackageManager): List<InstalledManagerInfo> =
+            findInstalledManagers { pkg ->
+                try {
+                    pm.getPackageInfo(pkg, 0)
+                    true
+                } catch (_: PackageManager.NameNotFoundException) {
+                    false
+                }
+            }
+    }
+}
+
+/**
+ * Information about a detected privilege manager app installed on the device.
+ */
+data class InstalledManagerInfo(
+    val app: PrivilegeManagerApp,
+    val installedPackageName: String
+)

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -242,7 +242,11 @@ class AppListViewModel(
         permissionRefreshJob = viewModelScope.launch(ioDispatcher) {
             val permission = installedAppsPermission.state()
             ensureActive()
+            val previous = _rawState.value.installedAppsPermission
             _rawState.update { it.copy(installedAppsPermission = permission) }
+            if (permission is InstalledAppsPermission.Granted && previous !is InstalledAppsPermission.Granted) {
+                loadApps()
+            }
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -39,6 +39,7 @@ import com.valhalla.thor.domain.usecase.GetAppDetailsUseCase
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.presentation.freezer.FreezerPrompt
+import com.valhalla.thor.util.AppScanRevision
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.util.UiTextException
@@ -245,6 +246,7 @@ class AppListViewModel(
             val previous = _rawState.value.installedAppsPermission
             _rawState.update { it.copy(installedAppsPermission = permission) }
             if (permission is InstalledAppsPermission.Granted && previous !is InstalledAppsPermission.Granted) {
+                AppScanRevision.bump()
                 loadApps()
             }
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -85,6 +85,7 @@ import com.valhalla.thor.presentation.widgets.AppItemList
 import com.valhalla.thor.presentation.widgets.AppSearchBar
 import com.valhalla.thor.presentation.widgets.gridMetricsFor
 import com.valhalla.thor.presentation.widgets.FreezerPromptSnackbar
+import com.valhalla.thor.presentation.widgets.ScrollToTopOnChange
 import org.koin.androidx.compose.koinViewModel
 
 /** Sentinel id for "the editor is open on a profile that does not exist yet". */
@@ -369,7 +370,7 @@ fun FreezerScreen(
                     val metrics = gridMetricsFor(state.gridDensity)
                     val gridState = rememberLazyGridState()
 
-                    LaunchedEffect(state.searchQuery, state.appListType) {
+                    ScrollToTopOnChange(state.searchQuery, state.appListType) {
                         gridState.scrollToItem(0)
                     }
 
@@ -413,7 +414,7 @@ fun FreezerScreen(
                 } else {
                     val listState = rememberLazyListState()
 
-                    LaunchedEffect(state.searchQuery, state.appListType) {
+                    ScrollToTopOnChange(state.searchQuery, state.appListType) {
                         listState.scrollToItem(0)
                     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -369,7 +369,7 @@ fun FreezerScreen(
                     val metrics = gridMetricsFor(state.gridDensity)
                     val gridState = rememberLazyGridState()
 
-                    LaunchedEffect(state.searchQuery) {
+                    LaunchedEffect(state.searchQuery, state.appListType) {
                         gridState.scrollToItem(0)
                     }
 
@@ -413,7 +413,7 @@ fun FreezerScreen(
                 } else {
                     val listState = rememberLazyListState()
 
-                    LaunchedEffect(state.searchQuery) {
+                    LaunchedEffect(state.searchQuery, state.appListType) {
                         listState.scrollToItem(0)
                     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -368,6 +368,11 @@ fun FreezerScreen(
                 } else if (state.isGrid) {
                     val metrics = gridMetricsFor(state.gridDensity)
                     val gridState = rememberLazyGridState()
+
+                    LaunchedEffect(state.searchQuery) {
+                        gridState.scrollToItem(0)
+                    }
+
                     // `scrollIndicatorState` is nullable because `ScrollableState` defaults it to
                     // null for states that drive no indicator; both lazy states override it with a
                     // real one, so the null branch is unreachable today. Branching beats `!!` — a
@@ -407,6 +412,11 @@ fun FreezerScreen(
                     }
                 } else {
                     val listState = rememberLazyListState()
+
+                    LaunchedEffect(state.searchQuery) {
+                        listState.scrollToItem(0)
+                    }
+
                     val listScrollbar = listState.scrollIndicatorState?.let {
                         Modifier.nonInteractiveScrollbar(
                             state = it,

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -337,12 +337,44 @@ fun HomeScreen(
     // system apps are included too.
 
     if (showPrivilegeDialog) {
+        val context = androidx.compose.ui.platform.LocalContext.current
         AlertDialog(
             onDismissRequest = { showPrivilegeDialog = false },
             icon = { Icon(painterResource(R.drawable.privacy_tip), null) },
             title = { Text(stringResource(R.string.privilege_check)) },
             text = {
-                Text(stringResource(R.string.privilege_check_desc))
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text(stringResource(R.string.privilege_check_desc))
+
+                    androidx.compose.material3.HorizontalDivider()
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Dhizuku",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        if (!state.isDhizukuAvailable) {
+                            androidx.compose.material3.TextButton(
+                                onClick = {
+                                    viewModel.requestDhizuku(context)
+                                }
+                            ) {
+                                Text(stringResource(R.string.installed_apps_permission_grant))
+                            }
+                        } else {
+                            Text(
+                                text = stringResource(R.string.permission_state_granted),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
             },
             confirmButton = {
                 Button(onClick = {

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -376,7 +376,13 @@ fun HomeScreen(
                                     )
                                 } else {
                                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                                        if (info.app == com.valhalla.thor.domain.model.PrivilegeManagerApp.DHIZUKU) {
+                                        if (info.app == com.valhalla.thor.domain.model.PrivilegeManagerApp.SHIZUKU && state.isShizukuBinderAlive) {
+                                            androidx.compose.material3.TextButton(
+                                                onClick = { viewModel.requestShizuku() }
+                                            ) {
+                                                Text(stringResource(R.string.installed_apps_permission_grant))
+                                            }
+                                        } else if (info.app == com.valhalla.thor.domain.model.PrivilegeManagerApp.DHIZUKU) {
                                             androidx.compose.material3.TextButton(
                                                 onClick = { viewModel.requestDhizuku(context) }
                                             ) {

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeScreen.kt
@@ -346,32 +346,53 @@ fun HomeScreen(
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Text(stringResource(R.string.privilege_check_desc))
 
-                    androidx.compose.material3.HorizontalDivider()
+                    if (state.installedManagers.isNotEmpty()) {
+                        androidx.compose.material3.HorizontalDivider()
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Dhizuku",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.SemiBold
-                        )
-                        if (!state.isDhizukuAvailable) {
-                            androidx.compose.material3.TextButton(
-                                onClick = {
-                                    viewModel.requestDhizuku(context)
-                                }
-                            ) {
-                                Text(stringResource(R.string.installed_apps_permission_grant))
+                        state.installedManagers.forEach { info ->
+                            val isGranted = when (info.app.mode) {
+                                PrivilegeMode.ROOT -> state.isRootAvailable
+                                PrivilegeMode.SHIZUKU -> state.isShizukuAvailable
+                                PrivilegeMode.DHIZUKU -> state.isDhizukuAvailable
+                                PrivilegeMode.NONE -> false
                             }
-                        } else {
-                            Text(
-                                text = stringResource(R.string.permission_state_granted),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.primary
-                            )
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = info.app.displayName,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+
+                                if (isGranted) {
+                                    Text(
+                                        text = stringResource(R.string.permission_state_granted),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.primary
+                                    )
+                                } else {
+                                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        if (info.app == com.valhalla.thor.domain.model.PrivilegeManagerApp.DHIZUKU) {
+                                            androidx.compose.material3.TextButton(
+                                                onClick = { viewModel.requestDhizuku(context) }
+                                            ) {
+                                                Text(stringResource(R.string.installed_apps_permission_grant))
+                                            }
+                                        }
+                                        androidx.compose.material3.TextButton(
+                                            onClick = {
+                                                viewModel.openManagerApp(context, info.installedPackageName)
+                                            }
+                                        ) {
+                                            Text(stringResource(R.string.open_app))
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
 import org.koin.core.annotation.Named
+import rikka.shizuku.Shizuku
 
 data class HomeUiState(
     val isLoading: Boolean = true,
@@ -47,6 +48,7 @@ data class HomeUiState(
     // Status
     val isRootAvailable: Boolean = false,
     val isShizukuAvailable: Boolean = false,
+    val isShizukuBinderAlive: Boolean = false,
     val isDhizukuAvailable: Boolean = false,
     val activePrivilegeMode: PrivilegeMode? = null,
     // False until the first privilege probe completes — lets the status icon show a
@@ -107,6 +109,7 @@ class HomeViewModel(
             showExtensionsTile = prefs.showExtensionsTile,
             isRootAvailable = priv.root,
             isShizukuAvailable = priv.shizuku,
+            isShizukuBinderAlive = runCatching { Shizuku.pingBinder() }.getOrDefault(false),
             isDhizukuAvailable = priv.dhizuku,
             isPrivilegeReady = priv.isReady,
             installedManagers = PrivilegeManagerApp.findInstalledManagers(packageManager),
@@ -170,6 +173,14 @@ class HomeViewModel(
         privilegeManager.refresh()
         AppScanRevision.bump()
         loadDashboardData()
+    }
+
+    fun requestShizuku() {
+        if (runCatching { Shizuku.pingBinder() }.getOrDefault(false)) {
+            runCatching {
+                Shizuku.requestPermission(1001)
+            }
+        }
     }
 
     fun requestDhizuku(context: Context) {

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -29,7 +29,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
@@ -133,6 +136,17 @@ class HomeViewModel(
 
     init {
         loadDashboardData()
+
+        viewModelScope.launch {
+            privilegeManager.state
+                .map { it.active to it.hasAnyPrivilege }
+                .distinctUntilChanged()
+                .drop(1)
+                .collect {
+                    AppScanRevision.bump()
+                    loadDashboardData()
+                }
+        }
     }
 
     fun loadDashboardData() {

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -4,6 +4,8 @@
 package com.valhalla.thor.presentation.home
 
 import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.BuildConfig
@@ -11,6 +13,8 @@ import com.valhalla.thor.data.manager.PrivilegeManager
 import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
+import com.valhalla.thor.domain.model.InstalledManagerInfo
+import com.valhalla.thor.domain.model.PrivilegeManagerApp
 import com.valhalla.thor.domain.model.PrivilegeMode
 import com.valhalla.thor.domain.model.fixStoreCandidates
 import com.valhalla.thor.domain.repository.InstallerLabelResolver
@@ -48,6 +52,7 @@ data class HomeUiState(
     // False until the first privilege probe completes — lets the status icon show a
     // neutral "detecting" state instead of flashing the red "no privilege" icon on cold start.
     val isPrivilegeReady: Boolean = false,
+    val installedManagers: List<InstalledManagerInfo> = emptyList(),
 
     // Preferences
     val showReinstallCard: Boolean = true, // <--- Controlled by DataStore
@@ -64,6 +69,7 @@ class HomeViewModel(
     private val privilegeManager: PrivilegeManager,
     private val preferenceRepository: PreferenceRepository, // Injected
     private val installerLabelResolver: InstallerLabelResolver,
+    private val packageManager: PackageManager,
     @Named("io") private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
 
@@ -103,6 +109,7 @@ class HomeViewModel(
             isShizukuAvailable = priv.shizuku,
             isDhizukuAvailable = priv.dhizuku,
             isPrivilegeReady = priv.isReady,
+            installedManagers = PrivilegeManagerApp.findInstalledManagers(packageManager),
             // Keep the existing "null = no privilege" contract for the UI. Until the
             // first probe completes (isReady == false), optimistically fall back to the
             // persisted preference so a configured user never sees a "no privilege"
@@ -172,6 +179,14 @@ class HomeViewModel(
                 AppScanRevision.bump()
                 loadDashboardData()
             }
+        }
+    }
+
+    fun openManagerApp(context: Context, packageName: String) {
+        val intent = context.packageManager.getLaunchIntentForPackage(packageName)
+        if (intent != null) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            runCatching { context.startActivity(intent) }
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -3,10 +3,12 @@
 
 package com.valhalla.thor.presentation.home
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.manager.PrivilegeManager
+import com.valhalla.thor.data.source.local.dhizuku.DhizukuHelper
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.AppListType
 import com.valhalla.thor.domain.model.PrivilegeMode
@@ -14,6 +16,7 @@ import com.valhalla.thor.domain.model.fixStoreCandidates
 import com.valhalla.thor.domain.repository.InstallerLabelResolver
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
+import com.valhalla.thor.util.AppScanRevision
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -158,7 +161,18 @@ class HomeViewModel(
      */
     fun refreshPrivileges() {
         privilegeManager.refresh()
+        AppScanRevision.bump()
         loadDashboardData()
+    }
+
+    fun requestDhizuku(context: Context) {
+        DhizukuHelper.requestPermission(context) { granted ->
+            if (granted) {
+                privilegeManager.refresh()
+                AppScanRevision.bump()
+                loadDashboardData()
+            }
+        }
     }
 
     fun onTypeChanged(type: AppListType) {

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -197,12 +197,24 @@ class HomeViewModel(
         }
     }
 
+    /**
+     * Off the main thread, because [DhizukuHelper.requestPermission] opens with `DhizukuAPI.init`
+     * and `isPermissionGranted()` — both synchronous binder round-trips to another process.
+     * `DhizukuSystemGateway` confines the same helper to [ioDispatcher] for exactly that reason and
+     * this call site, reached straight from the Privilege Check dialog's `onClick`, was the one that
+     * did not. The bind is normally already latched by `ThorApplication.onCreate`, so the usual cost
+     * is a stall rather than an ANR — but "usually already bound" is not a thread policy.
+     *
+     * The `granted` callback arrives on whichever thread Dhizuku's listener fires on, so the
+     * follow-up is posted back through [viewModelScope] rather than run inline — [refreshPrivileges]
+     * reads and reassigns `dashboardJob`, and every other caller of it is on the main dispatcher.
+     * It is the same three steps this used to inline; sharing them keeps the two grant paths from
+     * drifting.
+     */
     fun requestDhizuku(context: Context) {
-        DhizukuHelper.requestPermission(context) { granted ->
-            if (granted) {
-                privilegeManager.refresh()
-                AppScanRevision.bump()
-                loadDashboardData()
+        viewModelScope.launch(ioDispatcher) {
+            DhizukuHelper.requestPermission(context) { granted ->
+                if (granted) viewModelScope.launch { refreshPrivileges() }
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/HomeViewModel.kt
@@ -139,7 +139,7 @@ class HomeViewModel(
 
         viewModelScope.launch {
             privilegeManager.state
-                .map { it.active to it.hasAnyPrivilege }
+                .map { Triple(it.root, it.shizuku, it.dhizuku) to it.active }
                 .distinctUntilChanged()
                 .drop(1)
                 .collect {

--- a/app/src/main/java/com/valhalla/thor/presentation/home/components/DashboardHeader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/home/components/DashboardHeader.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.Box
@@ -248,6 +249,7 @@ private fun easterEggText(tapCount: Int, title: String): String = when {
     else -> title
 }
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 private fun StatusIcon(
     isRoot: Boolean,
@@ -282,16 +284,19 @@ private fun StatusIcon(
             .size(40.dp)
             .clip(CircleShape)
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
-            .clickable {
-                if (availableModes.size > 1) {
-                    // Cycle through available modes
-                    val currentIndex = availableModes.indexOf(activeMode)
-                    val nextIndex = (currentIndex + 1) % availableModes.size
-                    onModeSelected(availableModes[nextIndex])
-                } else if (availableModes.isEmpty()) {
-                    onClick()
-                }
-            },
+            .combinedClickable(
+                onClick = {
+                    if (availableModes.size > 1) {
+                        // Cycle through available modes
+                        val currentIndex = availableModes.indexOf(activeMode)
+                        val nextIndex = (currentIndex + 1) % availableModes.size
+                        onModeSelected(availableModes[nextIndex])
+                    } else {
+                        onClick()
+                    }
+                },
+                onLongClick = { onClick() }
+            ),
         contentAlignment = Alignment.Center
     ) {
         Icon(

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
@@ -261,6 +261,12 @@ fun AppList(
                             multiSelection = toggleSelection(multiSelection, app)
                         }
                     },
+                    sortBy = sortBy,
+                    sortOrder = sortOrder,
+                    selectedFilter = selectedFilter,
+                    filterType = filterType,
+                    appListType = appListType,
+                    searchQuery = searchQuery,
                     sharedTransitionScope = sharedTransitionScope,
                     animatedVisibilityScope = animatedVisibilityScope
                 )
@@ -561,6 +567,12 @@ private fun AppListContent(
     selectedPackageNames: Set<String>,
     onAppClick: (AppInfo) -> Unit,
     onAppLongClick: (AppInfo) -> Unit,
+    sortBy: SortBy = SortBy.NAME,
+    sortOrder: SortOrder = SortOrder.ASCENDING,
+    selectedFilter: String? = null,
+    filterType: FilterType = FilterType.Source,
+    appListType: AppListType = AppListType.USER,
+    searchQuery: String = "",
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null
 ) {
@@ -577,6 +589,11 @@ private fun AppListContent(
     if (isGrid) {
         val metrics = gridMetricsFor(gridDensity)
         val gridState = rememberLazyGridState()
+
+        LaunchedEffect(sortBy, sortOrder, selectedFilter, filterType, appListType, searchQuery) {
+            gridState.scrollToItem(0)
+        }
+
         LazyVerticalGrid(
             columns = GridCells.Adaptive(minSize = metrics.minCellSize),
             state = gridState,
@@ -599,6 +616,11 @@ private fun AppListContent(
         }
     } else {
         val listState = rememberLazyListState()
+
+        LaunchedEffect(sortBy, sortOrder, selectedFilter, filterType, appListType, searchQuery) {
+            listState.scrollToItem(0)
+        }
+
         LazyColumn(
             state = listState,
             contentPadding = padding,

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -1120,7 +1121,13 @@ private fun AppFilterSheet(
         shape = RoundedCornerShape(topStart = 48.dp, topEnd = 48.dp),
         tonalElevation = 0.dp
     ) {
-        Column(modifier = Modifier.padding(24.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp)
+                .padding(top = 8.dp, bottom = 24.dp)
+        ) {
             Text(
                 stringResource(R.string.configuration),
                 style = MaterialTheme.typography.headlineMedium,
@@ -1198,25 +1205,26 @@ private fun AppFilterSheet(
 
             when (activeTab) {
                 SheetTab.FILTERS -> {
-                    LazyColumn(
-                        modifier = Modifier.height(200.dp),
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        items(filterTypes) { type ->
+                        filterTypes.forEach { type ->
+                            val isSelected = filterType == type
                             ListItem(
                                 trailingContent = {
-                                    if (filterType == type) Icon(
+                                    if (isSelected) Icon(
                                         painterResource(R.drawable.check_circle),
                                         null,
                                         tint = MaterialTheme.colorScheme.primary
                                     )
                                 },
                                 modifier = Modifier
+                                    .fillMaxWidth()
                                     .clip(RoundedCornerShape(16.dp))
                                     .background(
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(
-                                            alpha = 0.5f
-                                        )
+                                        if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+                                        else MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f)
                                     )
                                     .clickable { onFilterTypeChanged(type) },
                                 colors = androidx.compose.material3.ListItemDefaults.colors(
@@ -1234,19 +1242,21 @@ private fun AppFilterSheet(
                 }
 
                 SheetTab.SORT -> {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
                         Text(
                             stringResource(R.string.order),
                             style = MaterialTheme.typography.titleMedium
                         )
-                        Spacer(Modifier.width(8.dp))
                         FilterChip(
                             selected = sortOrder == SortOrder.ASCENDING,
                             onClick = { onSortOrderChanged(SortOrder.ASCENDING) },
                             label = { Text(stringResource(R.string.ascending)) },
                             leadingIcon = { Icon(painterResource(R.drawable.arrow_upward), null) }
                         )
-                        Spacer(Modifier.width(8.dp))
                         FilterChip(
                             selected = sortOrder == SortOrder.DESCENDING,
                             onClick = { onSortOrderChanged(SortOrder.DESCENDING) },
@@ -1255,25 +1265,26 @@ private fun AppFilterSheet(
                         )
                     }
                     Spacer(Modifier.height(12.dp))
-                    LazyColumn(
-                        modifier = Modifier.height(200.dp),
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        items(SortBy.entries) { item ->
+                        SortBy.entries.forEach { item ->
+                            val isSelected = sortBy == item
                             ListItem(
                                 trailingContent = {
-                                    if (sortBy == item) Icon(
+                                    if (isSelected) Icon(
                                         painterResource(R.drawable.check_circle),
                                         null,
                                         tint = MaterialTheme.colorScheme.primary
                                     )
                                 },
                                 modifier = Modifier
+                                    .fillMaxWidth()
                                     .clip(RoundedCornerShape(16.dp))
                                     .background(
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(
-                                            alpha = 0.5f
-                                        )
+                                        if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+                                        else MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f)
                                     )
                                     .clickable { onSortByChanged(item) },
                                 colors = androidx.compose.material3.ListItemDefaults.colors(

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppList.kt
@@ -590,7 +590,7 @@ private fun AppListContent(
         val metrics = gridMetricsFor(gridDensity)
         val gridState = rememberLazyGridState()
 
-        LaunchedEffect(sortBy, sortOrder, selectedFilter, filterType, appListType, searchQuery) {
+        ScrollToTopOnChange(sortBy, sortOrder, selectedFilter, filterType, appListType, searchQuery) {
             gridState.scrollToItem(0)
         }
 
@@ -617,7 +617,7 @@ private fun AppListContent(
     } else {
         val listState = rememberLazyListState()
 
-        LaunchedEffect(sortBy, sortOrder, selectedFilter, filterType, appListType, searchQuery) {
+        ScrollToTopOnChange(sortBy, sortOrder, selectedFilter, filterType, appListType, searchQuery) {
             listState.scrollToItem(0)
         }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/ScrollToTopOnChange.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/ScrollToTopOnChange.kt
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.widgets
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Send a lazy list back to the top whenever [keys] change — but never on the first composition.
+ *
+ * Sorting, filtering or searching leaves the user looking at row 40 of a list whose row 40 is now a
+ * different app, so the reset is right. What is *not* right is doing it the first time the effect
+ * runs: `rememberLazyListState`/`rememberLazyGridState` are `rememberSaveable`-backed, so on an
+ * activity recreation (rotation, theme change, process death) or on re-entering the destination
+ * Compose restores `firstVisibleItemIndex` — and a bare `LaunchedEffect(keys) { scrollToItem(0) }`
+ * then fires with unchanged keys and throws that restored position away. [skipInitialReset] is what
+ * separates "the keys changed" from "this composition is new".
+ *
+ * The flag is `remember`, deliberately **not** `rememberSaveable`. Its correctness depends on it
+ * being `true` again on exactly the recompositions where the scroll position is restored, which is
+ * exactly the ones a `rememberSaveable` would carry a stale `false` across.
+ *
+ * [scrollToTop] is a suspend lambda rather than a state parameter because `scrollToItem` lives on
+ * `LazyListState` and `LazyGridState` separately, not on their common `ScrollableState` supertype.
+ */
+@Composable
+fun ScrollToTopOnChange(
+    vararg keys: Any?,
+    scrollToTop: suspend () -> Unit,
+) {
+    var skipInitialReset by remember { mutableStateOf(true) }
+    LaunchedEffect(*keys) {
+        if (skipInitialReset) skipInitialReset = false
+        else scrollToTop()
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/util/AppScanRevision.kt
+++ b/app/src/main/java/com/valhalla/thor/util/AppScanRevision.kt
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.util
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Process-wide trigger to request a package scan / cache refresh in
+ * [com.valhalla.thor.data.repository.AppRepositoryImpl].
+ *
+ * Emitted whenever an external permission grant, self-grant, or privilege elevation occurs that changes
+ * package visibility so that the repository rescans PackageManager immediately.
+ */
+object AppScanRevision {
+
+    private val _changes = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /** Emits once per requested package scan. */
+    val changes: SharedFlow<Unit> = _changes.asSharedFlow()
+
+    /** Request a package scan / cache refresh. */
+    fun bump() {
+        _changes.tryEmit(Unit)
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -58,6 +58,7 @@
     <string name="no">لا</string>
     <string name="done">تم</string>
     <string name="close">إغلاق</string>
+    <string name="open_app">فتح</string>
     <string name="installed_label">مثبت</string>
     <string name="new_version_label">نسخة جديدة</string>
     <string name="version_prefix">الإصدار: </string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -58,6 +58,7 @@
     <string name="no">No</string>
     <string name="done">Hecho</string>
     <string name="close">Cerrar</string>
+    <string name="open_app">Abrir</string>
     <string name="installed_label">INSTALADO</string>
     <string name="new_version_label">NUEVA VERSIÓN</string>
     <string name="version_prefix">Versión: </string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -58,6 +58,7 @@
     <string name="no">Non</string>
     <string name="done">Terminé</string>
     <string name="close">Fermer</string>
+    <string name="open_app">Ouvrir</string>
     <string name="installed_label">INSTALLÉ</string>
     <string name="new_version_label">NOUVELLE VERSION</string>
     <string name="version_prefix">Version : </string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -69,6 +69,7 @@
     <string name="no">Nie</string>
     <string name="done">Gotowe</string>
     <string name="close">Zamknij</string>
+    <string name="open_app">Otwórz</string>
     <string name="installed_label">ZAINSTALOWANA</string>
     <string name="new_version_label">NOWA WERSJA</string>
     <string name="version_prefix">Wersja: </string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -67,6 +67,8 @@
     <string name="clear_all_cache_done_unmeasured">Concluído. O Thor não conseguiu medir quanto espaço isso liberou — conceda a ele acesso ao uso nas Configurações para ver o valor da próxima vez.</string>
     <string name="system_apps">Aplicativos do sistema</string>
     <string name="active">Ativo</string>
+    <string name="close">Fechar</string>
+    <string name="open_app">Abrir</string>
     <string name="frozen">Congelado</string>
     <string name="suspended">Suspenso</string>
     <string name="privilege_check_desc">O Thor precisa de acesso Root, Shizuku ou Dhizuku para funcionar corretamente.\n\nConceda o acesso no seu aplicativo de gerenciamento e toque em Atualizar.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -69,6 +69,7 @@
     <string name="no">Não</string>
     <string name="done">Concluído</string>
     <string name="close">Fechar</string>
+    <string name="open_app">Abrir</string>
     <string name="installed_label">INSTALADA</string>
     <string name="new_version_label">NOVA VERSÃO</string>
     <string name="version_prefix">Versão: </string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -57,6 +57,7 @@
     <string name="no">否</string>
     <string name="done">完成</string>
     <string name="close">关闭</string>
+    <string name="open_app">打开</string>
     <string name="installed_label">已安装</string>
     <string name="new_version_label">新版本</string>
     <string name="version_prefix">版本：</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="no">No</string>
     <string name="done">Done</string>
     <string name="close">Close</string>
+    <string name="open_app">Open</string>
     <string name="installed_label">INSTALLED</string>
     <string name="new_version_label">NEW VERSION</string>
     <string name="version_prefix">Version: </string>

--- a/app/src/test/java/com/valhalla/thor/data/repository/AppRepositoryScanTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/AppRepositoryScanTest.kt
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import com.valhalla.thor.domain.model.RetainReason
+import com.valhalla.thor.domain.model.ScanVerdict
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies that label locale recording only occurs when an accepted scan's cache
+ * sync succeeds without failure.
+ */
+class AppRepositoryScanTest {
+
+    private fun shouldRecordLabelLocale(
+        forceRefresh: Boolean,
+        verdict: ScanVerdict,
+        syncCacheSucceeded: Boolean
+    ): Boolean = forceRefresh && verdict == ScanVerdict.Accept && syncCacheSucceeded
+
+    @Test
+    fun `recordLabelLocale is only executed when scan is accepted and cache sync succeeds`() {
+        assertTrue(
+            shouldRecordLabelLocale(
+                forceRefresh = true,
+                verdict = ScanVerdict.Accept,
+                syncCacheSucceeded = true
+            )
+        )
+    }
+
+    @Test
+    fun `recordLabelLocale is skipped when cache sync fails during accepted scan`() {
+        assertFalse(
+            shouldRecordLabelLocale(
+                forceRefresh = true,
+                verdict = ScanVerdict.Accept,
+                syncCacheSucceeded = false
+            )
+        )
+    }
+
+    @Test
+    fun `recordLabelLocale is skipped when scan is retained`() {
+        assertFalse(
+            shouldRecordLabelLocale(
+                forceRefresh = true,
+                verdict = ScanVerdict.Retain(RetainReason.Collapsed),
+                syncCacheSucceeded = true
+            )
+        )
+    }
+
+    @Test
+    fun `recordLabelLocale is skipped when not a forced refresh`() {
+        assertFalse(
+            shouldRecordLabelLocale(
+                forceRefresh = false,
+                verdict = ScanVerdict.Accept,
+                syncCacheSucceeded = true
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
@@ -475,6 +475,19 @@ class PerUserCommandsTest {
         assertTrue(usageStatsGrantCommand(pkg, 10).endsWith(" GET_USAGE_STATS allow"))
     }
 
+    @Test
+    fun `the installed apps appops grant names the user and covers OEM op names`() {
+        val commands = installedAppsAppOpGrantCommands(pkg, 10)
+        assertEquals(3, commands.size)
+        commands.forEach { cmd ->
+            assertEquals(10, userArgOf(cmd))
+            assertTrue(cmd.endsWith(" allow"))
+        }
+        assertEquals("appops set --user 10 $pkg GET_INSTALLED_APPS allow", commands[0])
+        assertEquals("appops set --user 10 $pkg android:get_installed_apps allow", commands[1])
+        assertEquals("appops set --user 10 $pkg 10022 allow", commands[2])
+    }
+
     // --- the shape of the whole file, not one instance of it ---
 
     /**

--- a/app/src/test/java/com/valhalla/thor/domain/model/InstalledAppsVisibilityTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/InstalledAppsVisibilityTest.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.domain.model
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 /**
@@ -248,6 +249,37 @@ class InstalledAppsVisibilityTest {
         )
     }
 
+    @Test
+    fun visibilityFallbackIsNeverAVerdictThisFunctionReaches() {
+        // VisibilityFallback is the caller's word, not a rule here, and the KDoc says so. A flags=0
+        // getInstalledPackages leaves no trace in its own output — the packages it cannot see are
+        // exactly the ones it does not report — so no combination of scan, cache and permission can
+        // infer it. AppRepositoryImpl short-circuits to it instead, and this asserts the boundary:
+        // if a rule below ever starts producing it, the two sources of the reason have collided.
+        val everyCase = listOf(
+            emptySet<String>(),
+            packages(5, withPlatform = false),
+            packages(5),
+            packages(400),
+        )
+        for (scanned in everyCase) {
+            for (permission in listOf(
+                InstalledAppsPermission.Unsupported,
+                InstalledAppsPermission.Denied,
+                InstalledAppsPermission.Granted,
+            )) {
+                for (suspectScans in 0..SUSPECT_SCAN_TOLERANCE) {
+                    val result = verdict(scanned, permission, suspectScans = suspectScans)
+                    assertNotEquals(
+                        "scanVerdict must not mint VisibilityFallback itself",
+                        ScanVerdict.Retain(RetainReason.VisibilityFallback),
+                        result
+                    )
+                }
+            }
+        }
+    }
+
     // --- prunableWatchlistRows: the second consumer of the same verdict ---
 
     private val watchlist = setOf("com.example.gone", "com.example.here")
@@ -266,10 +298,11 @@ class InstalledAppsVisibilityTest {
 
     @Test
     fun aDisbelievedScanPrunesNothingWhateverItsReason() {
-        // The whole safety property, one case per reason. Delete the `Accept` check in
-        // prunableWatchlistRows and all three of these turn red: on a collapsed scan every one of
-        // these rows looks uninstalled, so the user's entire watchlist would go in a single pass —
-        // silently, with no undo, and for a device that is working perfectly well.
+        // The whole safety property, one case per reason — iterating `entries` rather than listing
+        // them so a reason added later is covered without anyone remembering to come back here.
+        // Delete the `Accept` check in prunableWatchlistRows and every one of these turns red: on a
+        // disbelieved scan all of these rows look uninstalled, so the user's entire watchlist would
+        // go in a single pass — silently, with no undo, and for a device working perfectly well.
         for (reason in RetainReason.entries) {
             assertEquals(
                 "retained scan (${reason.name}) must not prune",

--- a/app/src/test/java/com/valhalla/thor/domain/model/PrivilegeManagerAppTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/PrivilegeManagerAppTest.kt
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrivilegeManagerAppTest {
+
+    @Test
+    fun `every registered privilege manager has valid metadata`() {
+        for (manager in PrivilegeManagerApp.entries) {
+            assertTrue("Display name must not be empty", manager.displayName.isNotBlank())
+            assertTrue("Package names must not be empty", manager.packageNames.isNotEmpty())
+            assertTrue("Mode must be valid", manager.mode != PrivilegeMode.NONE)
+            for (pkg in manager.packageNames) {
+                assertTrue("Package name must contain a dot", pkg.contains('.'))
+            }
+        }
+    }
+
+    @Test
+    fun `findInstalledManagers returns only installed manager packages`() {
+        val installedPackages = setOf("me.weishu.kernelsu", "moe.shizuku.privileged.api")
+
+        val installed = PrivilegeManagerApp.findInstalledManagers { pkg ->
+            pkg in installedPackages
+        }
+
+        val installedApps = installed.map { it.app }
+        assertEquals(2, installed.size)
+        assertTrue(installedApps.contains(PrivilegeManagerApp.KERNEL_SU))
+        assertTrue(installedApps.contains(PrivilegeManagerApp.SHIZUKU))
+        assertTrue(!installedApps.contains(PrivilegeManagerApp.DHIZUKU))
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses package visibility collapse on fresh installs, privilege manager detection/acquisition (KernelSU, Shizuku, Dhizuku), and UI touch responsiveness in the App List bottom sheet.

### Key Changes
1. **Package Visibility & Permissions Recovery**:
   - Resolved package visibility collapse on fresh installs and Chinese OEM ROMs (ColorOS, OxygenOS, HyperOS, MIUI) by applying fallback flag queries and automatic AppOps grants.
   - Synchronized `SelfPermissionGranter` with `AppRepository` rescans.

2. **Privilege Acquisition & Dynamic Detection**:
   - Added `PrivilegeManagerApp` registry with package name resolution for known root and privilege managers (KernelSU, KernelSU-Next, APatch, Magisk, Shizuku, Dhizuku, etc.).
   - Added inline in-app permission grant requests for Shizuku and Dhizuku.
   - Removed `FLAG_MOUNT_MASTER` to prevent KernelSU / APatch root failure.
   - Added automatic privilege re-probing in `HomeActivity.onResume()` so switching back from KernelSU/Magisk manager auto-acquires root without app restart.
   - Made `HomeViewModel` reactively reload data on any privilege availability transition.

3. **App List Sort & Filter Touch Responsiveness**:
   - Replaced nested fixed-height `LazyColumn(200.dp)` in `AppFilterSheet` with a unified scrollable column to eliminate touch slop/gesture collisions in `ModalBottomSheet`.
   - Added automatic `scrollToItem(0)` when sort, order, filter, or search query changes so the list always resets to the top.

### Verification
- Ran `./gradlew test lintFossDebug lintStoreRelease`: **PASSED (0 errors, 0 lint warnings)**
- Ran test suite: **ALL PASSED**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection and management controls for installed privilege-manager apps.
  * Added options to request Shizuku or Dhizuku access and open manager apps.
  * Enhanced app-list filtering, sorting, and scroll-position behavior.
  * Improved privilege-mode selection with tap and long-press actions.

* **Bug Fixes**
  * Improved installed-app permission handling and refreshed app scans after permission changes.
  * Improved app discovery, fallback labels, scan resilience, and compatibility across supported setups.
  * Prevented incomplete visibility scans from triggering unsafe app removal.

* **Localization**
  * Added translated “Open” and Brazilian Portuguese “Close” labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->