### PR TITLE
fix: post-release review findings from v1.94.4-dev-26 onwards

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/backup/ArchiveOrphanSweeper.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/ArchiveOrphanSweeper.kt
@@ -17,9 +17,11 @@ import java.io.File
  * §10's launch sweep, plus §8.5's interruption report.
  *
  * Five things get cleaned, by three different rules:
- * 1. **Thor's own staging directory** under `cacheDir` — emptied wholesale. Nothing but staged tars
- *    and staged bundles is ever written there, and the Odin shell dies with the process, so anything
- *    surviving a restart is garbage.
+ * 1. **Thor's own staging directory** under `cacheDir` *and* under `externalCacheDir` — emptied
+ *    wholesale. Which of the two the gateway used is a runtime decision it makes per call (see
+ *    [sweepStaging]), so both are swept unconditionally. Nothing but staged tars and staged bundles
+ *    is ever written there, and the Odin shell dies with the process, so anything surviving a
+ *    restart is garbage.
  * 2. **The bundle build tree** `ArchiveBackupWorker` hands to `AppBundleBuilder` — also emptied
  *    wholesale, and for the same reason. Not in the plan's list of three; see the class KDoc on
  *    [ArchiveBundleCacheDir]. The worker deletes only the `.xapk` it was handed back, so a kill
@@ -55,8 +57,9 @@ import java.io.File
  * `compileSafety` turns into a build failure. Bound by a `@Single` function in `di/Modules.kt`.
  *
  * @param externalCacheDir nullable, because `Context.getExternalCacheDir()` is: external storage can
- *   be unmounted or unavailable at launch. Null means target 3 is skipped — the builder could not have
- *   staged anything there either, since it reads the same nullable value.
+ *   be unmounted or unavailable at launch. Null means the external halves of targets 1 and 3 are
+ *   skipped — neither the builder nor the gateway could have staged anything there either, since both
+ *   read the same nullable value.
  */
 class ArchiveOrphanSweeper(
     private val ledger: PartialArchiveLedger,
@@ -86,9 +89,21 @@ class ArchiveOrphanSweeper(
         return SweepReport(interrupted, containers, staged)
     }
 
-    /** The directory survives; only its contents go. See the test that pins this. */
-    private fun sweepStaging(): Int {
-        val staging = File(cacheDir, AppDataArchiveStagingDir.NAME)
+    /**
+     * Both roots, because the gateway picks between them at runtime.
+     *
+     * `AppDataArchiveGatewayImpl.stagingRoot` stages under `cacheDir` when the privileged runner can
+     * read Thor's private data directory and under `externalCacheDir` when it cannot — a Shizuku
+     * shell at uid 2000 cannot write into `/data/data/<thor>` (0700). Sweeping only `cacheDir` left
+     * every plaintext staged tar a killed Shizuku backup produced sitting on shared external
+     * storage, which is both the leak and the worse half of it.
+     *
+     * The directory survives; only its contents go. See the test that pins this.
+     */
+    private fun sweepStaging(): Int = sweepStagingUnder(cacheDir) + sweepStagingUnder(externalCacheDir)
+
+    private fun sweepStagingUnder(root: File?): Int {
+        val staging = File(root ?: return 0, AppDataArchiveStagingDir.NAME)
         val children = staging.listFiles() ?: return 0
         return children.count { it.deleteRecursively() }
     }

--- a/app/src/main/java/com/valhalla/thor/data/backup/job/AppArchiveWorker.kt
+++ b/app/src/main/java/com/valhalla/thor/data/backup/job/AppArchiveWorker.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.valhalla.thor.data.backup.AppArchiveCipher
+import com.valhalla.thor.data.repository.archiveStagingVolume
 import com.valhalla.thor.domain.model.ArchiveBackupOutcome
 import com.valhalla.thor.domain.model.ArchiveBackupRequest
 import com.valhalla.thor.domain.model.ArchiveBundleCacheDir
@@ -26,6 +27,7 @@ import com.valhalla.thor.domain.model.ThorJobKind
 import com.valhalla.thor.domain.model.captureName
 import com.valhalla.thor.domain.model.evaluateArchiveRestoreGate
 import com.valhalla.thor.domain.repository.AppBundleBuilder
+import com.valhalla.thor.domain.repository.AppDataProbe
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.ArchiveOpenOutcome
 import com.valhalla.thor.domain.repository.ArchiveSourceFactory
@@ -68,6 +70,9 @@ internal class ArchiveBackupWorker(
     private val appRepository: AppRepository,
     private val bundleBuilder: AppBundleBuilder,
     private val systemRepository: SystemRepository,
+    // For [usableStagingBytes] alone — the one question that decides which volume §7.4 is measured
+    // against. Same implementing object as `systemRepository`; a narrow port, see [AppDataProbe].
+    private val dataProbe: AppDataProbe,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
     sheetTargets: JobSheetTargets,
 ) : ThorJobWorker(appContext, params, notifications, registry, sheetTargets) {
@@ -208,13 +213,20 @@ internal class ArchiveBackupWorker(
      * `ObbInstaller.usableBytes` and `AppBundleBuilderImpl`, and the reason #373's cache-clear bug is
      * the cautionary tale attached to obeying that hint.
      *
-     * **`cacheDir` alone, and never the larger of two volumes.** `AppDataArchiveGatewayImpl.stagingRoot`
-     * resolves `File(context.cacheDir, AppDataArchiveStagingDir.NAME)` and has no external fallback —
-     * that is a §14 limitation held on purpose, because a staged tar is plaintext app data and
-     * external cache is world-readable on some device configurations. Measuring the *larger* of the
-     * two therefore reported another volume's free space for a write that only ever lands on this
-     * one, which is precisely how §7.4's gate is defeated: on a phone with a roomy SD card and a full
-     * internal partition it passes every class and the `tar` fills the device.
+     * **The volume staging will actually use — never `cacheDir` unconditionally, and never the larger
+     * of two.** `AppDataArchiveGatewayImpl.stagingRoot` stages under `cacheDir` when the privileged
+     * runner can read `/data/data/<thor>` at mode 0700 and under `externalCacheDir` when it cannot — a
+     * Shizuku shell at uid 2000 cannot — so both readers of that rule go through
+     * [archiveStagingVolume]. This measured `cacheDir` outright while asserting the external route did
+     * not exist, which on a device whose shared storage is a separate volume reported the wrong
+     * partition's headroom; that is precisely how §7.4's gate is defeated, passing every class before
+     * the `tar` fills a volume nobody measured. Taking the larger of the two is the same defect with a
+     * friendlier face.
+     *
+     * The probe is a shell round trip and is not cached here. `DataArchiveCapabilityCache` is the
+     * cached reader, but it awaits `PrivilegeState.isReady` — an unbounded suspension inside a
+     * foreground-service worker. Asking [AppDataProbe] directly is what the gateway itself does moments
+     * later, so the measurement and the routing cannot disagree about where the tar goes.
      *
      * Nor is over-reporting cheap. `ThorJobWorker` forbids `Result.retry()` outright — the key is in
      * process memory and a retry cannot succeed — so a `tar` that runs out of space ends the backup
@@ -222,8 +234,12 @@ internal class ArchiveBackupWorker(
      *
      * Zero is "unmeasurable", which the rule deliberately fails open on.
      */
+    // No `withContext(ioDispatcher)`: the only call site is already inside one, and the probe makes
+    // its own hop.
     @Suppress("UsableSpace")
-    private fun usableStagingBytes(): Long = applicationContext.cacheDir?.usableSpace ?: 0L
+    private suspend fun usableStagingBytes(): Long =
+        archiveStagingVolume(applicationContext, dataProbe.probePrivateDataCapability())
+            ?.usableSpace ?: 0L
 }
 
 /**

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -488,15 +488,13 @@ class DhizukuSystemGateway(
                 .map { DhizukuHelper.execute(it) }
                 .any { it.first == 0 }
 
-            // Whose grant this is decides what may count as success. This method is not self-only:
-            // PermissionManagerScreen -> TogglePermissionUseCase reaches it for arbitrary
-            // third-party packages, and that screen's row shows the *runtime permission*, flipped
-            // optimistically without a re-read, so folding an app-op success into "granted" there
-            // would leave the row disagreeing with PackageManager.checkPermission. For Thor's own
-            // package the routes are interchangeable — SelfPermissionGranter re-reads
-            // checkSelfPermission and acts on the outcome. The app-ops are issued either way.
-            val isSelfGrant = packageName == context.packageName
-            if (result.first == 0 || (isSelfGrant && appOpTook)) Result.success(Unit)
+            // The report follows the gate that actually opened, for every package and not just
+            // Thor's own — RootSystemGateway.grantPermission holds the reasoning. Short version:
+            // this method is not self-only, and restricting the fold to self-grants left a
+            // third-party grant on a MIUI-class ROM writing the app-op, reporting failure, and
+            // leaving the row OFF, from where the screen can only ever grant again — so nothing
+            // could reach revokePermission to close the op it had just opened.
+            if (result.first == 0 || appOpTook) Result.success(Unit)
             else grantFailure()
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -13,6 +13,7 @@ import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
 import com.valhalla.thor.data.source.local.installCommand
 import com.valhalla.thor.data.source.local.installedAppsAppOpGrantCommands
+import com.valhalla.thor.data.source.local.installedAppsAppOpRevokeCommands
 import com.valhalla.thor.data.source.local.pmPathCommand
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
@@ -487,10 +488,16 @@ class DhizukuSystemGateway(
                 .map { DhizukuHelper.execute(it) }
                 .any { it.first == 0 }
 
-            // Either route opening is a success; only both failing is a failure, and then the
-            // grant's own diagnostic is the useful one. The caller does not trust this either way
-            // — SelfPermissionGranter re-reads checkSelfPermission — so this is for the log.
-            if (result.first == 0 || appOpTook) Result.success(Unit) else grantFailure()
+            // Whose grant this is decides what may count as success. This method is not self-only:
+            // PermissionManagerScreen -> TogglePermissionUseCase reaches it for arbitrary
+            // third-party packages, and that screen's row shows the *runtime permission*, flipped
+            // optimistically without a re-read, so folding an app-op success into "granted" there
+            // would leave the row disagreeing with PackageManager.checkPermission. For Thor's own
+            // package the routes are interchangeable — SelfPermissionGranter re-reads
+            // checkSelfPermission and acts on the outcome. The app-ops are issued either way.
+            val isSelfGrant = packageName == context.packageName
+            if (result.first == 0 || (isSelfGrant && appOpTook)) Result.success(Unit)
+            else grantFailure()
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -509,6 +516,18 @@ class DhizukuSystemGateway(
         val escapedPermissionName = permissionName.escapeForShell()
         return try {
             val result = DhizukuHelper.execute("pm revoke --user $userId $escapedPackageName $escapedPermissionName")
+
+            // The revoke half of the parallel route: the app-op grant outlives `pm revoke`, so a
+            // revoke that only ran `pm revoke` reported success while package visibility stayed
+            // open, and nothing else in the app could close it. Issued whatever the revoke
+            // returned, and deliberately not folded into the result — all three resets failing is
+            // the ordinary outcome on any device that does not define this op, so reading that as a
+            // failed revoke would report one on every AOSP device. `pm revoke` stays the verdict.
+            if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
+                installedAppsAppOpRevokeCommands(escapedPackageName, userId)
+                    .forEach { DhizukuHelper.execute(it) }
+            }
+
             if (result.first == 0) Result.success(Unit)
             else Result.failure(Exception("Dhizuku: pm revoke failed with exit code ${result.first}: ${result.second}"))
         } catch (e: Exception) {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1353,14 +1353,18 @@ class RootSystemGateway(
         // the app knows how to open that gate.
         //
         // `runProbe`, not `runCommand`: at most one of the three spellings exists on any given
-        // device, so two of them failing is the *success* path. `map` and not `any`, so all three
+        // device, so two of them failing is the *success* path. `filter` and not `any`, so all three
         // are still issued — short-circuiting on the first that lands would change what Thor writes.
+        // The accepted command is named, not just counted, because *which* spelling the ROM answered
+        // is the one thing the per-command error lines carried that a bare tally would drop.
         val appOpGrants = installedAppsAppOpGrantCommands(escapedPackage, userId)
-        val appOpsTaken = appOpGrants.map { runProbe(it) }.count { it }
+        val acceptedGrants = appOpGrants.filter { runProbe(it) }
+        val appOpsTaken = acceptedGrants.size
         Logger.d(
             "RootSystemGateway",
             "GET_INSTALLED_APPS app-op grant for $packageName (user $userId): " +
-                "$appOpsTaken of ${appOpGrants.size} spellings accepted"
+                "$appOpsTaken of ${appOpGrants.size} spellings accepted" +
+                if (acceptedGrants.isEmpty()) "" else " — ${acceptedGrants.joinToString("; ")}"
         )
 
         // The report follows the gate that actually opened, for every package and not just Thor's
@@ -1405,14 +1409,15 @@ class RootSystemGateway(
         // while package visibility stayed open — and nothing else in the app could close it. Issued
         // whatever the revoke returned, for the same reason the grant is: on these ROMs the shell's
         // verdict on a vendor permission is not the state of the gate.
-        // `runProbe` for the same reason as the grant: `count` issues all three either way, and the
-        // failures are not errors — see the aggregate below.
+        // `runProbe` for the same reason as the grant: `filter` issues all three either way, and the
+        // failures are not errors — see the aggregate below, which names the spelling that landed.
         val appOpResets = installedAppsAppOpRevokeCommands(escapedPackage, userId)
-        val appOpsReset = appOpResets.count { runProbe(it) }
+        val acceptedResets = appOpResets.filter { runProbe(it) }
         Logger.d(
             "RootSystemGateway",
             "GET_INSTALLED_APPS app-op reset for $packageName (user $userId): " +
-                "$appOpsReset of ${appOpResets.size} spellings accepted"
+                "${acceptedResets.size} of ${appOpResets.size} spellings accepted" +
+                if (acceptedResets.isEmpty()) "" else " — ${acceptedResets.joinToString("; ")}"
         )
 
         // And unlike the grant, the fold stays narrow: `pm revoke` is the verdict. All three app-op

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1353,18 +1353,23 @@ class RootSystemGateway(
         // the app knows how to open that gate.
         val appOps = installedAppsAppOpGrantCommands(escapedPackage, userId).map { runCommand(it) }
 
-        // Whose grant this is decides what may count as success. This method is not self-only:
-        // PermissionManagerScreen -> TogglePermissionUseCase reaches it for arbitrary third-party
-        // packages, and that screen's row shows the *runtime permission*, flipped optimistically
-        // without a re-read. Folding an app-op success into "granted" there would leave the row
-        // disagreeing with PackageManager.checkPermission until something else refreshed it.
+        // The report follows the gate that actually opened, for every package and not just Thor's
+        // own. Restricting this fold to self-grants put a one-way door in the permission manager:
+        // this method is not self-only — PermissionManagerScreen -> TogglePermissionUseCase reaches
+        // it for arbitrary third-party packages — so on the ROMs where `pm grant` refuses and the
+        // app-op is what opens the package list, a third-party grant wrote the op, returned
+        // failure, and left the row reading OFF, because `AppPermission.isGranted` comes from
+        // REQUESTED_PERMISSION_GRANTED and an app-op does not move it. The only gesture the screen
+        // then offers is *grant* again, and revokePermission — the sole issuer of
+        // `appops set … default` — is never reached. Thor had opened a gate, reported that it had
+        // not, and could not close it.
         //
-        // For Thor's own package the two routes really are interchangeable — SelfPermissionGranter
-        // re-reads checkSelfPermission and acts on the *outcome*, so an app-op that opened the
-        // package list is the success it was after even when `pm grant` refused. The app-ops are
-        // issued either way; which route counts is a reporting question, not a gating one.
-        val isSelfGrant = packageName == context.packageName
-        return if (res.isSuccess || (isSelfGrant && appOps.any { it.isSuccess })) {
+        // The cost is the known one and it is the lesser: PermissionManagerScreen flips the row
+        // optimistically, so it reads granted while PackageManager.checkPermission still says
+        // denied until something refreshes it. That disagreement is with the runtime permission,
+        // not with what the app can now do, and unlike the alternative it leaves the toggle able to
+        // undo itself.
+        return if (res.isSuccess || appOps.any { it.isSuccess }) {
             Result.success(Unit)
         } else {
             res

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -21,6 +21,7 @@ import com.valhalla.thor.data.source.local.clearAppDataCommand
 import com.valhalla.thor.data.source.local.clearCachePaths
 import com.valhalla.thor.data.source.local.forceStopCommand
 import com.valhalla.thor.data.source.local.installedAppsAppOpGrantCommands
+import com.valhalla.thor.data.source.local.installedAppsAppOpRevokeCommands
 import com.valhalla.thor.data.source.local.pmPathCommand
 import com.valhalla.thor.data.source.local.setAppEnabledCommand
 import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
@@ -1352,10 +1353,22 @@ class RootSystemGateway(
         // the app knows how to open that gate.
         val appOps = installedAppsAppOpGrantCommands(escapedPackage, userId).map { runCommand(it) }
 
-        // Either route opening is a success; only both failing is a failure, and then the grant's
-        // own diagnostic is the useful one. The caller does not trust this either way —
-        // SelfPermissionGranter re-reads checkSelfPermission — so this is for the log.
-        return if (res.isSuccess || appOps.any { it.isSuccess }) Result.success(Unit) else res
+        // Whose grant this is decides what may count as success. This method is not self-only:
+        // PermissionManagerScreen -> TogglePermissionUseCase reaches it for arbitrary third-party
+        // packages, and that screen's row shows the *runtime permission*, flipped optimistically
+        // without a re-read. Folding an app-op success into "granted" there would leave the row
+        // disagreeing with PackageManager.checkPermission until something else refreshed it.
+        //
+        // For Thor's own package the two routes really are interchangeable — SelfPermissionGranter
+        // re-reads checkSelfPermission and acts on the *outcome*, so an app-op that opened the
+        // package list is the success it was after even when `pm grant` refused. The app-ops are
+        // issued either way; which route counts is a reporting question, not a gating one.
+        val isSelfGrant = packageName == context.packageName
+        return if (res.isSuccess || (isSelfGrant && appOps.any { it.isSuccess })) {
+            Result.success(Unit)
+        } else {
+            res
+        }
     }
 
     override suspend fun revokePermission(
@@ -1369,7 +1382,20 @@ class RootSystemGateway(
             ?: return Result.failure(Exception("Cannot resolve the Android user for $packageName; refusing to revoke on user 0."))
         val escapedPackage = packageName.escapeForShell()
         val escapedPerm = permissionName.escapeForShell()
-        return runCommand("pm revoke --user $userId $escapedPackage $escapedPerm")
+        val res = runCommand("pm revoke --user $userId $escapedPackage $escapedPerm")
+        if (permissionName != GET_INSTALLED_APPS_PERMISSION) return res
+
+        // The revoke half of the parallel route, and the reason it cannot be left out: the app-op
+        // grant above outlives `pm revoke`, so a revoke that only ran `pm revoke` reported success
+        // while package visibility stayed open — and nothing else in the app could close it. Issued
+        // whatever the revoke returned, for the same reason the grant is: on these ROMs the shell's
+        // verdict on a vendor permission is not the state of the gate.
+        installedAppsAppOpRevokeCommands(escapedPackage, userId).forEach { runCommand(it) }
+
+        // And unlike the grant, the fold stays narrow: `pm revoke` is the verdict. All three app-op
+        // resets failing is the ordinary outcome on any device that does not define this op, so
+        // reading that as a failed revoke would report one on every AOSP device.
+        return res
     }
 
     /**

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1351,7 +1351,17 @@ class RootSystemGateway(
         // them on the grant succeeding is what made a Chinese-ROM install come back with Thor as
         // the only visible app: the grant failed, the app-op was never set, and nothing else in
         // the app knows how to open that gate.
-        val appOps = installedAppsAppOpGrantCommands(escapedPackage, userId).map { runCommand(it) }
+        //
+        // `runProbe`, not `runCommand`: at most one of the three spellings exists on any given
+        // device, so two of them failing is the *success* path. `map` and not `any`, so all three
+        // are still issued — short-circuiting on the first that lands would change what Thor writes.
+        val appOpGrants = installedAppsAppOpGrantCommands(escapedPackage, userId)
+        val appOpsTaken = appOpGrants.map { runProbe(it) }.count { it }
+        Logger.d(
+            "RootSystemGateway",
+            "GET_INSTALLED_APPS app-op grant for $packageName (user $userId): " +
+                "$appOpsTaken of ${appOpGrants.size} spellings accepted"
+        )
 
         // The report follows the gate that actually opened, for every package and not just Thor's
         // own. Restricting this fold to self-grants put a one-way door in the permission manager:
@@ -1369,7 +1379,7 @@ class RootSystemGateway(
         // denied until something refreshes it. That disagreement is with the runtime permission,
         // not with what the app can now do, and unlike the alternative it leaves the toggle able to
         // undo itself.
-        return if (res.isSuccess || appOps.any { it.isSuccess }) {
+        return if (res.isSuccess || appOpsTaken > 0) {
             Result.success(Unit)
         } else {
             res
@@ -1395,7 +1405,15 @@ class RootSystemGateway(
         // while package visibility stayed open — and nothing else in the app could close it. Issued
         // whatever the revoke returned, for the same reason the grant is: on these ROMs the shell's
         // verdict on a vendor permission is not the state of the gate.
-        installedAppsAppOpRevokeCommands(escapedPackage, userId).forEach { runCommand(it) }
+        // `runProbe` for the same reason as the grant: `count` issues all three either way, and the
+        // failures are not errors — see the aggregate below.
+        val appOpResets = installedAppsAppOpRevokeCommands(escapedPackage, userId)
+        val appOpsReset = appOpResets.count { runProbe(it) }
+        Logger.d(
+            "RootSystemGateway",
+            "GET_INSTALLED_APPS app-op reset for $packageName (user $userId): " +
+                "$appOpsReset of ${appOpResets.size} spellings accepted"
+        )
 
         // And unlike the grant, the fold stays narrow: `pm revoke` is the verdict. All three app-op
         // resets failing is the ordinary outcome on any device that does not define this op, so
@@ -1456,6 +1474,19 @@ class RootSystemGateway(
             Result.failure(exception)
         }
     }
+
+    /**
+     * Run [cmd] for its exit code alone, without logging a non-zero one as an error.
+     *
+     * For commands whose failure is the *ordinary* outcome. `installedAppsAppOpGrantCommands` and its
+     * revoke twin each fire three spellings of one app-op precisely because no device defines all
+     * three, so routing them through [runCommand] put two or three `Logger.e` lines — each with a
+     * synthesized `IOException` and a stack trace — into the log on every AOSP device, for the path
+     * that worked. `Command execution failed: appops set …` beside a successful grant is what a
+     * maintainer reads first in a bug report, and the callers' own comments already call it normal.
+     * Both callers log one debug-level aggregate instead, which is the line that carries the answer.
+     */
+    private suspend fun runProbe(cmd: String): Boolean = shellRepository.exec(cmd).isSuccess
 
     private fun getApplicationInfoCompat(packageName: String): android.content.pm.ApplicationInfo? = runCatching {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -494,15 +494,13 @@ class ShizukuSystemGateway(
                 .map { ShizukuHelper.execute(it) }
                 .any { it.first == 0 }
 
-            // Whose grant this is decides what may count as success. This method is not self-only:
-            // PermissionManagerScreen -> TogglePermissionUseCase reaches it for arbitrary
-            // third-party packages, and that screen's row shows the *runtime permission*, flipped
-            // optimistically without a re-read, so folding an app-op success into "granted" there
-            // would leave the row disagreeing with PackageManager.checkPermission. For Thor's own
-            // package the routes are interchangeable — SelfPermissionGranter re-reads
-            // checkSelfPermission and acts on the outcome. The app-ops are issued either way.
-            val isSelfGrant = packageName == context.packageName
-            if (result.first == 0 || (isSelfGrant && appOpTook)) Result.success(Unit)
+            // The report follows the gate that actually opened, for every package and not just
+            // Thor's own — RootSystemGateway.grantPermission holds the reasoning. Short version:
+            // this method is not self-only, and restricting the fold to self-grants left a
+            // third-party grant on a MIUI-class ROM writing the app-op, reporting failure, and
+            // leaving the row OFF, from where the screen can only ever grant again — so nothing
+            // could reach revokePermission to close the op it had just opened.
+            if (result.first == 0 || appOpTook) Result.success(Unit)
             else grantFailure()
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -15,6 +15,7 @@ import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
 import com.valhalla.thor.data.source.local.installCommand
 import com.valhalla.thor.data.source.local.installedAppsAppOpGrantCommands
+import com.valhalla.thor.data.source.local.installedAppsAppOpRevokeCommands
 import com.valhalla.thor.data.source.local.pmPathCommand
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.domain.gateway.SystemGateway
@@ -493,10 +494,16 @@ class ShizukuSystemGateway(
                 .map { ShizukuHelper.execute(it) }
                 .any { it.first == 0 }
 
-            // Either route opening is a success; only both failing is a failure, and then the
-            // grant's own diagnostic is the useful one. The caller does not trust this either way
-            // — SelfPermissionGranter re-reads checkSelfPermission — so this is for the log.
-            if (result.first == 0 || appOpTook) Result.success(Unit) else grantFailure()
+            // Whose grant this is decides what may count as success. This method is not self-only:
+            // PermissionManagerScreen -> TogglePermissionUseCase reaches it for arbitrary
+            // third-party packages, and that screen's row shows the *runtime permission*, flipped
+            // optimistically without a re-read, so folding an app-op success into "granted" there
+            // would leave the row disagreeing with PackageManager.checkPermission. For Thor's own
+            // package the routes are interchangeable — SelfPermissionGranter re-reads
+            // checkSelfPermission and acts on the outcome. The app-ops are issued either way.
+            val isSelfGrant = packageName == context.packageName
+            if (result.first == 0 || (isSelfGrant && appOpTook)) Result.success(Unit)
+            else grantFailure()
         } catch (e: Exception) {
             Result.failure(e)
         }
@@ -515,6 +522,18 @@ class ShizukuSystemGateway(
         val escapedPermissionName = permissionName.escapeForShell()
         return try {
             val result = ShizukuHelper.execute("pm revoke --user $userId $escapedPackageName $escapedPermissionName")
+
+            // The revoke half of the parallel route: the app-op grant outlives `pm revoke`, so a
+            // revoke that only ran `pm revoke` reported success while package visibility stayed
+            // open, and nothing else in the app could close it. Issued whatever the revoke
+            // returned, and deliberately not folded into the result — all three resets failing is
+            // the ordinary outcome on any device that does not define this op, so reading that as a
+            // failed revoke would report one on every AOSP device. `pm revoke` stays the verdict.
+            if (permissionName == GET_INSTALLED_APPS_PERMISSION) {
+                installedAppsAppOpRevokeCommands(escapedPackageName, userId)
+                    .forEach { ShizukuHelper.execute(it) }
+            }
+
             if (result.first == 0) Result.success(Unit)
             else Result.failure(Exception("Shizuku: pm revoke failed with exit code ${result.first}: ${result.second}"))
         } catch (e: Exception) {

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -120,12 +120,30 @@ class AppAnalyzerImpl(
                         if (res != null && res.first == 0 &&
                             tmpFile.exists() && tmpFile.length() > 0
                         ) {
-                            tmpFile.inputStream().use { input ->
+                            // The same budget as the provider branch, for the same reason: the
+                            // invariant the two whole-file copies downstream rely on is a property
+                            // of `bundleFile`, not of how it was filled. This path had no bound at
+                            // all, so a 4 GB file the content resolver refused to open was copied
+                            // whole while a 100 MB one it opened was rejected.
+                            val copied = tmpFile.inputStream().use { input ->
                                 FileOutputStream(bundleFile).use { output ->
-                                    input.copyTo(output)
+                                    input.copyAtMostTo(output, MAX_EXTRACTED_TOTAL_BYTES)
                                 }
                             }
-                            readMetadata(bundleFile, apkFile, displayName)
+                            if (copied == null) {
+                                // Deliberately not the provider branch's wording: the shell has
+                                // already read the whole file into /data/local/tmp by this point,
+                                // so "was not read" would be untrue here. Only the copy Thor would
+                                // install from was declined.
+                                Result.failure(
+                                    Exception(
+                                        "The selected file is larger than " +
+                                            "${MAX_EXTRACTED_TOTAL_BYTES / (1024 * 1024)} MB and was not staged."
+                                    )
+                                )
+                            } else {
+                                readMetadata(bundleFile, apkFile, displayName)
+                            }
                         } else {
                             Result.failure(Exception("Could not open the selected file."))
                         }

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -21,6 +21,7 @@ import com.valhalla.thor.domain.model.escapeShellArg
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.util.getDisplayName
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Named
@@ -105,26 +106,33 @@ class AppAnalyzerImpl(
                     val src = path.escapeShellArg()
                     val dst = tmpPath.escapeShellArg()
                     val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
-                    val res = systemRepository.executeShellCommand(cmd).getOrNull()
-                    if (res != null && res.first == 0) {
+                    // Uncancellable, and hoisted outside the branches so every exit passes through
+                    // it: `cat` can have produced the file even when this coroutine is cancelled
+                    // before the call returns, and a `finally` whose body is a suspend call never
+                    // executes once cancellation is in progress — it throws at the first suspension
+                    // point instead. `ArchiveOrphanSweeper` sweeps `cacheDir`,
+                    // `externalCacheDir/obb_out` and the SAF ledger but not `/data/local/tmp`, so
+                    // what is left there is a full-size, `chmod 666` copy of the user's package
+                    // that nothing in the app can reclaim.
+                    try {
+                        val res = systemRepository.executeShellCommand(cmd).getOrNull()
                         val tmpFile = File(tmpPath)
-                        if (tmpFile.exists() && tmpFile.length() > 0) {
-                            try {
-                                tmpFile.inputStream().use { input ->
-                                    FileOutputStream(bundleFile).use { output ->
-                                        input.copyTo(output)
-                                    }
+                        if (res != null && res.first == 0 &&
+                            tmpFile.exists() && tmpFile.length() > 0
+                        ) {
+                            tmpFile.inputStream().use { input ->
+                                FileOutputStream(bundleFile).use { output ->
+                                    input.copyTo(output)
                                 }
-                                readMetadata(bundleFile, apkFile, displayName)
-                            } finally {
-                                systemRepository.executeShellCommand("rm -f $dst")
                             }
+                            readMetadata(bundleFile, apkFile, displayName)
                         } else {
-                            systemRepository.executeShellCommand("rm -f $dst")
                             Result.failure(Exception("Could not open the selected file."))
                         }
-                    } else {
-                        Result.failure(Exception("Could not open the selected file."))
+                    } finally {
+                        withContext(NonCancellable) {
+                            systemRepository.executeShellCommand("rm -f $dst")
+                        }
                     }
                 } else {
                     Result.failure(Exception("Could not open the selected file."))

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
@@ -64,6 +64,21 @@ internal fun isSafeStagingName(name: String): Boolean =
 internal fun isInsideStagingRoot(outCanonical: String, stagingCanonical: String): Boolean =
     outCanonical.startsWith("$stagingCanonical/")
 
+/**
+ * The volume a staged tar lands on: `cacheDir` when the privileged runner can read Thor's private data
+ * directory, `externalCacheDir` when it cannot (§7.1). [AppDataArchiveGatewayImpl.stagingRoot]'s KDoc
+ * owns the reasoning and the cost.
+ *
+ * A shared function rather than a line inside `stagingRoot`, because the choice has a second reader:
+ * `ArchiveBackupWorker` measures §7.4's free space, and measuring `cacheDir` while the tar is written
+ * to external storage reports a different volume's headroom. Two copies of one routing rule is exactly
+ * how that happened — the worker's copy said the external route did not exist — so there is one.
+ *
+ * Null only if the platform returns neither directory; both callers read that as "unmeasurable".
+ */
+internal fun archiveStagingVolume(context: Context, privateDataCapable: Boolean): File? =
+    if (privateDataCapable) context.cacheDir else context.externalCacheDir ?: context.cacheDir
+
 @Single(binds = [AppDataArchiveGateway::class])
 internal class AppDataArchiveGatewayImpl(
     private val context: Context,
@@ -99,11 +114,7 @@ internal class AppDataArchiveGatewayImpl(
      * writes. Pair any further staging root with a sweeper rule in the same change.
      */
     private suspend fun stagingRoot(): File = withContext(ioDispatcher) {
-        val rootDir = if (probe.probePrivateDataCapability()) {
-            context.cacheDir
-        } else {
-            context.externalCacheDir ?: context.cacheDir
-        }
+        val rootDir = archiveStagingVolume(context, probe.probePrivateDataCapability())
         File(rootDir, AppDataArchiveStagingDir.NAME).also { it.mkdirs() }
     }
 

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppDataArchiveGatewayImpl.kt
@@ -83,12 +83,20 @@ internal class AppDataArchiveGatewayImpl(
      * Resolves and creates the single staging directory. All [stagingFile] calls land here, so the
      * canonical path used in [tarClass]'s traversal guard is always the same base.
      *
-     * §7.1 provides for an `externalCacheDir` fallback when internal cache is unavailable. This
-     * implementation does not provide one (§14 limitation). A staged tar is plaintext app data;
-     * external cache is on the shared external storage volume and is world-readable on some device
-     * configurations. Writing plaintext app data there would defeat the exact property the rest of
-     * this feature is built around. If `cacheDir` is unavailable the job will fail loudly rather than
-     * silently downgrade to a less secure location.
+     * §7.1's `externalCacheDir` route, and the condition on it is a *capability*, not availability.
+     * `cacheDir` is `/data/data/<thor>` at mode 0700, which the privileged runner has to be able to
+     * read for a staged tar to be produced at all: a root shell can, a Shizuku shell at uid 2000
+     * cannot. [AppDataProbe.probePrivateDataCapability] is that question, and answering it `false`
+     * is what moves staging to `externalCacheDir` — the same reason `AppBundleBuilderImpl` stages
+     * expansion files there.
+     *
+     * Say the cost plainly, because this KDoc used to claim the downgrade did not exist: a staged tar
+     * is plaintext app data, and on external storage it is readable by anything holding
+     * `READ_EXTERNAL_STORAGE` on the device configurations where that still grants broad access. The
+     * exposure lasts as long as the file does, which is why the staged tar is deleted on every exit
+     * from [tarClass] under `NonCancellable` and why [ArchiveOrphanSweeper] sweeps this directory
+     * under *both* roots — a sweep of `cacheDir` alone would leave exactly the copies this branch
+     * writes. Pair any further staging root with a sweeper rule in the same change.
      */
     private suspend fun stagingRoot(): File = withContext(ioDispatcher) {
         val rootDir = if (probe.probePrivateDataCapability()) {

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -18,7 +18,6 @@ import com.valhalla.thor.data.source.local.room.AppEntity
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.PermissionDetail
-import com.valhalla.thor.domain.model.RetainReason
 import com.valhalla.thor.domain.model.ScanVerdict
 import com.valhalla.thor.domain.model.prunableWatchlistRows
 import com.valhalla.thor.domain.model.scanVerdict
@@ -366,17 +365,20 @@ class AppRepositoryImpl(
                     //
                     // A scan that needed the weaker-flags fallback skips the rules entirely: none of
                     // them can see that MATCH_UNINSTALLED_PACKAGES was dropped, and every one of them
-                    // would happily Accept the 300 packages such a scan *does* return.
-                    val verdict = if (usedVisibilityFallback) {
-                        ScanVerdict.Retain(RetainReason.VisibilityFallback)
-                    } else {
-                        scanVerdict(
-                            scannedPackageNames = currentPackageNames,
-                            cachedCount = initialCachedCount,
-                            consecutiveSuspectScans = consecutiveSuspectScans,
-                            permission = installedAppsPermission.state()
-                        )
-                    }
+                    // would happily Accept the 300 packages such a scan *does* return. See
+                    // [scanVerdictFor].
+                    val verdict = scanVerdictFor(
+                        usedVisibilityFallback = usedVisibilityFallback,
+                        scannedPackageNames = currentPackageNames,
+                        cachedCount = initialCachedCount,
+                        consecutiveSuspectScans = consecutiveSuspectScans,
+                        permission = installedAppsPermission.state()
+                    )
+
+                    // Accept resets the tolerance, an ordinary Retain spends one of it, and a
+                    // VisibilityFallback Retain does neither — [nextSuspectScanCount] holds the
+                    // reasoning. Read before the `when` below so both branches see the same rule.
+                    consecutiveSuspectScans = nextSuspectScanCount(consecutiveSuspectScans, verdict)
 
                     // The cached rows this scan did not see and was not allowed to delete. Mapped
                     // through the same AppEntity.toDomain() the initial cache emission above uses,
@@ -384,7 +386,6 @@ class AppRepositoryImpl(
                     var syncCacheSucceeded = true
                     val retained = when (verdict) {
                         ScanVerdict.Accept -> {
-                            consecutiveSuspectScans = 0
                             if (toUpdate.isNotEmpty() || toDelete.isNotEmpty()) {
                                 try {
                                     appDao.syncCache(toUpdate, toDelete)
@@ -408,15 +409,6 @@ class AppRepositoryImpl(
                         }
 
                         is ScanVerdict.Retain -> {
-                            // VisibilityFallback deliberately does not count. The tolerance exists
-                            // to let a *genuinely* shrinking device eventually be believed after
-                            // SUSPECT_SCAN_TOLERANCE agreeing scans; a fallback scan is not evidence
-                            // of shrinkage at all, and spending the budget on it would hand the
-                            // third truncated scan the Accept the guard was built to withhold. Not
-                            // reset either — this scan is no proof the device is healthy.
-                            if (verdict.reason != RetainReason.VisibilityFallback) {
-                                consecutiveSuspectScans++
-                            }
                             Logger.w(
                                 "AppRepository",
                                 "not pruning against this scan (${verdict.reason}): saw " +
@@ -448,12 +440,11 @@ class AppRepositoryImpl(
                     producer.send(currentList + retained)
 
                     // Only now, and only on a scan that was trusted enough to prune against and whose
-                    // cache synchronization succeeded. Moving the key up next to the `forceRefresh`
-                    // read would let a scan that was cancelled mid-loop, or one that ran while package
-                    // visibility was truncated, record a language for rows it never re-mapped — and
-                    // nothing would ever force-refresh them again. Re-mapping twice costs a rescan;
-                    // recording too early costs the stale labels this key exists to prevent.
-                    if (forceRefresh && verdict == ScanVerdict.Accept && syncCacheSucceeded) {
+                    // cache synchronization succeeded — [shouldRecordLabelLocale] holds the rule.
+                    // Moving the key up next to the `forceRefresh` read would let a scan that was
+                    // cancelled mid-loop, or one that ran while package visibility was truncated,
+                    // record a language for rows it never re-mapped.
+                    if (shouldRecordLabelLocale(forceRefresh, verdict, syncCacheSucceeded)) {
                         lastLocale = currentLocale
                         recordLabelLocale(currentLocale)
                     }

--- a/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/BundleZip.kt
@@ -40,6 +40,23 @@ internal const val MAX_EXTRACTED_TOTAL_BYTES = 4L * 1024 * 1024 * 1024
 internal const val MAX_EXPANSION_TOTAL_BYTES = 16L * 1024 * 1024 * 1024
 
 /**
+ * Ceiling on a whole app-bundle container staged out of a `.thorbak` before anything unpacks it.
+ *
+ * The *sum* of the two budgets above, because one `.xapk` member legitimately holds both: an install
+ * set, charged against [MAX_EXTRACTED_TOTAL_BYTES] when `extractEntries` unpacks it, and an expansion
+ * set, charged against [MAX_EXPANSION_TOTAL_BYTES] when `extractExpansions` does. Both still apply to
+ * the contents; this only bounds the copy of the container itself. Bounding that copy at the APK-only
+ * figure is what the comment on [MAX_EXPANSION_TOTAL_BYTES] rules out — it refuses archives Thor
+ * itself writes, since a 4 GB game's XAPK is an ordinary backup — and it refuses them during staging,
+ * which happens before a single data class is restored.
+ *
+ * A bound is still wanted, hence the sum rather than nothing: staging runs before any verifier or
+ * passphrase check, so it is the one restore step where a caller who proved nothing chooses how many
+ * bytes Thor writes.
+ */
+internal const val MAX_STAGED_BUNDLE_BYTES = MAX_EXTRACTED_TOTAL_BYTES + MAX_EXPANSION_TOTAL_BYTES
+
+/**
  * Ceiling on how *many* expansion files one archive may unpack.
  *
  * [MAX_EXPANSION_TOTAL_BYTES] does not bound this. An archive carrying a manifest is limited by what

--- a/app/src/main/java/com/valhalla/thor/data/repository/ScanCachePolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/ScanCachePolicy.kt
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import com.valhalla.thor.domain.model.InstalledAppsPermission
+import com.valhalla.thor.domain.model.RetainReason
+import com.valhalla.thor.domain.model.SUSPECT_SCAN_TOLERANCE
+import com.valhalla.thor.domain.model.ScanVerdict
+import com.valhalla.thor.domain.model.scanVerdict
+
+/**
+ * The three decisions `AppRepositoryImpl`'s scan loop takes about its own cache, as pure functions.
+ *
+ * They were inline in a `callbackFlow` that needs a live `PackageManager`, a Room DAO and a
+ * `SharedPreferences` to reach — which is to say they were untestable, and the test that claimed to
+ * cover one of them re-implemented the condition inside the test file and could therefore never
+ * fail. Extracting them is the seam: the rules live here, the loop reads them, and a change to a
+ * rule is a change a test can see.
+ *
+ * The verdict *rules* stay in the domain — [scanVerdict] and `prunableWatchlistRows` — because they
+ * are about whether a scan is honest. What is here is what the data layer adds on top: a flag only
+ * the caller can know, a counter only the caller keeps, and a write only the caller performs.
+ */
+
+/**
+ * The verdict for a scan, given whether it needed the weaker-flags fallback to see anything.
+ *
+ * A fallback scan skips [scanVerdict]'s rules entirely. None of them can detect that
+ * `MATCH_UNINSTALLED_PACKAGES` was dropped — a flags-0 query leaves no trace in its own output, the
+ * packages it cannot see being exactly the ones it does not report — and every rule would happily
+ * `Accept` the 300 packages such a scan *does* return. Believing it deletes the Room row, the cached
+ * icon PNG and the Freezer watchlist row of every uninstall-frozen app on the device, and the
+ * watchlist row is the one a later scan cannot repair.
+ *
+ * This is the only place [RetainReason.VisibilityFallback] is minted; `InstalledAppsVisibilityTest`
+ * asserts the other side of that boundary, that no rule in [scanVerdict] can ever produce it.
+ */
+internal fun scanVerdictFor(
+    usedVisibilityFallback: Boolean,
+    scannedPackageNames: Set<String>,
+    cachedCount: Int,
+    consecutiveSuspectScans: Int,
+    permission: InstalledAppsPermission,
+): ScanVerdict = if (usedVisibilityFallback) {
+    ScanVerdict.Retain(RetainReason.VisibilityFallback)
+} else {
+    scanVerdict(
+        scannedPackageNames = scannedPackageNames,
+        cachedCount = cachedCount,
+        consecutiveSuspectScans = consecutiveSuspectScans,
+        permission = permission,
+    )
+}
+
+/**
+ * The suspect-scan counter after [verdict], from its value before it.
+ *
+ * Three outcomes, and the middle one is the reason this is a function rather than a `++`:
+ * - [ScanVerdict.Accept] resets. The device just answered honestly, so nothing is outstanding.
+ * - A [RetainReason.VisibilityFallback] retain changes nothing. [SUSPECT_SCAN_TOLERANCE] exists to
+ *   let a *genuinely* shrinking device eventually be believed after that many agreeing scans; a
+ *   fallback scan is not evidence of shrinkage at all, so spending the budget on it would hand the
+ *   third truncated scan the `Accept` the guard was built to withhold. Not a reset either — a
+ *   fallback scan is no proof the device is healthy.
+ * - Any other retain spends one. That is the tolerance doing its job.
+ */
+internal fun nextSuspectScanCount(current: Int, verdict: ScanVerdict): Int = when (verdict) {
+    ScanVerdict.Accept -> 0
+    is ScanVerdict.Retain ->
+        if (verdict.reason == RetainReason.VisibilityFallback) current else current + 1
+}
+
+/**
+ * Whether this scan may record the locale its labels were mapped under.
+ *
+ * All three conjuncts are load-bearing, and each one is a stale-label bug if dropped:
+ * - `forceRefresh` false means the labels were reused from the cache, not re-read from each app's
+ *   resources, so this scan mapped nothing and has nothing to attest to.
+ * - a [ScanVerdict.Retain] means the scan itself was not believed — it may have seen a fraction of
+ *   the installed packages, so most rows still carry the previous language's labels.
+ * - a failed `syncCache` means the re-mapped labels never reached Room, so the rows on disk are
+ *   still the old ones.
+ *
+ * Record the key in any of those cases and nothing will ever force-refresh those rows again: the key
+ * says they are in the current language and no package event will contradict it. Re-mapping twice
+ * costs one rescan; recording too early costs labels that stay wrong until the next language change.
+ */
+internal fun shouldRecordLabelLocale(
+    forceRefresh: Boolean,
+    verdict: ScanVerdict,
+    syncCacheSucceeded: Boolean,
+): Boolean = forceRefresh && verdict == ScanVerdict.Accept && syncCacheSucceeded

--- a/app/src/main/java/com/valhalla/thor/data/repository/UriArchiveSourceFactory.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/UriArchiveSourceFactory.kt
@@ -10,6 +10,7 @@ import androidx.core.net.toUri
 import com.valhalla.thor.domain.model.escapeShellArg
 import com.valhalla.thor.domain.repository.ArchiveOpenOutcome
 import com.valhalla.thor.domain.repository.ArchiveSourceFactory
+import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.Logger
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.NonCancellable
@@ -37,8 +38,6 @@ import java.util.zip.ZipException
  * A [ZipException] from the fd path means the bytes were readable but are not a zip; the copy
  * fallback would fail identically, so that case gives up immediately.
  */
-import com.valhalla.thor.domain.repository.SystemRepository
-
 @Single(binds = [ArchiveSourceFactory::class])
 class UriArchiveSourceFactory(
     private val context: Context,
@@ -136,18 +135,25 @@ class UriArchiveSourceFactory(
                     val src = path.escapeShellArg()
                     val dst = tmpPath.escapeShellArg()
                     val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
-                    val res = systemRepository.executeShellCommand(cmd).getOrNull()
-                    if (res != null && res.first == 0) {
-                        val tmpFile = File(tmpPath)
-                        if (tmpFile.exists() && tmpFile.length() > 0) {
-                            try {
+                    // One uncancellable `finally` covering every exit, replacing two removals that
+                    // between them missed the path that matters: `cat` can have produced the file
+                    // even when this coroutine is cancelled before the call returns, and a `finally`
+                    // whose body is a suspend call is a no-op once cancellation is in progress.
+                    // `ArchiveOrphanSweeper` does not sweep `/data/local/tmp`, so anything left
+                    // there is a full-size, `chmod 666` copy of the user's archive that nothing in
+                    // the app can reclaim. Same shape as `ArchiveIconFetcher.extractIcon`.
+                    try {
+                        val res = systemRepository.executeShellCommand(cmd).getOrNull()
+                        if (res != null && res.first == 0) {
+                            val tmpFile = File(tmpPath)
+                            if (tmpFile.exists() && tmpFile.length() > 0) {
                                 tmpFile.inputStream().use { input ->
                                     copy.outputStream().use(input::copyTo)
                                 }
-                            } finally {
-                                systemRepository.executeShellCommand("rm -f $dst")
                             }
-                        } else {
+                        }
+                    } finally {
+                        withContext(NonCancellable) {
                             systemRepository.executeShellCommand("rm -f $dst")
                         }
                     }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/PerUserCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/PerUserCommands.kt
@@ -257,11 +257,52 @@ internal fun backgroundRestrictionCommand(
 internal fun usageStatsGrantCommand(escapedPackage: String, userId: Int): String =
     appOpsCommand(escapedPackage, userId, op = "GET_USAGE_STATS", mode = "allow")
 
-internal fun installedAppsAppOpGrantCommands(escapedPackage: String, userId: Int): List<String> = listOf(
-    appOpsCommand(escapedPackage, userId, op = "GET_INSTALLED_APPS", mode = "allow"),
-    appOpsCommand(escapedPackage, userId, op = "android:get_installed_apps", mode = "allow"),
-    appOpsCommand(escapedPackage, userId, op = "10022", mode = "allow"),
-)
+/**
+ * The three spellings of the `GET_INSTALLED_APPS` app-op, tried together because which one a ROM
+ * answers to is not knowable from here.
+ *
+ * `GET_INSTALLED_APPS` is the bare name AOSP's `appops` shell accepts, `android:get_installed_apps`
+ * is the fully-qualified form some ROMs register the op under, and `10022` is the op *number* MIUI
+ * and HyperOS assign it — a ROM that knows the op by number rejects both names with "Unknown
+ * operation string". They are alternatives, not a sequence, so all three are always issued and any
+ * one of them landing is the whole of the success condition.
+ */
+private val INSTALLED_APPS_APP_OP_SPELLINGS =
+    listOf("GET_INSTALLED_APPS", "android:get_installed_apps", "10022")
+
+/**
+ * `appops set … allow` for every spelling in [INSTALLED_APPS_APP_OP_SPELLINGS].
+ *
+ * **The app-op is the real gate, not a follow-up to `pm grant`.** On MIUI/HyperOS `pm grant` of
+ * `com.android.permission.GET_INSTALLED_APPS` exits non-zero — the ROM does not let a shell grant
+ * its own vendor permission — while setting the app-op is what actually opens the package list. The
+ * two are parallel routes to the same outcome, which is why gating these commands on `pm grant`
+ * having succeeded silently re-broke every Chinese ROM once already.
+ */
+internal fun installedAppsAppOpGrantCommands(escapedPackage: String, userId: Int): List<String> =
+    INSTALLED_APPS_APP_OP_SPELLINGS.map { op ->
+        appOpsCommand(escapedPackage, userId, op = op, mode = "allow")
+    }
+
+/**
+ * The counterpart to [installedAppsAppOpGrantCommands], and the reason a revoke has to issue one.
+ *
+ * `pm revoke` alone does not undo the grant: on the ROMs that define this op, an app-op left at
+ * `allow` keeps answering `MODE_ALLOWED` after the runtime permission is gone, so package visibility
+ * stays open while Thor reports the revoke as successful. Nothing else in the app could close it —
+ * [appOpsCommand] is private and had only an `allow` caller.
+ *
+ * **`default`, not `ignore`.** `ignore` would be the deterministic fail-closed choice, but it pins
+ * the op to hard-denied *independently of the permission*, and the ROM's own permission toggle
+ * cannot lift an explicit app-op mode — a later grant from Settings would look applied and do
+ * nothing, with Thor the only way back. `default` hands the answer back to the platform, where the
+ * `pm revoke` this accompanies has already denied the permission, so visibility closes and stays
+ * reversible from either side.
+ */
+internal fun installedAppsAppOpRevokeCommands(escapedPackage: String, userId: Int): List<String> =
+    INSTALLED_APPS_APP_OP_SPELLINGS.map { op ->
+        appOpsCommand(escapedPackage, userId, op = op, mode = "default")
+    }
 
 /**
  * The one place that knows how an `appops set` line is spelled.

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppDataArchiveGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppDataArchiveGateway.kt
@@ -38,12 +38,14 @@ internal interface AppDataArchiveGateway {
     suspend fun externalStorageDir(): String
 
     /**
-     * A path in Thor's **internal** cache for the shell to write and Thor to read back.
+     * A path in Thor's own cache for the shell to write and Thor to read back.
      *
-     * Internal, not `externalCacheDir` (§7.1): the staged file is a plaintext tar of someone's app
-     * data, and on shared storage any all-files-access app could read it. The OBB feature staged
-     * externally because Thor's own uid had to *write* there; here the shell writes and Thor only
-     * reads, and root can write anywhere.
+     * The **internal** cache wherever it can be: the staged file is a plaintext tar of someone's app
+     * data, and on shared storage any all-files-access app could read it. Root writes anywhere and
+     * takes that route. A Shizuku shell at uid 2000 cannot read `/data/data/<thor>` at all, and §7.1
+     * spends the exposure rather than the feature — `AppDataArchiveGatewayImpl.stagingRoot` resolves
+     * `externalCacheDir` in that case, and its KDoc owns both the condition and the cost. Anything
+     * measuring or sweeping this path has to honour the same condition, not assume the internal one.
      */
     suspend fun stagingFile(name: String): File
 

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/RestoreAppArchiveUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/RestoreAppArchiveUseCase.kt
@@ -485,13 +485,13 @@ internal class RestoreAppArchiveUseCase(
             } catch (e: Throwable) {
                 // Delete here rather than in `getOrElse`, where `out` is out of scope: a half-copied
                 // `.xapk` left in the cache is what the installer would pick up on the next attempt.
-                out.delete()
+                discardPartial(out)
                 throw e
             }
             if (copied == null) {
                 // Same reason as the catch above — `copyAtMostTo` leaves the partial output for its
                 // caller to discard, and here the installer is what would otherwise find it.
-                out.delete()
+                discardPartial(out)
                 return BundleStaging.Unreadable(
                     "this archive's app bundle is larger than " +
                         "${MAX_EXTRACTED_TOTAL_BYTES / (1024 * 1024 * 1024)} GB"
@@ -505,6 +505,21 @@ internal class RestoreAppArchiveUseCase(
             if (it is CancellationException) throw it
             Logger.e(TAG, "could not stage the app bundle", it)
             BundleStaging.Unreadable("this archive's app bundle could not be unpacked: ${it.message}")
+        }
+    }
+
+    /**
+     * Drop a partially-written bundle, and say so when the filesystem refuses.
+     *
+     * Not fatal, and deliberately not an error: `stagingFile` hands back the same path every time, so
+     * the next restore truncates this file before it writes and the launch sweep reclaims it either
+     * way — a survivor is wasted cache, never a bundle a later install could mistake for a whole one.
+     * Silent, though, and a staging directory that only ever grows is what a bug report describes as
+     * "Thor is using 3 GB".
+     */
+    private fun discardPartial(out: File) {
+        if (!out.delete() && out.exists()) {
+            Logger.w(TAG, "could not delete the partial bundle ${out.name}; the launch sweep will reclaim it")
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/RestoreAppArchiveUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/RestoreAppArchiveUseCase.kt
@@ -5,6 +5,8 @@ package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.data.backup.AppArchiveCipher
 import com.valhalla.thor.data.backup.ArchiveIntegrityException
+import com.valhalla.thor.data.repository.MAX_EXTRACTED_TOTAL_BYTES
+import com.valhalla.thor.data.repository.copyAtMostTo
 import com.valhalla.thor.domain.model.ArchiveCompression
 import com.valhalla.thor.domain.model.ArchiveHeader
 import com.valhalla.thor.domain.model.ArchiveMember
@@ -444,7 +446,8 @@ internal class RestoreAppArchiveUseCase(
 
         /**
          * The header declares a bundle this run could not produce: the entry is missing from the
-         * container, reading it threw, or Thor's cache could not hold the copy. [reason] says which.
+         * container, reading it threw, the entry expanded past [MAX_EXTRACTED_TOTAL_BYTES], or Thor's
+         * cache could not hold the copy. [reason] says which.
          */
         data class Unreadable(val reason: String) : BundleStaging
     }
@@ -466,19 +469,39 @@ internal class RestoreAppArchiveUseCase(
                     "this archive says it holds ${declared.fileName}, but that file is not in it"
                 )
             val out = gateway.stagingFile(THORBAK_BUNDLE_ENTRY)
-            try {
-                entry.use { input -> out.outputStream().use(input::copyTo) }
+            // Bounded, like `extractEntries` already bounds the same `.xapk` content on the installer
+            // side, and for the same reason: this is a deflated entry out of a container the user did
+            // not author, so its expanded size is the container's to choose. It is also the one member
+            // written before any verifier or passphrase check — `invoke` stages the bundle first, and
+            // an install-first restore never asks for a credential — so it is the only restore path
+            // where an unauthenticated caller decides how many bytes Thor writes. The header's
+            // `declared.bytes` is not the bound: it comes out of the same container.
+            val copied = try {
+                entry.use { input ->
+                    out.outputStream().use { output ->
+                        input.copyAtMostTo(output, MAX_EXTRACTED_TOTAL_BYTES)
+                    }
+                }
             } catch (e: Throwable) {
                 // Delete here rather than in `getOrElse`, where `out` is out of scope: a half-copied
                 // `.xapk` left in the cache is what the installer would pick up on the next attempt.
                 out.delete()
                 throw e
             }
+            if (copied == null) {
+                // Same reason as the catch above — `copyAtMostTo` leaves the partial output for its
+                // caller to discard, and here the installer is what would otherwise find it.
+                out.delete()
+                return BundleStaging.Unreadable(
+                    "this archive's app bundle is larger than " +
+                        "${MAX_EXTRACTED_TOTAL_BYTES / (1024 * 1024 * 1024)} GB"
+                )
+            }
             BundleStaging.Staged(out)
         }.getOrElse {
             // `runCatching` catches `Throwable`, so a cancellation would otherwise come back as a
-            // failed restore instead of a cancelled one. `copyTo` has no suspension point today; the
-            // rethrow is here so that stays true the moment it is chunked or made suspending.
+            // failed restore instead of a cancelled one. `copyAtMostTo` has no suspension point today;
+            // the rethrow is here so that stays true the moment it is chunked or made suspending.
             if (it is CancellationException) throw it
             Logger.e(TAG, "could not stage the app bundle", it)
             BundleStaging.Unreadable("this archive's app bundle could not be unpacked: ${it.message}")

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/RestoreAppArchiveUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/RestoreAppArchiveUseCase.kt
@@ -5,7 +5,7 @@ package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.data.backup.AppArchiveCipher
 import com.valhalla.thor.data.backup.ArchiveIntegrityException
-import com.valhalla.thor.data.repository.MAX_EXTRACTED_TOTAL_BYTES
+import com.valhalla.thor.data.repository.MAX_STAGED_BUNDLE_BYTES
 import com.valhalla.thor.data.repository.copyAtMostTo
 import com.valhalla.thor.domain.model.ArchiveCompression
 import com.valhalla.thor.domain.model.ArchiveHeader
@@ -446,7 +446,7 @@ internal class RestoreAppArchiveUseCase(
 
         /**
          * The header declares a bundle this run could not produce: the entry is missing from the
-         * container, reading it threw, the entry expanded past [MAX_EXTRACTED_TOTAL_BYTES], or Thor's
+         * container, reading it threw, the entry expanded past [MAX_STAGED_BUNDLE_BYTES], or Thor's
          * cache could not hold the copy. [reason] says which.
          */
         data class Unreadable(val reason: String) : BundleStaging
@@ -469,17 +469,25 @@ internal class RestoreAppArchiveUseCase(
                     "this archive says it holds ${declared.fileName}, but that file is not in it"
                 )
             val out = gateway.stagingFile(THORBAK_BUNDLE_ENTRY)
-            // Bounded, like `extractEntries` already bounds the same `.xapk` content on the installer
-            // side, and for the same reason: this is a deflated entry out of a container the user did
-            // not author, so its expanded size is the container's to choose. It is also the one member
-            // written before any verifier or passphrase check — `invoke` stages the bundle first, and
-            // an install-first restore never asks for a credential — so it is the only restore path
-            // where an unauthenticated caller decides how many bytes Thor writes. The header's
-            // `declared.bytes` is not the bound: it comes out of the same container.
+            // Bounded because this is a deflated entry out of a container the user did not author, so
+            // its expanded size is the container's to choose — and it is the one member written before
+            // any verifier or passphrase check (`invoke` stages the bundle first, and an install-first
+            // restore never asks for a credential), so it is the only restore path where a caller who
+            // proved nothing decides how many bytes Thor writes. The header's `declared.bytes` is not
+            // the bound: it comes out of the same container.
+            //
+            // `MAX_STAGED_BUNDLE_BYTES` and not `MAX_EXTRACTED_TOTAL_BYTES`, which this first used on
+            // the reasoning that `extractEntries` bounds the same content downstream. It does not
+            // bound all of it: that budget covers the resolved install set, and the expansion files in
+            // the same `.xapk` are unpacked against a separate, larger one precisely because a game's
+            // OBB set legitimately reaches gigabytes. The APK-only figure therefore refused a
+            // Thor-written XAPK backup of a large game, and refused it here — before the signer check,
+            // before any class is restored, and on the install-first path there is no toggle to
+            // decline the game data and get the rest.
             val copied = try {
                 entry.use { input ->
                     out.outputStream().use { output ->
-                        input.copyAtMostTo(output, MAX_EXTRACTED_TOTAL_BYTES)
+                        input.copyAtMostTo(output, MAX_STAGED_BUNDLE_BYTES)
                     }
                 }
             } catch (e: Throwable) {
@@ -494,7 +502,7 @@ internal class RestoreAppArchiveUseCase(
                 discardPartial(out)
                 return BundleStaging.Unreadable(
                     "this archive's app bundle is larger than " +
-                        "${MAX_EXTRACTED_TOTAL_BYTES / (1024 * 1024 * 1024)} GB"
+                        "${MAX_STAGED_BUNDLE_BYTES / (1024 * 1024 * 1024)} GB"
                 )
             }
             BundleStaging.Staged(out)

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListScreen.kt
@@ -367,11 +367,15 @@ fun AppListScreen(
                     }
                     // Deliberately no `selectedPackageForSheet = null` here. AppInfoSheet owns its
                     // own dismissal and already calls onDismiss() for every terminal action (launch,
-                    // freeze, uninstall, clear data, fix store); the rest — suspend, force-stop,
-                    // clear cache, share, system settings — are meant to leave the sheet up so you
-                    // can see the result and keep going. Clearing unconditionally would close it for
-                    // those too, and would do it by dropping the composable, so there'd be no exit
-                    // animation either.
+                    // freeze, uninstall, clear data, fix store, manage permissions); the rest —
+                    // suspend, force-stop, clear cache, share, system settings — are meant to leave
+                    // the sheet up so you can see the result and keep going. Clearing
+                    // unconditionally would close it for those too, and would do it by dropping the
+                    // composable, so there'd be no exit animation either.
+                    //
+                    // Manage permissions belongs in the first list and was missing from it: the
+                    // action is a destination push (ThorRoute.PermissionManager), and a sheet left
+                    // standing behind a pushed screen re-materialises on the way back.
                 },
                 // No dismissal here, unlike the Freezer tab: this list is the whole scan, so the app
                 // stays in it either way, and the selection resolves against allUserApps /

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -115,6 +116,14 @@ fun BackupRestoreHubScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
     var showInstallerSheet by remember { mutableStateOf(false) }
+
+    // The row does not disappear when a delete is refused, so something has to say why it did not.
+    LaunchedEffect(state.deleteFailed) {
+        if (state.deleteFailed) {
+            Toast.makeText(context, R.string.unknown_error_occurred, Toast.LENGTH_SHORT).show()
+            viewModel.consumeDeleteFailure()
+        }
+    }
 
     val handleRestoreOrInstall = { item: BackupArchiveItem ->
         if (item.kind == BackupArchiveKind.DATA_BACKUP) {

--- a/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModel.kt
@@ -35,6 +35,8 @@ data class BackupRestoreHubState(
     val appPickerSearchQuery: String = "",
     val installedApps: List<AppInfo> = emptyList(),
     val archiveToDelete: BackupArchiveItem? = null,
+    /** One-shot: a delete the volume refused, to be reported once and cleared. */
+    val deleteFailed: Boolean = false,
 ) {
     val hasBackups: Boolean get() = archives.any { it.kind == BackupArchiveKind.DATA_BACKUP }
     val hasBundles: Boolean get() = archives.any { it.kind == BackupArchiveKind.APP_BUNDLE }
@@ -158,9 +160,21 @@ class BackupRestoreHubViewModel(
         val target = _state.value.archiveToDelete ?: return
         viewModelScope.launch {
             _state.update { it.copy(archiveToDelete = null) }
+            // A false from `deleteArchive` is a delete that did not happen — a read-only volume, a
+            // SAF grant that no longer covers the tree, a `rm` the shell refused. Dropping it, as
+            // this did, closes the confirmation dialog and leaves the row exactly where it was,
+            // which reads as a broken list rather than as a refusal, and invites the user to try
+            // again forever.
             if (scanner.deleteArchive(target)) {
                 refreshArchives()
+            } else {
+                _state.update { it.copy(deleteFailed = true) }
             }
         }
+    }
+
+    /** Clear [BackupRestoreHubState.deleteFailed] once the UI has reported it. */
+    fun consumeDeleteFailure() {
+        _state.update { it.copy(deleteFailed = false) }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerScreen.kt
@@ -593,7 +593,12 @@ fun FreezerScreen(
             onAppAction = { action ->
                 // No clears below, same as the Apps tab: AppInfoSheet calls onDismiss() itself for
                 // every terminal action, and the rest — suspend, force-stop, clear cache, share,
-                // settings, permissions — are meant to leave the sheet up so you can see the result.
+                // settings — are meant to leave the sheet up so you can see the result.
+                //
+                // Permissions used to be listed as one of those, which is what hid the bug: it is
+                // the one action in that group that pushes a destination
+                // (ThorRoute.PermissionManager, added to freezerBackStack in MainScreen), so the
+                // sheet has to go with it. AppInfoSheet dismisses on it now.
                 // Freezing and unfreezing don't touch membership, so neither can pull this app out
                 // of state.freezerApps.
                 when (action) {

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
@@ -22,8 +22,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -785,11 +787,15 @@ private fun LanguageBottomSheet(
         containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp)
     ) {
+        // Scrollable, not merely tall: the picker lists every entry in AppLanguage.PICKER_ORDER,
+        // which is nine rows plus a header — taller than a bottom sheet gets in landscape, where the
+        // last entries would otherwise be laid out past the bottom edge and be unreachable.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 48.dp)
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp)
+                .padding(bottom = 48.dp)
         ) {
             Text(
                 stringResource(R.string.select_language),

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/customization/AppInfoActionsCustomizationScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/customization/AppInfoActionsCustomizationScreen.kt
@@ -149,11 +149,36 @@ fun AppInfoActionsCustomizationScreen(
         }
     }
 
+    // An order that arrived mid-drag, held until the finger lifts. Deferred rather than dropped:
+    // the effect below is keyed on `currentOrder`, so a value it declines to apply is not seen
+    // again, and the case where that bites is the one that leaves no trace — a drag that settles
+    // back where it started writes nothing, `currentOrder` never changes again, and `localActions`
+    // stays diverged from what is actually stored until the screen is left. Any later drag then
+    // persists that stale snapshot over the change it never applied.
+    var deferredOrder by remember { mutableStateOf<List<AppInfoActionId>?>(null) }
+
     // Synchronize local snapshot with repository when not in active drag
     LaunchedEffect(currentOrder) {
-        if (reorderState.draggingItemKey == null && localActions.toList() != currentOrder) {
+        if (reorderState.draggingItemKey != null) {
+            deferredOrder = currentOrder
+        } else if (localActions.toList() != currentOrder) {
+            deferredOrder = null
             localActions.clear()
             localActions.addAll(currentOrder)
+        }
+    }
+
+    // Keyed on the drag, and doing nothing unless something was actually deferred: the drag's own
+    // completion writes `localActions` back through the view model, and that write takes a few
+    // frames to return through `prefs`, so an unconditional re-sync here would flash the pre-drag
+    // order in the window between the two.
+    LaunchedEffect(reorderState.draggingItemKey) {
+        if (reorderState.draggingItemKey != null) return@LaunchedEffect
+        val pending = deferredOrder ?: return@LaunchedEffect
+        deferredOrder = null
+        if (localActions.toList() != pending) {
+            localActions.clear()
+            localActions.addAll(pending)
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/customization/AppInfoActionsCustomizationScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/customization/AppInfoActionsCustomizationScreen.kt
@@ -122,6 +122,14 @@ fun AppInfoActionsCustomizationScreen(
 
     var showResetConfirmation by rememberSaveable { mutableStateOf(false) }
 
+    // An order that arrived mid-drag, held until the finger lifts. Deferred rather than dropped:
+    // the effect below is keyed on `currentOrder`, so a value it declines to apply is not seen
+    // again, and the case where that bites is the one that leaves no trace — a drag that settles
+    // back where it started writes nothing, `currentOrder` never changes again, and `localActions`
+    // stays diverged from what is actually stored until the screen is left. Any later drag then
+    // persists that stale snapshot over the change it never applied.
+    var deferredOrder by remember { mutableStateOf<List<AppInfoActionId>?>(null) }
+
     val reorderState = rememberReorderableLazyListState(
         listState = listState,
         onMove = { fromKey, toKey ->
@@ -133,6 +141,16 @@ fun AppInfoActionsCustomizationScreen(
             }
         },
         onDragCompleted = {
+            // Whatever was deferred during this drag is older than what the drag just built, so it
+            // is dropped rather than applied: the only writers of this preference are this screen,
+            // and none of them writes optimistically, so every value that can reach the deferral is
+            // a snapshot from before the finger went down. Cleared here and not in the effect below
+            // because `finishDrag` calls this synchronously, before the `draggingItemKey` change
+            // recomposes — so the effect sees `null` and leaves the list alone. Left set, it applied
+            // that older snapshot *after* this write, and a reorder the user had just finished
+            // visibly snapped back until its own echo returned. A drag that moved nothing never
+            // reaches here (`movedDuringGesture`), which is the case the deferral exists for.
+            deferredOrder = null
             viewModel.setAppInfoActionsOrder(localActions.toList())
         }
     )
@@ -149,14 +167,6 @@ fun AppInfoActionsCustomizationScreen(
         }
     }
 
-    // An order that arrived mid-drag, held until the finger lifts. Deferred rather than dropped:
-    // the effect below is keyed on `currentOrder`, so a value it declines to apply is not seen
-    // again, and the case where that bites is the one that leaves no trace — a drag that settles
-    // back where it started writes nothing, `currentOrder` never changes again, and `localActions`
-    // stays diverged from what is actually stored until the screen is left. Any later drag then
-    // persists that stale snapshot over the change it never applied.
-    var deferredOrder by remember { mutableStateOf<List<AppInfoActionId>?>(null) }
-
     // Synchronize local snapshot with repository when not in active drag
     LaunchedEffect(currentOrder) {
         if (reorderState.draggingItemKey != null) {
@@ -171,7 +181,9 @@ fun AppInfoActionsCustomizationScreen(
     // Keyed on the drag, and doing nothing unless something was actually deferred: the drag's own
     // completion writes `localActions` back through the view model, and that write takes a few
     // frames to return through `prefs`, so an unconditional re-sync here would flash the pre-drag
-    // order in the window between the two.
+    // order in the window between the two. `onDragCompleted` has already cleared the deferral in
+    // that case, so what reaches here is a drag that moved nothing — the one drag whose own list is
+    // not newer than what arrived.
     LaunchedEffect(reorderState.draggingItemKey) {
         if (reorderState.draggingItemKey != null) return@LaunchedEffect
         val pending = deferredOrder ?: return@LaunchedEffect

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/customization/ReorderableState.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/customization/ReorderableState.kt
@@ -121,8 +121,17 @@ class ReorderableLazyListState(
         autoScrollJob = scope.launch { runAutoScroll() }
     }
 
-    fun onDrag(dragAmount: Float) {
-        if (draggingItemKey == null) return
+    /**
+     * Moves the dragged card by [dragAmount], if [key] is the one holding the drag.
+     *
+     * Keyed for the same reason [finishDrag] is, and it is the same bug: a handle whose
+     * [onDragStart] was turned away still has a live gesture detector, and a bare
+     * `draggingItemKey == null` check passes for it — so a second finger anywhere in the list
+     * steered the *first* finger's card, at double speed when both moved together. The owner
+     * check is the whole guard; a rejected gesture contributes nothing until it starts its own.
+     */
+    fun onDrag(key: Any, dragAmount: Float) {
+        if (draggingItemKey != key) return
         trackDragDirection(dragAmount)
         draggingItemOffset += dragAmount
         // Nothing else this pass if a swap happened: `settleDropTarget` has already taken the slot
@@ -340,7 +349,7 @@ fun Modifier.dragHandle(
         onDragCancel = { state.onDragCancel(key) },
         onVerticalDrag = { change, dragAmount ->
             change.consume()
-            state.onDrag(dragAmount)
+            state.onDrag(key, dragAmount)
         }
     )
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/customization/ReorderableState.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/customization/ReorderableState.kt
@@ -98,7 +98,18 @@ class ReorderableLazyListState(
      */
     private var movedDuringGesture = false
 
+    /**
+     * Begins a drag on [key], unless one is already running.
+     *
+     * Every handle installs its own `pointerInput`, so two fingers on two handles are two
+     * independent gesture detectors that both call in here. Letting the second one through reset the
+     * key and the offset mid-gesture: the first finger's deltas then moved the *second* row, and
+     * whichever finger lifted first cleared the whole state — so the other one went dead, and
+     * [onDragCompleted] fired while a drag was still in progress or, if [movedDuringGesture] was
+     * lost with the reset, never fired at all and the reorder was not persisted.
+     */
     fun onDragStart(key: Any) {
+        if (draggingItemKey != null) return
         draggingItemKey = key
         draggingItemOffset = 0f
         autoScrollVelocity = 0f
@@ -114,16 +125,27 @@ class ReorderableLazyListState(
         if (draggingItemKey == null) return
         trackDragDirection(dragAmount)
         draggingItemOffset += dragAmount
-        settleDropTarget()
+        // Nothing else this pass if a swap happened: `settleDropTarget` has already taken the slot
+        // gap off the translation, but `listState.layoutInfo` still describes the order from before
+        // it, and the velocity is computed from the two together. Mixing a pre-swap slot offset with
+        // a post-swap translation puts the card a whole row away from where it is rendered — enough,
+        // against a 96 dp edge zone, to start or stop the auto-scroller for a frame on nothing. The
+        // last velocity holds until the next pointer event or frame reads a layout that agrees with
+        // itself.
+        if (settleDropTarget()) return
         updateAutoScrollVelocity()
     }
 
-    fun onDragEnd() = finishDrag()
+    fun onDragEnd(key: Any) = finishDrag(key)
 
-    fun onDragCancel() = finishDrag()
+    fun onDragCancel(key: Any) = finishDrag(key)
 
-    private fun finishDrag() {
-        if (draggingItemKey == null) return
+    /**
+     * Ends the drag, if [key] is the one holding it — a gesture that [onDragStart] turned away must
+     * not be able to end the gesture that won.
+     */
+    private fun finishDrag(key: Any) {
+        if (draggingItemKey != key) return
         autoScrollJob?.cancel()
         autoScrollJob = null
         autoScrollVelocity = 0f
@@ -159,7 +181,9 @@ class ReorderableLazyListState(
             // point at exactly the speed the list is scrolling.
             if (consumed == 0f) continue // an end of the list; nothing moved, nothing to absorb
             draggingItemOffset += consumed
-            settleDropTarget()
+            // Same reason as in `onDrag`: a swap makes this frame's layout disagree with this
+            // frame's translation, and the next frame is one vsync away.
+            if (settleDropTarget()) continue
             updateAutoScrollVelocity()
         }
     }
@@ -171,11 +195,14 @@ class ReorderableLazyListState(
      * are not a uniform height (a two-line description makes one taller than its neighbour), and
      * the offset correction below — the gap between the two slots — is only exact for a single
      * adjacent swap. Repeated calls converge on the same place without accumulating that error.
+     *
+     * Returns true when it swapped, which tells the caller that [LazyListState.layoutInfo] is now a
+     * frame behind the translation and must not be read again until it catches up.
      */
-    private fun settleDropTarget() {
-        val key = draggingItemKey ?: return
+    private fun settleDropTarget(): Boolean {
+        val key = draggingItemKey ?: return false
         val visibleItems = listState.layoutInfo.visibleItemsInfo
-        val currentItem = visibleItems.firstOrNull { it.key == key } ?: return
+        val currentItem = visibleItems.firstOrNull { it.key == key } ?: return false
         val currentCenter = currentItem.offset + (currentItem.size / 2f) + draggingItemOffset
 
         val targetItem = if (draggingItemOffset > 0) {
@@ -192,7 +219,7 @@ class ReorderableLazyListState(
                     val otherCenter = other.offset + (other.size / 2f)
                     currentCenter < otherCenter
                 }
-        } ?: return
+        } ?: return false
 
         // The row is about to be laid out in the target's slot, so the same amount comes off the
         // translation to leave it rendered where the finger currently holds it.
@@ -200,6 +227,7 @@ class ReorderableLazyListState(
         movedDuringGesture = true
         haptics?.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
         onMove(key, targetItem.key)
+        return true
     }
 
     /**
@@ -308,8 +336,8 @@ fun Modifier.dragHandle(
 ): Modifier = pointerInput(key, state) {
     detectVerticalDragGestures(
         onDragStart = { state.onDragStart(key) },
-        onDragEnd = { state.onDragEnd() },
-        onDragCancel = { state.onDragCancel() },
+        onDragEnd = { state.onDragEnd(key) },
+        onDragCancel = { state.onDragCancel(key) },
         onVerticalDrag = { change, dragAmount ->
             change.consume()
             state.onDrag(dragAmount)

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/customization/ReorderableState.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/customization/ReorderableState.kt
@@ -140,7 +140,8 @@ class ReorderableLazyListState(
         // a post-swap translation puts the card a whole row away from where it is rendered — enough,
         // against a 96 dp edge zone, to start or stop the auto-scroller for a frame on nothing. The
         // last velocity holds until the next pointer event or frame reads a layout that agrees with
-        // itself.
+        // itself — including when that last velocity is zero, which is why `runAutoScroll` re-reads
+        // a zero rather than only sustaining a non-zero one.
         if (settleDropTarget()) return
         updateAutoScrollVelocity()
     }
@@ -180,6 +181,15 @@ class ReorderableLazyListState(
             val frame = withFrameNanos { it }
             val seconds = ((frame - previousFrame) / 1_000_000_000f).coerceIn(0f, MAX_FRAME_SECONDS)
             previousFrame = frame
+
+            // A frame that is not scrolling is still a frame whose layout agrees with the
+            // translation, so this is where a zero velocity gets its second look. Without it this
+            // loop could only *sustain* a velocity, never start one — the `continue` below skipped
+            // the recompute at the bottom — so an `onDrag` that both swapped and crossed into an
+            // edge zone left the velocity at zero and a finger then held still at the edge never
+            // scrolled at all. What keeps this from scrolling on a mere press is the direction gate
+            // in `updateAutoScrollVelocity`: `dragDirection` is 0 until the finger has travelled.
+            if (autoScrollVelocity == 0f) updateAutoScrollVelocity()
 
             val velocity = autoScrollVelocity
             if (velocity == 0f) continue

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
@@ -448,12 +448,18 @@ class ArchiveIconFetcher(
         // every icon inside the budget and breaks it only where the alternative is an allocation
         // that fails or a bitmap the canvas refuses to draw.
         //
-        // Guarded on both dimensions because integer division floors: once one of them is down to
-        // 1 px, doubling again only drives it to 0 — the decode gets narrower, not cheaper, and the
-        // budget may still not be met. That is the degenerate strip, and it stops here.
+        // `maxOf(1, …)` and `||`, because that is what the decoder does: `SkAndroidCodec` floors
+        // each sampled axis at 1 px and never at 0. Estimating with a bare division instead made
+        // doubling look pointless as soon as one axis reached 1 px — 1 / 2 = 0, so the product read
+        // as 0 and the guard refused to advance — which exempted the most extreme aspect ratio from
+        // the ceiling that exists for exactly that shape: a 1 × 40000000 strip stayed at
+        // `inSampleSize = 1` and decoded all 160 MB of itself. Progress is still possible while
+        // *either* axis is above 1, and the loop terminates because doubling drives both divisions
+        // to 0, where the product is 1.
         while (
-            (sourceWidth / sample).toLong() * (sourceHeight / sample) > MAX_DECODED_ICON_PIXELS &&
-            sourceWidth / sample > 1 && sourceHeight / sample > 1
+            maxOf(1, sourceWidth / sample).toLong() * maxOf(1, sourceHeight / sample) >
+                MAX_DECODED_ICON_PIXELS &&
+            (sourceWidth / sample > 1 || sourceHeight / sample > 1)
         ) {
             sample *= 2
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
@@ -52,6 +52,31 @@ import org.json.JSONObject
  */
 private const val MAX_ICON_STAGE_BYTES = 256L * 1024 * 1024
 
+/**
+ * The most pixels `decodeSampled` will allocate, whatever the caller asked for — 4 MB of ARGB_8888.
+ *
+ * Target-size sampling cannot carry this on its own, and the hole is not an exotic one: the sample
+ * step advances only while **both** axes are still at or above the target, so a source with one axis
+ * already below it never samples at all. A 263 × 150000 `icon.png` — about 160 KB of PNG if its rows
+ * are uniform, so well inside [com.valhalla.thor.data.repository.MAX_METADATA_ENTRY_BYTES] — decodes
+ * whole against a 132 px request: 39 Mpx, 158 MB, from a file BundleZip's header already calls
+ * untrusted. Bigger than that and the allocation throws `OutOfMemoryError`, which is an `Error` and
+ * so escapes the `catch (Exception)` in [ArchiveIconFetcher.fetch]; smaller and it *succeeds*, gets
+ * PNG-encoded into `cacheDir` at quality 100, and is then handed to a `RecordingCanvas` that refuses
+ * any bitmap past `ro.hwui.max_texture_allocation_size` (floor 150 MB) with a UI-thread exception.
+ *
+ * A second, latent route reaches the same place: Coil's `Size` is two [coil3.size.Dimension]s and
+ * either may be `Undefined`, in which case `pxOrElse` falls back to the *source* dimension and
+ * nothing samples. Not reachable today — the one model site sizes the image at 44 dp, so both
+ * dimensions are `Pixels` — but `contentScale = ContentScale.None` on that call would make it so.
+ *
+ * Deliberately absolute rather than `maxOf(this, requested area)`: raising the ceiling to match the
+ * request would restore the full decode on precisely the `Undefined` path above, where the request
+ * *is* the source. An entry named `icon.png` is drawn at 44 dp, and 1024×1024 is past every real
+ * icon (a 108 dp adaptive icon at 4× density is 432 px), so the clamp costs nothing real.
+ */
+private const val MAX_DECODED_ICON_PIXELS = 1024L * 1024
+
 data class ArchiveIconModel(
     val uriString: String,
     val packageName: String?,
@@ -87,7 +112,14 @@ class ArchiveIconFetcher(
             val cacheKey = "icon_${model.uriString.hashCode()}_${model.sizeBytes}_${model.lastModifiedEpochSec}"
             val cachedFile = File(iconCacheDir, "$cacheKey.png")
             if (cachedFile.exists() && cachedFile.length() > 0) {
-                val bitmap = BitmapFactory.decodeFile(cachedFile.absolutePath)
+                // Sampled on the way out as well as in. `decodeFile` takes no options, so it has no
+                // ceiling: an entry written by a build that decoded a crafted strip whole is still
+                // on disk, keyed by size and mtime, and would be re-decoded at full size on every
+                // launch until the pruner reaches it — the ceiling would then protect only the
+                // devices that never hit the bug.
+                val bitmap = runCatching { cachedFile.readBytes() }
+                    .getOrNull()
+                    ?.let { decodeSampled(it) }
                 if (bitmap != null) {
                     return ImageFetchResult(
                         image = bitmap.toDrawable(context.resources).asImage(),
@@ -387,7 +419,9 @@ class ArchiveIconFetcher(
      * [fetch] would not contain it either.
      *
      * The sample step stops at the last power of two still at or above the requested size, so the
-     * result is never smaller than what was asked for; Coil scales it the rest of the way.
+     * result is never smaller than what was asked for; Coil scales it the rest of the way. The one
+     * exception is [MAX_DECODED_ICON_PIXELS], which overrides that property rather than extending
+     * it — the alternative to an icon smaller than requested there is no icon and a dead list row.
      */
     private fun decodeSampled(bytes: ByteArray): Bitmap? {
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
@@ -402,6 +436,24 @@ class ArchiveIconFetcher(
         while (
             sourceWidth / (sample * 2) >= targetWidth &&
             sourceHeight / (sample * 2) >= targetHeight
+        ) {
+            sample *= 2
+        }
+
+        // The absolute ceiling, applied after the target-size step and independent of it. The `&&`
+        // above is why it is needed: the loop stops the moment *either* axis drops below the target,
+        // so an asymmetric source pins sample at 1 however many pixels the other axis carries, and
+        // both axes come out of the archive. [MAX_DECODED_ICON_PIXELS] has the numbers. Doubling
+        // from whatever the first loop chose keeps the "never smaller than requested" property for
+        // every icon inside the budget and breaks it only where the alternative is an allocation
+        // that fails or a bitmap the canvas refuses to draw.
+        //
+        // Guarded on both dimensions because integer division floors: once one of them is down to
+        // 1 px, doubling again only drives it to 0 — the decode gets narrower, not cheaper, and the
+        // budget may still not be met. That is the degenerate strip, and it stops here.
+        while (
+            (sourceWidth / sample).toLong() * (sourceHeight / sample) > MAX_DECODED_ICON_PIXELS &&
+            sourceWidth / sample > 1 && sourceHeight / sample > 1
         ) {
             sample *= 2
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
@@ -448,18 +448,20 @@ class ArchiveIconFetcher(
         // every icon inside the budget and breaks it only where the alternative is an allocation
         // that fails or a bitmap the canvas refuses to draw.
         //
-        // `maxOf(1, …)` and `||`, because that is what the decoder does: `SkAndroidCodec` floors
-        // each sampled axis at 1 px and never at 0. Estimating with a bare division instead made
-        // doubling look pointless as soon as one axis reached 1 px — 1 / 2 = 0, so the product read
-        // as 0 and the guard refused to advance — which exempted the most extreme aspect ratio from
-        // the ceiling that exists for exactly that shape: a 1 × 40000000 strip stayed at
-        // `inSampleSize = 1` and decoded all 160 MB of itself. Progress is still possible while
-        // *either* axis is above 1, and the loop terminates because doubling drives both divisions
-        // to 0, where the product is 1.
+        // `maxOf(1, …)`, because that is what the decoder does: AOSP's `get_scaled_dimension` is
+        // `max(1, floor(dim / sample))`, so a sampled axis floors at 1 px and never at 0. Estimating
+        // with a bare division read 1 / 2 as 0, so a one-pixel axis made the product 0 and needed a
+        // `> 1 && > 1` guard to look sensible — and that guard exempted the most extreme aspect
+        // ratio from the ceiling that exists for exactly that shape. Nothing decodable reached the
+        // exemption, so this replaces a wrong reason rather than a shipped over-allocation: libpng
+        // caps an axis at `PNG_USER_{WIDTH,HEIGHT}_MAX` = 1000000, itself under the ceiling, and
+        // every other format Skia sniffs caps lower, so a strip long enough to matter fails the
+        // bounds pass and returns null above. The guard is gone because the clamped product implies
+        // it — a product over the ceiling needs an axis over 1 — and that is also why this
+        // terminates: doubling drives both divisions to 0, where the clamped product is 1.
         while (
             maxOf(1, sourceWidth / sample).toLong() * maxOf(1, sourceHeight / sample) >
-                MAX_DECODED_ICON_PIXELS &&
-            (sourceWidth / sample > 1 || sourceHeight / sample > 1)
+                MAX_DECODED_ICON_PIXELS
         ) {
             sample *= 2
         }

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
@@ -34,6 +34,8 @@ import java.io.FileOutputStream
 import java.util.UUID
 import java.util.zip.ZipFile
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
 data class ArchiveIconModel(
@@ -157,40 +159,47 @@ class ArchiveIconFetcher(
                     }
                 } else {
                     val path = uri.path
-                    if (!path.isNullOrBlank()) {
-                        val tmpPath = "/data/local/tmp/thor_ico_$token"
-                        val src = path.escapeShellArg()
-                        val dst = tmpPath.escapeShellArg()
-                        val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
+                    if (path.isNullOrBlank()) return null
+                    val tmpPath = "/data/local/tmp/thor_ico_$token"
+                    val src = path.escapeShellArg()
+                    val dst = tmpPath.escapeShellArg()
+                    val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
+                    // One `finally` for every exit, and an uncancellable one. The `cat` can have
+                    // produced the file even when this coroutine is cancelled before the call
+                    // returns, so a removal placed on the success paths only — as this was — never
+                    // runs on the path that matters. Coil cancels these fetches routinely as the
+                    // archive list scrolls, and `ArchiveOrphanSweeper` sweeps `cacheDir`,
+                    // `externalCacheDir/obb_out` and the SAF ledger but *not* `/data/local/tmp`, so
+                    // a skipped `rm -f` strands a full-size, `chmod 666` copy of the user's archive
+                    // where nothing in the app can ever reclaim it. `NonCancellable` alone, without
+                    // a dispatcher: `executeShellCommand` makes its own `ioDispatcher` hop.
+                    try {
                         val res = systemRepository.executeShellCommand(cmd).getOrNull()
-                        if (res != null && res.first == 0) {
-                            val tmpFile = File(tmpPath)
-                            if (tmpFile.exists() && tmpFile.length() > 0) {
-                                try {
-                                    tmpFile.inputStream().use { inputStream ->
-                                        FileOutputStream(tempStaging).use { outputStream -> inputStream.copyTo(outputStream) }
-                                    }
-                                    staged = true
-                                    tempStaging
-                                } catch (e: Throwable) {
-                                    tempStaging.delete()
-                                    throw e
-                                } finally {
-                                    systemRepository.executeShellCommand("rm -f $dst")
-                                }
-                            } else {
-                                systemRepository.executeShellCommand("rm -f $dst")
-                                return null
+                        if (res == null || res.first != 0) return null
+                        val tmpFile = File(tmpPath)
+                        if (!tmpFile.exists() || tmpFile.length() <= 0) return null
+                        try {
+                            tmpFile.inputStream().use { inputStream ->
+                                FileOutputStream(tempStaging).use { outputStream -> inputStream.copyTo(outputStream) }
                             }
-                        } else {
-                            return null
+                        } catch (e: Throwable) {
+                            tempStaging.delete()
+                            throw e
                         }
-                    } else {
-                        return null
+                        staged = true
+                        tempStaging
+                    } finally {
+                        withContext(NonCancellable) {
+                            systemRepository.executeShellCommand("rm -f $dst")
+                        }
                     }
                 }
             }
         } catch (e: CancellationException) {
+            // Above the rethrow, not below it: a cancellation arriving here leaves the same staged
+            // copy behind as any other failure, and `File.delete()` is a blocking call that still
+            // completes while cancellation is in progress.
+            tempStaging.delete()
             throw e
         } catch (_: Exception) {
             tempStaging.delete()

--- a/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/utils/ArchiveIconLoader.kt
@@ -26,17 +26,31 @@ import coil3.request.Options
 import coil3.request.bitmapConfig
 import coil3.size.pxOrElse
 import com.valhalla.thor.data.repository.BundleZip
+import com.valhalla.thor.data.repository.copyAtMostTo
+import com.valhalla.thor.domain.model.THORBAK_EXTENSION
+import com.valhalla.thor.domain.model.THORBAK_HEADER_ENTRY
 import com.valhalla.thor.domain.model.escapeShellArg
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.Logger
 import java.io.File
 import java.io.FileOutputStream
 import java.util.UUID
-import java.util.zip.ZipFile
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+
+/**
+ * Most of the user's disk one 44 dp icon may spend on a scratch copy of the archive it came from.
+ *
+ * There is no way to avoid the copy for the formats that reach it: the icon comes out of a zip,
+ * `ZipFile` is the only reader that can be trusted with an installer bundle (BundleZip's header has
+ * the APKPure case that rules `ZipInputStream` out), and `ZipFile` needs a real path. So the copy
+ * is a given and its size is the lever. 256 MB clears the ordinary `.apk`/`.xapk` in a Downloads
+ * folder by a wide margin and refuses the multi-gigabyte game bundle, whose icon is not worth
+ * writing a gigabyte of cacheDir — and whose entry in the list still shows its name, size and date.
+ */
+private const val MAX_ICON_STAGE_BYTES = 256L * 1024 * 1024
 
 data class ArchiveIconModel(
     val uriString: String,
@@ -55,27 +69,16 @@ class ArchiveIconFetcher(
 
     override suspend fun fetch(): FetchResult? {
         return try {
-            val pm = context.packageManager
-
             // 1. If packageName is known, try loading installed app icon first
             val pkg = model.packageName
             if (!pkg.isNullOrBlank()) {
-                try {
-                    val flags = PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
-                    val appInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        pm.getApplicationInfo(pkg, PackageManager.ApplicationInfoFlags.of(flags))
-                    } else {
-                        pm.getApplicationInfo(pkg, PackageManager.MATCH_UNINSTALLED_PACKAGES)
-                    }
-                    val drawable = appInfo.loadIcon(pm)
-                    val bitmap = drawable.toBitmap(options)
+                val installed = installedIcon(pkg)
+                if (installed != null) {
                     return ImageFetchResult(
-                        image = bitmap.toDrawable(context.resources).asImage(),
+                        image = installed.toDrawable(context.resources).asImage(),
                         isSampled = false,
                         dataSource = DataSource.DISK,
                     )
-                } catch (_: Exception) {
-                    // Not installed or cannot load from PM, proceed to extract from archive
                 }
             }
 
@@ -94,16 +97,29 @@ class ArchiveIconFetcher(
                 }
             }
 
+            // 2b. A remembered miss. Coil caches an image, not the absence of one, so without this
+            // a fetch that ends in null is redone on every pass over the list — and for an archive
+            // that has to be staged first, "redone" means copying it again. The key carries the
+            // size and the mtime, so a file that changes is re-examined, and the marker is evicted
+            // on the same schedule as an icon. A transient failure is therefore remembered as a
+            // permanent one until one of those happens: that is the trade, and it is the right way
+            // round for a list whose entries can be gigabytes each.
+            val missMarker = File(iconCacheDir, "$cacheKey.none")
+            if (missMarker.exists()) return null
+
             // 3. Extract icon from archive (APK, XAPK, APKS, THORBAK)
-            val extractedBitmap = extractIcon(model) ?: return null
+            val extractedBitmap = extractIcon(model)
+            if (extractedBitmap == null) {
+                runCatching {
+                    prepareCacheDir(iconCacheDir)
+                    missMarker.createNewFile()
+                }
+                return null
+            }
 
             // Cache extracted bitmap
             try {
-                if (!iconCacheDir.exists()) {
-                    iconCacheDir.mkdirs()
-                } else {
-                    cleanStaleCacheIfNeeded(iconCacheDir)
-                }
+                prepareCacheDir(iconCacheDir)
                 FileOutputStream(cachedFile).use { out ->
                     extractedBitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
                 }
@@ -126,6 +142,15 @@ class ArchiveIconFetcher(
         }
     }
 
+    /** Create the icon cache directory, or prune it if it is already over its ceiling. */
+    private fun prepareCacheDir(dir: File) {
+        if (!dir.exists()) {
+            dir.mkdirs()
+        } else {
+            cleanStaleCacheIfNeeded(dir)
+        }
+    }
+
     private fun cleanStaleCacheIfNeeded(dir: File) {
         val files = dir.listFiles() ?: return
         if (files.size > 100) {
@@ -137,61 +162,114 @@ class ArchiveIconFetcher(
 
     private suspend fun extractIcon(model: ArchiveIconModel): Bitmap? {
         val uri = runCatching { model.uriString.toUri() }.getOrNull() ?: return null
+        val lower = model.displayName.lowercase()
+        val localFile = uri.path
+            ?.let(::File)
+            ?.takeIf { uri.scheme == "file" && it.canRead() }
+
+        // Two refusals before anything is staged, because staging is where the cost of this fetcher
+        // lives — it writes a whole second copy of the archive into cacheDir.
+        if (localFile == null) {
+            // A `.thorbak` never gets one. The format carries no icon entry at all; the only thing
+            // a reader can take from it is the `packageName` in `thorbak.json`, and that entry is
+            // written LAST (chunk counts are unknown until the members exist), so reaching it means
+            // reading a whole multi-gigabyte archive to arrive at the identity the scanner already
+            // parsed out of the `<pkg>-<versionCode>.thorbak` file name and step 1 above has
+            // already tried against the package manager.
+            if (lower.endsWith(".$THORBAK_EXTENSION")) return null
+            if (model.sizeBytes > MAX_ICON_STAGE_BYTES) return null
+        }
+
         val token = UUID.randomUUID().toString()
         val tempStaging = File(context.cacheDir, "temp_ico_$token")
-        var staged = false
 
-        val sourceFile: File = try {
-            if (uri.scheme == "file" && uri.path != null && File(uri.path!!).canRead()) {
-                File(uri.path!!)
-            } else {
-                val input = runCatching { context.contentResolver.openInputStream(uri) }.getOrNull()
-                if (input != null) {
-                    try {
-                        input.use { src ->
-                            FileOutputStream(tempStaging).use { dst -> src.copyTo(dst) }
+        val sourceFile: File = localFile ?: stageArchive(uri, tempStaging, token) ?: return null
+        val staged = sourceFile === tempStaging
+
+        try {
+            return when {
+                lower.endsWith(".apk") -> parseApkIcon(sourceFile)
+                lower.endsWith(".xapk") || lower.endsWith(".apks") -> parseBundleIcon(sourceFile)
+                lower.endsWith(".$THORBAK_EXTENSION") -> parseThorbakIcon(sourceFile)
+                else -> parseApkIcon(sourceFile) ?: parseBundleIcon(sourceFile)
+            }
+        } finally {
+            if (staged) {
+                tempStaging.delete()
+            }
+        }
+    }
+
+    /**
+     * Copy the archive at [uri] into [tempStaging] so a `ZipFile` reader can open it, and return
+     * that file — or null when it cannot be staged, or should not be.
+     *
+     * Owns the cleanup of everything it writes, on every exit including a cancellation, so a caller
+     * holding a null has nothing left to undo.
+     */
+    private suspend fun stageArchive(uri: Uri, tempStaging: File, token: String): File? {
+        return try {
+            val input = runCatching { context.contentResolver.openInputStream(uri) }.getOrNull()
+            if (input != null) {
+                try {
+                    // Bounded, not merely size-checked by the caller: `sizeBytes` reaches it from
+                    // the same provider as the bytes, and a provider that reports 0 for a length it
+                    // does not know — plenty do — sails straight through that check.
+                    val copied = input.use { src ->
+                        FileOutputStream(tempStaging).use { dst ->
+                            src.copyAtMostTo(dst, MAX_ICON_STAGE_BYTES)
                         }
-                        staged = true
+                    }
+                    if (copied == null) {
+                        tempStaging.delete()
+                        null
+                    } else {
                         tempStaging
+                    }
+                } catch (e: Throwable) {
+                    tempStaging.delete()
+                    throw e
+                }
+            } else {
+                val path = uri.path
+                if (path.isNullOrBlank()) return null
+                val tmpPath = "/data/local/tmp/thor_ico_$token"
+                val src = path.escapeShellArg()
+                val dst = tmpPath.escapeShellArg()
+                val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
+                // One `finally` for every exit, and an uncancellable one. The `cat` can have
+                // produced the file even when this coroutine is cancelled before the call
+                // returns, so a removal placed on the success paths only — as this was — never
+                // runs on the path that matters. Coil cancels these fetches routinely as the
+                // archive list scrolls, and `ArchiveOrphanSweeper` sweeps `cacheDir`,
+                // `externalCacheDir/obb_out` and the SAF ledger but *not* `/data/local/tmp`, so
+                // a skipped `rm -f` strands a full-size, `chmod 666` copy of the user's archive
+                // where nothing in the app can ever reclaim it. `NonCancellable` alone, without
+                // a dispatcher: `executeShellCommand` makes its own `ioDispatcher` hop.
+                try {
+                    val res = systemRepository.executeShellCommand(cmd).getOrNull()
+                    if (res == null || res.first != 0) return null
+                    val tmpFile = File(tmpPath)
+                    if (!tmpFile.exists() || tmpFile.length() <= 0) return null
+                    val copied = try {
+                        tmpFile.inputStream().use { inputStream ->
+                            FileOutputStream(tempStaging).use { outputStream ->
+                                inputStream.copyAtMostTo(outputStream, MAX_ICON_STAGE_BYTES)
+                            }
+                        }
                     } catch (e: Throwable) {
                         tempStaging.delete()
                         throw e
                     }
-                } else {
-                    val path = uri.path
-                    if (path.isNullOrBlank()) return null
-                    val tmpPath = "/data/local/tmp/thor_ico_$token"
-                    val src = path.escapeShellArg()
-                    val dst = tmpPath.escapeShellArg()
-                    val cmd = "cat $src > $dst 2>/dev/null && chmod 666 $dst 2>/dev/null"
-                    // One `finally` for every exit, and an uncancellable one. The `cat` can have
-                    // produced the file even when this coroutine is cancelled before the call
-                    // returns, so a removal placed on the success paths only — as this was — never
-                    // runs on the path that matters. Coil cancels these fetches routinely as the
-                    // archive list scrolls, and `ArchiveOrphanSweeper` sweeps `cacheDir`,
-                    // `externalCacheDir/obb_out` and the SAF ledger but *not* `/data/local/tmp`, so
-                    // a skipped `rm -f` strands a full-size, `chmod 666` copy of the user's archive
-                    // where nothing in the app can ever reclaim it. `NonCancellable` alone, without
-                    // a dispatcher: `executeShellCommand` makes its own `ioDispatcher` hop.
-                    try {
-                        val res = systemRepository.executeShellCommand(cmd).getOrNull()
-                        if (res == null || res.first != 0) return null
-                        val tmpFile = File(tmpPath)
-                        if (!tmpFile.exists() || tmpFile.length() <= 0) return null
-                        try {
-                            tmpFile.inputStream().use { inputStream ->
-                                FileOutputStream(tempStaging).use { outputStream -> inputStream.copyTo(outputStream) }
-                            }
-                        } catch (e: Throwable) {
-                            tempStaging.delete()
-                            throw e
-                        }
-                        staged = true
+                    if (copied == null) {
+                        tempStaging.delete()
+                        null
+                    } else {
                         tempStaging
-                    } finally {
-                        withContext(NonCancellable) {
-                            systemRepository.executeShellCommand("rm -f $dst")
-                        }
+                    }
+                } finally {
+                    withContext(NonCancellable) {
+                        systemRepository.executeShellCommand("rm -f $dst")
                     }
                 }
             }
@@ -203,21 +281,7 @@ class ArchiveIconFetcher(
             throw e
         } catch (_: Exception) {
             tempStaging.delete()
-            return null
-        }
-
-        try {
-            val lower = model.displayName.lowercase()
-            return when {
-                lower.endsWith(".apk") -> parseApkIcon(sourceFile)
-                lower.endsWith(".xapk") || lower.endsWith(".apks") -> parseBundleIcon(sourceFile)
-                lower.endsWith(".thorbak") -> parseThorbakIcon(sourceFile)
-                else -> parseApkIcon(sourceFile) ?: parseBundleIcon(sourceFile)
-            }
-        } finally {
-            if (staged) {
-                tempStaging.delete()
-            }
+            null
         }
     }
 
@@ -246,7 +310,7 @@ class ArchiveIconFetcher(
                 ?: contents.bytes["icon.jpg"]
                 ?: contents.bytes["icon.webp"]
             if (iconBytes != null && iconBytes.isNotEmpty()) {
-                val bitmap = BitmapFactory.decodeByteArray(iconBytes, 0, iconBytes.size)
+                val bitmap = decodeSampled(iconBytes)
                 if (bitmap != null) return bitmap
             }
 
@@ -267,34 +331,90 @@ class ArchiveIconFetcher(
         return null
     }
 
+    /**
+     * The icon for a `.thorbak`, which is the *installed* app's icon or nothing: the format carries
+     * no icon of its own, only the identity in `thorbak.json`.
+     *
+     * Reached only for an archive Thor can open in place — [extractIcon] refuses to stage one, since
+     * the header is the last entry written and a stream would have to be read to its end to reach
+     * it. Here [BundleZip.read] takes it from the central directory, so its position costs nothing.
+     *
+     * The entry this looked for was `header.json`, a name no `.thorbak` has ever carried
+     * ([THORBAK_HEADER_ENTRY] is `thorbak.json`). Every read missed, fell through to an `icon.png`
+     * the writer does not produce either, and returned null — after the caller had copied the whole
+     * archive to get here, and with nothing recording the miss, so the next scroll did it again.
+     */
     private fun parseThorbakIcon(file: File): Bitmap? {
-        try {
-            ZipFile(file).use { zip ->
-                val headerEntry = zip.getEntry("header.json")
-                if (headerEntry != null) {
-                    val jsonStr = zip.getInputStream(headerEntry).bufferedReader().readText()
-                    val pkg = runCatching { JSONObject(jsonStr).optString("packageName") }.getOrNull()
-                    if (!pkg.isNullOrBlank()) {
-                        val pm = context.packageManager
-                        val flags = PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
-                        val appInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            pm.getApplicationInfo(pkg, PackageManager.ApplicationInfoFlags.of(flags))
-                        } else {
-                            pm.getApplicationInfo(pkg, PackageManager.MATCH_UNINSTALLED_PACKAGES)
-                        }
-                        return appInfo.loadIcon(pm).toBitmap(options)
-                    }
-                }
-                val iconEntry = zip.getEntry("icon.png")
-                if (iconEntry != null) {
-                    val bytes = zip.getInputStream(iconEntry).readBytes()
-                    if (bytes.isNotEmpty()) {
-                        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                    }
-                }
-            }
-        } catch (_: Exception) {}
+        val contents = runCatching {
+            BundleZip.read(file, setOf(THORBAK_HEADER_ENTRY, "icon.png"))
+        }.getOrNull() ?: return null
+
+        val header = contents.bytes[THORBAK_HEADER_ENTRY]
+        if (header != null) {
+            val pkg = runCatching {
+                JSONObject(header.toString(Charsets.UTF_8)).optString("packageName")
+            }.getOrNull()
+            if (!pkg.isNullOrBlank()) installedIcon(pkg)?.let { return it }
+        }
+        // Thor writes no such entry, but honouring a foreign writer's costs nothing now that both
+        // names come out of one pass.
+        val iconBytes = contents.bytes["icon.png"]
+        if (iconBytes != null && iconBytes.isNotEmpty()) return decodeSampled(iconBytes)
         return null
+    }
+
+    /** The installed icon for [pkg] at the requested size, or null if the device has no such app. */
+    private fun installedIcon(pkg: String): Bitmap? = try {
+        val pm = context.packageManager
+        val flags = PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong()
+        val appInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pm.getApplicationInfo(pkg, PackageManager.ApplicationInfoFlags.of(flags))
+        } else {
+            pm.getApplicationInfo(pkg, PackageManager.MATCH_UNINSTALLED_PACKAGES)
+        }
+        appInfo.loadIcon(pm).toBitmap(options)
+    } catch (_: Exception) {
+        null
+    }
+
+    /**
+     * Decode [bytes] no larger than the icon has to be.
+     *
+     * `decodeByteArray` with no options allocates the source's full pixel buffer. A bundle icon is
+     * bounded at 8 MB of *file* ([com.valhalla.thor.data.repository.MAX_METADATA_ENTRY_BYTES]),
+     * which a PNG turns into 10000×10000 pixels without difficulty — 400 MB of ARGB_8888 for
+     * something drawn at 44 dp, and OutOfMemoryError is an `Error`, so the `catch (Exception)` in
+     * [fetch] would not contain it either.
+     *
+     * The sample step stops at the last power of two still at or above the requested size, so the
+     * result is never smaller than what was asked for; Coil scales it the rest of the way.
+     */
+    private fun decodeSampled(bytes: ByteArray): Bitmap? {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+        val sourceWidth = bounds.outWidth
+        val sourceHeight = bounds.outHeight
+        if (sourceWidth <= 0 || sourceHeight <= 0) return null
+
+        val targetWidth = options.size.width.pxOrElse { sourceWidth }.coerceAtLeast(1)
+        val targetHeight = options.size.height.pxOrElse { sourceHeight }.coerceAtLeast(1)
+        var sample = 1
+        while (
+            sourceWidth / (sample * 2) >= targetWidth &&
+            sourceHeight / (sample * 2) >= targetHeight
+        ) {
+            sample *= 2
+        }
+
+        val decodeOptions = BitmapFactory.Options().apply {
+            inSampleSize = sample
+            inPreferredConfig = if (options.bitmapConfig == Bitmap.Config.HARDWARE) {
+                Bitmap.Config.ARGB_8888
+            } else {
+                options.bitmapConfig
+            }
+        }
+        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decodeOptions)
     }
 
     private fun Drawable.toBitmap(options: Options): Bitmap {

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoSheet.kt
@@ -270,7 +270,20 @@ fun AppInfoSheet(
                         )
                     },
                     onForceStop = { onAppAction(AppClickAction.Kill(appInfo)) },
-                    onManagePermissions = { onAppAction(AppClickAction.ManagePermissions(appInfo)) },
+                    // Dismisses, unlike the in-place actions either side of it, because both hosts
+                    // turn this one into a *destination push* — `MainScreen` adds
+                    // ThorRoute.PermissionManager to the Apps or Freezer back stack. Left up, the
+                    // sheet survives the forward navigation inside the entry's saveable state
+                    // holder, and Nav3's predictive back *seeks* the pop, so it re-composes the
+                    // previous scene at the first few percent of the gesture: the sheet's dialog is
+                    // a focusable full-screen window, so adding it mid-gesture steals focus,
+                    // cancels the in-flight back, and Nav3 animates forward again — the flicker
+                    // users reported. `onSystemSettings` above is not the same case; it leaves for
+                    // an external activity and pushes nothing here.
+                    onManagePermissions = {
+                        onAppAction(AppClickAction.ManagePermissions(appInfo))
+                        onDismiss()
+                    },
                     onToggleFreezerMembership = onToggleFreezerMembership,
                     freezerRemoveLabelRes = freezerRemoveLabelRes,
                     onClearCache = { onAppAction(AppClickAction.ClearCache(appInfo)) },

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -14,6 +14,7 @@
     gerir → gerenciar          gestor → gerenciador    eliminar → excluir
     cópia de segurança → backup            anular → cancelar
     "está a fazer" → "está fazendo"        "premir" → "tocar"
+    divisões (de APK) → splits de APK      "uma shell" → "um shell" (masculine in BR)
 -->
 <resources>
 
@@ -563,7 +564,7 @@
     <string name="backup_hub_empty_title">Nenhum backup em Downloads/Thor</string>
     <string name="backup_hub_empty_desc">Os arquivos salvos em Downloads/Thor aparecerão aqui para restauração rápida com um toque.</string>
     <string name="backup_hub_tip_thorbak_title">Backups de dados (.thorbak)</string>
-    <string name="backup_hub_tip_thorbak_desc">Arquivos completos criptografados contendo dados de aplicativos e divisões APK opcionais. Os dados privados de aplicativos (CE/DE) exigem root, enquanto os dados do armazenamento compartilhado podem ser restaurados com uma shell privilegiada.</string>
+    <string name="backup_hub_tip_thorbak_desc">Arquivos completos criptografados contendo dados de aplicativos e splits de APK opcionais. Os dados privados de aplicativos (CE/DE) exigem root, enquanto os dados do armazenamento compartilhado podem ser restaurados com um shell privilegiado.</string>
     <string name="backup_hub_tip_bundle_title">Pacotes de aplicativos (.xapk / .apks / .apk)</string>
     <string name="backup_hub_tip_bundle_desc">Pacotes de instalação autônomos para instalação offline ou compartilhamento entre dispositivos sem precisar de root.</string>
     <string name="backup_hub_tip_discovery_title">Detecção automática</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -547,4 +547,34 @@
     <string name="passphrase_error_mismatch">As duas senhas não coincidem.</string>
     <string name="passphrase_error_store_failed">O Thor não conseguiu salvar a senha neste dispositivo. O backup continua funcionando — você só vai ter que digitá-la a cada vez.</string>
 
+    <!--
+      Backup &amp; Restore Hub UI
+
+      Absent on purpose: backup_hub_filter_all, backup_hub_filter_bundles,
+      backup_hub_hero_restore_desc, backup_hub_no_archives and restore_archive_version read the
+      same in both variants, so values-pt already says it right.
+    -->
+    <string name="home_backup_restore_subtitle">Gerenciar backups e restaurar dados</string>
+    <string name="backup_hub_hero_backup_title">Fazer backup de um aplicativo</string>
+    <string name="backup_hub_hero_backup_desc">Criar backup de dados criptografado (.thorbak) ou pacote APK</string>
+    <string name="backup_hub_hero_restore_title">Restaurar de um arquivo</string>
+    <string name="backup_hub_section_backups">Backups em Downloads/Thor</string>
+    <string name="backup_hub_filter_backups">Backups</string>
+    <string name="backup_hub_empty_title">Nenhum backup em Downloads/Thor</string>
+    <string name="backup_hub_empty_desc">Os arquivos salvos em Downloads/Thor aparecerão aqui para restauração rápida com um toque.</string>
+    <string name="backup_hub_tip_thorbak_title">Backups de dados (.thorbak)</string>
+    <string name="backup_hub_tip_thorbak_desc">Arquivos completos criptografados contendo dados de aplicativos e divisões APK opcionais. Os dados privados de aplicativos (CE/DE) exigem root, enquanto os dados do armazenamento compartilhado podem ser restaurados com uma shell privilegiada.</string>
+    <string name="backup_hub_tip_bundle_title">Pacotes de aplicativos (.xapk / .apks / .apk)</string>
+    <string name="backup_hub_tip_bundle_desc">Pacotes de instalação autônomos para instalação offline ou compartilhamento entre dispositivos sem precisar de root.</string>
+    <string name="backup_hub_tip_discovery_title">Detecção automática</string>
+    <string name="backup_hub_tip_discovery_desc">Qualquer arquivo exportado ou colocado em Downloads/Thor será listado aqui automaticamente para restauração imediata.</string>
+    <string name="backup_hub_pick_app_title">Selecionar um aplicativo para backup</string>
+    <string name="backup_hub_search_apps_placeholder">Pesquisar aplicativos…</string>
+    <string name="backup_hub_delete_confirm_title">Excluir backup?</string>
+    <string name="backup_hub_delete_confirm_message">Tem certeza de que deseja excluir %1$s do armazenamento? Esta ação é irreversível.</string>
+    <string name="backup_hub_badge_data_backup">Backup de dados</string>
+    <string name="backup_hub_badge_app_bundle">Pacote de aplicativo</string>
+    <string name="backup_hub_action_delete">Excluir</string>
+    <string name="backup_hub_action_share">Compartilhar</string>
+
 </resources>

--- a/app/src/test/java/com/valhalla/thor/data/backup/ArchiveOrphanSweeperTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/backup/ArchiveOrphanSweeperTest.kt
@@ -308,4 +308,36 @@ class ArchiveOrphanSweeperTest {
         assertEquals(emptyList<File>(), staging.listFiles()?.toList() ?: emptyList<File>())
         assertEquals(1, report.stagedFilesRemoved)
     }
+
+    /**
+     * The staged tars themselves can also be outside `cacheDir`, which is the case this sweep was
+     * missing entirely.
+     *
+     * `AppDataArchiveGatewayImpl.stagingRoot` asks `probePrivateDataCapability()` and stages under
+     * `externalCacheDir` when the answer is false — a Shizuku shell at uid 2000 cannot read
+     * `/data/data/<thor>` at 0700. So every plaintext staged tar a killed Shizuku backup produced
+     * lived on shared external storage, where a sweep of `cacheDir` alone walked straight past it.
+     * Both roots, and the directory survives in both.
+     */
+    @Test
+    fun `staged tars the gateway wrote outside cacheDir are deleted too`() = runTest {
+        val (cache, internalStaging) = cacheWith("ce.tar")
+        val external = temp.newFolder("ext-staging")
+        val externalStaging = File(external, AppDataArchiveStagingDir.NAME).apply { mkdirs() }
+        File(externalStaging, "de.tar").writeText("plaintext app data")
+        File(externalStaging, "restore-ce.tar").writeText("plaintext app data")
+        val keep = File(external, "coil_disk_cache").apply { mkdirs() }
+        val sweeper = ArchiveOrphanSweeper(
+            PartialArchiveLedger(temp.newFolder("files12")), FakeStore(emptySet()), FakeBreadcrumbs(null), cache,
+            external,
+        )
+
+        val report = sweeper.sweep()
+
+        assertEquals(emptyList<File>(), externalStaging.listFiles()?.toList() ?: emptyList<File>())
+        assertEquals(emptyList<File>(), internalStaging.listFiles()?.toList() ?: emptyList<File>())
+        assertTrue("the staging directory itself must survive under either root", externalStaging.isDirectory)
+        assertTrue(keep.isDirectory)
+        assertEquals(3, report.stagedFilesRemoved)
+    }
 }

--- a/app/src/test/java/com/valhalla/thor/data/repository/AppRepositoryScanTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/AppRepositoryScanTest.kt
@@ -3,26 +3,148 @@
 
 package com.valhalla.thor.data.repository
 
+import com.valhalla.thor.domain.model.InstalledAppsPermission
+import com.valhalla.thor.domain.model.PLATFORM_PACKAGE
 import com.valhalla.thor.domain.model.RetainReason
+import com.valhalla.thor.domain.model.SUSPECT_SCAN_TOLERANCE
 import com.valhalla.thor.domain.model.ScanVerdict
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Verifies that label locale recording only occurs when an accepted scan's cache
- * sync succeeds without failure.
+ * The scan loop's three decisions about its own cache: [scanVerdictFor], [nextSuspectScanCount] and
+ * [shouldRecordLabelLocale].
+ *
+ * These call the production functions. An earlier version of this file declared a private
+ * `shouldRecordLabelLocale` re-implementing the condition and asserted *that*, so every test passed
+ * no matter what `AppRepositoryImpl` did — including if the rule were deleted outright. A test whose
+ * subject is its own fixture cannot fail, which makes it worse than no test: it reports coverage the
+ * code does not have.
  */
 class AppRepositoryScanTest {
 
-    private fun shouldRecordLabelLocale(
-        forceRefresh: Boolean,
-        verdict: ScanVerdict,
-        syncCacheSucceeded: Boolean
-    ): Boolean = forceRefresh && verdict == ScanVerdict.Accept && syncCacheSucceeded
+    private fun packages(count: Int, withPlatform: Boolean = true): Set<String> =
+        buildSet {
+            if (withPlatform) add(PLATFORM_PACKAGE)
+            while (size < count) add("com.example.app$size")
+        }
+
+    // --- scanVerdictFor: the fallback flag the domain rules cannot see ---
 
     @Test
-    fun `recordLabelLocale is only executed when scan is accepted and cache sync succeeds`() {
+    fun `a fallback scan is retained however healthy it looks`() {
+        // The case that makes the flag necessary: 400 packages, the platform package present, the
+        // permission granted, no shrinkage — every rule in scanVerdict() accepts this. Only the
+        // caller knows MATCH_UNINSTALLED_PACKAGES was dropped, so only the caller can withhold the
+        // Accept, and an accepted fallback scan deletes the Freezer row of every uninstall-frozen
+        // app on the device.
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.VisibilityFallback),
+            scanVerdictFor(
+                usedVisibilityFallback = true,
+                scannedPackageNames = packages(400),
+                cachedCount = 400,
+                consecutiveSuspectScans = 0,
+                permission = InstalledAppsPermission.Granted
+            )
+        )
+    }
+
+    @Test
+    fun `a fallback scan is retained even with an empty cache`() {
+        // scanVerdict()'s first rule accepts unconditionally when there is nothing to protect. The
+        // fallback short-circuit sits in front of it, so this must still retain — an empty cache is
+        // a reason to trust a scan's *deletions*, and a fallback scan's deletions are the problem.
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.VisibilityFallback),
+            scanVerdictFor(
+                usedVisibilityFallback = true,
+                scannedPackageNames = packages(3),
+                cachedCount = 0,
+                consecutiveSuspectScans = 0,
+                permission = InstalledAppsPermission.Granted
+            )
+        )
+    }
+
+    @Test
+    fun `a fallback scan never runs out of tolerance`() {
+        // The tolerance is what lets a genuinely shrinking device eventually be believed. It must
+        // never apply here, at any count: a fallback scan repeated ten times is still ten scans that
+        // could not see uninstall-frozen packages.
+        for (suspectScans in 0..(SUSPECT_SCAN_TOLERANCE + 8)) {
+            assertEquals(
+                "fallback scan accepted after $suspectScans suspect scan(s)",
+                ScanVerdict.Retain(RetainReason.VisibilityFallback),
+                scanVerdictFor(
+                    usedVisibilityFallback = true,
+                    scannedPackageNames = emptySet(),
+                    cachedCount = 200,
+                    consecutiveSuspectScans = suspectScans,
+                    permission = InstalledAppsPermission.Granted
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `without the fallback the domain rules decide`() {
+        assertEquals(
+            ScanVerdict.Accept,
+            scanVerdictFor(
+                usedVisibilityFallback = false,
+                scannedPackageNames = packages(200),
+                cachedCount = 200,
+                consecutiveSuspectScans = 0,
+                permission = InstalledAppsPermission.Granted
+            )
+        )
+        assertEquals(
+            ScanVerdict.Retain(RetainReason.Collapsed),
+            scanVerdictFor(
+                usedVisibilityFallback = false,
+                scannedPackageNames = packages(20),
+                cachedCount = 200,
+                consecutiveSuspectScans = 0,
+                permission = InstalledAppsPermission.Denied
+            )
+        )
+    }
+
+    // --- nextSuspectScanCount: the tolerance the fallback must not spend ---
+
+    @Test
+    fun `an accepted scan resets the tolerance`() {
+        assertEquals(0, nextSuspectScanCount(SUSPECT_SCAN_TOLERANCE, ScanVerdict.Accept))
+    }
+
+    @Test
+    fun `a suspect retain spends one of the tolerance`() {
+        for (reason in RetainReason.entries - RetainReason.VisibilityFallback) {
+            assertEquals(
+                "retain (${reason.name}) must count towards the tolerance",
+                3,
+                nextSuspectScanCount(2, ScanVerdict.Retain(reason))
+            )
+        }
+    }
+
+    @Test
+    fun `a fallback retain neither spends nor resets the tolerance`() {
+        // Spending it would hand the third truncated scan the Accept the guard exists to withhold;
+        // resetting it would treat a scan Thor did not believe as proof the device is healthy.
+        val fallback = ScanVerdict.Retain(RetainReason.VisibilityFallback)
+        assertEquals(0, nextSuspectScanCount(0, fallback))
+        assertEquals(1, nextSuspectScanCount(1, fallback))
+        assertEquals(SUSPECT_SCAN_TOLERANCE, nextSuspectScanCount(SUSPECT_SCAN_TOLERANCE, fallback))
+    }
+
+    // --- shouldRecordLabelLocale: the key that stops a re-map ever happening again ---
+
+    @Test
+    fun `the locale is recorded when a forced refresh was accepted and synced`() {
         assertTrue(
             shouldRecordLabelLocale(
                 forceRefresh = true,
@@ -33,7 +155,8 @@ class AppRepositoryScanTest {
     }
 
     @Test
-    fun `recordLabelLocale is skipped when cache sync fails during accepted scan`() {
+    fun `a failed cache sync does not record the locale`() {
+        // The re-mapped labels never reached Room, so the rows on disk are still the old language.
         assertFalse(
             shouldRecordLabelLocale(
                 forceRefresh = true,
@@ -44,18 +167,24 @@ class AppRepositoryScanTest {
     }
 
     @Test
-    fun `recordLabelLocale is skipped when scan is retained`() {
-        assertFalse(
-            shouldRecordLabelLocale(
-                forceRefresh = true,
-                verdict = ScanVerdict.Retain(RetainReason.Collapsed),
-                syncCacheSucceeded = true
+    fun `no retained scan records the locale whatever its reason`() {
+        // A retained scan may have seen a fraction of the installed packages, so most rows still
+        // carry the previous language. Iterating `entries` so a reason added later is covered.
+        for (reason in RetainReason.entries) {
+            assertFalse(
+                "retained scan (${reason.name}) must not record the locale",
+                shouldRecordLabelLocale(
+                    forceRefresh = true,
+                    verdict = ScanVerdict.Retain(reason),
+                    syncCacheSucceeded = true
+                )
             )
-        )
+        }
     }
 
     @Test
-    fun `recordLabelLocale is skipped when not a forced refresh`() {
+    fun `an unforced scan does not record the locale`() {
+        // It reused the cached labels rather than re-reading them, so it mapped nothing.
         assertFalse(
             shouldRecordLabelLocale(
                 forceRefresh = false,

--- a/app/src/test/java/com/valhalla/thor/data/repository/ObbExpansionZipTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/ObbExpansionZipTest.kt
@@ -135,6 +135,16 @@ class ObbExpansionZipTest {
     }
 
     @Test
+    fun `the staged bundle bound admits a full apk set beside a full expansion set`() {
+        // The corollary of the test above, and the mistake it does not catch on its own: one `.xapk`
+        // member holds an install set *and* an expansion set, each charged against its own budget
+        // when that member is unpacked. A staging bound below their sum refuses archives Thor itself
+        // writes — a large game's XAPK backup — and refuses them during staging, which runs before a
+        // single data class is restored.
+        assertTrue(MAX_STAGED_BUNDLE_BYTES >= MAX_EXTRACTED_TOTAL_BYTES + MAX_EXPANSION_TOTAL_BYTES)
+    }
+
+    @Test
     fun `too many expansions refuses without creating the staging directory`() {
         // The byte budget does not bound the entry count: a manifest-free archive has every *.obb
         // entry treated as an expansion, and a million one-byte entries costs a million inodes and a

--- a/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
@@ -488,6 +488,47 @@ class PerUserCommandsTest {
         assertEquals("appops set --user 10 $pkg 10022 allow", commands[2])
     }
 
+    /**
+     * The revoke exists at all because `pm revoke` does not undo the grant: an app-op left at
+     * `allow` keeps answering `MODE_ALLOWED` after the runtime permission is gone, so package
+     * visibility stayed open while Thor reported the revoke as successful.
+     *
+     * `default`, not `ignore` — asserted rather than implied, because `ignore` is the plausible
+     * wrong answer. It pins the op to hard-denied independently of the permission, and an explicit
+     * app-op mode is not something the ROM's own permission toggle can lift, so a later grant from
+     * Settings would look applied and do nothing. `default` hands the answer back to the platform,
+     * where the accompanying `pm revoke` has already denied the permission.
+     */
+    @Test
+    fun `the installed apps appops revoke resets the same three ops to default`() {
+        val commands = installedAppsAppOpRevokeCommands(pkg, 10)
+        assertEquals(3, commands.size)
+        commands.forEach { cmd ->
+            assertEquals(10, userArgOf(cmd))
+            assertTrue("$cmd does not reset the op to the platform default", cmd.endsWith(" default"))
+            assertFalse("$cmd hard-denies the op instead of resetting it", cmd.endsWith(" ignore"))
+        }
+        assertEquals("appops set --user 10 $pkg GET_INSTALLED_APPS default", commands[0])
+        assertEquals("appops set --user 10 $pkg android:get_installed_apps default", commands[1])
+        assertEquals("appops set --user 10 $pkg 10022 default", commands[2])
+    }
+
+    /**
+     * The pair has to name the *same* ops, in the same order, or a revoke leaves whichever spelling
+     * the grant used and the ROM answers to still set to `allow` — the exact defect the revoke was
+     * added to close, reintroduced by a one-line edit to either list. Both builders read the same
+     * private spelling list today; this is what makes that a requirement rather than a coincidence.
+     */
+    @Test
+    fun `grant and revoke cover the same ops in the same order`() {
+        val opOf = { command: String -> command.removePrefix("appops set --user 10 $pkg ").substringBefore(' ') }
+
+        assertEquals(
+            installedAppsAppOpGrantCommands(pkg, 10).map(opOf),
+            installedAppsAppOpRevokeCommands(pkg, 10).map(opOf)
+        )
+    }
+
     // --- the shape of the whole file, not one instance of it ---
 
     /**

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -323,7 +323,12 @@ def main():
             print(f"  [Unresolved] {key}")
 
     if not catalog_updates and not inline_lib_updates and not inline_plugin_updates:
-        if len(unresolved) == len(results):
+        if not results:
+            # No lookup was even attempted, which on a repo with a populated catalog means the
+            # parse found nothing — a renamed section or a syntax change in the TOML, not a
+            # network problem. Distinct from the message below, which needs a failed lookup.
+            print("\nNo dependencies were checked — nothing was parsed out of the catalog.")
+        elif len(unresolved) == len(results):
             print("\nNothing was checked — every lookup failed. Not a clean bill of health.")
         else:
             print(f"\nAll {len(results) - len(unresolved)} resolved dependencies are up to date.")

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -302,6 +302,12 @@ def main():
     inline_lib_updates = {}
     inline_plugin_updates = {}
     
+    # Everything that could not be resolved at all. Without this list a network outage, a renamed
+    # artifact or a repository that has stopped serving maven-metadata.xml all look identical to
+    # "already on the latest version" — the script would print "All dependencies are up to date."
+    # having checked nothing.
+    unresolved = sorted(key for _, key, _, _, status in results if status != "Success")
+
     for item_type, key, current, best, status in results:
         if status == "Success" and current != best:
             if item_type == "catalog":
@@ -311,10 +317,18 @@ def main():
             elif item_type == "inline_plugin":
                 inline_plugin_updates[key] = (current, best)
                 
+    if unresolved:
+        print(f"\nCould not resolve {len(unresolved)} of {len(results)} — versions unknown, not current:")
+        for key in unresolved:
+            print(f"  [Unresolved] {key}")
+
     if not catalog_updates and not inline_lib_updates and not inline_plugin_updates:
-        print("All dependencies are up to date.")
+        if len(unresolved) == len(results):
+            print("\nNothing was checked — every lookup failed. Not a clean bill of health.")
+        else:
+            print(f"\nAll {len(results) - len(unresolved)} resolved dependencies are up to date.")
         return
-        
+
     print("\nProposed Updates:")
     for key, (current, best) in sorted(catalog_updates.items()):
         print(f"  [Catalog Version] {key}: {current} -> {best}")

--- a/update_dependencies.py
+++ b/update_dependencies.py
@@ -324,10 +324,12 @@ def main():
 
     if not catalog_updates and not inline_lib_updates and not inline_plugin_updates:
         if not results:
-            # No lookup was even attempted, which on a repo with a populated catalog means the
-            # parse found nothing — a renamed section or a syntax change in the TOML, not a
-            # network problem. Distinct from the message below, which needs a failed lookup.
-            print("\nNo dependencies were checked — nothing was parsed out of the catalog.")
+            # `results` is empty exactly when `to_check` was, so no lookup was attempted and no
+            # network failure is implied. The message stays on that observation rather than naming a
+            # cause: an empty or renamed catalog section and a catalog whose entries never resolve
+            # to a versioned `group:name` both land here, and the script cannot tell them apart.
+            # Distinct from the message below, which needs a lookup to have run and failed.
+            print("\nNo versioned dependencies were found to check — nothing was verified.")
         elif len(unresolved) == len(results):
             print("\nNothing was checked — every lookup failed. Not a clean bill of health.")
         else:

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,11 +1,13 @@
 # Thor — https://thor.trinadhthatakula.com
 # Open-source Android App Manager
 #
-# A crawler obeys the single most specific group whose token it matches and ignores the `*` group
-# entirely (RFC 9309, §2.2.1). So a named group containing only `Allow: /` does not inherit the
-# wildcard group's rules — it *overrides* them, and grants the access the wildcard withholds. That
-# is how /styleguide and the follow-up pages were open to every crawler named here except
-# Googlebot, Bingbot and four of the AI agents: their groups simply left the Disallow lines out.
+# A crawler obeys the groups whose token it matches, combining their rules if there is more than
+# one, and falls back to the `*` group only when *no* named group matches it (RFC 9309, §2.2.1).
+# So a named group containing only `Allow: /` does not inherit the wildcard group's rules — the
+# wildcard group is never selected for it — and grants the access the wildcard withholds. That is
+# how /styleguide and the follow-up pages were open to every crawler named here except Googlebot,
+# Bingbot and four of the AI agents: their groups simply left the Disallow lines out. Each token
+# below appears in exactly one group, so nothing here relies on the combining rule.
 #
 # Consecutive `User-agent:` lines share one rule block, so each class of crawler states the rules
 # once and a token added to a block picks them up automatically.

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,5 +1,14 @@
 # Thor — https://thor.trinadhthatakula.com
 # Open-source Android App Manager
+#
+# A crawler obeys the single most specific group whose token it matches and ignores the `*` group
+# entirely (RFC 9309, §2.2.1). So a named group containing only `Allow: /` does not inherit the
+# wildcard group's rules — it *overrides* them, and grants the access the wildcard withholds. That
+# is how /styleguide and the follow-up pages were open to every crawler named here except
+# Googlebot, Bingbot and four of the AI agents: their groups simply left the Disallow lines out.
+#
+# Consecutive `User-agent:` lines share one rule block, so each class of crawler states the rules
+# once and a token added to a block picks them up automatically.
 
 User-agent: *
 Allow: /
@@ -9,133 +18,57 @@ Disallow: /follow-ups-report
 
 # Primary Search Engine Crawlers
 User-agent: Googlebot
-Allow: /
-Disallow: /styleguide
-Disallow: /follow-ups
-Disallow: /follow-ups-report
-
 User-agent: Bingbot
-Allow: /
-Disallow: /styleguide
-Disallow: /follow-ups
-Disallow: /follow-ups-report
-
 User-agent: Slurp
-Allow: /
-
 User-agent: DuckDuckBot
-Allow: /
-
 User-agent: Baiduspider
-Allow: /
-
 User-agent: YandexBot
-Allow: /
-
 User-agent: Sogou web spider
-Allow: /
-
 User-agent: Yeti
 Allow: /
+Disallow: /styleguide
+Disallow: /follow-ups
+Disallow: /follow-ups-report
 
 # AI Search & Retrieval Crawlers (GEO / Real-Time LLM Search)
 User-agent: OAI-SearchBot
-Allow: /
-Disallow: /styleguide
-Disallow: /follow-ups
-Disallow: /follow-ups-report
-
 User-agent: GPTBot
-Allow: /
-Disallow: /styleguide
-Disallow: /follow-ups
-Disallow: /follow-ups-report
-
 User-agent: ChatGPT-User
-Allow: /
-
 User-agent: ClaudeBot
-Allow: /
-Disallow: /styleguide
-Disallow: /follow-ups
-Disallow: /follow-ups-report
-
 User-agent: Claude-Web
-Allow: /
-
 User-agent: PerplexityBot
-Allow: /
-Disallow: /styleguide
-Disallow: /follow-ups
-Disallow: /follow-ups-report
-
 User-agent: Google-Extended
-Allow: /
-
 User-agent: Applebot
-Allow: /
-
 User-agent: Applebot-Extended
-Allow: /
-
 User-agent: Meta-ExternalAgent
-Allow: /
-
 User-agent: Meta-ExternalFetcher
-Allow: /
-
 User-agent: TavilyBot
-Allow: /
-
 User-agent: ExaBot
-Allow: /
-
 User-agent: MistralBot
-Allow: /
-
 User-agent: YouBot
-Allow: /
-
 User-agent: DuckAssistBot
-Allow: /
-
 User-agent: cohere-ai
-Allow: /
-
 User-agent: Amazonbot
-Allow: /
-
 User-agent: Bytespider
-Allow: /
-
 User-agent: CCBot
-Allow: /
-
 User-agent: Diffbot
 Allow: /
+Disallow: /styleguide
+Disallow: /follow-ups
+Disallow: /follow-ups-report
 
 # Social & Messaging Link Preview Crawlers
+#
+# Deliberately unrestricted, unlike every group above. These fetch a single URL because a person
+# just pasted it into a chat, so a Disallow here does not keep a page out of an index — it only
+# strips the preview from a link someone chose to share, including the internal ones.
 User-agent: LinkedInBot
-Allow: /
-
 User-agent: Twitterbot
-Allow: /
-
 User-agent: facebookexternalhit
-Allow: /
-
 User-agent: Slackbot
-Allow: /
-
 User-agent: Slackbot-LinkExpanding
-Allow: /
-
 User-agent: TelegramBot
-Allow: /
-
 User-agent: Discordbot
-Allow: /
-
 User-agent: WhatsApp
 Allow: /
 

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -11,6 +11,16 @@ import ThemeScript from '../components/ThemeScript.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
 import { SITE, canonical } from '../lib/site.ts'
+/**
+ * The one importer of `repoFacts` outside `Fact.astro`, and a deliberate exception to that rule.
+ *
+ * The JSON-LD below is not prose — it is a machine-readable claim in a <script> tag, where a
+ * component cannot render. It stated `operatingSystem: 'Android 8.0+'` while `minSdk` has been 28
+ * (Android 9) for the life of this site, so every consumer of the structured data was told Thor
+ * installs on a release it refuses to install on. Deriving it is the only version of this that
+ * cannot drift again.
+ */
+import { repoFacts } from '../lib/repo-facts/index.ts'
 
 import '../styles/fonts.css'
 import '../styles/tokens.css'
@@ -61,7 +71,7 @@ const jsonLd = {
       '@type': 'SoftwareApplication',
       '@id': `${SITE.origin}/#software`,
       name: 'Thor',
-      operatingSystem: 'Android 8.0+',
+      operatingSystem: `${repoFacts.minSdkAndroidName}+`,
       applicationCategory: 'UtilitiesApplication',
       offers: {
         '@type': 'Offer',


### PR DESCRIPTION
The confirmed findings from the review of everything merged since `v1.94.4-dev-26`, fixed in priority order, plus the flicker a user reported while it was in progress.

## Release blockers

1. **The language picker could not reach its last locales.** `SettingsCategoryScreen`'s picker sheet was a plain `Column`, so on a short screen the bottom entries were unreachable — no scroll, no affordance, nothing to indicate more existed.
2. **`ArchiveIconLoader` leaked a staged copy on every cancelled fetch.** Coil cancels an icon fetch whenever a row scrolls out, and the cleanup was in a `finally` calling a suspend function, which never runs on cancellation. Every scroll of the Backup Hub left a full archive copy behind.

## P1

3. **`revokePermission` left the app-op open** in all three gateways. `pm revoke` clears the grant; the matching app-op stays `allow`, so a revoked permission kept working on the ROMs where the op is what is actually consulted. Also folds a caller-aware `grantPermission`.
4. **The same cancellation leak in two more places** — `UriArchiveSourceFactory` and `AppAnalyzerImpl`.
5. **`AppDataArchiveGatewayImpl.stagingRoot()` downgrades to `externalCacheDir`** when the internal volume is short, and `ArchiveOrphanSweeper` had no rule for that root — so a crash mid-backup stranded a multi-gigabyte tar with nothing to ever clean it up. The KDoc directly above the downgrade claimed no downgrade existed.

## P2

6. **The Backup Hub copied an entire archive to draw a 44 dp icon**, and `parseThorbakIcon` looked for `header.json`, an entry no `.thorbak` has ever contained. So every `.thorbak` row staged a copy of a potentially multi-gigabyte backup, found nothing, cached nothing, and did it again on the next scroll — forever, because Coil caches an image but not the absence of one. Now: `.thorbak` is never staged (its identity is already in the file name), every other stage is capped at 256 MB enforced by `copyAtMostTo` rather than by the provider's `sizeBytes` — which is 0 for many providers — decoding is sampled instead of allocating the source's full pixel buffer, and a miss is remembered with a marker file.
7. **`BackupRestoreHubViewModel` discarded a `false` from `deleteArchive`.** A read-only volume or a lapsed SAF grant closed the dialog and left the row where it was, which reads as a broken list rather than a refusal. Now reported, reusing an existing string so no new translation coupling.
8. **Three ways a reorder drag came apart** — `settleDropTarget()` mixed `layoutInfo` from before the swap it had just performed, two fingers on two handles drove one state holder, and a drag could be ended by a key that was not dragging.
9. **The actions customization screen dropped the prefs resync** that arrived mid-drag instead of deferring it, so a change made elsewhere was lost. Keying the effect on `draggingItemKey` instead would flash the pre-drag order, hence the two-effect deferred form.
10. **`values-pt-rBR` was missing all 22 Backup Hub strings.** It is an override layer, not a second translation, so they resolved through `values-pt` and showed European Portuguese to Brazilian users: Eliminar/Partilhar rather than Excluir/Compartilhar, "cópia de segurança" rather than "backup", ficheiro, aplicação, encriptada, autónomos, Deteção, restauro. The five keys that read identically in both variants are deliberately not overridden, and a comment says so.
11. **`AppRepositoryScanTest` could not fail.** It declared a private copy of the condition in `AppRepositoryImpl` and asserted *that* — deleting the production rule outright left the suite green. The rule was unreachable from a test because it sat inside a `callbackFlow` needing a live `PackageManager`, so the scan loop's three cache decisions are now pure functions in `ScanCachePolicy.kt`. That also covers the untested half: `RetainReason.VisibilityFallback` is minted in one place and nothing touched it, including the rule that it must not spend `SUSPECT_SCAN_TOLERANCE` — if it ever did, the third truncated scan would get the `Accept` the guard exists to withhold. Verified by mutation: breaking each rule turns 5 of the 11 tests red.
12. **Three quiet wrong answers** outside `:app` — 22 of 38 `robots.txt` crawler groups overrode the wildcard's `Disallow` lines rather than inheriting them (RFC 9309 §2.2.1) and so invited most crawlers into `/styleguide` and the follow-up pages; the `SoftwareApplication` JSON-LD claimed `Android 8.0+` while `minSdk` has been 28 (Android 9) for the life of the site; and `update_dependencies.py` printed "All dependencies are up to date." when every lookup had failed.

## User report: the permissions-screen flicker

Opening Permissions from the app-info sheet and pressing back flickered back and forth. Both hosts turn `onManagePermissions` into a `ThorRoute.PermissionManager` push, but the sheet stayed up behind it — so back popped the route, the still-open sheet re-emitted, and the two fought. The sheet now dismisses itself when it hands off, and the host comments that listed permissions as a leave-the-sheet-up action are corrected.

## Validation

- `:app:testFossDebugUnitTest --rerun-tasks` — 122 suites, **1633 tests, 0 failures** (counts from `build/test-results`, not the log line).
- `:app:lintStoreRelease` — clean, hints only, no `MissingTranslation`.
- `web`: `vitest run` 304 passed, and a full `npm run build` including `check:types`, `check:links`, `check:claims`, `check:markup` and `check:sitemap`. Built page reads `"operatingSystem":"Android 9+"`.
- `update_dependencies.py`: both new paths exercised against a temporary catalog.
- No `versionCode` bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved permission granting and revocation across supported system-access methods.
  - Ensured temporary archive, backup, and icon files are cleaned up after failures or cancellation.
  - Added error feedback when archive deletion fails.
  - Improved scan decisions, cache handling, and drag-and-drop reordering reliability.
  - Prevented oversized or unsupported archives from affecting icon loading and restoration.

- **Improvements**
  - Added scrolling to the language selection sheet.
  - Permission management now dismisses the app information sheet correctly.
  - Added Brazilian Portuguese translations for Backup & Restore.
  - Improved staging cleanup across internal and external storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->