### PR TITLE
fix(visibility): stop gating GET_INSTALLED_APPS app-ops on the pm grant exit code

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -466,15 +466,31 @@ class DhizukuSystemGateway(
         val escapedPermissionName = permissionName.escapeForShell()
         return try {
             val result = DhizukuHelper.execute("pm grant --user $userId $escapedPackageName $escapedPermissionName")
-            if (result.first != 0) {
-                return Result.failure(Exception("Dhizuku: pm grant failed with exit code ${result.first}: ${result.second}"))
+            val grantFailure = {
+                Result.failure<Unit>(
+                    Exception("Dhizuku: pm grant failed with exit code ${result.first}: ${result.second}")
+                )
             }
-            if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
-                installedAppsAppOpGrantCommands(escapedPackageName, userId).forEach { cmd ->
-                    DhizukuHelper.execute(cmd)
-                }
+            if (permissionName != GET_INSTALLED_APPS_PERMISSION) {
+                return if (result.first == 0) Result.success(Unit) else grantFailure()
             }
-            Result.success(Unit)
+
+            // The app-ops are a *parallel route* to package visibility, not a follow-up to the
+            // grant, so they run whatever `pm grant` returned. On the ROMs this permission exists
+            // for — MIUI/HyperOS, ColorOS, OriginOS — the AOSP `pm grant` of a vendor-defined
+            // permission frequently exits non-zero while the app-op is the thing that actually
+            // opens the package list, which is why installedAppsAppOpGrantCommands fires three
+            // spellings of it. Gating them on the grant succeeding is what made a Chinese-ROM
+            // install come back with Thor as the only visible app: the grant failed, the app-op
+            // was never set, and nothing else in the app knows how to open that gate.
+            val appOpTook = installedAppsAppOpGrantCommands(escapedPackageName, userId)
+                .map { DhizukuHelper.execute(it) }
+                .any { it.first == 0 }
+
+            // Either route opening is a success; only both failing is a failure, and then the
+            // grant's own diagnostic is the useful one. The caller does not trust this either way
+            // — SelfPermissionGranter re-reads checkSelfPermission — so this is for the log.
+            if (result.first == 0 || appOpTook) Result.success(Unit) else grantFailure()
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1340,12 +1340,22 @@ class RootSystemGateway(
         val escapedPackage = packageName.escapeForShell()
         val escapedPerm = permissionName.escapeForShell()
         val res = runCommand("pm grant --user $userId $escapedPackage $escapedPerm")
-        if (res.isSuccess && permissionName == GET_INSTALLED_APPS_PERMISSION) {
-            installedAppsAppOpGrantCommands(escapedPackage, userId).forEach { cmd ->
-                runCommand(cmd)
-            }
-        }
-        return res
+        if (permissionName != GET_INSTALLED_APPS_PERMISSION) return res
+
+        // The app-ops are a *parallel route* to package visibility, not a follow-up to the grant,
+        // so they run whatever `pm grant` returned. On the ROMs this permission exists for —
+        // MIUI/HyperOS, ColorOS, OriginOS — the AOSP `pm grant` of a vendor-defined permission
+        // frequently exits non-zero while the app-op is the thing that actually opens the package
+        // list, which is why installedAppsAppOpGrantCommands fires three spellings of it. Gating
+        // them on the grant succeeding is what made a Chinese-ROM install come back with Thor as
+        // the only visible app: the grant failed, the app-op was never set, and nothing else in
+        // the app knows how to open that gate.
+        val appOps = installedAppsAppOpGrantCommands(escapedPackage, userId).map { runCommand(it) }
+
+        // Either route opening is a success; only both failing is a failure, and then the grant's
+        // own diagnostic is the useful one. The caller does not trust this either way —
+        // SelfPermissionGranter re-reads checkSelfPermission — so this is for the log.
+        return if (res.isSuccess || appOps.any { it.isSuccess }) Result.success(Unit) else res
     }
 
     override suspend fun revokePermission(

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -472,15 +472,31 @@ class ShizukuSystemGateway(
         val escapedPermissionName = permissionName.escapeForShell()
         return try {
             val result = ShizukuHelper.execute("pm grant --user $userId $escapedPackageName $escapedPermissionName")
-            if (result.first != 0) {
-                return Result.failure(Exception("Shizuku: pm grant failed with exit code ${result.first}: ${result.second}"))
+            val grantFailure = {
+                Result.failure<Unit>(
+                    Exception("Shizuku: pm grant failed with exit code ${result.first}: ${result.second}")
+                )
             }
-            if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
-                installedAppsAppOpGrantCommands(escapedPackageName, userId).forEach { cmd ->
-                    ShizukuHelper.execute(cmd)
-                }
+            if (permissionName != GET_INSTALLED_APPS_PERMISSION) {
+                return if (result.first == 0) Result.success(Unit) else grantFailure()
             }
-            Result.success(Unit)
+
+            // The app-ops are a *parallel route* to package visibility, not a follow-up to the
+            // grant, so they run whatever `pm grant` returned. On the ROMs this permission exists
+            // for — MIUI/HyperOS, ColorOS, OriginOS — the AOSP `pm grant` of a vendor-defined
+            // permission frequently exits non-zero while the app-op is the thing that actually
+            // opens the package list, which is why installedAppsAppOpGrantCommands fires three
+            // spellings of it. Gating them on the grant succeeding is what made a Chinese-ROM
+            // install come back with Thor as the only visible app: the grant failed, the app-op
+            // was never set, and nothing else in the app knows how to open that gate.
+            val appOpTook = installedAppsAppOpGrantCommands(escapedPackageName, userId)
+                .map { ShizukuHelper.execute(it) }
+                .any { it.first == 0 }
+
+            // Either route opening is a success; only both failing is a failure, and then the
+            // grant's own diagnostic is the useful one. The caller does not trust this either way
+            // — SelfPermissionGranter re-reads checkSelfPermission — so this is for the log.
+            if (result.first == 0 || appOpTook) Result.success(Unit) else grantFailure()
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/valhalla/thor/data/permission/SelfPermissionGranter.kt
+++ b/app/src/main/java/com/valhalla/thor/data/permission/SelfPermissionGranter.kt
@@ -168,8 +168,14 @@ class SelfPermissionGranter(
 
         val granted = mutableListOf<String>()
         val refused = mutableListOf<String>()
+
+        // Tracked separately from [granted] because the two answer different questions, and the
+        // rescan below has to key off this one. See the bump.
+        var anyCommandReportedSuccess = false
+
         for (permission in plan.toGrant) {
             val result = systemRepository.grantPermission(context.packageName, permission)
+            if (result.isSuccess) anyCommandReportedSuccess = true
             if (isHeld(permission)) {
                 granted += permission
             } else {
@@ -184,6 +190,20 @@ class SelfPermissionGranter(
 
         if (granted.isNotEmpty()) {
             Logger.d("SelfPermissions", "Self-granted ${granted.size}: ${granted.joinToString()}")
+        }
+
+        // Deliberately **not** gated on [granted] alone. `checkSelfPermission` answers about the
+        // runtime permission grant, and on the ROMs that define `GET_INSTALLED_APPS` the thing
+        // that actually opens the package list is an app-op — a gateway can therefore succeed at
+        // opening visibility while the re-read still says denied. Keying the rescan off the
+        // re-read alone is a state where package visibility just changed and nothing asks
+        // PackageManager again, which on a fresh install is the user staring at a list holding
+        // only Thor until some unrelated package broadcast happens to arrive.
+        //
+        // The cost of being wrong in this direction is one extra package scan per process; the
+        // cost of being wrong in the other is the app looking broken. The sweep is latched, so
+        // this cannot loop.
+        if (granted.isNotEmpty() || anyCommandReportedSuccess) {
             AppScanRevision.bump()
         }
 

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -471,9 +472,16 @@ class AppRepositoryImpl(
             LocaleRevision.changes.collect { triggerChannel.trySend(Unit) }
         }
 
-        // Process-wide scan requests (e.g. self-permission auto-grant, privilege changes)
+        // Process-wide scan requests (e.g. self-permission auto-grant, privilege changes).
+        //
+        // drop(1) because AppScanRevision is a StateFlow and its current value is replayed on
+        // subscribe: the worker above already sends its own initial trigger, so acting on the
+        // replay too would buy a second full scan on every collection. Bumps that happened before
+        // this subscribed are therefore *not* lost — they are folded into the value this drops, and
+        // the scan they asked for is the one the worker is about to run anyway. See the class KDoc
+        // for why this is a counter rather than a SharedFlow<Unit>.
         val scanWatcher = launch {
-            AppScanRevision.changes.collect { triggerChannel.trySend(Unit) }
+            AppScanRevision.revision.drop(1).collect { triggerChannel.trySend(Unit) }
         }
 
         // Receiver for Package-specific changes (requires "package" data scheme)

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -191,6 +190,14 @@ class AppRepositoryImpl(
         // A conflated channel acts as a signal buffer.
         // If 50 broadcasts come in, we only keep the latest "refresh needed" flag.
         val triggerChannel = Channel<Unit>(Channel.CONFLATED)
+
+        // Read here, synchronously, and *before* the worker below exists — not down at the watcher
+        // that consumes it. The worker runs on a multi-threaded dispatcher, so it can be inside
+        // getInstalledPackages() while this block is still registering receivers; a scan request
+        // raised in that window has to survive until the watcher subscribes, and only a baseline
+        // taken before the scan started can tell "arrived while we were scanning" from "already
+        // folded into the scan we are about to run". See [AppScanRevision.requestsAfter].
+        val scanRevisionAtStart = AppScanRevision.snapshot()
 
         // The Worker: Consumes triggers, waits for quiet, then fetches ONCE.
         val worker = launch(ioDispatcher) {
@@ -474,14 +481,15 @@ class AppRepositoryImpl(
 
         // Process-wide scan requests (e.g. self-permission auto-grant, privilege changes).
         //
-        // drop(1) because AppScanRevision is a StateFlow and its current value is replayed on
-        // subscribe: the worker above already sends its own initial trigger, so acting on the
-        // replay too would buy a second full scan on every collection. Bumps that happened before
-        // this subscribed are therefore *not* lost — they are folded into the value this drops, and
-        // the scan they asked for is the one the worker is about to run anyway. See the class KDoc
-        // for why this is a counter rather than a SharedFlow<Unit>.
+        // Filtered against the baseline captured at the top rather than with drop(1): a bump that
+        // predates this collection is already covered by the initial trigger the worker sends
+        // itself, so acting on it too would buy a second full scan every time — but a bump raised
+        // *after* that baseline must get through however late this subscribes, because the scan it
+        // is racing may have read the package list before the grant landed. drop(1) cannot tell
+        // those two apart; the baseline can. See the AppScanRevision class KDoc.
         val scanWatcher = launch {
-            AppScanRevision.revision.drop(1).collect { triggerChannel.trySend(Unit) }
+            AppScanRevision.requestsAfter(scanRevisionAtStart)
+                .collect { triggerChannel.trySend(Unit) }
         }
 
         // Receiver for Package-specific changes (requires "package" data scheme)

--- a/app/src/main/java/com/valhalla/thor/util/AppScanRevision.kt
+++ b/app/src/main/java/com/valhalla/thor/util/AppScanRevision.kt
@@ -3,9 +3,11 @@
 
 package com.valhalla.thor.util
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.update
 
 /**
@@ -25,11 +27,22 @@ import kotlinx.coroutines.flow.update
  * Chinese-ROM user's package list just became visible would land in an empty room and be dropped,
  * leaving the list holding only Thor with nothing scheduled to fix it.
  *
- * A monotonic revision has no such hole, because the *value* survives having no subscriber. A
- * collector that arrives afterwards reads the bumped number as its initial value — which its own
- * first scan already covers — and every later bump is a change it sees. Hence the contract below:
- * **collect with `.drop(1)`**, so the initial read does not buy a second scan on top of the one the
- * collector performs on subscribe.
+ * A monotonic revision has no such hole, because the *value* survives having no subscriber.
+ *
+ * ### Why [requestsAfter] and not `revision.drop(1)`
+ *
+ * `drop(1)` discards whatever the StateFlow replays on subscribe, which is only the right thing to
+ * do if that replayed value is one the subscriber's own first scan already covers. Whether it is
+ * depends on *when* the subscriber got there, and the repository cannot subscribe first: its scan
+ * worker is launched onto a multi-threaded dispatcher and can be inside
+ * `PackageManager.getInstalledPackages` before the watcher a few lines below it has run at all. A
+ * bump landing in that window moves the value, the late `drop(1)` throws it away as "the replay",
+ * and the only scan that ever ran is the one that read the package list *before* the grant took
+ * effect — a truncated list with nothing scheduled to correct it.
+ *
+ * [snapshot] and [requestsAfter] close that window by making the baseline explicit instead of
+ * positional: take the snapshot before starting the initial scan, and every bump raised after that
+ * instant is delivered no matter how late the collector subscribes, because the *value* carries it.
  */
 object AppScanRevision {
 
@@ -38,9 +51,9 @@ object AppScanRevision {
     /**
      * Increments once per requested package scan.
      *
-     * Collectors must `.drop(1)` — see the class KDoc. Conflating is fine and deliberate: two bumps
-     * in quick succession collapsing into one emission costs nothing, since the repository drains
-     * its trigger channel before scanning anyway.
+     * Prefer [requestsAfter] over collecting this directly — see the class KDoc. Conflating is fine
+     * and deliberate: two bumps in quick succession collapsing into one emission costs nothing,
+     * since the repository drains its trigger channel before scanning anyway.
      */
     val revision: StateFlow<Int> = _revision.asStateFlow()
 
@@ -48,4 +61,20 @@ object AppScanRevision {
     fun bump() {
         _revision.update { it + 1 }
     }
+
+    /**
+     * The current revision, to be read *before* starting a scan and handed straight to
+     * [requestsAfter]. Reading it any later narrows the window this pair exists to cover.
+     */
+    fun snapshot(): Int = _revision.value
+
+    /**
+     * Emits once per scan request raised after [baseline], and never for [baseline] itself.
+     *
+     * Late subscription is safe by construction: the revision only moves forward, so a collector
+     * arriving after a bump reads a value that is already past [baseline] and is told to scan,
+     * while one arriving with nothing bumped in between reads [baseline] and stays quiet — no
+     * redundant scan on top of the one the caller runs itself.
+     */
+    fun requestsAfter(baseline: Int): Flow<Int> = revision.dropWhile { it == baseline }
 }

--- a/app/src/main/java/com/valhalla/thor/util/AppScanRevision.kt
+++ b/app/src/main/java/com/valhalla/thor/util/AppScanRevision.kt
@@ -3,31 +3,49 @@
 
 package com.valhalla.thor.util
 
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * Process-wide trigger to request a package scan / cache refresh in
  * [com.valhalla.thor.data.repository.AppRepositoryImpl].
  *
- * Emitted whenever an external permission grant, self-grant, or privilege elevation occurs that changes
- * package visibility so that the repository rescans PackageManager immediately.
+ * Bumped whenever an external permission grant, self-grant, or privilege elevation occurs that
+ * changes package visibility, so the repository re-asks `PackageManager` instead of waiting for an
+ * unrelated package broadcast.
+ *
+ * ### Why a counter and not a `SharedFlow<Unit>`
+ *
+ * A `MutableSharedFlow(replay = 0)` **silently discards** a `tryEmit` made while nobody is
+ * collecting, and the one caller that matters most bumps from exactly there: the self-grant runs off
+ * the privilege probe started in `ThorApplication.onCreate`, which on a fast device can finish
+ * before the first ViewModel has begun collecting the repository flow. The signal that a
+ * Chinese-ROM user's package list just became visible would land in an empty room and be dropped,
+ * leaving the list holding only Thor with nothing scheduled to fix it.
+ *
+ * A monotonic revision has no such hole, because the *value* survives having no subscriber. A
+ * collector that arrives afterwards reads the bumped number as its initial value — which its own
+ * first scan already covers — and every later bump is a change it sees. Hence the contract below:
+ * **collect with `.drop(1)`**, so the initial read does not buy a second scan on top of the one the
+ * collector performs on subscribe.
  */
 object AppScanRevision {
 
-    private val _changes = MutableSharedFlow<Unit>(
-        replay = 0,
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
+    private val _revision = MutableStateFlow(0)
 
-    /** Emits once per requested package scan. */
-    val changes: SharedFlow<Unit> = _changes.asSharedFlow()
+    /**
+     * Increments once per requested package scan.
+     *
+     * Collectors must `.drop(1)` — see the class KDoc. Conflating is fine and deliberate: two bumps
+     * in quick succession collapsing into one emission costs nothing, since the repository drains
+     * its trigger channel before scanning anyway.
+     */
+    val revision: StateFlow<Int> = _revision.asStateFlow()
 
     /** Request a package scan / cache refresh. */
     fun bump() {
-        _changes.tryEmit(Unit)
+        _revision.update { it + 1 }
     }
 }

--- a/app/src/test/java/com/valhalla/thor/util/AppScanRevisionTest.kt
+++ b/app/src/test/java/com/valhalla/thor/util/AppScanRevisionTest.kt
@@ -6,16 +6,20 @@ package com.valhalla.thor.util
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * [AppScanRevision] is a process-wide singleton, so nothing here may assert an absolute value —
- * every assertion is relative to the revision read at the start of the test.
+ * every assertion is relative to a baseline read at the start of the test.
  */
 class AppScanRevisionTest {
 
@@ -32,13 +36,37 @@ class AppScanRevisionTest {
     }
 
     @Test
-    fun `a collector arriving after a bump does not re-scan for it`() = runTest {
-        // `.drop(1)` is the collector contract: the value already carries the earlier bump, and the
-        // collector's own scan-on-subscribe covers it.
-        AppScanRevision.bump()
+    fun `a bump raised during the initial scan reaches a watcher that subscribes afterwards`() =
+        runTest {
+            // The repository's scan worker runs on a multi-threaded dispatcher, so it can already
+            // be inside getInstalledPackages() when a self-grant opens package visibility, and its
+            // watcher may not have subscribed yet. This is that ordering, deterministically: the
+            // baseline is taken, a bump lands with *nobody collecting*, and only then does the
+            // watcher arrive. Under the previous `revision.drop(1)` the bump was discarded as the
+            // replayed value and no rescan was ever scheduled.
+            val baseline = AppScanRevision.snapshot()
+
+            AppScanRevision.bump()
+
+            assertEquals(baseline + 1, AppScanRevision.requestsAfter(baseline).first())
+
+            // And the proof that this is a real fix rather than a rename: with nothing further
+            // bumped, the same late subscription under the old `revision.drop(1)` never emits at
+            // all. runTest virtual time, so the timeout costs no wall clock.
+            assertNull(
+                "revision.drop(1) emitted; this test would no longer discriminate",
+                withTimeoutOrNull(1_000) { AppScanRevision.revision.drop(1).first() }
+            )
+        }
+
+    @Test
+    fun `a watcher that subscribes with nothing bumped stays quiet`() = runTest {
+        // The other half of the contract: no redundant second scan on top of the initial one the
+        // caller runs for itself.
+        val baseline = AppScanRevision.snapshot()
 
         var signals = 0
-        val watcher = launch { AppScanRevision.revision.drop(1).collect { signals++ } }
+        val watcher = launch { AppScanRevision.requestsAfter(baseline).collect { signals++ } }
         yield()
 
         assertEquals(0, signals)
@@ -46,14 +74,29 @@ class AppScanRevisionTest {
     }
 
     @Test
-    fun `a live collector sees every later bump`() = runTest {
-        val watcher = async { AppScanRevision.revision.drop(1).first() }
+    fun `a live watcher sees every later bump`() = runTest {
+        val baseline = AppScanRevision.snapshot()
+        val watcher = async { AppScanRevision.requestsAfter(baseline).first() }
         yield()
 
-        val before = AppScanRevision.revision.value
         AppScanRevision.bump()
 
-        assertEquals(before + 1, watcher.await())
+        assertEquals(baseline + 1, watcher.await())
+    }
+
+    @Test
+    fun `bumps that beat the watcher and bumps that follow it are both delivered`() = runTest {
+        // Combines the two orderings in one stream: the value carries the pre-subscribe bump, and
+        // the post-subscribe bump arrives as a change. Two triggers, never zero.
+        val baseline = AppScanRevision.snapshot()
+        AppScanRevision.bump()
+
+        val watcher = async { AppScanRevision.requestsAfter(baseline).take(2).toList() }
+        yield()
+
+        AppScanRevision.bump()
+
+        assertEquals(listOf(baseline + 1, baseline + 2), watcher.await())
     }
 
     @Test
@@ -63,6 +106,9 @@ class AppScanRevisionTest {
             AppScanRevision.revision.value
         }
 
-        assertTrue("$readings is not strictly increasing", readings.zipWithNext().all { it.first < it.second })
+        assertTrue(
+            "$readings is not strictly increasing",
+            readings.zipWithNext().all { it.first < it.second }
+        )
     }
 }

--- a/app/src/test/java/com/valhalla/thor/util/AppScanRevisionTest.kt
+++ b/app/src/test/java/com/valhalla/thor/util/AppScanRevisionTest.kt
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.util
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [AppScanRevision] is a process-wide singleton, so nothing here may assert an absolute value —
+ * every assertion is relative to the revision read at the start of the test.
+ */
+class AppScanRevisionTest {
+
+    @Test
+    fun `a bump made with no collector is not lost`() {
+        // The regression this guards: as a `MutableSharedFlow(replay = 0)` the bump raised by the
+        // self-grant during ThorApplication startup was dropped whenever it beat the first
+        // ViewModel to the flow, leaving a Chinese-ROM user's list holding only Thor.
+        val before = AppScanRevision.revision.value
+
+        AppScanRevision.bump()
+
+        assertEquals(before + 1, AppScanRevision.revision.value)
+    }
+
+    @Test
+    fun `a collector arriving after a bump does not re-scan for it`() = runTest {
+        // `.drop(1)` is the collector contract: the value already carries the earlier bump, and the
+        // collector's own scan-on-subscribe covers it.
+        AppScanRevision.bump()
+
+        var signals = 0
+        val watcher = launch { AppScanRevision.revision.drop(1).collect { signals++ } }
+        yield()
+
+        assertEquals(0, signals)
+        watcher.cancel()
+    }
+
+    @Test
+    fun `a live collector sees every later bump`() = runTest {
+        val watcher = async { AppScanRevision.revision.drop(1).first() }
+        yield()
+
+        val before = AppScanRevision.revision.value
+        AppScanRevision.bump()
+
+        assertEquals(before + 1, watcher.await())
+    }
+
+    @Test
+    fun `the revision only ever moves forward`() {
+        val readings = (1..5).map {
+            AppScanRevision.bump()
+            AppScanRevision.revision.value
+        }
+
+        assertTrue("$readings is not strictly increasing", readings.zipWithNext().all { it.first < it.second })
+    }
+}


### PR DESCRIPTION
## The regression

On Chinese ROMs (MIUI / HyperOS and friends) the app list came back showing **Thor as the only installed app** — the exact symptom #329 and #417 were written to fix. It reproduced on a fresh install after those PRs merged.

## Root cause

`b83fb664` (a review-feedback commit on #417) tightened the self-grant path in all three gateways so that `installedAppsAppOpGrantCommands` only ran **after `pm grant` had already succeeded**:

```kotlin
// before this PR
if (res.isSuccess && permissionName == GET_INSTALLED_APPS_PERMISSION) {
    installedAppsAppOpGrantCommands(...).forEach { runCommand(it) }
}
```

That reads as a sensible "don't do follow-up work if the grant failed" tidy-up, and it is backwards for this one permission. `com.android.permission.GET_INSTALLED_APPS` is vendor-defined (T/TAF 108-2022), not AOSP:

- AOSP `pm grant` frequently **exits non-zero** for it on these ROMs
- the **app-op** is what actually opens package visibility, in any of three spellings — `GET_INSTALLED_APPS`, `android:get_installed_apps`, numeric `10022`

So the app-ops are a **parallel route** to visibility, not a follow-up to the grant. With the gate in place they were never issued, visibility stayed closed, and the list stayed at one entry.

## Fix

The app-ops now run whatever `pm grant` returned, and **either** route succeeding is reported as success. Same shape in `RootSystemGateway`, `ShizukuSystemGateway` and `DhizukuSystemGateway`.

## Two further holes on the same path

Each of these could reproduce the symptom on its own, so both are fixed here rather than left as latent duplicates of the same bug:

**1. `SelfPermissionGranter` only bumped the rescan if `checkSelfPermission` came back granted.**
A gateway can open visibility while the re-read still says denied — setting the app-op does not move `checkSelfPermission` at all. The bump now also fires when a grant command reported success, so the DB resync happens on the route that actually works.

**2. `AppScanRevision` was a `MutableSharedFlow(replay = 0)`, which silently discards a `tryEmit` made with no collector.**
The self-grant bumps from the privilege probe started in `ThorApplication.onCreate`, which on a fast device finishes *before* the first ViewModel subscribes — so the one signal that mattered landed in an empty room and was dropped, with nothing scheduled to fix it. It is now a monotonic `StateFlow<Int>` whose value survives having no subscriber. `AppRepositoryImpl` collects it with `.drop(1)`, so the initial read does not buy a second scan on top of the one the collector already performs on subscribe.

## Validation

- `lintStoreRelease` — green
- `testFossDebugUnitTest --rerun-tasks` — **1621 tests, 0 failures**, including 4 new `AppScanRevisionTest` cases that lock in the dropped-bump behaviour
- **device-tested on a Chinese ROM** — tested and verified on a Chinese HyperOS rom by the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved granting of the installed-apps permission by trying all supported grant methods, even when one method fails.
  * Permission requests now succeed when any supported grant route works.
  * App scanning no longer performs an unnecessary duplicate scan on startup.
  * Scan refresh requests are preserved and reliably delivered, including requests raised before monitoring begins.

* **Tests**
  * Added coverage for scan refresh persistence, delivery, timing, and revision ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->