### PR TITLE
feat(app-info): tap the icon to open an app, long-press for its settings

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -70,11 +70,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.valhalla.thor.presentation.backup.AppBackupSheet
 import com.valhalla.thor.presentation.widgets.AppActionRow
+import com.valhalla.thor.presentation.widgets.AppHeaderIcon
 import com.valhalla.thor.presentation.widgets.AppRiskAction
 import com.valhalla.thor.presentation.widgets.AppRiskDialog
 import com.valhalla.thor.presentation.widgets.FreezerPromptSnackbar
 import com.valhalla.thor.presentation.widgets.StatusChip
-import coil3.compose.AsyncImage
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
@@ -84,7 +84,6 @@ import com.valhalla.thor.domain.model.PermissionDetail
 import com.valhalla.thor.domain.model.freezeNeedsConfirmation
 import com.valhalla.thor.presentation.theme.bodyFontFamily
 import com.valhalla.thor.presentation.theme.firaMonoFontFamily
-import com.valhalla.thor.presentation.utils.AppIconModel
 import com.valhalla.thor.presentation.utils.ObserveAsEvents
 import com.valhalla.thor.presentation.utils.getBloatRecommendationColors
 import com.valhalla.thor.util.AppLocale
@@ -282,9 +281,16 @@ fun AppInfoHeaderAndActions(
     var showExportSheet by remember { mutableStateOf(false) }
     var showBackupSheet by remember { mutableStateOf(false) }
 
+    // Hoisted so the header icon's tap and long-press shortcuts are the *same* lambdas the row's
+    // Open and Settings actions get, exactly as `AppInfoSheet` does it. See `AppHeaderIcon`.
+    val onLaunchApp: () -> Unit = { onAppAction(AppClickAction.Launch(appInfo)) }
+    val onOpenSystemSettings: () -> Unit = { onAppAction(AppClickAction.AppInfoSettings(appInfo)) }
+
     Column(modifier = modifier) {
         AppDetailsHeader(
             appInfo = appInfo,
+            onOpen = onLaunchApp,
+            onOpenSettings = onOpenSystemSettings,
             sharedTransitionScope = sharedTransitionScope,
             animatedVisibilityScope = animatedVisibilityScope
         )
@@ -295,8 +301,8 @@ fun AppInfoHeaderAndActions(
             isShizuku = isShizuku,
             isDhizuku = isDhizuku,
             isInFreezer = isInFreezer,
-            onLaunch = { onAppAction(AppClickAction.Launch(appInfo)) },
-            onSystemSettings = { onAppAction(AppClickAction.AppInfoSettings(appInfo)) },
+            onLaunch = onLaunchApp,
+            onSystemSettings = onOpenSystemSettings,
             onFreezeToggle = { shouldFreeze ->
                 // Unfreeze immediately. When freezing, only SYSTEM apps get the
                 // safety-warning dialog (instability / reboot-loop risk); user
@@ -511,6 +517,8 @@ fun AppInfoDetailBody(
 @Composable
 private fun AppDetailsHeader(
     appInfo: AppInfo,
+    onOpen: () -> Unit,
+    onOpenSettings: () -> Unit,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null
 ) {
@@ -527,32 +535,30 @@ private fun AppDetailsHeader(
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Box(
-            modifier = Modifier
-                .size(72.dp)
-                .clip(RoundedCornerShape(20.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                .padding(12.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            val sharedModifier = if (sharedTransitionScope != null && animatedVisibilityScope != null) {
-                with(sharedTransitionScope) {
-                    Modifier.sharedElement(
-                        sharedContentState = rememberSharedContentState(key = "icon-${appInfo.packageName}"),
-                        animatedVisibilityScope = animatedVisibilityScope
-                    )
-                }
-            } else {
-                Modifier
+        val sharedModifier = if (sharedTransitionScope != null && animatedVisibilityScope != null) {
+            with(sharedTransitionScope) {
+                Modifier.sharedElement(
+                    sharedContentState = rememberSharedContentState(key = "icon-${appInfo.packageName}"),
+                    animatedVisibilityScope = animatedVisibilityScope
+                )
             }
-            AsyncImage(
-                model = AppIconModel(appInfo.packageName),
-                contentDescription = null,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .then(sharedModifier)
-            )
+        } else {
+            Modifier
         }
+        // Tap opens the app, long-press opens its system settings page — the same shortcuts the
+        // sheet's header carries, on the same widget, because these two headers are one header on
+        // two surfaces. The glow's default diameter scales off the icon, which is what keeps it
+        // inside this card's clip without a per-surface number.
+        AppHeaderIcon(
+            appInfo = appInfo,
+            onOpen = onOpen,
+            onOpenSettings = onOpenSettings,
+            size = 72.dp,
+            cornerRadius = 20.dp,
+            contentPadding = 12.dp,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+            imageModifier = sharedModifier
+        )
 
         Spacer(modifier = Modifier.width(16.dp))
 

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -75,6 +75,7 @@ import com.valhalla.thor.presentation.widgets.AppRiskAction
 import com.valhalla.thor.presentation.widgets.AppRiskDialog
 import com.valhalla.thor.presentation.widgets.FreezerPromptSnackbar
 import com.valhalla.thor.presentation.widgets.StatusChip
+import com.valhalla.thor.presentation.widgets.appHeaderIconGlowInset
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
@@ -526,13 +527,22 @@ private fun AppDetailsHeader(
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val valueLabel = stringResource(R.string.value_label)
+    val iconSize = 72.dp
+    // The icon reserves this much transparent margin on every side for its glow, so the card's own
+    // 16 dp of padding is already more than paid for on the icon's side. Spending it rather than
+    // adding to it keeps the icon 16 dp from the card edge instead of 32, keeps the gap to the app
+    // name at 16 rather than doubling it, and — the reason it is worth the arithmetic — leaves the
+    // name/package/chips column the width it had. This header also renders in `MainScreen`'s narrow
+    // list pane, where 32 dp is the difference between a one-line app name and a wrapped one.
+    val iconGlowInset = appHeaderIconGlowInset(iconSize)
+    val iconGap = (16.dp - iconGlowInset).coerceAtLeast(0.dp)
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(16.dp)
             .clip(RoundedCornerShape(28.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.6f))
-            .padding(16.dp),
+            .padding(start = iconGap, top = 16.dp, end = 16.dp, bottom = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         val sharedModifier = if (sharedTransitionScope != null && animatedVisibilityScope != null) {
@@ -553,14 +563,14 @@ private fun AppDetailsHeader(
             appInfo = appInfo,
             onOpen = onOpen,
             onOpenSettings = onOpenSettings,
-            size = 72.dp,
+            size = iconSize,
             cornerRadius = 20.dp,
             contentPadding = 12.dp,
             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
             imageModifier = sharedModifier
         )
 
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(iconGap))
 
         Column(modifier = Modifier.weight(1f)) {
             val textSharedModifier = if (sharedTransitionScope != null && animatedVisibilityScope != null) {

--- a/app/src/main/java/com/valhalla/thor/presentation/security/BiometricScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/BiometricScreen.kt
@@ -45,6 +45,20 @@ import com.valhalla.thor.R
 import com.valhalla.thor.presentation.theme.greenDark
 import com.valhalla.thor.presentation.widgets.AmbientGlow
 
+/**
+ * How much of this screen's wash holds its colour before the fade starts.
+ *
+ * The glow here used to be a solid 400 dp disc at 5 % alpha with a 120 dp blur over it, and became a
+ * shared widget when the app-info headers wanted the same motif. That widget carries the fade in a
+ * gradient rather than in the blur, so that it also works on API 28-30, where `Modifier.blur` does
+ * nothing — but a gradient fading from the dead centre spreads about a third of the ink a solid disc
+ * does, and this screen is a near-black background where a third of 5 % is nothing at all. A core
+ * restores the disc: full colour out to 65 % of the radius, then the fade. Measured against the old
+ * profile that is within a few percent everywhere out to r = 160 dp, and past that it goes to zero
+ * instead of being cut off square at the node edge, which is what the old blur did.
+ */
+private const val AMBIENT_WASH_CORE = 0.65f
+
 @Composable
 fun BiometricScreen(
     isError: Boolean,
@@ -68,7 +82,7 @@ fun BiometricScreen(
             .background(MaterialTheme.colorScheme.background)
     ) {
         // 1. Ambient Glow
-        AmbientGlow(Modifier.fillMaxSize())
+        AmbientGlow(Modifier.fillMaxSize(), coreFraction = AMBIENT_WASH_CORE)
 
         if (isError) {
             BiometricErrorView(
@@ -114,7 +128,7 @@ fun BiometricUnavailableScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        AmbientGlow(Modifier.fillMaxSize())
+        AmbientGlow(Modifier.fillMaxSize(), coreFraction = AMBIENT_WASH_CORE)
 
         Column(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/valhalla/thor/presentation/security/BiometricScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/security/BiometricScreen.kt
@@ -30,8 +30,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -45,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.valhalla.thor.R
 import com.valhalla.thor.presentation.theme.greenDark
+import com.valhalla.thor.presentation.widgets.AmbientGlow
 
 @Composable
 fun BiometricScreen(
@@ -69,7 +68,7 @@ fun BiometricScreen(
             .background(MaterialTheme.colorScheme.background)
     ) {
         // 1. Ambient Glow
-        AmbientGlow()
+        AmbientGlow(Modifier.fillMaxSize())
 
         if (isError) {
             BiometricErrorView(
@@ -115,7 +114,7 @@ fun BiometricUnavailableScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        AmbientGlow()
+        AmbientGlow(Modifier.fillMaxSize())
 
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -189,22 +188,6 @@ fun BiometricUnavailableScreen(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-    }
-}
-
-@Composable
-private fun AmbientGlow() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Box(
-            modifier = Modifier
-                .size(400.dp)
-                .alpha(0.05f)
-                .blur(120.dp)
-                .background(greenDark, CircleShape)
-        )
     }
 }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AmbientGlow.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AmbientGlow.kt
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.widgets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.valhalla.thor.presentation.theme.greenDark
+
+/**
+ * A soft coloured wash centred behind whatever it is placed under — Thor's one ambient-light motif.
+ *
+ * Lifted out of `BiometricScreen`, which is still a caller, when the app-info headers wanted the
+ * same glow behind their app icon. One implementation rather than two: this is a look, and a look
+ * that exists twice drifts.
+ *
+ * Three things here are deliberate.
+ *
+ * **A radial gradient, not a solid circle with a blur.** [Modifier.blur] is a `RenderEffect`, and
+ * `RenderEffect` starts at API 31 — on 28-30, which this app supports, the blur is a documented
+ * no-op. A solid circle therefore renders as a hard-edged disc on those releases. At the biometric
+ * screen's 5% alpha nobody could tell, but this is now also the affordance behind a tappable app
+ * icon whose alpha *rises* on press, and a hard disc there reads as a rendering bug rather than a
+ * glow. A gradient that fades to transparent is a glow on every supported API, and the blur only
+ * softens it further where it exists.
+ *
+ * **[alpha] and [scale] are lambdas, not values.** Callers animate them, and a `State` read inside
+ * the `graphicsLayer` block re-records the layer without recomposing anyone — the same reason
+ * `BiometricLockView`'s pulsing ring uses `graphicsLayer { this.alpha = … }` instead of
+ * `Modifier.alpha(…)`. Taking `Float`s here would move that read to the call site's composition and
+ * hand every caller a header that recomposes every frame.
+ *
+ * **[requiredSize], not `size`.** The glow is normally larger than the thing it sits behind, so it
+ * is usually placed with `Modifier.matchParentSize()` to keep it out of the parent's measurement.
+ * That hands it the parent's bounds as constraints, and `size` would quietly clamp [diameter] down
+ * to them.
+ *
+ * @param coreFraction how much of the radius holds [color] at full strength before the fade to
+ *   transparent begins, as a fraction of the radius. 0 is a plain two-stop gradient — brightest at
+ *   the dead centre, which is right for a wash nothing sits on top of. It is wrong when something
+ *   opaque covers the middle, as an app icon covers the middle of its own halo: then the only
+ *   visible part of the gradient is its faintest tail, and the glow disappears at any tasteful
+ *   alpha. A core pushes the falloff outwards so the visible ring keeps most of the colour.
+ */
+@Composable
+internal fun AmbientGlow(
+    modifier: Modifier = Modifier,
+    diameter: Dp = 400.dp,
+    blurRadius: Dp = 120.dp,
+    color: Color = greenDark,
+    alpha: () -> Float = { 0.05f },
+    scale: () -> Float = { 1f },
+    coreFraction: Float = 0f,
+) {
+    val brush = if (coreFraction > 0f) {
+        Brush.radialGradient(
+            0f to color,
+            coreFraction.coerceAtMost(0.99f) to color,
+            1f to Color.Transparent
+        )
+    } else {
+        Brush.radialGradient(listOf(color, Color.Transparent))
+    }
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Box(
+            modifier = Modifier
+                .requiredSize(diameter)
+                .graphicsLayer {
+                    val currentScale = scale()
+                    scaleX = currentScale
+                    scaleY = currentScale
+                    this.alpha = alpha()
+                }
+                .blur(blurRadius)
+                .background(brush = brush, shape = CircleShape)
+        )
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AmbientGlow.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AmbientGlow.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -25,15 +27,23 @@ import com.valhalla.thor.presentation.theme.greenDark
  * same glow behind their app icon. One implementation rather than two: this is a look, and a look
  * that exists twice drifts.
  *
- * Three things here are deliberate.
+ * Four things here are deliberate.
  *
  * **A radial gradient, not a solid circle with a blur.** [Modifier.blur] is a `RenderEffect`, and
  * `RenderEffect` starts at API 31 — on 28-30, which this app supports, the blur is a documented
  * no-op. A solid circle therefore renders as a hard-edged disc on those releases. At the biometric
- * screen's 5% alpha nobody could tell, but this is now also the affordance behind a tappable app
- * icon whose alpha *rises* on press, and a hard disc there reads as a rendering bug rather than a
- * glow. A gradient that fades to transparent is a glow on every supported API, and the blur only
- * softens it further where it exists.
+ * screen's 5% alpha nobody could tell, but this is also the affordance behind a tappable app icon
+ * whose alpha *rises* on press, and a hard disc there reads as a rendering bug rather than a glow.
+ * The gradient carries the whole fade, so the glow looks the same on every supported API and a blur
+ * is optional decoration rather than the mechanism.
+ *
+ * **The fade is a smoothstep, and the blur does not clip to a rectangle.** A blur is what turns a
+ * glow square: [Modifier.blur] defaults to [BlurredEdgeTreatment.Rectangle], which smears the
+ * gradient outwards and then clips the result to the node's *rectangular* bounds, so a halo that
+ * fades to nothing in the gradient still ends in four straight lines on screen — measured at 13/255
+ * right at the node edge against 0 one pixel outside. Hence [BlurredEdgeTreatment.Unbounded] here,
+ * and a `smoothstep` alpha ramp rather than a linear one, which has zero slope at both ends: no kink
+ * where the fade starts and nothing left to cut off where it ends.
  *
  * **[alpha] and [scale] are lambdas, not values.** Callers animate them, and a `State` read inside
  * the `graphicsLayer` block re-records the layer without recomposing anyone — the same reason
@@ -46,12 +56,16 @@ import com.valhalla.thor.presentation.theme.greenDark
  * That hands it the parent's bounds as constraints, and `size` would quietly clamp [diameter] down
  * to them.
  *
- * @param coreFraction how much of the radius holds [color] at full strength before the fade to
- *   transparent begins, as a fraction of the radius. 0 is a plain two-stop gradient — brightest at
- *   the dead centre, which is right for a wash nothing sits on top of. It is wrong when something
- *   opaque covers the middle, as an app icon covers the middle of its own halo: then the only
- *   visible part of the gradient is its faintest tail, and the glow disappears at any tasteful
- *   alpha. A core pushes the falloff outwards so the visible ring keeps most of the colour.
+ * @param blurRadius extra softening on top of the gradient, or `0.dp` for none. Unbounded, so it is
+ *   drawn outside the node's bounds rather than cut off at them — which means an ancestor that clips
+ *   can still cut it, and a caller that has a tight clip nearby is better off at 0 and letting the
+ *   gradient do the work.
+ * @param coreFraction how much of the radius holds [color] at full strength before the fade begins,
+ *   as a fraction of the radius. 0 fades from the dead centre, which is right for a wash nothing
+ *   sits on top of. It is wrong when something opaque covers the middle, as an app icon covers the
+ *   middle of its own halo: then the only visible part of the gradient is its faintest tail, and the
+ *   glow disappears at any tasteful alpha. A core pushes the falloff outwards so the visible ring
+ *   keeps most of the colour.
  */
 @Composable
 internal fun AmbientGlow(
@@ -63,14 +77,8 @@ internal fun AmbientGlow(
     scale: () -> Float = { 1f },
     coreFraction: Float = 0f,
 ) {
-    val brush = if (coreFraction > 0f) {
-        Brush.radialGradient(
-            0f to color,
-            coreFraction.coerceAtMost(0.99f) to color,
-            1f to Color.Transparent
-        )
-    } else {
-        Brush.radialGradient(listOf(color, Color.Transparent))
+    val brush = remember(color, coreFraction) {
+        Brush.radialGradient(colorStops = glowColorStops(color, coreFraction))
     }
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Box(
@@ -82,8 +90,38 @@ internal fun AmbientGlow(
                     scaleY = currentScale
                     this.alpha = alpha()
                 }
-                .blur(blurRadius)
+                .then(
+                    if (blurRadius > 0.dp) {
+                        Modifier.blur(blurRadius, BlurredEdgeTreatment.Unbounded)
+                    } else {
+                        Modifier
+                    }
+                )
                 .background(brush = brush, shape = CircleShape)
         )
+    }
+}
+
+/**
+ * Stops for a glow that holds [color] out to [coreFraction] of the radius and then fades to nothing
+ * on a smoothstep curve.
+ *
+ * Sampled rather than analytic because a gradient brush interpolates linearly between stops — the
+ * curve has to be baked into the positions. Eight segments is where the banding stops being
+ * measurable at the alphas this is used at.
+ *
+ * The curve matters at both ends. A linear ramp kinks visibly where the core meets the fade, and it
+ * still has slope when it reaches the rim, so anything that cuts the glow there (a blur clipped to
+ * bounds, an ancestor clip, a scale that outgrows the reserved space) cuts a *visible* edge.
+ * `smoothstep` arrives at zero flat, which leaves nothing to cut.
+ */
+private fun glowColorStops(color: Color, coreFraction: Float): Array<Pair<Float, Color>> {
+    val core = coreFraction.coerceIn(0f, 0.9f)
+    val segments = 8
+    return Array(segments + 1) { index ->
+        val t = index / segments.toFloat()
+        // 1 - smoothstep(t): starts at full colour with zero slope, reaches zero with zero slope.
+        val fade = 1f - t * t * (3f - 2f * t)
+        (core + (1f - core) * t) to color.copy(alpha = color.alpha * fade)
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AmbientGlow.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AmbientGlow.kt
@@ -61,11 +61,12 @@ import com.valhalla.thor.presentation.theme.greenDark
  *   can still cut it, and a caller that has a tight clip nearby is better off at 0 and letting the
  *   gradient do the work.
  * @param coreFraction how much of the radius holds [color] at full strength before the fade begins,
- *   as a fraction of the radius. 0 fades from the dead centre, which is right for a wash nothing
- *   sits on top of. It is wrong when something opaque covers the middle, as an app icon covers the
- *   middle of its own halo: then the only visible part of the gradient is its faintest tail, and the
- *   glow disappears at any tasteful alpha. A core pushes the falloff outwards so the visible ring
- *   keeps most of the colour.
+ *   as a fraction of the radius. 0 fades from the dead centre, which spreads roughly a third of the
+ *   ink a solid disc of the same alpha would — so it is the wrong default to *drift* into: both
+ *   callers pass a core. An app icon covers the middle of its own halo, leaving only the gradient's
+ *   faintest tail visible, and a full-screen wash replacing a solid blurred disc has to put back the
+ *   ink the gradient's centre gives away. In both cases a core pushes the falloff outwards so the
+ *   part that is actually seen keeps most of the colour.
  */
 @Composable
 internal fun AmbientGlow(

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppHeaderIcon.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppHeaderIcon.kt
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.widgets
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.valhalla.asgard.expressivePress
+import com.valhalla.thor.R
+import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.presentation.utils.AppIconModel
+
+/**
+ * The app icon as it appears at the top of both app-info surfaces — and the two shortcuts on it.
+ *
+ * Tap opens the app, long-press opens its system settings page. Both are shortcuts to actions the
+ * row below already offers, which is the point: the row is user-customisable and anything in it can
+ * be hidden, so users who hide Open and Settings to shorten the row keep both within reach. Nothing
+ * is *only* here.
+ *
+ * **[onOpen] and [onOpenSettings] must be the very lambdas the row's `onLaunch` and
+ * `onSystemSettings` get.** Not a copy that does the same thing — the same instances. "Open" is not
+ * `startActivity`: a frozen or suspended app has to be restored first (`MainViewModel` turns
+ * [com.valhalla.thor.domain.model.AppClickAction.Launch] into an unfreeze/unsuspend and *then* a
+ * launch), and a shortcut that skipped that would silently do nothing on exactly the apps a user of
+ * this app is most likely to tap. Sharing the lambda makes the two paths identical by construction
+ * rather than by inspection.
+ *
+ * **The glow is the discoverability story.** An icon that is suddenly tappable, with no ripple until
+ * it is touched, is a gesture nobody finds. [AmbientGlow] behind it breathes slowly at rest to say
+ * "this is alive", brightens and swells under a finger, and flares once when a long press is
+ * recognised — that last one because a long press hands off to an external activity, so the frame or
+ * two before it appears is the only feedback Thor still owns. Every animated value is read inside a
+ * `graphicsLayer` block, so none of it recomposes the header.
+ *
+ * Sizing is passed in rather than fixed: the sheet's header draws this at 100 dp and the details
+ * screen's at 72 dp. Everything else about it is shared, so the two cannot drift.
+ *
+ * @param imageModifier applied to the icon image itself, for the details screen's shared-element
+ *   transition. On the container it would animate the glow and the ripple with it.
+ * @param glowDiameter defaults to 1.45x [size] — a halo hugging the icon, not a wash behind the
+ *   header. Twice [size] was the first attempt and it was wrong: at 100 dp that is a 220 dp patch
+ *   reaching 60 dp past the icon, which on the sheet lands under the app title and reads as a
+ *   discoloured background rather than as something around the icon. The blur clips to these bounds
+ *   (`BlurredEdgeTreatment.Rectangle`), so this is the real footprint, scale aside.
+ *
+ * The difference between [glowDiameter] and [size] is *reserved* around the icon rather than left to
+ * overflow, because both surfaces sit inside something that clips: the sheet's scrolling column and
+ * the details card's rounded background. Overflowing, the glow was sliced off flat along the icon's
+ * own top edge on the sheet — a bright straight line where a halo should be, and only above, since
+ * the bottom half had a spacer to bleed into. The widget therefore measures [glowDiameter], not
+ * [size]; a caller placing something immediately below the icon wants roughly that much less spacing
+ * than it would otherwise use.
+ */
+@Composable
+internal fun AppHeaderIcon(
+    appInfo: AppInfo,
+    onOpen: () -> Unit,
+    onOpenSettings: () -> Unit,
+    size: Dp,
+    cornerRadius: Dp,
+    contentPadding: Dp,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceContainerHigh,
+    glowDiameter: Dp = size * 1.45f,
+    imageModifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+
+    // The resting breath. Slow and shallow on purpose: this is a hint sitting under the user's eyes
+    // for as long as the sheet is open, not a call to action.
+    val transition = rememberInfiniteTransition(label = "appHeaderIconGlow")
+    val breath by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "appHeaderIconGlowBreath"
+    )
+
+    val press by animateFloatAsState(
+        targetValue = if (pressed) 1f else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "appHeaderIconGlowPress"
+    )
+
+    // Counter rather than a Boolean: two long presses in a row have to replay the flare, and a
+    // Boolean that is already true is not a change. snapTo, then decay — a long press is recognised
+    // at the end of the hold, so there is nothing left to ramp up to.
+    var longPressCount by remember { mutableIntStateOf(0) }
+    val flare = remember { Animatable(0f) }
+    LaunchedEffect(longPressCount) {
+        if (longPressCount == 0) return@LaunchedEffect
+        flare.snapTo(1f)
+        flare.animateTo(
+            targetValue = 0f,
+            animationSpec = tween(durationMillis = 700, easing = LinearOutSlowInEasing)
+        )
+    }
+
+    // The room the glow needs on every side. Padding rather than a larger Box so the icon stays
+    // centred in it and the glow, matching the *padded* bounds, stays centred on the icon.
+    val glowInset = ((glowDiameter - size) / 2).coerceAtLeast(0.dp)
+
+    // One alpha cannot serve both schemes. Dark mode puts a pale green on near-black, where a few
+    // percent already reads as light; light mode puts a *dark* green on a near-white surface, where
+    // the same figure is a grey smudge — measured at 11/255 against the sheet, which is nothing. So
+    // light mode gets a much stronger alpha and `primaryContainer`, the saturated mid-green, rather
+    // than `primary`, which at these alphas tints towards shade rather than towards colour.
+    //
+    // Luminance of `surface`, not `isSystemInDarkTheme`: `ThorTheme` also has an AMOLED variant and
+    // takes `darkTheme` as a parameter the caller can override, so the scheme actually in hand is
+    // the only reliable answer to what this glow is being drawn over.
+    val onLightScheme = MaterialTheme.colorScheme.surface.luminance() > 0.5f
+    val glowColor = if (onLightScheme) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+    val restAlpha = if (onLightScheme) 0.40f else 0.16f
+    val breathAlpha = if (onLightScheme) 0.12f else 0.08f
+    val pressAlpha = if (onLightScheme) 0.28f else 0.22f
+    val flareAlpha = if (onLightScheme) 0.32f else 0.30f
+
+    Box(modifier = modifier.padding(glowInset), contentAlignment = Alignment.Center) {
+        // matchParentSize so the glow never enters the parent's measurement: it is bigger than the
+        // icon, and a glow that pushed the header's layout around would move the title. The inset
+        // above is what keeps it inside this widget's own bounds regardless.
+        AmbientGlow(
+            modifier = Modifier.matchParentSize(),
+            diameter = glowDiameter,
+            blurRadius = size / 4f,
+            color = glowColor,
+            // The icon container is opaque and covers the middle of its own halo, so without a core
+            // the only visible part of the gradient is the tail that has already faded to nearly
+            // nothing. 0.45 puts the falloff just outside the icon's edge.
+            coreFraction = 0.45f,
+            // Concentrated rather than spread: a tighter halo needs a little more alpha to read at
+            // all. Punch comes from alpha, not size — the scale deltas peak at about 1.11x, which is
+            // the most the reserved inset absorbs; a press that swelled the glow past it would clip
+            // against the sheet's scroll bounds, and reserving for the peak would cost 40 dp of
+            // permanent layout to serve 300 ms of animation.
+            alpha = {
+                restAlpha + breathAlpha * breath + pressAlpha * press + flareAlpha * flare.value
+            },
+            scale = { 1f + 0.02f * breath + 0.04f * press + 0.05f * flare.value }
+        )
+
+        Box(
+            modifier = Modifier
+                .size(size)
+                // Modifier order follows the app list's tappable rows: clip, then the press squish,
+                // then the click, then the background. Background *inside* the squish's
+                // graphicsLayer, or the icon shrinks under a container that stays put.
+                .clip(RoundedCornerShape(cornerRadius))
+                .expressivePress(interactionSource)
+                .combinedClickable(
+                    interactionSource = interactionSource,
+                    role = Role.Button,
+                    // The row's own labels for these two actions, reused verbatim: already
+                    // translated everywhere, and TalkBack then names the shortcut and the action
+                    // identically. No haptics here — CombinedClickableNode performs the long-press
+                    // haptic itself, and a second one is a double buzz.
+                    onClickLabel = stringResource(R.string.action_open),
+                    onLongClickLabel = stringResource(R.string.settings),
+                    onLongClick = {
+                        longPressCount++
+                        onOpenSettings()
+                    },
+                    onClick = onOpen
+                )
+                .background(containerColor)
+                .padding(contentPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            AsyncImage(
+                model = AppIconModel(appInfo.packageName),
+                // The app's name, where this image used to be decorative. It is the only child of a
+                // clickable node now, so with a null description TalkBack reaches a button it can
+                // only call "unlabelled".
+                contentDescription = appInfo.appName ?: appInfo.packageName,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(imageModifier)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppHeaderIcon.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppHeaderIcon.kt
@@ -170,7 +170,12 @@ internal fun AppHeaderIcon(
         AmbientGlow(
             modifier = Modifier.matchParentSize(),
             diameter = glowDiameter,
-            blurRadius = size / 4f,
+            // No blur. A blur is what put a square edge on this: it smears the halo out to the
+            // node's rectangular bounds, and the default edge treatment then clips it there, so the
+            // glow ended in four straight lines a few pixels short of where the gradient had already
+            // faded to nothing. The gradient's own smoothstep falloff is the softness, which also
+            // means this renders identically on API 28-30, where `Modifier.blur` does nothing at all.
+            blurRadius = 0.dp,
             color = glowColor,
             // The icon container is opaque and covers the middle of its own halo, so without a core
             // the only visible part of the gradient is the tail that has already faded to nearly

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppHeaderIcon.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppHeaderIcon.kt
@@ -45,6 +45,37 @@ import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppInfo
 import com.valhalla.thor.presentation.utils.AppIconModel
 
+/** How much wider than the icon [AppHeaderIcon]'s glow is, by default. */
+internal const val APP_HEADER_ICON_GLOW_RATIO = 1.45f
+
+// The three animated scale bumps. They are additive and can all be at maximum at once: a long press
+// is recognised while the finger is still down, so `press` is at 1 when `flare` snaps to 1, and
+// `breath` is free-running and answers to nothing.
+private const val GLOW_BREATH_SCALE = 0.02f
+private const val GLOW_PRESS_SCALE = 0.04f
+private const val GLOW_FLARE_SCALE = 0.05f
+
+/**
+ * The transparent margin [AppHeaderIcon] reserves on every side of a [size]-dp icon for its glow.
+ *
+ * Callers subtract this from the spacing they want around the icon. The widget measures
+ * `size * `[APP_HEADER_ICON_GLOW_RATIO], so a caller that leaves its usual gap on top of that leaves
+ * about twice the gap it intended.
+ */
+internal fun appHeaderIconGlowInset(size: Dp): Dp = size * (APP_HEADER_ICON_GLOW_RATIO - 1f) / 2f
+
+/**
+ * How far past its own bounds [AppHeaderIcon]'s glow reaches at the peak of a press-and-hold.
+ *
+ * [appHeaderIconGlowInset] reserves room for the glow at rest — scale 1.0 and no more. The press and
+ * flare take it to about 1.11x, and nothing inside the widget clips, so that last 11 % draws outside
+ * it. It is the outermost ring of a smoothstep falloff, which has arrived at zero alpha by then, so
+ * a clip there costs nothing visible; a caller that wants the peak intact anyway can reserve this.
+ */
+internal fun appHeaderIconGlowOvershoot(size: Dp): Dp =
+    size * APP_HEADER_ICON_GLOW_RATIO *
+        (GLOW_BREATH_SCALE + GLOW_PRESS_SCALE + GLOW_FLARE_SCALE) / 2f
+
 /**
  * The app icon as it appears at the top of both app-info surfaces — and the two shortcuts on it.
  *
@@ -73,19 +104,25 @@ import com.valhalla.thor.presentation.utils.AppIconModel
  *
  * @param imageModifier applied to the icon image itself, for the details screen's shared-element
  *   transition. On the container it would animate the glow and the ripple with it.
- * @param glowDiameter defaults to 1.45x [size] — a halo hugging the icon, not a wash behind the
- *   header. Twice [size] was the first attempt and it was wrong: at 100 dp that is a 220 dp patch
- *   reaching 60 dp past the icon, which on the sheet lands under the app title and reads as a
- *   discoloured background rather than as something around the icon. The blur clips to these bounds
- *   (`BlurredEdgeTreatment.Rectangle`), so this is the real footprint, scale aside.
+ * @param glowDiameter defaults to [APP_HEADER_ICON_GLOW_RATIO] x [size] — a halo hugging the icon,
+ *   not a wash behind the header. Twice [size] was the first attempt and it was wrong: at 100 dp
+ *   that is a 220 dp patch reaching 60 dp past the icon, which on the sheet lands under the app
+ *   title and reads as a discoloured background rather than as something around the icon.
  *
  * The difference between [glowDiameter] and [size] is *reserved* around the icon rather than left to
  * overflow, because both surfaces sit inside something that clips: the sheet's scrolling column and
  * the details card's rounded background. Overflowing, the glow was sliced off flat along the icon's
  * own top edge on the sheet — a bright straight line where a halo should be, and only above, since
  * the bottom half had a spacer to bleed into. The widget therefore measures [glowDiameter], not
- * [size]; a caller placing something immediately below the icon wants roughly that much less spacing
- * than it would otherwise use.
+ * [size]: [appHeaderIconGlowInset] of transparent margin on every side.
+ *
+ * **Callers have to spend that margin, not add to it.** A caller that keeps the spacing it used
+ * before the glow existed puts the next thing along twice as far away as it means to, and on a
+ * horizontal layout takes the same amount off whatever shares the row. Both call sites subtract
+ * [appHeaderIconGlowInset] from the gap they want; see either one. The reserved margin covers the
+ * glow at rest — the press and flare scale it up to [appHeaderIconGlowOvershoot] past the widget's
+ * bounds, which is the *outermost* ring of a smoothstep falloff and so has essentially no alpha
+ * left, but a caller with a clip right there can pay for it as the sheet's header does.
  */
 @Composable
 internal fun AppHeaderIcon(
@@ -97,7 +134,7 @@ internal fun AppHeaderIcon(
     contentPadding: Dp,
     modifier: Modifier = Modifier,
     containerColor: Color = MaterialTheme.colorScheme.surfaceContainerHigh,
-    glowDiameter: Dp = size * 1.45f,
+    glowDiameter: Dp = size * APP_HEADER_ICON_GLOW_RATIO,
     imageModifier: Modifier = Modifier,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -152,11 +189,21 @@ internal fun AppHeaderIcon(
     // Luminance of `surface`, not `isSystemInDarkTheme`: `ThorTheme` also has an AMOLED variant and
     // takes `darkTheme` as a parameter the caller can override, so the scheme actually in hand is
     // the only reliable answer to what this glow is being drawn over.
-    val onLightScheme = MaterialTheme.colorScheme.surface.luminance() > 0.5f
-    val glowColor = if (onLightScheme) {
-        MaterialTheme.colorScheme.primaryContainer
-    } else {
-        MaterialTheme.colorScheme.primary
+    val scheme = MaterialTheme.colorScheme
+    val surfaceLuminance = scheme.surface.luminance()
+    val onLightScheme = surfaceLuminance > 0.5f
+    val glowColor = when {
+        !onLightScheme -> scheme.primary
+        // Thor's own light scheme is unusual: its `primaryContainer` is a *dark* green (#4c662b,
+        // luminance 0.11 against a 0.95 surface), which is why it is the better choice above. Every
+        // dynamic light scheme puts the ordinary M3 tone there instead — accent1-90, a near-white
+        // pastel — and `useDynamicColor` is a user preference (`HomeActivity`), so that scheme is
+        // reachable. At 0.40 alpha a pastel over a near-white sheet is an 8/255 delta: the
+        // affordance simply is not there. So take `primaryContainer` only when it is actually dark
+        // enough to register, and fall back to `primary`, which is the 40-tone in every M3 light
+        // scheme and so always is.
+        surfaceLuminance - scheme.primaryContainer.luminance() > 0.35f -> scheme.primaryContainer
+        else -> scheme.primary
     }
     val restAlpha = if (onLightScheme) 0.40f else 0.16f
     val breathAlpha = if (onLightScheme) 0.12f else 0.08f
@@ -182,24 +229,33 @@ internal fun AppHeaderIcon(
             // nothing. 0.45 puts the falloff just outside the icon's edge.
             coreFraction = 0.45f,
             // Concentrated rather than spread: a tighter halo needs a little more alpha to read at
-            // all. Punch comes from alpha, not size — the scale deltas peak at about 1.11x, which is
-            // the most the reserved inset absorbs; a press that swelled the glow past it would clip
-            // against the sheet's scroll bounds, and reserving for the peak would cost 40 dp of
-            // permanent layout to serve 300 ms of animation.
+            // all. Punch comes from alpha, not size — the scale deltas are small deliberately. The
+            // reserved inset covers scale 1.0 exactly, so every bump above it draws outside the
+            // widget ([appHeaderIconGlowOvershoot]); keeping the peak at 1.11x keeps what escapes to
+            // the zero-alpha tail of the falloff, where a clip is invisible. Reserving for the peak
+            // instead would cost 16 dp of permanent layout to serve 300 ms of animation.
             alpha = {
                 restAlpha + breathAlpha * breath + pressAlpha * press + flareAlpha * flare.value
             },
-            scale = { 1f + 0.02f * breath + 0.04f * press + 0.05f * flare.value }
+            scale = {
+                1f + GLOW_BREATH_SCALE * breath + GLOW_PRESS_SCALE * press +
+                    GLOW_FLARE_SCALE * flare.value
+            }
         )
 
         Box(
             modifier = Modifier
                 .size(size)
-                // Modifier order follows the app list's tappable rows: clip, then the press squish,
-                // then the click, then the background. Background *inside* the squish's
-                // graphicsLayer, or the icon shrinks under a container that stays put.
-                .clip(RoundedCornerShape(cornerRadius))
+                // Squish first, then clip, then the click, then the background — everything visible
+                // inside the squish's `graphicsLayer`, or it shrinks under something that stays put.
+                // The app list's rows clip *outside* it, which is subtly wrong on a shape this
+                // round: `expressivePress` is a scale layer (`Motion.kt`), and a clip above it keeps
+                // its corner arcs at the unscaled radius while the fill shrinks under them, so a
+                // pressed 32 dp corner is cut by a stationary r=32 arc and gains a visible kink
+                // where the arc meets the straight edge. Inside the layer the whole silhouette
+                // scales together and the press is a squish rather than a change of shape.
                 .expressivePress(interactionSource)
+                .clip(RoundedCornerShape(cornerRadius))
                 .combinedClickable(
                     interactionSource = interactionSource,
                     role = Role.Button,

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoSheet.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -58,7 +57,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.rememberViewModelStoreOwner
-import coil3.compose.AsyncImage
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
@@ -67,7 +65,6 @@ import com.valhalla.thor.presentation.appList.AppInfoDetailBody
 import com.valhalla.thor.presentation.appList.AppInfoDetailsViewModel
 import com.valhalla.thor.presentation.appList.ExportBottomSheet
 import com.valhalla.thor.presentation.backup.AppBackupSheet
-import com.valhalla.thor.presentation.utils.AppIconModel
 import com.valhalla.thor.presentation.utils.getBloatRecommendationColors
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -225,8 +222,25 @@ fun AppInfoSheet(
                     .semantics { paneTitle = paneTitleText },
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                // Hoisted, because the header icon is a shortcut to these two actions and gets the
+                // *same* lambdas the row does — see AppHeaderIcon for why sharing the instance
+                // rather than duplicating the body is the point. Open dismisses (the user is
+                // leaving for another app); settings does not, for the reason spelled out on
+                // onManagePermissions below.
+                val onLaunchApp: () -> Unit = {
+                    onAppAction(AppClickAction.Launch(appInfo))
+                    onDismiss()
+                }
+                val onOpenSystemSettings: () -> Unit = {
+                    onAppAction(AppClickAction.AppInfoSettings(appInfo))
+                }
+
                 // 1. Header (Icon + Title)
-                AppHeader(appInfo)
+                AppHeader(
+                    appInfo = appInfo,
+                    onOpen = onLaunchApp,
+                    onOpenSettings = onOpenSystemSettings
+                )
 
                 Spacer(modifier = Modifier.height(16.dp))
 
@@ -237,11 +251,8 @@ fun AppInfoSheet(
                     isShizuku = isShizuku,
                     isDhizuku = isDhizuku,
                     isInFreezer = isInFreezer,
-                    onLaunch = {
-                        onAppAction(AppClickAction.Launch(appInfo))
-                        onDismiss()
-                    },
-                    onSystemSettings = { onAppAction(AppClickAction.AppInfoSettings(appInfo)) },
+                    onLaunch = onLaunchApp,
+                    onSystemSettings = onOpenSystemSettings,
                     onFreezeToggle = { shouldFreeze ->
                         // Only SYSTEM apps get the safety-warning dialog; unfreezing and user apps
                         // go straight through. `freezeNeedsConfirmation` also answers the newer
@@ -478,7 +489,11 @@ fun AppInfoSheet(
 }
 
 @Composable
-private fun AppHeader(appInfo: AppInfo) {
+private fun AppHeader(
+    appInfo: AppInfo,
+    onOpen: () -> Unit,
+    onOpenSettings: () -> Unit
+) {
     val clipboard = LocalClipboard.current
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -488,24 +503,26 @@ private fun AppHeader(appInfo: AppInfo) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 24.dp)
+            // The scrolling column above clips, and its top edge is this content's top edge. The
+            // icon's glow reserves its own room, so this is only the margin between the glow's outer
+            // rim and that clip — enough that a press, which swells the glow slightly, still has
+            // somewhere to go.
+            .padding(top = 8.dp)
     ) {
-        // Icon with a nice background
-        Box(
-            modifier = Modifier
-                .size(100.dp)
-                .clip(RoundedCornerShape(32.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                .padding(16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            AsyncImage(
-                model = AppIconModel(appInfo.packageName),
-                contentDescription = null,
-                modifier = Modifier.fillMaxSize()
-            )
-        }
+        // Icon with a nice background — and the two shortcuts on it: tap opens the app,
+        // long-press opens its system settings page.
+        AppHeaderIcon(
+            appInfo = appInfo,
+            onOpen = onOpen,
+            onOpenSettings = onOpenSettings,
+            size = 100.dp,
+            cornerRadius = 32.dp,
+            contentPadding = 16.dp
+        )
 
-        Spacer(Modifier.height(24.dp))
+        // 8, not the 24 this was before the icon grew a glow: the icon block now carries ~22 dp of
+        // reserved glow around itself, so 24 here would have put the title 46 dp adrift.
+        Spacer(Modifier.height(8.dp))
 
         // Title
         Text(

--- a/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoSheet.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/widgets/AppInfoSheet.kt
@@ -498,16 +498,17 @@ private fun AppHeader(
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val valueLabel = stringResource(R.string.value_label)
+    val iconSize = 100.dp
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 24.dp)
             // The scrolling column above clips, and its top edge is this content's top edge. The
-            // icon's glow reserves its own room, so this is only the margin between the glow's outer
-            // rim and that clip — enough that a press, which swells the glow slightly, still has
-            // somewhere to go.
-            .padding(top = 8.dp)
+            // icon's glow reserves its own room, so this is only the room the press and flare need
+            // to swell into — derived rather than guessed, because a straight line across the top of
+            // a halo is exactly what the reserved inset was introduced to stop.
+            .padding(top = appHeaderIconGlowOvershoot(iconSize))
     ) {
         // Icon with a nice background — and the two shortcuts on it: tap opens the app,
         // long-press opens its system settings page.
@@ -515,14 +516,16 @@ private fun AppHeader(
             appInfo = appInfo,
             onOpen = onOpen,
             onOpenSettings = onOpenSettings,
-            size = 100.dp,
+            size = iconSize,
             cornerRadius = 32.dp,
             contentPadding = 16.dp
         )
 
-        // 8, not the 24 this was before the icon grew a glow: the icon block now carries ~22 dp of
-        // reserved glow around itself, so 24 here would have put the title 46 dp adrift.
-        Spacer(Modifier.height(8.dp))
+        // The gap this header wants under the icon is 24 dp, and the icon block already carries most
+        // of it as reserved glow. Spending it rather than adding to it keeps the title where it was
+        // before the glow existed — and keeps the sheet's partially-expanded detent, which shows a
+        // fixed half of the screen, from losing that much of its budget to the header.
+        Spacer(Modifier.height((24.dp - appHeaderIconGlowInset(iconSize)).coerceAtLeast(0.dp)))
 
         // Title
         Text(


### PR DESCRIPTION
## What

Two gestures on the app icon at the top of both app-info surfaces (the sheet and the details card):

- **tap** → open the app
- **long-press** → the system app-info page

Both are shortcuts to actions the row below already offers. That is the point: the row is
user-customisable, so users who hide Open and Settings to shorten it keep both within reach.
Nothing is *only* a gesture.

## Why "open" is not `startActivity`

The header and the action row are handed the **same lambda instances**, not two copies that do the
same thing. `MainViewModel` turns `AppClickAction.Launch` into an unfreeze/unsuspend and *then* a
launch, and a shortcut that skipped that would silently do nothing on exactly the apps a Thor user
is most likely to tap. Sharing the instance makes the two paths identical by construction rather
than by inspection.

## The glow

An icon that is suddenly tappable, with no ripple until it is touched, is a gesture nobody finds.
`BiometricScreen`'s `AmbientGlow` moves to `presentation/widgets` and sits behind the icon: it
breathes slowly at rest, brightens and swells under a finger, and flares once when a long press is
recognised — the last one because a long press hands off to an external activity, so the frame or
two before it appears is the only feedback Thor still owns.

Three things about it are load-bearing:

- **Radial gradient, not a solid circle with a blur.** `Modifier.blur` is a `RenderEffect`, which
  starts at API 31; on 28–30 it is a documented no-op, so a solid circle renders as a hard-edged
  disc. Invisible at the biometric screen's 5% alpha, a rendering bug behind an app icon whose
  alpha rises on press.
- **The gradient has a solid core.** The icon container is opaque and covers the middle of its own
  halo, so a plain two-stop gradient shows only its faintest tail — measured at 11/255 against the
  sheet, i.e. nothing. The core pushes the falloff just past the icon's edge.
- **Light mode gets its own alpha and colour.** Dark mode puts a pale green on near-black, light
  mode a dark green on near-white; the same alpha reads as light in one and as a grey smudge in the
  other. Light mode uses `primaryContainer` at more than double the alpha. The branch is on
  `surface.luminance()`, not `isSystemInDarkTheme()`, because `ThorTheme` has an AMOLED variant and
  a caller-overridable `darkTheme`.

The glow also *reserves* its overshoot around the icon instead of overflowing, because both
surfaces sit inside something that clips — the sheet's scrolling column and the details card's
rounded background — and overflowing got it sliced off flat along the icon's own top edge.

## No new strings

The gestures reuse `action_open` and `settings`, the row's own labels: already translated in all
eight locales, and TalkBack names the shortcut and the action identically. The icon also gains the
app's name as its content description, since it is now the only child of a clickable node.

## Verification

- `:app:testFossDebugUnitTest --rerun-tasks` → 122 suites, **1634 tests, 0 failures, 0 errors, 0 skipped**
- `:app:lintStoreRelease` → green, 9 pre-existing hints only (`AndroidGradlePluginVersion` ×4, `VectorPath` ×5)
- `:app:compileFossDebugAndroidTestKotlin` → green
- On a Pixel 10 Pro Fold emulator (API 37), folded and unfolded, light and dark: tap launched
  `com.valhalla.arena.sudoku.challenger/.MainActivity`, long-press landed on
  `com.android.settings/.spa.SpaActivity`, and pixel measurement confirms the glow is symmetric
  around the icon on both surfaces with no clipping at any edge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive app header icons with tap-to-launch and long-press access to settings.
  - Added animated glow effects, press feedback, and accessibility labels for app icons.
  - Added configurable ambient glow visuals with smooth gradient falloff.

- **Improvements**
  - Updated app details and information views to use the shared interactive icon experience.
  - Improved header spacing and presentation around app icons.
  - Standardized ambient glow visuals across biometric screens for a more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->