### PR TITLE
chore(shizu): sync store changelog to v1.95.1

### DIFF
--- a/shizu_store.json
+++ b/shizu_store.json
@@ -24,7 +24,7 @@
   "repo_url": "https://github.com/trinadhthatakula/Thor",
   "app_website": "https://thor.trinadhthatakula.com",
   "download_url": "https://github.com/trinadhthatakula/Thor/releases/latest/download/foss-release.apk",
-  "changelog": "• 📦 Backup & Restore Hub: browse, manage, share and restore backups & bundles from one dedicated screen\n\n• 💾 Offline encrypted app data backup (.thorbak) with AES-256-GCM & WorkManager background sync\n\n• ⚙️ Customize App Info actions: drag-and-drop reordering and visibility controls\n\n• 🎮 Full .xapk & OBB split support for games and large apps\n\n• ❄️ Differentiated freezer actions & watchlist auto-cleanup\n\n• 🌐 Full translations in 8 languages: EN, AR, ES, FR, PL, PT, PT-BR, ZH",
+  "changelog": "• 📦 Backup & Restore Hub: browse, restore, share or delete backups and app bundles from one screen\n\n• 💾 Encrypted offline backups: full app data on root, APK + shared storage on Shizuku, plus .xapk & OBB\n\n• 🔀 Reorder or hide App Info actions; tap an app's icon to open it, long-press for system settings\n\n• 🔧 Fixed app lists that showed only Thor; newly granted root or Dhizuku applies on Refresh\n\n• 🌐 8 languages: EN, AR, ES, FR, PL, PT, PT-BR, ZH, plus clearer freezer action labels",
   "store_issue_number": 279,
   "category": "Tools",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Why

Companion to the `master`-targeting PR for the same one-line fix. The Shizu store reads `shizu_store.json` from the **default branch**, so the audit fix has to land on `master` — but `dev` must carry the same value or the next promotion diff reintroduces a stale field.

The weekly audit ([run 32698484093](https://github.com/trinadhthatakula/Thor/actions/runs/32698484093), issue #430) found `changelog` still holding `release-notes/v1.95.0/playstore.txt` after production was promoted to versionCode 1951 on 2026-08-23.

## What

One line — `.github/scripts/sync-shizu-changelog.sh`, cherry-picked from the `master` branch so both copies are byte-identical.

## Verification

`.github/scripts/check-shizu-manifest.sh --network` reports `shizu_store.json: all checks passed`, including the tier CI can never reach:

```
== upstream schema ==
  ok   manifest validates against the LIVE schema
  ok   vendored schema is identical to upstream
```

`pr-ci.yml` passes `--warn-changelog-drift`, so this check was only ever a `::warning::` on `dev` PRs — which is why nothing here was red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English changelog with information about the Backup & Restore Hub.
  * Documented encrypted offline backup coverage and customizable App Info actions.
  * Added notes on improved app-list refresh behavior after granting new privileges.
  * Clarified freezer labels and language support.
  * Removed outdated references to WorkManager synchronization, game split support, watchlist cleanup, and complete translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->