### PR TITLE
fix(customization): pin the action preview above the scrolling list

### DIFF
--- a/app/src/androidTest/java/com/valhalla/thor/presentation/settings/customization/PinnedHeaderScaffoldTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/presentation/settings/customization/PinnedHeaderScaffoldTest.kt
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings.customization
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsAtLeast
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The one invariant [PinnedHeaderScaffold] exists to hold: the body is never measured to nothing.
+ *
+ * The customization screen pins its hint, reset button and live preview above a `LazyColumn` that
+ * takes the remaining space with `weight(1f)`. A `Column` measures an *unweighted* child against
+ * everything left over, so a header that outgrows the viewport — landscape on a short screen, or a
+ * display/font scale that wraps the hint and stretches the preview chips — is handed the whole
+ * height and the weighted list is measured at zero. The list is the entire point of the screen, and
+ * because nothing scrolls in that state there is no gesture that recovers it: the user sees a
+ * preview and no actions.
+ *
+ * So the header is capped and scrolls inside the cap, and a header that fits is left exactly as it
+ * was.
+ */
+@RunWith(AndroidJUnit4::class)
+class PinnedHeaderScaffoldTest {
+
+    @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+    private val bodyTag = "body"
+
+    /**
+     * Hosts the scaffold in a viewport of a known size, independent of the device the test runs on.
+     */
+    private fun setScaffold(
+        width: Dp,
+        height: Dp,
+        fontScale: Float = 1f,
+        header: @Composable () -> Unit
+    ) = rule.setContent {
+        val density = LocalDensity.current
+        CompositionLocalProvider(
+            LocalDensity provides Density(density.density, fontScale)
+        ) {
+            Box(modifier = Modifier.requiredSize(width, height)) {
+                PinnedHeaderScaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    header = header
+                ) {
+                    Box(modifier = Modifier.fillMaxSize().testTag(bodyTag))
+                }
+            }
+        }
+    }
+
+    private fun bodyHeight(): Dp = rule.onNodeWithTag(bodyTag).getUnclippedBoundsInRoot().height
+
+    @Test
+    fun headerThatFitsLeavesTheBodyTheRest() {
+        setScaffold(width = 360.dp, height = 400.dp) {
+            Box(modifier = Modifier.fillMaxWidth().height(120.dp))
+        }
+
+        // Untouched by the cap: 400 - 120. Tolerance covers dp/px rounding at any density.
+        val body = bodyHeight()
+        assertTrue("body was $body, expected ~280dp", body.value in 279f..281f)
+    }
+
+    @Test
+    fun headerTallerThanTheViewportStillLeavesHalfForTheBody() {
+        setScaffold(width = 360.dp, height = 400.dp) {
+            Box(modifier = Modifier.fillMaxWidth().height(4_000.dp))
+        }
+
+        // Without the cap this is 0dp and the action list is unreachable.
+        rule.onNodeWithTag(bodyTag).assertHeightIsAtLeast(199.dp)
+    }
+
+    @Test
+    fun largeFontScaleStillLeavesTheBodyOnScreen() {
+        setScaffold(width = 360.dp, height = 400.dp, fontScale = 2f) {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "Drag to reorder actions, or use the arrows. " +
+                        "Toggle a switch to hide an action from the app info sheet."
+                )
+            }
+        }
+
+        rule.onNodeWithTag(bodyTag).assertHeightIsAtLeast(199.dp)
+    }
+
+    @Test
+    fun landscapeShortViewportStillLeavesTheBodyOnScreen() {
+        // A phone in landscape below the system bars: wide, and short enough that the real header
+        // (hint row + preview card, roughly 150dp) is a large fraction of what is left.
+        setScaffold(width = 800.dp, height = 300.dp) {
+            Box(modifier = Modifier.fillMaxWidth().height(280.dp))
+        }
+
+        rule.onNodeWithTag(bodyTag).assertHeightIsAtLeast(149.dp)
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/customization/AppInfoActionsCustomizationScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/customization/AppInfoActionsCustomizationScreen.kt
@@ -3,26 +3,32 @@
 
 package com.valhalla.thor.presentation.settings.customization
 
+import androidx.annotation.DrawableRes
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -38,16 +44,25 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -59,7 +74,28 @@ import com.valhalla.thor.domain.model.AppInfoActionId
 import com.valhalla.thor.presentation.settings.SettingsIconBox
 import com.valhalla.thor.presentation.settings.SettingsTopBar
 import com.valhalla.thor.presentation.settings.SettingsViewModel
+import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
+
+/** Breathing room left around a row that a Move button has just scrolled back into view. */
+private val RevealMargin = 12.dp
+
+/**
+ * Share of the body the pinned header may take before it starts scrolling inside its own bounds.
+ *
+ * A `Column` measures an unweighted child against whatever height is left, so a header that grows
+ * — landscape, or a large display/font scale, where the hint wraps and the preview chips get taller
+ * — can eat the whole body and leave the weighted list measured at zero height, with no scroll
+ * anywhere to recover it. No ordinary configuration comes near this cap; it exists so the failure
+ * degrades into a scrollable header rather than an empty screen.
+ */
+private const val HEADER_MAX_HEIGHT_FRACTION = 0.5f
+
+/** Opacity applied to a hidden action's glyph and labels. */
+private const val HIDDEN_ROW_ALPHA = 0.45f
+
+/** Opacity of a Move button that has run out of list in its direction. */
+private const val DISABLED_ICON_ALPHA = 0.38f
 
 /**
  * Dedicated customization screen allowing users to reorder and toggle AppInfo sheet actions.
@@ -75,10 +111,16 @@ fun AppInfoActionsCustomizationScreen(
     val currentOrder = prefs.appInfoActionsOrder
     val hiddenActions = prefs.hiddenAppInfoActions
 
-    val localActions = remember { mutableStateListOf<AppInfoActionId>() }
+    // Seeded rather than left empty and filled by the effect below: an empty first frame renders the
+    // list with no rows and the preview with its "all actions are hidden" copy, which flashes past
+    // on every entry to the screen.
+    val localActions = remember { mutableStateListOf<AppInfoActionId>().apply { addAll(currentOrder) } }
     val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+    val haptics = LocalHapticFeedback.current
+    val revealMarginPx = with(LocalDensity.current) { RevealMargin.roundToPx() }
 
-    var showResetConfirmation by remember { mutableStateOf(false) }
+    var showResetConfirmation by rememberSaveable { mutableStateOf(false) }
 
     val reorderState = rememberReorderableLazyListState(
         listState = listState,
@@ -95,9 +137,21 @@ fun AppInfoActionsCustomizationScreen(
         }
     )
 
+    /** Steps a row one slot in [delta]'s direction and keeps it on screen while it travels. */
+    val moveBy: (index: Int, delta: Int) -> Unit = { index, delta ->
+        val target = index + delta
+        if (index in localActions.indices && target in localActions.indices) {
+            val item = localActions.removeAt(index)
+            localActions.add(target, item)
+            viewModel.setAppInfoActionsOrder(localActions.toList())
+            haptics.performHapticFeedback(HapticFeedbackType.SegmentTick)
+            scope.launch { listState.keepIndexVisible(target, revealMarginPx) }
+        }
+    }
+
     // Synchronize local snapshot with repository when not in active drag
     LaunchedEffect(currentOrder) {
-        if (reorderState.draggingItemKey == null) {
+        if (reorderState.draggingItemKey == null && localActions.toList() != currentOrder) {
             localActions.clear()
             localActions.addAll(currentOrder)
         }
@@ -113,109 +167,109 @@ fun AppInfoActionsCustomizationScreen(
             onBack = onBack
         )
 
-        // Pinned header: the drag hint, reset action and live preview stay on screen while the
-        // action list scrolls underneath, so the preview always reflects the current arrangement.
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.customization_drag_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                FilledIconButton(
-                    onClick = { showResetConfirmation = true },
-                    colors = IconButtonDefaults.filledIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
-                    ),
-                    modifier = Modifier.size(36.dp)
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.settings_backup_restore),
-                        contentDescription = stringResource(R.string.reset_to_default),
-                        modifier = Modifier.size(18.dp)
-                    )
-                }
-            }
-
-            // Live Preview Section
-            ActionRowPreviewCard(
-                actions = localActions.filterNot { it in hiddenActions }
-            )
-        }
-
-        LazyColumn(
-            state = listState,
+        // The drag hint, reset action and live preview stay on screen while the action list scrolls
+        // underneath, so the preview always reflects the arrangement being edited.
+        PinnedHeaderScaffold(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
-            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, bottom = 48.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            // Reorderable action items
-            itemsIndexed(
-                items = localActions,
-                key = { _, action -> action.name }
-            ) { index, action ->
-                val isHidden = action in hiddenActions
-                val isBeingDragged = reorderState.draggingItemKey == action.name
-
-                val elevation by animateDpAsState(
-                    targetValue = if (isBeingDragged) 12.dp else 0.dp,
-                    label = "item_elevation"
-                )
-                val scale by animateFloatAsState(
-                    targetValue = if (isBeingDragged) 1.03f else 1.0f,
-                    label = "item_scale"
-                )
-
-                Box(
+            header = {
+                Column(
                     modifier = Modifier
-                        .animateItem()
-                        .zIndex(if (isBeingDragged) 10f else 1f)
-                        .graphicsLayer {
-                            scaleX = scale
-                            scaleY = scale
-                            if (isBeingDragged) {
-                                translationY = reorderState.draggingItemOffset
-                            }
-                        }
-                        .shadow(elevation, RoundedCornerShape(24.dp))
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    CustomizableActionItemRow(
-                        action = action,
-                        index = index,
-                        totalCount = localActions.size,
-                        isVisible = !isHidden,
-                        isBeingDragged = isBeingDragged,
-                        reorderState = reorderState,
-                        onVisibilityChanged = { visible ->
-                            viewModel.setAppInfoActionVisibility(action, visible)
-                        },
-                        onMoveUp = {
-                            if (index > 0) {
-                                val item = localActions.removeAt(index)
-                                localActions.add(index - 1, item)
-                                viewModel.setAppInfoActionsOrder(localActions.toList())
-                            }
-                        },
-                        onMoveDown = {
-                            if (index < localActions.size - 1) {
-                                val item = localActions.removeAt(index)
-                                localActions.add(index + 1, item)
-                                viewModel.setAppInfoActionsOrder(localActions.toList())
-                            }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(R.string.customization_drag_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.weight(1f, fill = false)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        FilledIconButton(
+                            onClick = { showResetConfirmation = true },
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary
+                            ),
+                            modifier = Modifier.size(36.dp)
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.settings_backup_restore),
+                                contentDescription = stringResource(R.string.reset_to_default),
+                                modifier = Modifier.size(18.dp)
+                            )
                         }
+                    }
+
+                    // Live Preview Section
+                    ActionRowPreviewCard(
+                        actions = localActions.filterNot { it in hiddenActions }
                     )
+                }
+            }
+        ) {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(start = 24.dp, end = 24.dp, bottom = 48.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                // Reorderable action items
+                itemsIndexed(
+                    items = localActions,
+                    key = { _, action -> action.name }
+                ) { index, action ->
+                    val isHidden = action in hiddenActions
+                    val isBeingDragged = reorderState.draggingItemKey == action.name
+
+                    val elevation by animateDpAsState(
+                        targetValue = if (isBeingDragged) 12.dp else 0.dp,
+                        label = "item_elevation"
+                    )
+                    val scale by animateFloatAsState(
+                        targetValue = if (isBeingDragged) 1.03f else 1.0f,
+                        label = "item_scale"
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            // Everything but the dragged row animates into its new slot. The
+                            // dragged row is placed by hand through the translation below, and
+                            // the swap already subtracts the slot change from it — animating
+                            // the same move a second time makes the card lurch under the finger
+                            // on every reorder.
+                            .then(if (isBeingDragged) Modifier else Modifier.animateItem())
+                            .zIndex(if (isBeingDragged) 10f else 1f)
+                            .graphicsLayer {
+                                scaleX = scale
+                                scaleY = scale
+                                if (isBeingDragged) {
+                                    translationY = reorderState.draggingItemOffset
+                                }
+                            }
+                            .shadow(elevation, RoundedCornerShape(24.dp))
+                    ) {
+                        CustomizableActionItemRow(
+                            action = action,
+                            index = index,
+                            totalCount = localActions.size,
+                            isVisible = !isHidden,
+                            isBeingDragged = isBeingDragged,
+                            reorderState = reorderState,
+                            onVisibilityChanged = { visible ->
+                                viewModel.setAppInfoActionVisibility(action, visible)
+                            },
+                            onMoveUp = { moveBy(index, -1) },
+                            onMoveDown = { moveBy(index, 1) }
+                        )
+                    }
                 }
             }
         }
@@ -252,6 +306,70 @@ fun AppInfoActionsCustomizationScreen(
     }
 }
 
+/**
+ * A pinned [header] above a [body] that takes the rest of the space.
+ *
+ * The header is unweighted, and a `Column` measures an unweighted child against everything that is
+ * left — so a header that grows past the viewport (landscape, or a large display/font scale) would
+ * be handed the whole height and the weighted [body] would be measured at zero, with no scroll
+ * anywhere to recover it. Capping the header at [headerMaxHeightFraction] of the available height
+ * and letting it scroll inside that cap keeps the body non-empty at any configuration, while a
+ * header that fits — the normal case — is untouched and does not scroll.
+ */
+@Composable
+internal fun PinnedHeaderScaffold(
+    header: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    headerMaxHeightFraction: Float = HEADER_MAX_HEIGHT_FRACTION,
+    body: @Composable () -> Unit
+) {
+    BoxWithConstraints(modifier) {
+        val headerMaxHeight = maxHeight * headerMaxHeightFraction
+        Column(modifier = Modifier.fillMaxSize()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = headerMaxHeight)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                header()
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            ) {
+                body()
+            }
+        }
+    }
+}
+
+/**
+ * Brings the row at [index] back into view after a Move button has stepped something into it.
+ *
+ * Deliberately measured against the pre-move layout: the click handler runs before the list is
+ * remeasured, and the slot the moved row is about to occupy is the one [index] holds right now.
+ * Without this, holding down Move down walks the row past the edge of the viewport and the user
+ * loses sight of the thing they are moving.
+ */
+private suspend fun LazyListState.keepIndexVisible(index: Int, marginPx: Int) {
+    val info = layoutInfo
+    val item = info.visibleItemsInfo.firstOrNull { it.index == index }
+    if (item == null) {
+        animateScrollToItem(index)
+        return
+    }
+    val top = item.offset - marginPx
+    val bottom = item.offset + item.size + marginPx
+    val delta = when {
+        top < info.viewportStartOffset -> top - info.viewportStartOffset
+        bottom > info.viewportEndOffset -> bottom - info.viewportEndOffset
+        else -> 0
+    }
+    if (delta != 0) animateScrollBy(delta.toFloat())
+}
+
 @Composable
 private fun ActionRowPreviewCard(
     actions: List<AppInfoActionId>,
@@ -279,10 +397,16 @@ private fun ActionRowPreviewCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         } else {
+            // Each entry is an AsgardActionItem, which is clickable by construction, so left alone
+            // the preview hands assistive technology sixteen buttons that do nothing before the
+            // first real control on the screen. Collapsed to one node reading the order out loud,
+            // which is the only thing the preview is here to convey.
+            val spokenOrder = actions.map { stringResource(it.titleRes) }.joinToString(", ")
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState()),
+                    .horizontalScroll(rememberScrollState())
+                    .clearAndSetSemantics { contentDescription = spokenOrder },
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalAlignment = Alignment.Top
             ) {
@@ -317,6 +441,15 @@ private fun CustomizableActionItemRow(
     } else {
         MaterialTheme.colorScheme.surfaceContainerLow
     }
+    val title = stringResource(action.titleRes)
+
+    // A hidden action keeps its place in the list because it is still reorderable, so the switch is
+    // the only thing distinguishing it from a visible one — not something you can scan across
+    // sixteen rows. Dimming the glyph and the labels makes the state readable at a glance.
+    val contentAlpha by animateFloatAsState(
+        targetValue = if (isVisible) 1f else HIDDEN_ROW_ALPHA,
+        label = "row_content_alpha"
+    )
 
     Row(
         modifier = modifier
@@ -326,18 +459,21 @@ private fun CustomizableActionItemRow(
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Instant tactile drag handle
+        // Instant tactile drag handle. Cleared from the semantics tree because a drag is not a
+        // gesture TalkBack or a keyboard can perform, and the Move buttons below already expose
+        // reordering to both — left in, it would put the same unusable node in front of every row.
         Box(
             modifier = Modifier
                 .size(40.dp)
                 .clip(RoundedCornerShape(12.dp))
                 .background(MaterialTheme.colorScheme.surfaceContainerHighest.copy(alpha = 0.5f))
-                .dragHandle(action.name, reorderState),
+                .dragHandle(action.name, reorderState)
+                .clearAndSetSemantics { },
             contentAlignment = Alignment.Center
         ) {
             Icon(
                 painter = painterResource(R.drawable.drag_handle),
-                contentDescription = stringResource(R.string.customization_drag_hint),
+                contentDescription = null,
                 modifier = Modifier.size(20.dp),
                 tint = if (isBeingDragged) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -346,16 +482,21 @@ private fun CustomizableActionItemRow(
         Spacer(Modifier.width(12.dp))
 
         // Action Icon
-        SettingsIconBox(icon = action.defaultIconRes)
+        SettingsIconBox(
+            icon = action.defaultIconRes,
+            modifier = Modifier.alpha(contentAlpha)
+        )
 
         Spacer(Modifier.width(12.dp))
 
         // Action Label & Description
         Column(
-            modifier = Modifier.weight(1f)
+            modifier = Modifier
+                .weight(1f)
+                .alpha(contentAlpha)
         ) {
             Text(
-                text = stringResource(action.titleRes),
+                text = title,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
@@ -372,45 +513,61 @@ private fun CustomizableActionItemRow(
 
         Spacer(Modifier.width(8.dp))
 
-        // Accessibility Move Buttons for screen readers & discrete stepping
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(2.dp),
-            verticalAlignment = Alignment.CenterVertically
+        // Accessibility Move Buttons for screen readers & discrete stepping. Stacked rather than
+        // side by side: two 32dp buttons in a row cost twice the width in a layout that already has
+        // a handle, a glyph and a switch competing with the labels, and up-over-down matches the
+        // direction each one moves the row. Both are always present and disabled at the ends of the
+        // list, so the switch column does not jog sideways on the first and last rows.
+        Column(
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            if (index > 0) {
-                IconButton(
-                    onClick = onMoveUp,
-                    modifier = Modifier.size(32.dp)
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.arrow_upward),
-                        contentDescription = stringResource(R.string.cd_move_up),
-                        modifier = Modifier.size(16.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-            if (index < totalCount - 1) {
-                IconButton(
-                    onClick = onMoveDown,
-                    modifier = Modifier.size(32.dp)
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.arrow_downward),
-                        contentDescription = stringResource(R.string.cd_move_down),
-                        modifier = Modifier.size(16.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
+            MoveButton(
+                icon = R.drawable.arrow_upward,
+                contentDescription = stringResource(R.string.cd_move_up),
+                enabled = index > 0,
+                onClick = onMoveUp
+            )
+            MoveButton(
+                icon = R.drawable.arrow_downward,
+                contentDescription = stringResource(R.string.cd_move_down),
+                enabled = index < totalCount - 1,
+                onClick = onMoveDown
+            )
         }
 
         Spacer(Modifier.width(8.dp))
 
-        // Visibility Toggle
+        // Visibility Toggle. Named after the action it governs: on its own a Switch is announced
+        // with its state and no subject, and there are sixteen of them on this screen.
         Switch(
             checked = isVisible,
-            onCheckedChange = onVisibilityChanged
+            onCheckedChange = onVisibilityChanged,
+            modifier = Modifier.semantics { contentDescription = title }
+        )
+    }
+}
+
+@Composable
+private fun MoveButton(
+    @DrawableRes icon: Int,
+    contentDescription: String,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.size(32.dp)
+    ) {
+        Icon(
+            painter = painterResource(icon),
+            contentDescription = contentDescription,
+            modifier = Modifier.size(16.dp),
+            // Passing an explicit tint opts out of IconButton's disabled colour, so the disabled
+            // state has to be carried here or a Move button at the end of the list looks live.
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                .copy(alpha = if (enabled) 1f else DISABLED_ICON_ALPHA)
         )
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/customization/AppInfoActionsCustomizationScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/customization/AppInfoActionsCustomizationScreen.kt
@@ -113,53 +113,54 @@ fun AppInfoActionsCustomizationScreen(
             onBack = onBack
         )
 
-        LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 48.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+        // Pinned header: the drag hint, reset action and live preview stay on screen while the
+        // action list scrolls underneath, so the preview always reflects the current arrangement.
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            // Header summary & Preview Card
-            item(key = "header_preview") {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.customization_drag_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                FilledIconButton(
+                    onClick = { showResetConfirmation = true },
+                    colors = IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    ),
+                    modifier = Modifier.size(36.dp)
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = stringResource(R.string.customization_drag_hint),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        FilledIconButton(
-                            onClick = { showResetConfirmation = true },
-                            colors = IconButtonDefaults.filledIconButtonColors(
-                                containerColor = MaterialTheme.colorScheme.primary,
-                                contentColor = MaterialTheme.colorScheme.onPrimary
-                            ),
-                            modifier = Modifier.size(36.dp)
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.settings_backup_restore),
-                                contentDescription = stringResource(R.string.reset_to_default),
-                                modifier = Modifier.size(18.dp)
-                            )
-                        }
-                    }
-
-                    // Live Preview Section
-                    ActionRowPreviewCard(
-                        actions = localActions.filterNot { it in hiddenActions }
+                    Icon(
+                        painter = painterResource(R.drawable.settings_backup_restore),
+                        contentDescription = stringResource(R.string.reset_to_default),
+                        modifier = Modifier.size(18.dp)
                     )
                 }
             }
 
+            // Live Preview Section
+            ActionRowPreviewCard(
+                actions = localActions.filterNot { it in hiddenActions }
+            )
+        }
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentPadding = PaddingValues(start = 24.dp, end = 24.dp, bottom = 48.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
             // Reorderable action items
             itemsIndexed(
                 items = localActions,

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/customization/ReorderableState.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/customization/ReorderableState.kt
@@ -3,7 +3,7 @@
 
 package com.valhalla.thor.presentation.settings.customization
 
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
@@ -12,19 +12,62 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlin.math.abs
+
+/** How close to a viewport edge the dragged card has to get before the list starts scrolling. */
+private val EdgeZone = 96.dp
+
+/** Auto-scroll speed at the very edge of the viewport, tapering to zero at the far side of [EdgeZone]. */
+private val MaxAutoScrollPerSecond = 600.dp
 
 /**
- * State holder for smooth, jitter-free drag-and-drop reordering in LazyColumn.
+ * How far the finger has to travel back the other way before the drag counts as having reversed.
+ *
+ * Pointer noise on a held finger arrives as alternating sub-pixel deltas; without a slop the
+ * auto-scroller would flip direction on it several times a second.
+ */
+private val DirectionFlipSlop = 8.dp
+
+/**
+ * Ceiling on the frame delta fed to the auto-scroller. Without it, a dropped frame or a moment
+ * spent off the frame clock turns into one large jump the next time the loop runs.
+ */
+private const val MAX_FRAME_SECONDS = 0.064f
+
+/**
+ * State holder for drag-and-drop reordering in a [androidx.compose.foundation.lazy.LazyColumn].
+ *
+ * The dragged row is moved with a `graphicsLayer` translation ([draggingItemOffset]) rather than by
+ * relayout: the list keeps its normal item order and the caller reorders the backing list as the
+ * card passes its neighbours. Two consequences fall out of that and drive most of this class:
+ *
+ * - The offset is measured from the row's *laid-out* slot, so anything that moves the slot has to be
+ *   absorbed into the offset or the card drifts away from the finger. Both the auto-scroller and the
+ *   reorder swap do that compensation explicitly.
+ * - Nothing here runs unless something calls in. Pointer events stop arriving the moment the finger
+ *   stops moving, which is precisely when a drag held against the edge of the screen most needs to
+ *   scroll — so auto-scroll runs off the frame clock for the life of the gesture instead of being
+ *   driven one step per pointer event.
  */
 class ReorderableLazyListState(
     val listState: LazyListState,
     private val scope: CoroutineScope,
+    density: Density,
+    private val haptics: HapticFeedback?,
     private val onMove: (fromKey: Any, toKey: Any) -> Unit,
     private val onDragCompleted: () -> Unit
 ) {
@@ -34,26 +77,103 @@ class ReorderableLazyListState(
     var draggingItemOffset by mutableFloatStateOf(0f)
         private set
 
-    private val scrollChannel = Channel<Float>(Channel.CONFLATED)
+    private val edgeZonePx = with(density) { EdgeZone.toPx() }
+    private val maxAutoScrollPxPerSecond = with(density) { MaxAutoScrollPerSecond.toPx() }
+    private val directionFlipSlopPx = with(density) { DirectionFlipSlop.toPx() }
 
-    init {
-        scope.launch {
-            while (true) {
-                val scrollAmount = scrollChannel.receive()
-                listState.scrollBy(scrollAmount)
-            }
-        }
-    }
+    /** Signed px/second. Recomputed whenever the card moves; zero while it is clear of both edges. */
+    private var autoScrollVelocity = 0f
+    private var autoScrollJob: Job? = null
+
+    /** Which way the finger is currently travelling: +1 down, -1 up, 0 before the first move. */
+    private var dragDirection = 0
+
+    /** Distance travelled against [dragDirection] since the last move that agreed with it. */
+    private var reversalDistance = 0f
+
+    /**
+     * Whether the gesture actually reordered anything. A press that crosses touch slop and settles
+     * back where it started should not spend a DataStore write, nor bounce the whole list through
+     * the caller's re-sync.
+     */
+    private var movedDuringGesture = false
 
     fun onDragStart(key: Any) {
         draggingItemKey = key
         draggingItemOffset = 0f
+        autoScrollVelocity = 0f
+        dragDirection = 0
+        reversalDistance = 0f
+        movedDuringGesture = false
+        haptics?.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
+        autoScrollJob?.cancel()
+        autoScrollJob = scope.launch { runAutoScroll() }
     }
 
     fun onDrag(dragAmount: Float) {
-        val key = draggingItemKey ?: return
+        if (draggingItemKey == null) return
+        trackDragDirection(dragAmount)
         draggingItemOffset += dragAmount
+        settleDropTarget()
+        updateAutoScrollVelocity()
+    }
 
+    fun onDragEnd() = finishDrag()
+
+    fun onDragCancel() = finishDrag()
+
+    private fun finishDrag() {
+        if (draggingItemKey == null) return
+        autoScrollJob?.cancel()
+        autoScrollJob = null
+        autoScrollVelocity = 0f
+        draggingItemKey = null
+        draggingItemOffset = 0f
+        haptics?.performHapticFeedback(HapticFeedbackType.GestureEnd)
+        if (movedDuringGesture) {
+            movedDuringGesture = false
+            onDragCompleted()
+        }
+    }
+
+    /**
+     * Scrolls the list while the dragged card sits in an edge zone, for as long as it sits there —
+     * a finger held still against the bottom of the screen keeps scrolling instead of stalling.
+     *
+     * Driven by the frame clock and scaled by the real frame delta so the speed is the same on a
+     * 60Hz and a 120Hz panel.
+     */
+    private suspend fun runAutoScroll() {
+        var previousFrame = withFrameNanos { it }
+        while (true) {
+            val frame = withFrameNanos { it }
+            val seconds = ((frame - previousFrame) / 1_000_000_000f).coerceIn(0f, MAX_FRAME_SECONDS)
+            previousFrame = frame
+
+            val velocity = autoScrollVelocity
+            if (velocity == 0f) continue
+
+            val consumed = listState.scrollBy(velocity * seconds)
+            // scrollBy moves the content, not the finger. Every visible item's offset shifts by
+            // -consumed, so without adding it back here the card slides out from under the touch
+            // point at exactly the speed the list is scrolling.
+            if (consumed == 0f) continue // an end of the list; nothing moved, nothing to absorb
+            draggingItemOffset += consumed
+            settleDropTarget()
+            updateAutoScrollVelocity()
+        }
+    }
+
+    /**
+     * Swaps the dragged row past the nearest neighbour whose midpoint it has crossed.
+     *
+     * One step per call rather than jumping straight to the furthest neighbour crossed: rows here
+     * are not a uniform height (a two-line description makes one taller than its neighbour), and
+     * the offset correction below — the gap between the two slots — is only exact for a single
+     * adjacent swap. Repeated calls converge on the same place without accumulating that error.
+     */
+    private fun settleDropTarget() {
+        val key = draggingItemKey ?: return
         val visibleItems = listState.layoutInfo.visibleItemsInfo
         val currentItem = visibleItems.firstOrNull { it.key == key } ?: return
         val currentCenter = currentItem.offset + (currentItem.size / 2f) + draggingItemOffset
@@ -72,41 +192,78 @@ class ReorderableLazyListState(
                     val otherCenter = other.offset + (other.size / 2f)
                     currentCenter < otherCenter
                 }
+        } ?: return
+
+        // The row is about to be laid out in the target's slot, so the same amount comes off the
+        // translation to leave it rendered where the finger currently holds it.
+        draggingItemOffset -= (targetItem.offset - currentItem.offset).toFloat()
+        movedDuringGesture = true
+        haptics?.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
+        onMove(key, targetItem.key)
+    }
+
+    /**
+     * Keeps [dragDirection] pointing the way the finger is travelling, ignoring reversals smaller
+     * than [DirectionFlipSlop]. A move that agrees with the current direction clears the counter, so
+     * the alternating sub-pixel deltas a still finger produces never accumulate into a flip.
+     */
+    private fun trackDragDirection(dragAmount: Float) {
+        val moveDirection = when {
+            dragAmount > 0f -> 1
+            dragAmount < 0f -> -1
+            else -> return
         }
-
-        if (targetItem != null) {
-            val delta = (targetItem.offset - currentItem.offset).toFloat()
-            draggingItemOffset -= delta
-            onMove(key, targetItem.key)
+        if (moveDirection == dragDirection) {
+            reversalDistance = 0f
+            return
         }
-
-        // Auto-scroll near edges
-        val viewportStart = listState.layoutInfo.viewportStartOffset
-        val viewportEnd = listState.layoutInfo.viewportEndOffset
-        val itemTop = currentItem.offset + draggingItemOffset
-        val itemBottom = itemTop + currentItem.size
-
-        val scrollStep = 24f
-        if (itemTop < viewportStart + 120f) {
-            scrollChannel.trySend(-scrollStep)
-        } else if (itemBottom > viewportEnd - 120f) {
-            scrollChannel.trySend(scrollStep)
+        reversalDistance += abs(dragAmount)
+        if (dragDirection == 0 || reversalDistance >= directionFlipSlopPx) {
+            dragDirection = moveDirection
+            reversalDistance = 0f
         }
     }
 
-    fun onDragEnd() {
-        if (draggingItemKey != null) {
-            draggingItemKey = null
-            draggingItemOffset = 0f
-            onDragCompleted()
+    /**
+     * Recomputes the auto-scroll speed from where the dragged card is *rendered* — its slot plus the
+     * live translation — rather than from where it was laid out, which is what the user sees and
+     * therefore what they are aiming at when they push toward an edge.
+     */
+    private fun updateAutoScrollVelocity() {
+        if (draggingItemKey == null) {
+            autoScrollVelocity = 0f
+            return
         }
-    }
+        val layoutInfo = listState.layoutInfo
+        // No entry means the card has been dragged clear off the viewport, which only happens with
+        // the finger already past the edge: hold the last velocity rather than stalling there.
+        val currentItem = layoutInfo.visibleItemsInfo
+            .firstOrNull { it.key == draggingItemKey } ?: return
 
-    fun onDragCancel() {
-        if (draggingItemKey != null) {
-            draggingItemKey = null
-            draggingItemOffset = 0f
-            onDragCompleted()
+        val zone = edgeZonePx
+            .coerceAtMost((layoutInfo.viewportEndOffset - layoutInfo.viewportStartOffset) / 3f)
+        if (zone <= 0f) {
+            autoScrollVelocity = 0f
+            return
+        }
+
+        val renderedTop = currentItem.offset + draggingItemOffset
+        val renderedBottom = renderedTop + currentItem.size
+        val pastBottom = renderedBottom - (layoutInfo.viewportEndOffset - zone)
+        val pastTop = (layoutInfo.viewportStartOffset + zone) - renderedTop
+
+        // Gated on the travel direction, not on the zone alone: a row that already sits in the
+        // bottom edge zone when it is grabbed would otherwise scroll the list *down* while the user
+        // drags it up, and with the scroller running off the frame clock that fight is continuous
+        // rather than one step per pointer event.
+        autoScrollVelocity = when {
+            pastBottom > 0f && dragDirection > 0 ->
+                (pastBottom / zone).coerceAtMost(1f) * maxAutoScrollPxPerSecond
+
+            pastTop > 0f && dragDirection < 0 ->
+                -(pastTop / zone).coerceAtMost(1f) * maxAutoScrollPxPerSecond
+
+            else -> 0f
         }
     }
 }
@@ -118,27 +275,44 @@ fun rememberReorderableLazyListState(
     onDragCompleted: () -> Unit
 ): ReorderableLazyListState {
     val scope = rememberCoroutineScope()
-    return remember(listState) {
+    val density = LocalDensity.current
+    val haptics = LocalHapticFeedback.current
+
+    // The state holder outlives any single composition, so it must not close over the callbacks it
+    // was created with — those are re-created every recomposition and the originals go stale the
+    // moment a caller's lambda captures something that changes.
+    val currentOnMove by rememberUpdatedState(onMove)
+    val currentOnDragCompleted by rememberUpdatedState(onDragCompleted)
+
+    return remember(listState, scope, density, haptics) {
         ReorderableLazyListState(
             listState = listState,
             scope = scope,
-            onMove = onMove,
-            onDragCompleted = onDragCompleted
+            density = density,
+            haptics = haptics,
+            onMove = { fromKey, toKey -> currentOnMove(fromKey, toKey) },
+            onDragCompleted = { currentOnDragCompleted() }
         )
     }
 }
 
+/**
+ * Marks a composable as the grab point for reordering [key].
+ *
+ * Vertical-only detection: the list scrolls on one axis and the drag follows one axis, so claiming
+ * a horizontal swipe would consume a gesture this handle cannot act on.
+ */
 fun Modifier.dragHandle(
     key: Any,
     state: ReorderableLazyListState
 ): Modifier = pointerInput(key, state) {
-    detectDragGestures(
+    detectVerticalDragGestures(
         onDragStart = { state.onDragStart(key) },
         onDragEnd = { state.onDragEnd() },
         onDragCancel = { state.onDragCancel() },
-        onDrag = { change, dragAmount ->
+        onVerticalDrag = { change, dragAmount ->
             change.consume()
-            state.onDrag(dragAmount.y)
+            state.onDrag(dragAmount)
         }
     )
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Thor! -->

## What & why

Users asked for the live preview on the AppInfo actions customization screen to stay visible while
they rearrange actions.

The drag hint, the reset button and `ActionRowPreviewCard` were the **first item of the
`LazyColumn`** (`item(key = "header_preview")`), so they scrolled off the top as soon as the user
reached the actions further down the list — exactly the moment the preview is most useful, since
that's when you're moving something and want to see where it lands.

Pinning the preview turned out to be the small half. Once the screen was actually being used for
its whole length, the reorder implementation underneath it did not hold up, so this PR also carries
a pass over the drag-and-drop, the Move buttons, the accessibility surface and the header's
measurement contract.

## Changes

### Sticky preview

- Lifted the whole header block (hint text + reset button + live preview) out of the `LazyColumn`
  and into the parent `Column`, so it is pinned between `SettingsTopBar` and the scrolling list.
- Moved the header's horizontal padding out of the list's `contentPadding` onto the pinned block,
  and gave the `LazyColumn` `weight(1f)` so it takes exactly the remaining space.
- **Fixes a latent reorder bug as a side effect.** `ReorderableLazyListState.onDrag` picks a drop
  target from `listState.layoutInfo.visibleItemsInfo`, filtered only by list index. While the header
  was a list item, dragging a row *upwards* past it called `onMove(key, "header_preview")`, which
  resolved to `indexOfFirst { it.name == toKey } == -1` and silently dropped the reorder — while
  still consuming the drag offset via `draggingItemOffset -= delta`, so the row visually snapped
  without actually moving. The header is no longer a list item, so it can't be targeted.

### Drag and drop (`ReorderableState.kt`)

- **Auto-scroll near the edges never actually scrolled.** It was a one-shot conflated `Channel`
  drained once per drag event, so holding a row still against the edge scrolled nothing, and the
  list only crept forward while the finger kept moving. Replaced with a frame-clock loop driven by
  `withFrameNanos`, scaled by the frame delta so the speed is identical at 60 and 120 Hz.
- **The card slid out from under the finger while auto-scrolling.** `scrollBy` moves the content,
  not the touch point — every visible item's offset shifts by `-consumed`. The consumed distance is
  now added back into `draggingItemOffset`.
- **Auto-scroll is gated on drag direction**, with 8dp of hysteresis before a reversal counts.
  Without the gate, grabbing a row that is already inside the bottom edge zone and dragging it *up*
  scrolls the list *down* forever, fighting the user. Gating on the sign of `draggingItemOffset`
  instead would stutter roughly half the time, since each swap resets that offset toward zero.
- Switched to `detectVerticalDragGestures`, so the drag no longer competes with horizontal gestures.
- Haptics: a threshold tick when the drag starts, a frequent tick on each swap, a gesture-end tick
  on drop. `onDragCompleted` only fires if the gesture actually moved something.

### Screen (`AppInfoActionsCustomizationScreen.kt`)

- **`PinnedHeaderScaffold`.** The pinned header is unweighted, and a `Column` measures an unweighted
  child against whatever height is left — so a header that outgrows the viewport (landscape on a
  short screen, or a display/font scale that wraps the hint and stretches the preview chips) is
  handed the whole height and the weighted `LazyColumn` is measured at **zero**, with no scroll
  anywhere to recover it. The new scaffold caps the header at half the available height and lets it
  scroll inside that cap. A header that fits — the normal case — is untouched and does not scroll.
  (Raised by CodeRabbit on this PR; verified against the code and real.)
- **Move up/down always render**, disabled at the ends rather than vanishing, so a row's controls
  stop shifting sideways as you scroll past the first and last entries. They are stacked vertically,
  which is 32dp wide instead of 66dp side-by-side and hands the labels 34dp back on a 411dp phone —
  the second arrow is now always present *and* there is more room for text than before.
- **Move up/down scrolls the moved row back into view.** Holding Move down used to walk the row
  clean off the bottom edge, so you lost sight of the thing you were moving.
- The local order list is seeded from the current order at first composition, killing a one-frame
  "All actions are hidden" flash in the preview on entry.
- The re-sync `LaunchedEffect` no longer clobbers an in-flight drag.
- The dragged row is excluded from `animateItem()`: it is placed by hand through the `graphicsLayer`
  translation and the swap already subtracts the slot change from that offset, so animating the same
  move a second time made the card lurch under the finger on every reorder.
- **Accessibility.** The preview row is a single node reading the whole action order, instead of 16
  unlabelled icons; the drag handle no longer announces itself twice; the visibility `Switch` now
  carries the action's name rather than a bare "on/off".
- Hidden actions dim their glyph and labels, instead of the switch position being the only signal.

**No new string resources** anywhere in this PR, so no locale coupling.

No behaviour change to ordering semantics, persistence or the reset dialog.

## Testing

- [x] `./gradlew compileFossDebugKotlin` — BUILD SUCCESSFUL, no new warnings (only the two
      pre-existing ones: Koin compiler-plugin version notice, deprecated
      `rememberModalBottomSheetState` in `BackupRestoreHubScreen.kt`).
- [x] `./gradlew lintStoreRelease` — BUILD SUCCESSFUL, 0 errors / 0 warnings.
- [x] `./gradlew testFossDebugUnitTest --rerun-tasks` — 1609 tests, 0 failures, 0 errors, 0 skipped
      (counts parsed from `build/test-results/**/*.xml`, not the log line).
- [x] `./gradlew assembleFossDebugAndroidTest` — compiles.
- [x] **Sticky preview verified on a physical device** (Xiaomi `25053PC47G`, Android 16) — confirmed
      working by the maintainer.
- [ ] `PinnedHeaderScaffoldTest` **has not been executed.** It compiles, but the attached device
      rejects the test APK with `INSTALL_FAILED_USER_RESTRICTED` (HyperOS "Install via USB"), and
      CI does not run `connectedAndroidTest`. The four cases it covers — header that fits, header
      taller than the viewport, `fontScale = 2f`, and a short landscape viewport — are therefore
      *asserted in code but unproven at runtime*.
- [ ] The drag-and-drop rework itself has **not** been re-verified on device since the changes
      above; the device confirmation covers the sticky preview commit (`43630a15`) only.

## Screenshots

Not captured.

## Checklist

- [x] Changes are scoped to the stated purpose (no unrelated edits) — the customization screen, its
      reorder state, and one test for the layout invariant
- [x] Bumped `versionCode` in `gradle.properties` **if** this PR is release-bound — N/A, not
      release-bound
- [x] Updated docs / release notes if user-facing — N/A, no doc surface describes this screen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the customization screen layout so the drag hint, reset control, and live preview remain fixed above the reorderable action list.
  * Improved list presentation by separating controls and preview content from the scrolling area.
  * Added clearer move controls with boundary-aware behavior, haptic feedback, and automatic scrolling during reordering.
  * Improved accessibility with explicit control labels, clearer action-order descriptions, and visual dimming for hidden actions.
  * Enhanced drag-and-drop behavior for smoother scrolling and more predictable item movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->