### PR TITLE
chore(shizu): sync store changelog to v1.95.1

### DIFF
--- a/shizu_store.json
+++ b/shizu_store.json
@@ -24,7 +24,7 @@
   "repo_url": "https://github.com/trinadhthatakula/Thor",
   "app_website": "https://thor.trinadhthatakula.com",
   "download_url": "https://github.com/trinadhthatakula/Thor/releases/latest/download/foss-release.apk",
-  "changelog": "• 📦 Backup & Restore Hub: browse, manage, share and restore backups & bundles from one dedicated screen\n\n• 💾 Offline encrypted app data backup (.thorbak) with AES-256-GCM & WorkManager background sync\n\n• ⚙️ Customize App Info actions: drag-and-drop reordering and visibility controls\n\n• 🎮 Full .xapk & OBB split support for games and large apps\n\n• ❄️ Differentiated freezer actions & watchlist auto-cleanup\n\n• 🌐 Full translations in 8 languages: EN, AR, ES, FR, PL, PT, PT-BR, ZH",
+  "changelog": "• 📦 Backup & Restore Hub: browse, restore, share or delete backups and app bundles from one screen\n\n• 💾 Encrypted offline backups: full app data on root, APK + shared storage on Shizuku, plus .xapk & OBB\n\n• 🔀 Reorder or hide App Info actions; tap an app's icon to open it, long-press for system settings\n\n• 🔧 Fixed app lists that showed only Thor; newly granted root or Dhizuku applies on Refresh\n\n• 🌐 8 languages: EN, AR, ES, FR, PL, PT, PT-BR, ZH, plus clearer freezer action labels",
   "store_issue_number": 279,
   "category": "Tools",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Why

The weekly Shizu CoreFetch audit failed on `master` — [run 32698484093](https://github.com/trinadhthatakula/Thor/actions/runs/32698484093), tracking issue #430.

Exactly one check failed:

```
== changelog matches the current release notes ==
  FAIL changelog has drifted from release-notes/v1.95.1/playstore.txt
       (versionCode 1951 -> v1.95.1)
```

`shizu_store.json`'s `changelog` was byte-identical to `release-notes/v1.95.0/playstore.txt` — one release behind. The checker derives the expected version from `origin/production`, and rung 3 promoted **1951** on 2026-08-23, so the audit 18 hours later correctly reported that the store listing still advertised 1.95.0's notes. This is the designed post-promotion prompt, not a regression: the 2026-08-17 audit passed because production was still 1940.

The store reads the manifest from the **default branch**, so this has to land on `master` to reach any reader.

## What

One line — `.github/scripts/sync-shizu-changelog.sh`, no hand edits.

## Verification

The full checker, run locally so the `--network` tier actually executes (it 403s from every GitHub runner):

```
$ .github/scripts/check-shizu-manifest.sh --network
...
== upstream schema ==
  ok   manifest validates against the LIVE schema
  ok   vendored schema is identical to upstream

shizu_store.json: all checks passed
```

That also clears the standing question about upstream drift: `https://docshizu.siwane.xyz/schema.json` (HTTP 200, 8303 bytes) is still byte-identical to the copy #422 vendored on 2026-08-21, and the manifest validates against the live document. No `additionalProperties` rejection lurking this time.

Merging this turns the next audit green, which auto-closes #430.

## Notes

- No `versionCode` change, so `2-master-promote.yml`'s `on_unchanged_version: skip` builds and then skips the promotion.
- `chore/shizu-changelog-1951` carries the identical change into `dev` (verified byte-identical) so the next promotion does not reintroduce a stale field.

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English changelog with details about the Backup & Restore Hub and encrypted offline backup coverage.
  * Documented App Info action customization, app-list and root refresh fixes, and clearer freezer labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->