### PR TITLE
feat(components): open, force-open, stop and disable individual components

### DIFF
--- a/app/schemas/com.valhalla.thor.data.source.local.room.AppDatabase/7.json
+++ b/app/schemas/com.valhalla.thor.data.source.local.room.AppDatabase/7.json
@@ -1,0 +1,352 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "146ad7d9667c480df2c87f09bf066517",
+    "entities": [
+      {
+        "tableName": "apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `appName` TEXT, `versionName` TEXT, `versionCode` INTEGER NOT NULL, `minSdk` INTEGER NOT NULL, `targetSdk` INTEGER NOT NULL, `isSystem` INTEGER NOT NULL, `installerPackageName` TEXT, `publicSourceDir` TEXT, `splitPublicSourceDirs` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `dataDir` TEXT, `nativeLibraryDir` TEXT, `deviceProtectedDataDir` TEXT, `sharedLibraryFiles` TEXT, `obbFilePath` TEXT, `sourceDir` TEXT, `sharedDataDir` TEXT NOT NULL, `lastUpdateTime` INTEGER NOT NULL, `firstInstallTime` INTEGER NOT NULL, `isDebuggable` INTEGER NOT NULL, `isSuspended` INTEGER NOT NULL, `installSize` INTEGER, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appName",
+            "columnName": "appName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "versionName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "versionCode",
+            "columnName": "versionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minSdk",
+            "columnName": "minSdk",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetSdk",
+            "columnName": "targetSdk",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "isSystem",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installerPackageName",
+            "columnName": "installerPackageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publicSourceDir",
+            "columnName": "publicSourceDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "splitPublicSourceDirs",
+            "columnName": "splitPublicSourceDirs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataDir",
+            "columnName": "dataDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "nativeLibraryDir",
+            "columnName": "nativeLibraryDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deviceProtectedDataDir",
+            "columnName": "deviceProtectedDataDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sharedLibraryFiles",
+            "columnName": "sharedLibraryFiles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "obbFilePath",
+            "columnName": "obbFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceDir",
+            "columnName": "sourceDir",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sharedDataDir",
+            "columnName": "sharedDataDir",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstInstallTime",
+            "columnName": "firstInstallTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDebuggable",
+            "columnName": "isDebuggable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSuspended",
+            "columnName": "isSuspended",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installSize",
+            "columnName": "installSize",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "freezer_apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, PRIMARY KEY(`packageName`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName"
+          ]
+        }
+      },
+      {
+        "tableName": "extension_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`extensionPackageName` TEXT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`extensionPackageName`, `key`))",
+        "fields": [
+          {
+            "fieldPath": "extensionPackageName",
+            "columnName": "extensionPackageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "extensionPackageName",
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "freeze_profiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL COLLATE NOCASE, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_freeze_profiles_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_freeze_profiles_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "freeze_profile_apps",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`profileId` INTEGER NOT NULL, `packageName` TEXT NOT NULL, PRIMARY KEY(`profileId`, `packageName`), FOREIGN KEY(`profileId`) REFERENCES `freeze_profiles`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "profileId",
+            "columnName": "profileId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "profileId",
+            "packageName"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_freeze_profile_apps_packageName",
+            "unique": false,
+            "columnNames": [
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_freeze_profile_apps_packageName` ON `${TABLE_NAME}` (`packageName`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "freeze_profiles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "profileId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "component_overrides",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `className` TEXT NOT NULL, `userId` INTEGER NOT NULL, `componentType` TEXT NOT NULL, `restoreToEnabled` INTEGER NOT NULL, `disabledAt` INTEGER NOT NULL, PRIMARY KEY(`packageName`, `className`, `userId`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "packageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "className",
+            "columnName": "className",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "componentType",
+            "columnName": "componentType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restoreToEnabled",
+            "columnName": "restoreToEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "disabledAt",
+            "columnName": "disabledAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "packageName",
+            "className",
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_component_overrides_packageName",
+            "unique": false,
+            "columnNames": [
+              "packageName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_component_overrides_packageName` ON `${TABLE_NAME}` (`packageName`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '146ad7d9667c480df2c87f09bf066517')"
+    ]
+  }
+}

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -60,6 +60,45 @@ class DhizukuSystemGateway(
         return runCatching { DhizukuHelper.execute(command) }
     }
 
+    // --- Per-component control -------------------------------------------------------------
+    //
+    // Empty, not partial. `DevicePolicyManager` exposes no component-enabled API of any kind — a
+    // Device Owner can suspend, hide, block-uninstall and set permission policy for a *package*,
+    // and none of those reach an individual class. Its only launch-related privilege is a
+    // background-activity-launch exemption, which is not an export waiver:
+    // `ActivityManager.canAccessUnexportedComponents` is granted to `ROOT_UID` and `SYSTEM_UID`
+    // alone, and Dhizuku's shell runs as its own app uid — further from uid 0 than Shizuku's 2000,
+    // not closer.
+    //
+    // Three explicit refusals rather than a shared helper, so that each one is visible at the site a
+    // reader looks for it and none of them can be quietly turned into an unverified "try the shell
+    // and see". A refusal that names the reason is the whole contribution this mode can make here.
+
+    override suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: com.valhalla.thor.domain.gateway.ComponentEnabledState,
+        userId: Int,
+    ): Result<Unit> = Result.failure(
+        Exception(context.getString(R.string.component_control_unsupported_dhizuku))
+    )
+
+    override suspend fun forceLaunchActivity(
+        packageName: String,
+        className: String,
+        userId: Int,
+    ): Result<Unit> = Result.failure(
+        Exception(context.getString(R.string.component_control_unsupported_dhizuku))
+    )
+
+    override suspend fun stopService(
+        packageName: String,
+        className: String,
+        userId: Int,
+    ): Result<Unit> = Result.failure(
+        Exception(context.getString(R.string.component_control_unsupported_dhizuku))
+    )
+
     override suspend fun forceStopApp(packageName: String): Result<Unit> {
         return if (reflector.forceStop(packageName)) Result.success(Unit)
         else Result.failure(Exception("Dhizuku: Force stop failed. Shell command and reflection both denied."))

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -16,8 +16,14 @@ import com.valhalla.thor.rootservice.IThorRootService
 import com.valhalla.superuser.ktx.ShellRepository
 import com.valhalla.superuser.ktx.ShellResult
 import com.valhalla.thor.BuildConfig
+import com.valhalla.thor.data.source.local.asComponentState
 import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
 import com.valhalla.thor.data.source.local.clearAppDataCommand
+import com.valhalla.thor.data.source.local.componentCommandFailure
+import com.valhalla.thor.data.source.local.escapedComponentSpecOrNull
+import com.valhalla.thor.data.source.local.setComponentStateCommand
+import com.valhalla.thor.data.source.local.startActivityCommand
+import com.valhalla.thor.data.source.local.stopServiceCommand
 import com.valhalla.thor.data.source.local.clearCachePaths
 import com.valhalla.thor.data.source.local.forceStopCommand
 import com.valhalla.thor.data.source.local.SessionApk
@@ -29,6 +35,7 @@ import com.valhalla.thor.data.source.local.setAppEnabledCommand
 import com.valhalla.thor.data.source.local.shizuku.isPolicyRefusal
 import com.valhalla.thor.data.source.local.thorUserId
 import com.valhalla.thor.data.source.local.uninstallCommand
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.GET_INSTALLED_APPS_PERMISSION
 import com.valhalla.thor.domain.model.PrivilegeMode
@@ -1424,6 +1431,76 @@ class RootSystemGateway(
      */
     private fun getPackageUserId(packageName: String): Int? =
         getApplicationInfoCompat(packageName)?.let { userIdOf(it.uid) }
+
+    // --- Per-component control -------------------------------------------------------------
+    //
+    // Root is the mode all three of these were written for: uid 0 is the only uid PMS and AMS will
+    // accept them from. See the block comment on SystemGateway for why there is no second rung to
+    // fall back to when they fail.
+
+    override suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState,
+        userId: Int,
+    ): Result<Unit> {
+        val spec = escapedComponentSpecOrNull(packageName, className)
+            ?: return Result.failure(
+                IllegalArgumentException("Invalid component: $packageName/$className")
+            )
+        return runComponentCommand(setComponentStateCommand(spec, userId, state.asComponentState()))
+    }
+
+    override suspend fun forceLaunchActivity(
+        packageName: String,
+        className: String,
+        userId: Int,
+    ): Result<Unit> {
+        val spec = escapedComponentSpecOrNull(packageName, className)
+            ?: return Result.failure(
+                IllegalArgumentException("Invalid component: $packageName/$className")
+            )
+        return runComponentCommand(startActivityCommand(spec, userId))
+    }
+
+    override suspend fun stopService(
+        packageName: String,
+        className: String,
+        userId: Int,
+    ): Result<Unit> {
+        val spec = escapedComponentSpecOrNull(packageName, className)
+            ?: return Result.failure(
+                IllegalArgumentException("Invalid component: $packageName/$className")
+            )
+        return runComponentCommand(stopServiceCommand(spec, userId))
+    }
+
+    /**
+     * Run a component command and judge it by its *output*, not only by its exit code.
+     *
+     * Separate from [runCommand] because that one reads `ShellResult.isSuccess`, and for `am start`
+     * that is very nearly a constant: a launch refused for a permission denial still exits 0 on most
+     * releases while printing `Security exception:` and a stack trace. [componentCommandFailure]
+     * holds the rule, so that the rule is one function and is JVM-testable.
+     */
+    private suspend fun runComponentCommand(cmd: String): Result<Unit> {
+        val result = shellRepository.exec(cmd)
+        if (result.code == ShellResult.JOB_NOT_EXECUTED) {
+            return Result.failure(
+                java.io.IOException(
+                    result.stderr.joinToString("\n").ifBlank { "Root shell unavailable" }
+                )
+            )
+        }
+        val output = (result.stdout + result.stderr).joinToString("\n")
+        val failure = componentCommandFailure(result.code, output)
+        return if (failure == null) {
+            Result.success(Unit)
+        } else {
+            Logger.e("RootSystemGateway", "Component command failed: $cmd -> $failure")
+            Result.failure(java.io.IOException(failure))
+        }
+    }
 
     /**
      * Raw shell execution for extensions, via the root shell.

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -19,6 +19,7 @@ import com.valhalla.thor.BuildConfig
 import com.valhalla.thor.data.source.local.asComponentState
 import com.valhalla.thor.data.source.local.backgroundRestrictionCommand
 import com.valhalla.thor.data.source.local.clearAppDataCommand
+import com.valhalla.thor.data.source.local.ComponentCommandKind
 import com.valhalla.thor.data.source.local.componentCommandFailure
 import com.valhalla.thor.data.source.local.escapedComponentSpecOrNull
 import com.valhalla.thor.data.source.local.setComponentStateCommand
@@ -1472,7 +1473,10 @@ class RootSystemGateway(
             ?: return Result.failure(
                 IllegalArgumentException("Invalid component: $packageName/$className")
             )
-        return runComponentCommand(stopServiceCommand(spec, userId))
+        return runComponentCommand(
+            stopServiceCommand(spec, userId),
+            ComponentCommandKind.STOP_SERVICE,
+        )
     }
 
     /**
@@ -1480,10 +1484,17 @@ class RootSystemGateway(
      *
      * Separate from [runCommand] because that one reads `ShellResult.isSuccess`, and for `am start`
      * that is very nearly a constant: a launch refused for a permission denial still exits 0 on most
-     * releases while printing `Security exception:` and a stack trace. [componentCommandFailure]
-     * holds the rule, so that the rule is one function and is JVM-testable.
+     * releases while printing `Security exception:` and a stack trace — while `am stopservice` exits
+     * 255 even when it worked. [componentCommandFailure] holds both rules, so that the rules are one
+     * function and are JVM-testable.
+     *
+     * `stdout + stderr` and not one of them: on Android 17 `am` writes the outcome of every one of
+     * these commands to **stderr** and leaves stdout with nothing but the echo of the intent.
      */
-    private suspend fun runComponentCommand(cmd: String): Result<Unit> {
+    private suspend fun runComponentCommand(
+        cmd: String,
+        kind: ComponentCommandKind = ComponentCommandKind.STANDARD,
+    ): Result<Unit> {
         val result = shellRepository.exec(cmd)
         if (result.code == ShellResult.JOB_NOT_EXECUTED) {
             return Result.failure(
@@ -1493,7 +1504,7 @@ class RootSystemGateway(
             )
         }
         val output = (result.stdout + result.stderr).joinToString("\n")
-        val failure = componentCommandFailure(result.code, output)
+        val failure = componentCommandFailure(result.code, output, kind)
         return if (failure == null) {
             Result.success(Unit)
         } else {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -15,6 +15,7 @@ import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
 import com.valhalla.thor.data.source.local.SessionApk
 import com.valhalla.thor.data.source.local.asComponentState
+import com.valhalla.thor.data.source.local.ComponentCommandKind
 import com.valhalla.thor.data.source.local.componentCommandFailure
 import com.valhalla.thor.data.source.local.escapedComponentSpecOrNull
 import com.valhalla.thor.data.source.local.installViaSessionCommand
@@ -110,7 +111,11 @@ class ShizukuSystemGateway(
         packageName: String,
         className: String,
         userId: Int,
-    ): Result<Unit> = runComponentCommand(packageName, className) { spec ->
+    ): Result<Unit> = runComponentCommand(
+        packageName,
+        className,
+        ComponentCommandKind.STOP_SERVICE,
+    ) { spec ->
         stopServiceCommand(spec, userId)
     }
 
@@ -124,10 +129,18 @@ class ShizukuSystemGateway(
      * An unreadable uid refuses. `Shizuku.getUid()` throws when the binder has gone since the last
      * availability check, and the alternative — assuming root — paints working controls that throw a
      * `SecurityException` on every press.
+     *
+     * [ShizukuHelper.executeCombined] rather than `execute`, and this is the only caller of it in
+     * the codebase. `execute` returns stdout *or* stderr, preferring stdout whenever it has
+     * anything — and every command here writes its *outcome* to stderr while writing a content-free
+     * echo ("Starting: Intent { … }", "Stopping service: Intent { … }") to stdout. Through `execute`
+     * the verdict never sees the sentence it exists to read, which made every "Stop now" report a
+     * failure and every refused force-launch report the echo instead of the denial.
      */
     private suspend fun runComponentCommand(
         packageName: String,
         className: String,
+        kind: ComponentCommandKind = ComponentCommandKind.STANDARD,
         build: (escapedSpec: String) -> String,
     ): Result<Unit> = withContext(ioDispatcher) {
         val isRoot = runCatching { ShizukuHelper.isRoot }.getOrDefault(false)
@@ -140,9 +153,9 @@ class ShizukuSystemGateway(
             ?: return@withContext Result.failure(
                 IllegalArgumentException("Invalid component: $packageName/$className")
             )
-        val (code, output) = runCatching { ShizukuHelper.execute(build(spec)) }
+        val (code, output) = runCatching { ShizukuHelper.executeCombined(build(spec)) }
             .getOrElse { return@withContext Result.failure(it) }
-        val failure = componentCommandFailure(code, output.orEmpty())
+        val failure = componentCommandFailure(code, output, kind)
         if (failure == null) {
             Result.success(Unit)
         } else {

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -14,11 +14,18 @@ import com.valhalla.thor.data.source.local.shizuku.SystemAppRemovalOutcome
 import com.valhalla.thor.data.source.local.shizuku.displayLine
 import com.valhalla.thor.data.source.local.shizuku.isRootOnlySystemAppRemoval
 import com.valhalla.thor.data.source.local.SessionApk
+import com.valhalla.thor.data.source.local.asComponentState
+import com.valhalla.thor.data.source.local.componentCommandFailure
+import com.valhalla.thor.data.source.local.escapedComponentSpecOrNull
 import com.valhalla.thor.data.source.local.installViaSessionCommand
 import com.valhalla.thor.data.source.local.installedAppsAppOpGrantCommands
 import com.valhalla.thor.data.source.local.installedAppsAppOpRevokeCommands
 import com.valhalla.thor.data.source.local.pmPathCommand
+import com.valhalla.thor.data.source.local.setComponentStateCommand
+import com.valhalla.thor.data.source.local.startActivityCommand
+import com.valhalla.thor.data.source.local.stopServiceCommand
 import com.valhalla.thor.data.source.local.thorUserId
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.GET_INSTALLED_APPS_PERMISSION
 import com.valhalla.thor.domain.model.PrivilegeMode
@@ -65,6 +72,83 @@ class ShizukuSystemGateway(
     override suspend fun executeShellCommand(command: String): Result<Pair<Int, String?>> {
         // Runs through Shizuku's privileged process (shell uid), same path as in-app actions.
         return runCatching { ShizukuHelper.execute(command) }
+    }
+
+    // --- Per-component control -------------------------------------------------------------
+    //
+    // The one group of verbs on this interface with no shell rung and no reflection rung at the
+    // shell uid. `PackageManagerService.setEnabledSetting` carves out `Process.SHELL_UID` only for
+    // calls with a null class name — a per-component call throws
+    // `SecurityException("Shell cannot change component state for …")` — and
+    // `ActivityManager.canAccessUnexportedComponents` waives the launch checks for `ROOT_UID` and
+    // `SYSTEM_UID` alone. Going through `reflector` instead of through `pm`/`am` changes nothing:
+    // the binder call arrives at the same check carrying the same calling uid.
+    //
+    // A Shizuku that was started **as root** (`su -c sh /storage/…/starter.sh`, or Magisk's Shizuku
+    // module) runs its service at uid 0 and can do all three. That is the only case that succeeds
+    // here, and asking `Shizuku.getUid()` is the only way to tell the two apart — availability is
+    // permission-plus-`pingBinder`, which is equally true at uid 2000.
+
+    override suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState,
+        userId: Int,
+    ): Result<Unit> = runComponentCommand(packageName, className) { spec ->
+        setComponentStateCommand(spec, userId, state.asComponentState())
+    }
+
+    override suspend fun forceLaunchActivity(
+        packageName: String,
+        className: String,
+        userId: Int,
+    ): Result<Unit> = runComponentCommand(packageName, className) { spec ->
+        startActivityCommand(spec, userId)
+    }
+
+    override suspend fun stopService(
+        packageName: String,
+        className: String,
+        userId: Int,
+    ): Result<Unit> = runComponentCommand(packageName, className) { spec ->
+        stopServiceCommand(spec, userId)
+    }
+
+    /**
+     * Refuse unless this Shizuku is uid 0, then run [build] and judge it by its output.
+     *
+     * The refusal is a resource string, not an English literal, because it is read by the user and
+     * every caller funnels a failure's `message` into `R.string.error_format` — an untranslated
+     * sentence inside a translated one is the shape `clearAllCaches` above already documents.
+     *
+     * An unreadable uid refuses. `Shizuku.getUid()` throws when the binder has gone since the last
+     * availability check, and the alternative — assuming root — paints working controls that throw a
+     * `SecurityException` on every press.
+     */
+    private suspend fun runComponentCommand(
+        packageName: String,
+        className: String,
+        build: (escapedSpec: String) -> String,
+    ): Result<Unit> = withContext(ioDispatcher) {
+        val isRoot = runCatching { ShizukuHelper.isRoot }.getOrDefault(false)
+        if (!isRoot) {
+            return@withContext Result.failure(
+                Exception(context.getString(R.string.component_control_requires_root_shizuku))
+            )
+        }
+        val spec = escapedComponentSpecOrNull(packageName, className)
+            ?: return@withContext Result.failure(
+                IllegalArgumentException("Invalid component: $packageName/$className")
+            )
+        val (code, output) = runCatching { ShizukuHelper.execute(build(spec)) }
+            .getOrElse { return@withContext Result.failure(it) }
+        val failure = componentCommandFailure(code, output.orEmpty())
+        if (failure == null) {
+            Result.success(Unit)
+        } else {
+            Logger.e("ShizukuSystemGateway", "Component command failed: $failure")
+            Result.failure(Exception(failure))
+        }
     }
 
     override suspend fun forceStopApp(packageName: String): Result<Unit> {

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppRepositoryImpl.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.data.repository
 
 import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -16,6 +17,8 @@ import com.valhalla.thor.data.source.local.UadHelper
 import com.valhalla.thor.data.source.local.room.AppDao
 import com.valhalla.thor.data.source.local.room.AppEntity
 import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.ComponentDetail
+import com.valhalla.thor.domain.model.ComponentSnapshot
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.PermissionDetail
 import com.valhalla.thor.domain.model.ScanVerdict
@@ -581,10 +584,7 @@ class AppRepositoryImpl(
                     pm.getPackageInfo(packageName, flags.toInt())
                 }
 
-                val activities = packInfo.activities?.map { it.name } ?: emptyList()
-                val services = packInfo.services?.map { it.name } ?: emptyList()
-                val receivers = packInfo.receivers?.map { it.name } ?: emptyList()
-                val providers = packInfo.providers?.map { it.name } ?: emptyList()
+                val components = componentSnapshotOf(packageName, packInfo)
                 val reqFeatures = packInfo.reqFeatures?.map {
                     if (it.name != null) {
                         it.name
@@ -657,10 +657,7 @@ class AppRepositoryImpl(
 
                 DetailedAppInfo(
                     appInfo = appInfo,
-                    activities = activities,
-                    services = services,
-                    receivers = receivers,
-                    providers = providers,
+                    components = components,
                     permissions = permissions,
                     nativeLibs = nativeLibs,
                     reqFeatures = reqFeatures,
@@ -672,6 +669,92 @@ class AppRepositoryImpl(
                 null
             }
         }
+
+    override suspend fun getComponentDetails(packageName: String): ComponentSnapshot? =
+        withContext(ioDispatcher) {
+            try {
+                val flags = COMPONENT_QUERY_FLAGS
+                val packInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    pm.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(flags))
+                } else {
+                    @Suppress("DEPRECATION")
+                    pm.getPackageInfo(packageName, flags.toInt())
+                }
+                componentSnapshotOf(packageName, packInfo)
+            } catch (e: Exception) {
+                if (BuildConfig.DEBUG) e.printStackTrace()
+                null
+            }
+        }
+
+    /**
+     * Map one already-fetched [PackageInfo] onto the four [ComponentDetail] lists.
+     *
+     * The caller must have fetched with [COMPONENT_QUERY_FLAGS] — specifically with
+     * `MATCH_DISABLED_COMPONENTS` and `MATCH_DISABLED_UNTIL_USED_COMPONENTS`, without which
+     * `PackageManager` silently omits every component that is currently switched off, which are
+     * precisely the ones this screen exists to show and switch back on.
+     *
+     * The effective state comes from [PackageManager.getComponentEnabledSetting] rather than from a
+     * second, flagless `getPackageInfo` differenced against the first. Both would answer "is this
+     * component live", but the diff answers it wrongly in two situations that matter here:
+     *  - **A frozen app.** A package-level disable makes `PackageUserState.isMatch` reject *every*
+     *    component, so the flagless query comes back empty and the diff marks all several hundred
+     *    rows DISABLED. `getComponentEnabledSetting` is per-component and untouched by the package
+     *    state, so a frozen app still shows which of its components the user had individually
+     *    turned off.
+     *  - **An explicit `ENABLED` on a component the manifest already enables.** Indistinguishable
+     *    from `DEFAULT` by any diff, but it is a real stored override, and it is the one this
+     *    screen must offer "Reset to default" for.
+     *
+     * It costs one binder call per component. That is the same shape as the permission loop above
+     * (two calls per requested permission) and it runs on [ioDispatcher]; a `getComponentEnabledSetting`
+     * that throws for a component the parser produced but PMS does not recognise degrades that one
+     * row to its manifest default rather than failing the screen.
+     */
+    private fun componentSnapshotOf(
+        packageName: String,
+        packInfo: android.content.pm.PackageInfo,
+    ): ComponentSnapshot {
+        // PackageManager can hand back the same component twice; the tab used to compensate by
+        // putting the list index in the LazyColumn key, which made every row's identity change as
+        // soon as a filter was typed.
+        fun <T : android.content.pm.ComponentInfo> List<T>?.mapComponents(
+            permissionOf: (T) -> String?,
+        ): List<ComponentDetail> = this.orEmpty()
+            .distinctBy { it.name }
+            .map { info ->
+                val manifestDefaultEnabled = info.enabled
+                val setting = try {
+                    pm.getComponentEnabledSetting(ComponentName(packageName, info.name))
+                } catch (_: Exception) {
+                    PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+                }
+                ComponentDetail(
+                    className = info.name,
+                    exported = info.exported,
+                    enabled = when (setting) {
+                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED -> true
+                        PackageManager.COMPONENT_ENABLED_STATE_DEFAULT -> manifestDefaultEnabled
+                        else -> false
+                    },
+                    manifestDefaultEnabled = manifestDefaultEnabled,
+                    hasExplicitState = setting != PackageManager.COMPONENT_ENABLED_STATE_DEFAULT,
+                    permission = permissionOf(info),
+                )
+            }
+
+        return ComponentSnapshot(
+            activities = packInfo.activities?.toList().mapComponents { it.permission },
+            services = packInfo.services?.toList().mapComponents { it.permission },
+            receivers = packInfo.receivers?.toList().mapComponents { it.permission },
+            // A provider has no single entry permission: `android:permission` is shorthand for
+            // setting both halves, and either half alone is enough to keep a caller out.
+            providers = packInfo.providers?.toList().mapComponents {
+                it.readPermission ?: it.writePermission
+            },
+        )
+    }
 
     override suspend fun getApkDetails(apkPath: String): AppInfo? = withContext(ioDispatcher) {
         val flags = PackageManager.GET_PERMISSIONS
@@ -704,5 +787,24 @@ class AppRepositoryImpl(
          */
         const val LABEL_CACHE_PREFS = "app_label_cache"
         const val KEY_LABEL_LOCALE = "label_locale_key"
+
+        /**
+         * The flags a component query needs to see components that are switched **off**.
+         *
+         * Without `MATCH_DISABLED_COMPONENTS` and `MATCH_DISABLED_UNTIL_USED_COMPONENTS`,
+         * `PackageManager` omits exactly the rows the Components tab exists to switch back on, and
+         * omits them silently — the list simply comes back shorter. `MATCH_UNINSTALLED_PACKAGES`
+         * keeps the query working for a package that is installed for another user but frozen or
+         * archived for this one.
+         */
+        val COMPONENT_QUERY_FLAGS: Long = (
+                PackageManager.GET_ACTIVITIES or
+                        PackageManager.GET_SERVICES or
+                        PackageManager.GET_RECEIVERS or
+                        PackageManager.GET_PROVIDERS or
+                        PackageManager.MATCH_UNINSTALLED_PACKAGES or
+                        PackageManager.MATCH_DISABLED_COMPONENTS or
+                        PackageManager.MATCH_DISABLED_UNTIL_USED_COMPONENTS
+                ).toLong()
     }
 }

--- a/app/src/main/java/com/valhalla/thor/data/repository/ComponentOverrideRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/ComponentOverrideRepositoryImpl.kt
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import com.valhalla.thor.data.source.local.room.ComponentOverrideDao
+import com.valhalla.thor.data.source.local.room.ComponentOverrideEntity
+import com.valhalla.thor.data.source.local.thorUserId
+import com.valhalla.thor.domain.model.ComponentOverride
+import com.valhalla.thor.domain.model.ComponentType
+import com.valhalla.thor.domain.repository.ComponentOverrideRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.koin.core.annotation.Single
+
+@Single(binds = [ComponentOverrideRepository::class])
+class ComponentOverrideRepositoryImpl(
+    private val dao: ComponentOverrideDao,
+) : ComponentOverrideRepository {
+
+    override fun observe(packageName: String): Flow<List<ComponentOverride>> =
+        dao.observeForPackage(packageName, thorUserId).map { rows -> rows.map { it.toDomain() } }
+
+    override suspend fun getAll(): List<ComponentOverride> =
+        // Filtered here rather than in SQL so the DAO keeps one "everything" query: the table is
+        // small (it holds only what Thor changed) and this runs once, behind a confirmation dialog.
+        dao.getAll().filter { it.userId == thorUserId }.map { it.toDomain() }
+
+    override suspend fun record(
+        packageName: String,
+        className: String,
+        type: ComponentType,
+        restoreToEnabled: Boolean,
+    ) {
+        dao.upsert(
+            ComponentOverrideEntity(
+                packageName = packageName,
+                className = className,
+                userId = thorUserId,
+                componentType = type.name,
+                restoreToEnabled = restoreToEnabled,
+                disabledAt = System.currentTimeMillis(),
+            )
+        )
+    }
+
+    override suspend fun forget(packageName: String, className: String) {
+        dao.delete(packageName, className, thorUserId)
+    }
+
+    override suspend fun forgetPackage(packageName: String) {
+        dao.deleteForPackage(packageName, thorUserId)
+    }
+}
+
+/**
+ * An unrecognised `componentType` degrades to [ComponentType.ACTIVITY] rather than dropping the row.
+ *
+ * The column holds an enum *name*, so the only way it can fail to parse is a downgrade to a Thor
+ * that no longer knows a type a later version wrote. Losing the row would lose the record of a
+ * component Thor disabled — leaving it disabled with nothing to restore it from, which is the one
+ * outcome this table exists to prevent. Being filed under the wrong heading costs a misplaced row.
+ */
+private fun ComponentOverrideEntity.toDomain(): ComponentOverride = ComponentOverride(
+    packageName = packageName,
+    className = className,
+    type = ComponentType.entries.firstOrNull { it.name == componentType } ?: ComponentType.ACTIVITY,
+    restoreToEnabled = restoreToEnabled,
+    disabledAt = disabledAt,
+)

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -200,6 +200,10 @@ class PreferenceRepositoryImpl(
         val EXTENSIONS_UNLOCKED = booleanPreferencesKey("extensions_unlocked")
         val EXTENSION_CONSENT_ACCEPTED = booleanPreferencesKey("extension_consent_accepted")
 
+        // Component control
+        val COMPONENT_CONTROL_CONSENT_ACCEPTED =
+            booleanPreferencesKey("component_control_consent_accepted")
+
         // Auto Reinstall
         val AUTO_REINSTALL_ENABLED = booleanPreferencesKey("auto_reinstall_enabled")
 
@@ -408,6 +412,14 @@ class PreferenceRepositoryImpl(
     override suspend fun setExtensionConsentAccepted(accepted: Boolean) {
         context.dataStore.guardedWrite(SETTINGS_STORE) {
             it[Keys.EXTENSION_CONSENT_ACCEPTED] = accepted
+        }
+    }
+
+    // --- Component control ---
+
+    override suspend fun setComponentControlConsentAccepted(accepted: Boolean) {
+        context.dataStore.guardedWrite(SETTINGS_STORE) {
+            it[Keys.COMPONENT_CONTROL_CONSENT_ACCEPTED] = accepted
         }
     }
 
@@ -658,6 +670,8 @@ internal fun Preferences.toUserPreferences(
         appGridDensity = appGridDensity,
         extensionsUnlocked = prefs[Keys.EXTENSIONS_UNLOCKED] ?: false,
         extensionConsentAccepted = prefs[Keys.EXTENSION_CONSENT_ACCEPTED] ?: false,
+        componentControlConsentAccepted =
+            prefs[Keys.COMPONENT_CONTROL_CONSENT_ACCEPTED] ?: false,
         autoReinstallEnabled = prefs[Keys.AUTO_REINSTALL_ENABLED] ?: false,
         exportDirUri = prefs[Keys.EXPORT_DIR_URI],
         appInfoActionsOrder = AppInfoActionId.fromSavedNamesOrDefault(

--- a/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/SystemRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.valhalla.thor.data.gateway.DhizukuSystemGateway
 import com.valhalla.thor.data.gateway.RootSystemGateway
 import com.valhalla.thor.data.gateway.ShizukuSystemGateway
 import com.valhalla.thor.data.source.local.thorUserId
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
 import com.valhalla.thor.domain.gateway.SystemGateway
 import com.valhalla.thor.domain.model.DataClass
 import com.valhalla.thor.domain.model.DataClassSize
@@ -292,6 +293,42 @@ class SystemRepositoryImpl(
         permissionName: String
     ): Result<Unit> = withContext(ioDispatcher) {
         runGatewayAction { it.revokePermission(packageName, permissionName) }
+    }
+
+    // --- Per-component control -------------------------------------------------------------
+    //
+    // Routed, not root-gated. `clearCache` above short-circuits on `isRootAvailable()` because there
+    // Shizuku and Dhizuku genuinely have nothing to try; here a Shizuku *can* succeed — when it was
+    // started as root — and a pre-gate on `isRootAvailable()` would refuse that working
+    // configuration on a device with no `su` binary at all. The gateway is where the uid is known,
+    // so the gateway is where the refusal is made, and `componentCapability` is what stops the UI
+    // from offering the control in the first place.
+    //
+    // [thorUserId] rather than 0: `pm`'s enable/disable/default-state trio seeds
+    // `UserHandle.USER_SYSTEM`, so an unqualified command issued from a work profile edits the
+    // personal profile's copy of the package and exits 0. Same trap the clear/suspend paths already
+    // carry, same fix.
+
+    override suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState,
+    ): Result<Unit> = withContext(ioDispatcher) {
+        runGatewayAction { it.setComponentEnabled(packageName, className, state, thorUserId) }
+    }
+
+    override suspend fun forceLaunchActivity(
+        packageName: String,
+        className: String,
+    ): Result<Unit> = withContext(ioDispatcher) {
+        runGatewayAction { it.forceLaunchActivity(packageName, className, thorUserId) }
+    }
+
+    override suspend fun stopService(
+        packageName: String,
+        className: String,
+    ): Result<Unit> = withContext(ioDispatcher) {
+        runGatewayAction { it.stopService(packageName, className, thorUserId) }
     }
 
     override suspend fun executeShellCommand(command: String): Result<Pair<Int, String?>> =

--- a/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCapabilityProvider.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCapabilityProvider.kt
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import com.valhalla.thor.domain.model.ComponentCapability
+import com.valhalla.thor.domain.model.PrivilegeMode
+import com.valhalla.thor.domain.model.PrivilegeState
+import com.valhalla.thor.domain.model.componentCapability
+import com.valhalla.thor.domain.repository.PrivilegeStateProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
+import com.valhalla.thor.data.source.local.shizuku.Shizuku as ShizukuHelper
+
+/**
+ * "What may Thor do to an individual component on this device?", answered once per privilege state.
+ *
+ * Built on [DataArchiveCapabilityCache][com.valhalla.thor.data.backup.DataArchiveCapabilityCache]'s
+ * shape, and for the same two reasons:
+ *  - it awaits `state.first { it.isReady }` rather than reading `state.value`, because the cold-start
+ *    snapshot is `isReady = false, active = NONE`, which on a rooted device would answer "no
+ *    privilege" and paint a Components tab with every control greyed out until the probe lands; and
+ *  - it is keyed on the whole [PrivilegeState], so `PrivilegeManager.refresh()` landing a new state
+ *    *is* the invalidation. A TTL would leave a window where granting root leaves the tab dead.
+ *
+ * The one measurement it makes is `Shizuku.getUid()`, which is the only thing that distinguishes a
+ * Shizuku that can do this from one that cannot — availability is permission-plus-`pingBinder`, and
+ * that is equally true at uid 2000. It is read here, in the data layer, because `Shizuku`'s static
+ * initialiser builds a Binder and cannot load in a JVM test; keeping it out of
+ * [componentCapability] is what leaves the *rule* testable.
+ */
+@Single
+class ComponentCapabilityProvider(
+    private val privilegeState: PrivilegeStateProvider,
+) {
+
+    private val mutex = Mutex()
+
+    private var cached: Pair<PrivilegeState, ComponentCapability>? = null
+
+    suspend fun capability(): ComponentCapability {
+        val state = privilegeState.state.first { it.isReady }
+        mutex.withLock {
+            cached?.let { (key, value) -> if (key == state) return value }
+            val capability = componentCapability(
+                mode = state.active,
+                isReady = state.isReady,
+                shizukuUid = if (state.active == PrivilegeMode.SHIZUKU) readShizukuUid() else null,
+            )
+            cached = state to capability
+            return capability
+        }
+    }
+
+    /**
+     * Shizuku's own uid, or `null` when it cannot be read.
+     *
+     * `null` means **not capable** downstream, which is the opposite of the optimistic fold used
+     * when choosing a privileged installer. The asymmetry is deliberate: guessing wrong there costs
+     * one failed install with a clear message, guessing wrong here paints enabled Force Open and
+     * Disable controls that throw a `SecurityException` on every press.
+     */
+    private fun readShizukuUid(): Int? = runCatching { ShizukuHelper.uidOrNull() }.getOrNull()
+}

--- a/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCommands.kt
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import com.valhalla.superuser.utils.escapeForShell
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
+
+/**
+ * The privileged commands that act on a single **component** rather than on a whole package.
+ *
+ * Kept beside [clearAppDataCommand] and friends in [PerUserCommands] for the same reason those
+ * exist: every one of these has to name a user or it silently acts on user 0. `pm`'s
+ * enable/disable/default-state trio seeds `UserHandle.USER_SYSTEM`, and `am`'s `stopservice` seeds
+ * the current user — neither is "the user Thor is running in".
+ *
+ * The second trap these builders exist to close is the shell word itself. A component spec is
+ * `<package>/<class>`, and an inner class arrives from `PackageManager` with a **`$`** in it —
+ * `com.foo.Widget$Receiver` is an entirely ordinary receiver name. Interpolated into a
+ * double-quoted or bare shell word, `$Receiver` expands to nothing and the command acts on
+ * `com.foo.Widget`, which either does not exist (harmless) or is a *different, real* component
+ * (not harmless). [componentSpec] therefore returns the raw `pkg/cls` pair and every caller passes
+ * it through `escapeForShell()`, which single-quotes, before it reaches a builder here.
+ *
+ * As in [PerUserCommands], the builders take the user id and the already-escaped spec so that
+ * "does this command name a user, and is the spec quoted?" is assertable from a plain JVM test —
+ * `Process.myUserHandle()` is not callable there.
+ */
+
+/** The raw `<package>/<class>` pair. Escape it before it reaches any builder in this file. */
+internal fun componentSpec(packageName: String, className: String): String =
+    "$packageName/$className"
+
+/**
+ * What a class name may contain.
+ *
+ * Wider than the package regex the gateways already use, by exactly one character: `$`. An inner
+ * class is reported by `PackageManager` as `com.foo.Widget$Receiver`, and validating a class name
+ * against the package pattern would reject every one of them — turning a legitimate, common
+ * component into "Invalid package name" and making the feature look broken on the apps most likely
+ * to have interesting receivers.
+ */
+internal val COMPONENT_CLASS_REGEX = Regex("^[a-zA-Z0-9._\$]+\$")
+
+/** The package half. Same pattern the three gateways enforce for every other privileged verb. */
+internal val COMPONENT_PACKAGE_REGEX = Regex("^[a-zA-Z0-9._]+\$")
+
+/**
+ * The escaped `<package>/<class>` shell word, or `null` if either half is not a plausible name.
+ *
+ * Validation and escaping in one place because they are one decision: the escape makes a hostile
+ * name inert, and the pattern makes an implausible one visible as a bug rather than as a command
+ * that runs and does nothing.
+ */
+internal fun escapedComponentSpecOrNull(packageName: String, className: String): String? {
+    if (!packageName.matches(COMPONENT_PACKAGE_REGEX)) return null
+    if (!className.matches(COMPONENT_CLASS_REGEX)) return null
+    return componentSpec(packageName, className).escapeForShell()
+}
+
+/**
+ * The three states `pm` can put a component in, and the sub-command that reaches each.
+ *
+ * [DEFAULT] is not a synonym for [ENABLED]. `default-state` *removes* the override and lets the
+ * manifest's `android:enabled` decide again, which for a component that ships disabled means the
+ * component goes back to being off. That distinction is the whole reason
+ * `ComponentDetail.manifestDefaultEnabled` is carried next to `enabled`, and why
+ * `ComponentControlUseCase.enableTargetState` exists rather than a bare "enable" verb.
+ *
+ * [DISABLED] uses `disable` rather than `disable-user`. Both are accepted for a component, but
+ * `DISABLED_USER` is the state Settings' own "disable app" writes at *package* level, and reusing
+ * it here would make Thor's per-component rows indistinguishable from a user-disabled app in
+ * `dumpsys package`.
+ */
+internal enum class ComponentState(val pmVerb: String) {
+    DISABLED("disable"),
+    ENABLED("enable"),
+    DEFAULT("default-state"),
+}
+
+/**
+ * `pm enable` / `pm disable` / `pm default-state` on one component, scoped to [userId].
+ *
+ * Reachable at uid 0 only. `PackageManagerService.setEnabledSetting` allows `Process.SHELL_UID`
+ * through a carve-out that requires `className == null`; with a class name present it throws
+ * `SecurityException("Shell cannot change component state for …")`. There is no reflective way
+ * around it — `IPackageManager.setComponentEnabledSetting` lands on the same check with the same
+ * calling uid.
+ */
+internal fun setComponentStateCommand(
+    escapedComponent: String,
+    userId: Int,
+    state: ComponentState,
+): String = "pm ${state.pmVerb} --user $userId $escapedComponent"
+
+/**
+ * `am start` on one component, scoped to [userId].
+ *
+ * Deliberately carries no action, no category and no flags: an explicit component makes the intent
+ * filter irrelevant, and an invented `MAIN`/`LAUNCHER` action is visible to the target — several
+ * apps branch on `intent.action` in `onCreate` and would take a different path than the one the
+ * user asked to see. A null caller means `ActivityStarter` has no task to attach to and creates
+ * one, so `FLAG_ACTIVITY_NEW_TASK` is not needed either.
+ *
+ * Reachable at uid 0 only when the target is unexported or permission-guarded:
+ * `ActivityManager.canAccessUnexportedComponents` waives those checks for `ROOT_UID` and
+ * `SYSTEM_UID` and nothing else.
+ */
+internal fun startActivityCommand(escapedComponent: String, userId: Int): String =
+    "am start --user $userId -n $escapedComponent"
+
+/**
+ * `am stopservice` on one component, scoped to [userId].
+ *
+ * `-n` is required. `Intent.parseCommandArgs` treats a trailing bare argument as data or a package,
+ * never as a component, so `am stopservice pkg/cls` parses to an intent with no component and stops
+ * nothing while still exiting 0.
+ */
+internal fun stopServiceCommand(escapedComponent: String, userId: Int): String =
+    "am stopservice --user $userId -n $escapedComponent"
+
+/** The `pm` verb for a state the gateway contract names. */
+internal fun ComponentEnabledState.asComponentState(): ComponentState = when (this) {
+    ComponentEnabledState.ENABLED -> ComponentState.ENABLED
+    ComponentEnabledState.DISABLED -> ComponentState.DISABLED
+    ComponentEnabledState.DEFAULT -> ComponentState.DEFAULT
+}
+
+/**
+ * Substrings that mark a component command as having failed, whatever its exit code said.
+ *
+ * `Warning:` is deliberately absent. `am start` answers a perfectly successful launch of an
+ * already-running activity with "Warning: Activity not started, its current task has been brought
+ * to the front", and treating that as a failure would report an error for the single most common
+ * repeat press in the whole feature.
+ */
+private val COMPONENT_FAILURE_MARKERS = listOf(
+    "Security exception",
+    "SecurityException",
+    "Exception occurred while executing",
+    "Error:",
+    "Error type",
+)
+
+/**
+ * The failure line from a component command's output, or `null` if it succeeded.
+ *
+ * **The exit code alone cannot answer this**, in either direction:
+ *  - `am start` refused for a permission denial prints `Security exception:` followed by a stack
+ *    trace and still exits **0** on most releases; from Android 14 the same refusal is reported as
+ *    `Error: Activity class {…} does not exist.` instead, because `ActivityStarter` folds the
+ *    security failure into `START_CLASS_NOT_FOUND`. Trusting the code means reporting "Launched" for
+ *    a launch that visibly did not happen.
+ *  - a non-zero code with no marker in the output is still a failure, which is why the code is
+ *    checked too rather than replaced.
+ *
+ * Returns the first marked line rather than the whole output: `ShellCommand.exec` prints the entire
+ * stack trace on an exception, and a Toast is not the place for forty frames. Activity Launcher's
+ * `Toast.makeText(ctx, "…: " + e, LENGTH_LONG)` is the shape being avoided.
+ */
+internal fun componentCommandFailure(exitCode: Int, output: String): String? {
+    val marked = output.lineSequence()
+        .map { it.trim() }
+        .firstOrNull { line -> COMPONENT_FAILURE_MARKERS.any { line.contains(it) } }
+    if (marked != null) return marked.take(MAX_FAILURE_LINE_CHARS)
+    if (exitCode != 0) {
+        return output.lineSequence()
+            .map { it.trim() }
+            .firstOrNull { it.isNotEmpty() }
+            ?.take(MAX_FAILURE_LINE_CHARS)
+            ?: "exit $exitCode"
+    }
+    return null
+}
+
+private const val MAX_FAILURE_LINE_CHARS = 200

--- a/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCommands.kt
@@ -119,6 +119,21 @@ internal fun startActivityCommand(escapedComponent: String, userId: Int): String
 internal fun stopServiceCommand(escapedComponent: String, userId: Int): String =
     "am stopservice --user $userId -n $escapedComponent"
 
+/**
+ * Which rule [componentCommandFailure] should judge a command's output by.
+ *
+ * There are two, not three, because `pm enable|disable|default-state` and `am start` agree on the
+ * only thing that matters here: a non-zero exit code means something went wrong. `am stopservice`
+ * does not agree, so it gets its own rule rather than a special case bolted into the shared one.
+ */
+internal enum class ComponentCommandKind {
+    /** `pm enable|disable|default-state` and `am start`. Exit code *and* output markers. */
+    STANDARD,
+
+    /** `am stopservice`, whose exit code carries no information at all. Markers only. */
+    STOP_SERVICE,
+}
+
 /** The `pm` verb for a state the gateway contract names. */
 internal fun ComponentEnabledState.asComponentState(): ComponentState = when (this) {
     ComponentEnabledState.ENABLED -> ComponentState.ENABLED
@@ -127,20 +142,38 @@ internal fun ComponentEnabledState.asComponentState(): ComponentState = when (th
 }
 
 /**
- * Substrings that mark a component command as having failed, whatever its exit code said.
+ * Substrings that name *what* went wrong, and are therefore worth showing the user verbatim.
  *
  * `Warning:` is deliberately absent. `am start` answers a perfectly successful launch of an
  * already-running activity with "Warning: Activity not started, its current task has been brought
  * to the front", and treating that as a failure would report an error for the single most common
  * repeat press in the whole feature.
  */
-private val COMPONENT_FAILURE_MARKERS = listOf(
+private val SPECIFIC_FAILURE_MARKERS = listOf(
     "Security exception",
     "SecurityException",
-    "Exception occurred while executing",
+    // Any thrown exception that carries a message: `java.lang.IllegalArgumentException: Component
+    // class … does not exist in …` is what a "Restore all" hits for a component an app update has
+    // removed, and it is the most useful sentence in the whole output. The colon is what keeps this
+    // from also matching the content-free header below, which reads "Exception occurred while …".
+    "Exception:",
     "Error:",
     "Error type",
+    "Error stopping service",
 )
+
+/**
+ * The header `ShellCommand.exec` prints *above* a thrown exception.
+ *
+ * "Exception occurred while executing 'start':" names no cause, and it is the line a naive
+ * first-match scan picks because it comes first. It is searched for only after
+ * [SPECIFIC_FAILURE_MARKERS] have failed to match anywhere, and even then the line *after* it is
+ * preferred — that is where the exception itself is.
+ */
+private const val FAILURE_HEADER_MARKER = "Exception occurred while executing"
+
+/** A stack frame, which is never worth reporting on its own. */
+private const val STACK_FRAME_PREFIX = "at "
 
 /**
  * The failure line from a component command's output, or `null` if it succeeded.
@@ -154,23 +187,75 @@ private val COMPONENT_FAILURE_MARKERS = listOf(
  *  - a non-zero code with no marker in the output is still a failure, which is why the code is
  *    checked too rather than replaced.
  *
+ * …and for [ComponentCommandKind.STOP_SERVICE] the exit code is not merely unreliable, it is
+ * **constant**. `am stopservice` exits **255 in every case** — verified on Android 17 for a service
+ * that was stopped, a service that was not running, and a component that does not exist, through
+ * both `am` and `cmd activity stop-service`, with and without `--user`. The only thing that
+ * distinguishes them is a sentence `ActivityManagerShellCommand` writes to **stderr**:
+ *
+ * ```
+ * Service stopped                          → stopped it
+ * Service not stopped: was not running.    → nothing to stop
+ * Error stopping service                   → the one real failure
+ * ```
+ *
+ * So that kind judges on markers alone. "Was not running" counts as success rather than as an
+ * error: the button says stop the service, and a service that is not running is stopped. Reporting
+ * a failure there would put an error Toast on the *most* likely outcome of the press, since most
+ * services in a component list are not running when the user is looking at them.
+ *
+ * The corollary is that stderr has to reach this function. It does for root — `RootSystemGateway`
+ * concatenates `ShellResult.stdout + stderr` — and for Shizuku only through
+ * `ShizukuHelper.executeCombined`; plain `execute()` returns stdout *or* stderr, and `stopservice`
+ * always writes to both.
+ *
  * Returns the first marked line rather than the whole output: `ShellCommand.exec` prints the entire
  * stack trace on an exception, and a Toast is not the place for forty frames. Activity Launcher's
  * `Toast.makeText(ctx, "…: " + e, LENGTH_LONG)` is the shape being avoided.
  */
-internal fun componentCommandFailure(exitCode: Int, output: String): String? {
-    val marked = output.lineSequence()
-        .map { it.trim() }
-        .firstOrNull { line -> COMPONENT_FAILURE_MARKERS.any { line.contains(it) } }
-    if (marked != null) return marked.take(MAX_FAILURE_LINE_CHARS)
-    if (exitCode != 0) {
-        return output.lineSequence()
-            .map { it.trim() }
-            .firstOrNull { it.isNotEmpty() }
-            ?.take(MAX_FAILURE_LINE_CHARS)
-            ?: "exit $exitCode"
+internal fun componentCommandFailure(
+    exitCode: Int,
+    output: String,
+    kind: ComponentCommandKind = ComponentCommandKind.STANDARD,
+): String? {
+    val lines = output.lineSequence().map { it.trim() }.filter { it.isNotEmpty() }.toList()
+
+    if (kind == ComponentCommandKind.STOP_SERVICE &&
+        lines.any { line -> STOP_SERVICE_SUCCESS_MARKERS.any { line.startsWith(it) } }
+    ) {
+        return null
+    }
+
+    lines.firstOrNull { line -> SPECIFIC_FAILURE_MARKERS.any { line.contains(it) } }
+        ?.let { return it.take(MAX_FAILURE_LINE_CHARS) }
+
+    val headerIndex = lines.indexOfFirst { it.contains(FAILURE_HEADER_MARKER) }
+    if (headerIndex >= 0) {
+        // The line after the header is the exception itself — reported in preference to the header,
+        // which names no cause. Guarded against an output whose next line is already a stack frame.
+        val cause = lines.getOrNull(headerIndex + 1)?.takeUnless { it.startsWith(STACK_FRAME_PREFIX) }
+        return (cause ?: lines[headerIndex]).take(MAX_FAILURE_LINE_CHARS)
+    }
+
+    // Only the standard kind may draw a conclusion from the code; see the note above.
+    if (kind == ComponentCommandKind.STANDARD && exitCode != 0) {
+        return lines.firstOrNull()?.take(MAX_FAILURE_LINE_CHARS) ?: "exit $exitCode"
     }
     return null
 }
+
+/**
+ * The stderr sentences that mean `am stopservice` did its job.
+ *
+ * "Service not stopped: was not running." is in here on purpose — it is the *no-op* answer, not the
+ * failure one, and the failure answer has its own marker in [SPECIFIC_FAILURE_MARKERS]. Note that
+ * it does not contain "Service stopped" as a substring ("Service **not** stopped"), so the two
+ * cannot be confused by a `contains` check either.
+ */
+private val STOP_SERVICE_SUCCESS_MARKERS = listOf(
+    "Service stopped",
+    "Service stopping",
+    "Service not stopped: was not running",
+)
 
 private const val MAX_FAILURE_LINE_CHARS = 200

--- a/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCommands.kt
@@ -261,8 +261,13 @@ internal fun componentCommandFailure(
         return (cause ?: lines[headerIndex]).take(MAX_FAILURE_LINE_CHARS)
     }
 
-    // Only the standard kind may draw a conclusion from the code; see the note above.
-    if (kind == ComponentCommandKind.STANDARD && exitCode != 0) {
+    // Only the standard kind may draw a conclusion from a code the *command* chose — but a negative
+    // code is not one of those. `am` and `pm` exit 0..255; a negative code is Thor's own transport
+    // sentinel, set by `ShizukuHelper` for a dead binder, a timeout, or a thrown exception, and it
+    // means the command never ran at all. Without this, a stopservice issued through a binder that
+    // has just died returns "Shizuku binder is null" — no marker, no conclusion — and is reported to
+    // the user as a service successfully stopped.
+    if (exitCode != 0 && (kind == ComponentCommandKind.STANDARD || exitCode < 0)) {
         return lines.firstOrNull()?.take(MAX_FAILURE_LINE_CHARS) ?: "exit $exitCode"
     }
     return null

--- a/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/ComponentCommands.kt
@@ -158,8 +158,29 @@ private val SPECIFIC_FAILURE_MARKERS = listOf(
     // from also matching the content-free header below, which reads "Exception occurred while …".
     "Exception:",
     "Error:",
-    "Error type",
     "Error stopping service",
+)
+
+/**
+ * Markers that prove a failure but do not describe one, searched only after
+ * [SPECIFIC_FAILURE_MARKERS] have failed to match on *any* line.
+ *
+ * `ActivityManagerShellCommand` prints its numeric code on the line **above** the sentence:
+ *
+ * ```
+ * Starting: Intent { cmp=pkg/.Foo }
+ * Error type 3
+ * Error: Activity class {pkg/.Foo} does not exist.
+ * ```
+ *
+ * Both lines are marked, and the scan takes the first *line* that matches any marker rather than
+ * the first *marker* that matches any line — so keeping "Error type" in the list above would let
+ * line 2 beat line 3 and report "Error type 3" to the user. That is the same content-free-header
+ * failure mode [FAILURE_HEADER_MARKER] exists to avoid, reintroduced through the marker list.
+ * Splitting the tiers is what orders them by usefulness instead of by position.
+ */
+private val WEAK_FAILURE_MARKERS = listOf(
+    "Error type",
 )
 
 /**
@@ -227,6 +248,9 @@ internal fun componentCommandFailure(
     }
 
     lines.firstOrNull { line -> SPECIFIC_FAILURE_MARKERS.any { line.contains(it) } }
+        ?.let { return it.take(MAX_FAILURE_LINE_CHARS) }
+
+    lines.firstOrNull { line -> WEAK_FAILURE_MARKERS.any { line.contains(it) } }
         ?.let { return it.take(MAX_FAILURE_LINE_CHARS) }
 
     val headerIndex = lines.indexOfFirst { it.contains(FAILURE_HEADER_MARKER) }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDatabase.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/AppDatabase.kt
@@ -17,8 +17,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ExtensionDataEntity::class,
         FreezeProfileEntity::class,
         FreezeProfileAppEntity::class,
+        ComponentOverrideEntity::class,
     ],
-    version = 6,
+    version = 7,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
@@ -26,6 +27,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         // 5 → 6 adds the two freeze-profile tables and touches nothing that already exists, so
         // Room can generate it: a shipped database gets the new tables and keeps its watchlist.
         AutoMigration(from = 5, to = 6),
+        // 6 → 7 is the same shape: one new table, `component_overrides`, and no change to any
+        // existing column. No `spec =` because there is nothing for a spec to describe — a
+        // pure table-add needs no @DeleteColumn/@RenameTable hint.
+        AutoMigration(from = 6, to = 7),
     ],
     exportSchema = true
 )
@@ -35,6 +40,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun freezerDao(): FreezerDao
     abstract fun extensionDataDao(): ExtensionDataDao
     abstract fun freezeProfileDao(): FreezeProfileDao
+    abstract fun componentOverrideDao(): ComponentOverrideDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/ComponentOverrideDao.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/ComponentOverrideDao.kt
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ComponentOverrideDao {
+
+    /**
+     * Every row for one package and user, as a stream.
+     *
+     * A `Flow` rather than a one-shot read because the Components tab shows the "N restricted by
+     * Thor" header beside a list the user is actively changing; re-querying by hand after each
+     * toggle is how that count drifts one behind.
+     */
+    @Query("SELECT * FROM component_overrides WHERE packageName = :packageName AND userId = :userId")
+    fun observeForPackage(packageName: String, userId: Int): Flow<List<ComponentOverrideEntity>>
+
+    /** Every row, for the cross-app "restore everything Thor changed" path. */
+    @Query("SELECT * FROM component_overrides ORDER BY packageName, className")
+    suspend fun getAll(): List<ComponentOverrideEntity>
+
+    /**
+     * `REPLACE`, so re-disabling a component Thor had already disabled refreshes the timestamp
+     * rather than failing the insert. `restoreToEnabled` is rewritten with it, which is correct:
+     * the manifest default is re-read from the app that is installed *now*, and an update may have
+     * changed it.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ComponentOverrideEntity)
+
+    @Query(
+        "DELETE FROM component_overrides " +
+                "WHERE packageName = :packageName AND className = :className AND userId = :userId"
+    )
+    suspend fun delete(packageName: String, className: String, userId: Int)
+
+    @Query("DELETE FROM component_overrides WHERE packageName = :packageName AND userId = :userId")
+    suspend fun deleteForPackage(packageName: String, userId: Int)
+}

--- a/app/src/main/java/com/valhalla/thor/data/source/local/room/ComponentOverrideEntity.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/room/ComponentOverrideEntity.kt
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local.room
+
+import androidx.room.Entity
+import androidx.room.Index
+
+/**
+ * One component Thor switched off, and what it was before Thor touched it.
+ *
+ * **Bookkeeping only.** The PackageManager is the source of truth for what a component's state
+ * actually *is*; this table only records what Thor did, so that "Restore all" has something to
+ * restore to and so the user can find the changes they made across dozens of apps without
+ * remembering which apps those were. Nothing re-applies these rows: there is no boot receiver, no
+ * periodic sweep, and an override that the system, the app, or another tool undoes simply stops
+ * being true — which the Components tab reports as drift rather than silently re-imposing.
+ *
+ * That choice is what keeps the feature honest. A ledger that re-applied itself would be a second,
+ * invisible source of truth racing the first, and the failure mode is a component the user re-enabled
+ * in Settings turning itself off again on the next boot with no visible cause.
+ *
+ * @param componentType a [com.valhalla.thor.domain.model.ComponentType] name. Stored rather than
+ * looked up, because a row has to keep rendering after an app update removes the component it names
+ * — at which point `PackageManager` can no longer say whether it was a service or a receiver, and
+ * the row would otherwise have to be dropped or filed under "unknown".
+ * @param restoreToEnabled the component's `android:enabled` as it stood when Thor wrote this row.
+ * Restoring means putting the component back the way its developer shipped it, which for the
+ * majority of components means "enabled" but for a meaningful minority — stubs, A/B experiment
+ * receivers, OEM variants — means "disabled". Restoring those to *enabled* would be Thor inventing
+ * a state the app never had.
+ * @param userId the Android user the override was written for. Part of the key because the same
+ * package in a work profile is a different installation with its own component state, and a row
+ * that did not name the user would let a personal-profile restore claim to undo a work-profile
+ * change.
+ */
+@Entity(
+    tableName = "component_overrides",
+    primaryKeys = ["packageName", "className", "userId"],
+    indices = [Index("packageName")],
+)
+data class ComponentOverrideEntity(
+    val packageName: String,
+    val className: String,
+    val userId: Int,
+    val componentType: String,
+    val restoreToEnabled: Boolean,
+    val disabledAt: Long,
+)

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -281,6 +281,17 @@ object Shizuku {
 
     val isRoot get() = Shizuku.getUid() == 0
 
+    /**
+     * The uid Shizuku's service runs as, or `null` if it could not be read.
+     *
+     * [isRoot] throws when the binder has gone since the last availability check — `Shizuku.getUid()`
+     * is a live transaction, not a cached field — so a caller that has to *decide* something on the
+     * uid, rather than merely branch inside an already-privileged operation, needs the failure to be
+     * a value it can reason about. Every such caller here reads `null` as "not root", because the
+     * alternative is offering a control that throws a `SecurityException` on every press.
+     */
+    fun uidOrNull(): Int? = runCatching { Shizuku.getUid() }.getOrNull()
+
     private fun asInterface(className: String, original: IBinder): Any {
         val clazz = Class.forName("$className\$Stub")
         return Bypass.invoke(

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/Shizuku.kt
@@ -1365,8 +1365,39 @@ object Shizuku {
         }
     }
 
-    fun execute(command: String, root: Boolean = isRoot): Pair<Int, String?> = runCatching {
-        val binder = Shizuku.getBinder() ?: return -1 to "Shizuku binder is null"
+    /**
+     * The exit code and whichever stream had something to say — stdout if it did, else stderr.
+     *
+     * That preference is load-bearing for the dozens of callers that parse `pm`/`am` chatter out of
+     * `.second`, and it is also a hazard: a command that writes to **both** streams loses its stderr
+     * here silently. If what you need is the *outcome* of an `am` verb, use [executeCombined] —
+     * `am` writes "Starting: Intent { … }" to stdout and the permission denial to stderr, so this
+     * function returns the echo and drops the reason.
+     */
+    fun execute(command: String, root: Boolean = isRoot): Pair<Int, String?> =
+        executeStreams(command, root).let { (code, out, err) -> code to out.ifBlank { err } }
+
+    /**
+     * The exit code and **both** streams, stdout first, blank ones dropped.
+     *
+     * Exists for the per-component verbs, whose whole verdict lives in stderr while stdout always
+     * carries a content-free echo of the intent. See [execute] for why that one cannot simply be
+     * changed to do this: its stdout-or-stderr contract is what every other caller reads.
+     */
+    fun executeCombined(command: String, root: Boolean = isRoot): Pair<Int, String> =
+        executeStreams(command, root).let { (code, out, err) ->
+            code to sequenceOf(out, err).filter { it.isNotBlank() }.joinToString("\n") { it.trim() }
+        }
+
+    /**
+     * Run [command] in a privileged process and return its exit code with the two streams kept
+     * apart, so that each public entry point above can decide what to do with them.
+     */
+    private fun executeStreams(
+        command: String,
+        root: Boolean,
+    ): Triple<Int, String, String> = runCatching {
+        val binder = Shizuku.getBinder() ?: return Triple(-1, "", "Shizuku binder is null")
         IShizukuService.Stub.asInterface(binder)
             .newProcess(arrayOf(if (root) "su" else "sh"), null, null)
             .run {
@@ -1424,7 +1455,7 @@ object Shizuku {
                         // Give the readers a bounded window to drain, then stop waiting on them.
                         outThread.join(READER_JOIN_TIMEOUT_MS)
                         errThread.join(READER_JOIN_TIMEOUT_MS)
-                        exitCode to output.get().ifBlank { error.get() }
+                        Triple(exitCode, output.get(), error.get())
                     } else {
                         timedOut = true
                         Logger.e(
@@ -1443,9 +1474,19 @@ object Shizuku {
                         errThread.join(READER_JOIN_TIMEOUT_MS)
                         // Readers are already free; now request the (possibly slow) kill.
                         runCatching { destroy() }
-                        -1 to "Command timed out after ${EXECUTE_TIMEOUT_MS}ms".let { msg ->
-                            output.get().ifBlank { error.get() }.ifBlank { msg }
-                        }
+                        val partialOut = output.get()
+                        val partialErr = error.get()
+                        // The timeout sentence only stands in when the child said nothing at all;
+                        // whatever it did manage to write is more useful than "it timed out".
+                        Triple(
+                            -1,
+                            partialOut,
+                            if (partialOut.isBlank() && partialErr.isBlank()) {
+                                "Command timed out after ${EXECUTE_TIMEOUT_MS}ms"
+                            } else {
+                                partialErr
+                            },
+                        )
                     }
                 } finally {
                     // Always tear the process down (idempotent even if already destroyed on timeout).
@@ -1459,7 +1500,7 @@ object Shizuku {
             }
     }.getOrElse { err ->
         Logger.e("Shizuku", "Command execution failed: $command", err)
-        -1 to err.stackTraceToString()
+        Triple(-1, "", err.stackTraceToString())
     }
 
     private val ParcelFileDescriptor.text

--- a/app/src/main/java/com/valhalla/thor/di/Modules.kt
+++ b/app/src/main/java/com/valhalla/thor/di/Modules.kt
@@ -14,6 +14,7 @@ import com.valhalla.thor.data.backup.FileArchiveBreadcrumbStore
 import com.valhalla.thor.data.backup.PartialArchiveLedger
 import com.valhalla.thor.data.source.local.room.AppDao
 import com.valhalla.thor.data.source.local.room.AppDatabase
+import com.valhalla.thor.data.source.local.room.ComponentOverrideDao
 import com.valhalla.thor.data.source.local.room.FreezeProfileDao
 import com.valhalla.thor.data.source.local.room.FreezerDao
 import com.valhalla.thor.domain.repository.AppArchiveStore
@@ -81,6 +82,10 @@ class AppModule {
 
     @Single
     fun extensionDataDao(appDatabase: AppDatabase) = appDatabase.extensionDataDao()
+
+    @Single
+    fun componentOverrideDao(appDatabase: AppDatabase): ComponentOverrideDao =
+        appDatabase.componentOverrideDao()
 
     // RealShellRepository comes from the Odin library (com.valhalla.superuser.ktx), outside the
     // scan scope — the component scan only sees com.valhalla.thor.

--- a/app/src/main/java/com/valhalla/thor/domain/gateway/SystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/gateway/SystemGateway.kt
@@ -56,6 +56,66 @@ interface SystemGateway {
      */
     suspend fun clearAllCaches(targetFreeBytes: Long?): Result<Unit>
 
+    // Per-component control
+    //
+    // All three verbs below need the privileged transport to be executing at **uid 0**, and all
+    // three are therefore implemented for real only by Root and by a Shizuku that was itself started
+    // as root. This is not an accident of Thor's plumbing:
+    //
+    //  - `PackageManagerService.setEnabledSetting` lets `Process.SHELL_UID` through a carve-out that
+    //    requires `className == null`; with a class name it throws
+    //    `SecurityException("Shell cannot change component state for …")`. Reaching
+    //    `IPackageManager.setComponentEnabledSetting` by reflection lands on the same check with the
+    //    same calling uid, so there is no second rung to fall back to — which is the one thing that
+    //    makes these different from every other verb on this interface.
+    //  - `ActivityManager.canAccessUnexportedComponents` waives the export and permission checks for
+    //    `ROOT_UID` and `SYSTEM_UID` only. `START_ANY_ACTIVITY` is `signature` and is not declared by
+    //    `packages/Shell` in any release from 9 to 16.
+    //  - Dhizuku's `DevicePolicyManager` has no component-enabled API at all.
+    //
+    // A mode that cannot do one of these must fail with a message naming the reason. Reporting
+    // success it has no evidence for is the failure mode `clearAllCaches` above was written to
+    // document.
+
+    /**
+     * Sets one component's enabled state for [userId].
+     *
+     * @param state the `pm` sub-command to use — `enable`, `disable`, or `default-state`. `default`
+     * is not a synonym for `enable`: it removes the override, which puts a component that ships
+     * disabled back to disabled. See `ComponentCommands.enableStateFor`.
+     */
+    suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState,
+        userId: Int,
+    ): Result<Unit>
+
+    /**
+     * Launches one activity for [userId], ignoring whether it is exported or permission-guarded.
+     *
+     * Only for the components Thor cannot launch with an ordinary `startActivity` — an exported,
+     * unguarded activity should never reach here, because a plain `Intent` needs no privilege, shows
+     * the app's own task animation, and cannot fail on a device with no root.
+     */
+    suspend fun forceLaunchActivity(
+        packageName: String,
+        className: String,
+        userId: Int,
+    ): Result<Unit>
+
+    /**
+     * Stops one running service for [userId].
+     *
+     * Transient by construction: nothing stops the app from starting it again a moment later. It is
+     * the "stop now" half of the pair, and the persistent half is [setComponentEnabled].
+     */
+    suspend fun stopService(
+        packageName: String,
+        className: String,
+        userId: Int,
+    ): Result<Unit>
+
     /**
      * Runs a raw shell command through this privilege mechanism and returns the
      * (exitCode, output) pair. Used by the extension ShellExecutor so extensions
@@ -64,3 +124,13 @@ interface SystemGateway {
      */
     suspend fun executeShellCommand(command: String): Result<Pair<Int, String?>>
 }
+
+/**
+ * The three states a component can be put in, as this interface names them.
+ *
+ * A domain mirror of `ComponentCommands.ComponentState`, which is `internal` to the data layer and
+ * carries the `pm` verb. The duplication is the price of the rule in this file's header: the gateway
+ * contract has no Android *and* no data-layer dependencies, and a shell verb string is a data-layer
+ * detail.
+ */
+enum class ComponentEnabledState { ENABLED, DISABLED, DEFAULT }

--- a/app/src/main/java/com/valhalla/thor/domain/model/ComponentCapability.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ComponentCapability.kt
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Why per-component control is unavailable, so the UI can say something true instead of showing a
+ * row of dead switches.
+ *
+ * There is no `SHIZUKU_UNSUPPORTED`: Shizuku *can* do all of this when it was itself started as
+ * root, which is why the blocker for the ordinary shell-uid case names the uid rather than the
+ * transport.
+ */
+enum class ComponentControlBlocker {
+    /** Nothing is in the way. */
+    NONE,
+
+    /** The privilege probe has not settled yet — transient, and never a reason to say "no". */
+    NOT_READY,
+
+    /** No privilege transport at all. */
+    NO_PRIVILEGE,
+
+    /** Shizuku is connected but running at the shell uid (2000), not uid 0. */
+    SHIZUKU_NOT_ROOT,
+
+    /** Dhizuku's Device Owner API exposes no route to any of these operations. */
+    DHIZUKU_UNSUPPORTED,
+}
+
+/**
+ * What the active privilege transport may do to an individual component.
+ *
+ * Every privileged verb in this feature collapses onto one fact — **does the transport execute at
+ * uid 0** — so that is the only thing stored; the named accessors exist to say *why* at each call
+ * site rather than to record three independent facts that could drift apart.
+ *
+ * - **Setting component state** is uid 0 only. `PackageManagerService.setEnabledSetting` has a
+ *   carve-out for `Process.SHELL_UID` that permits *package*-level changes and explicitly rejects
+ *   anything with a non-null class name — `SecurityException("Shell cannot change component state
+ *   for …")`. Reaching `IPackageManager.setComponentEnabledSetting` by reflection instead of by
+ *   `pm` arrives at the same check with the same uid, so there is no fallback to write.
+ * - **Force-launching** is uid 0 only. `ActivityManager.canAccessUnexportedComponents` waives the
+ *   export and permission checks for `ROOT_UID` and `SYSTEM_UID` alone;
+ *   `START_ANY_ACTIVITY` is a `signature` permission that the Shell package does not declare in any
+ *   release from 9 to 16, and `pm grant` refuses it.
+ * - **Stopping a service** is uid 0 only *here*. `ActiveServices.retrieveServiceLocked` would in
+ *   fact let any uid stop an **exported** service, so a shell-uid Shizuku could stop some of them —
+ *   that narrower path is deliberately not offered, because Thor cannot verify it across OEMs and a
+ *   "Stop" that silently does nothing on half the rows is worse than one that is honestly absent.
+ *
+ * Dhizuku is not a partial case but an empty one: `DevicePolicyManager` has no component-enabled
+ * API at all, and a Device Owner's only launch-related privilege is a background-activity-launch
+ * exemption, which is not an export waiver.
+ */
+@Immutable
+data class ComponentCapability(
+    /** Whether the active transport executes at uid 0 — root, or Shizuku that was started as root. */
+    val hasUid0: Boolean,
+    val blocker: ComponentControlBlocker,
+) {
+    val canSetComponentState: Boolean get() = hasUid0
+    val canForceLaunch: Boolean get() = hasUid0
+    val canStopService: Boolean get() = hasUid0
+
+    /**
+     * Whether [component] can be launched at all — the one question whose answer varies per row.
+     *
+     * An exported, unguarded activity is launchable by anybody, Thor included, with no privilege
+     * whatsoever; everything else needs uid 0.
+     */
+    fun canLaunch(component: ComponentDetail): Boolean =
+        !component.launchRequiresRoot || hasUid0
+
+    companion object {
+        val None = ComponentCapability(hasUid0 = false, blocker = ComponentControlBlocker.NOT_READY)
+    }
+}
+
+/**
+ * Derive the capability from the settled privilege state.
+ *
+ * @param shizukuUid the uid Shizuku's own service runs as, or `null` when it could not be read.
+ * An unreadable uid resolves to **not capable**. That is the opposite of the fold used when picking
+ * a privileged installer, where an unknown uid is optimistically treated as root: a wrong guess
+ * there costs a failed install with a clear error, whereas a wrong guess here paints enabled Force
+ * Open and Disable controls that throw a `SecurityException` on every press.
+ */
+fun componentCapability(
+    mode: PrivilegeMode?,
+    isReady: Boolean,
+    shizukuUid: Int?,
+): ComponentCapability {
+    if (!isReady) return ComponentCapability(false, ComponentControlBlocker.NOT_READY)
+    return when (mode) {
+        null, PrivilegeMode.NONE -> ComponentCapability(false, ComponentControlBlocker.NO_PRIVILEGE)
+        PrivilegeMode.ROOT -> ComponentCapability(true, ComponentControlBlocker.NONE)
+        PrivilegeMode.SHIZUKU ->
+            if (shizukuUid == ROOT_UID) ComponentCapability(true, ComponentControlBlocker.NONE)
+            else ComponentCapability(false, ComponentControlBlocker.SHIZUKU_NOT_ROOT)
+
+        PrivilegeMode.DHIZUKU ->
+            ComponentCapability(false, ComponentControlBlocker.DHIZUKU_UNSUPPORTED)
+    }
+}
+
+/** `android.os.Process.ROOT_UID`, which is `@hide`. */
+const val ROOT_UID: Int = 0

--- a/app/src/main/java/com/valhalla/thor/domain/model/ComponentDetail.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ComponentDetail.kt
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import androidx.compose.runtime.Immutable
+import kotlinx.serialization.Serializable
+
+/**
+ * Which of the four manifest component kinds a [ComponentDetail] describes.
+ *
+ * Carried on the ledger row as well as on the live component, because a row has to keep rendering
+ * after the component it names has vanished from an app update — at which point the only thing left
+ * that can say which section it belongs under is the recorded type.
+ */
+@Serializable
+enum class ComponentType { ACTIVITY, SERVICE, RECEIVER, PROVIDER }
+
+/**
+ * One declared component, with the three facts that decide what Thor may do to it.
+ *
+ * Replaces the bare class-name string the Components tab used to render. The name alone cannot
+ * answer either question the tab now asks — "can this be opened?" and "is this switched off?" — and
+ * both answers are already sitting in the `PackageInfo` the detail loader fetches; they were being
+ * mapped away one line after they arrived.
+ *
+ * @param enabled the **effective** state right now: the runtime override if one has been set, and
+ * the manifest default otherwise. Not readable from `ComponentInfo.enabled`, which only ever reports
+ * the manifest attribute — see `AppRepositoryImpl.componentDetailsOf` for how it is derived.
+ * @param manifestDefaultEnabled `android:enabled` as the developer shipped it. Kept beside [enabled]
+ * so the UI can tell "somebody turned this off" apart from "this ships off", and so a restore puts
+ * the component back the way the developer shipped it rather than merely switching it on.
+ * @param hasExplicitState whether an explicit override exists at all, i.e. whether
+ * `getComponentEnabledSetting` answered something other than `COMPONENT_ENABLED_STATE_DEFAULT`.
+ * Not the same as `enabled != manifestDefaultEnabled`: a component the manifest already enables can
+ * carry an explicit `ENABLED` override, which looks identical from the outside but is a real row in
+ * `package-restrictions.xml` that "Reset to default" should be offered for and that survives an app
+ * update the way the developer's own default does not.
+ * @param permission `android:permission` — the permission a caller must hold to enter this
+ * component, or `null` when entry is ungated.
+ */
+@Serializable
+@Immutable
+data class ComponentDetail(
+    val className: String,
+    val exported: Boolean,
+    val enabled: Boolean,
+    val manifestDefaultEnabled: Boolean,
+    val hasExplicitState: Boolean = false,
+    val permission: String? = null,
+) {
+    /**
+     * Whether launching this activity needs uid 0.
+     *
+     * **Not simply `!exported`.** An *exported* activity guarded by an `android:permission` Thor
+     * does not hold fails in exactly the same way as an unexported one:
+     * `ActivityStarter.executeRequest` runs the export check and the permission check side by side,
+     * and `ActivityManager.canAccessUnexportedComponents` — the only waiver — is granted to
+     * `ROOT_UID` and `SYSTEM_UID` alone.
+     *
+     * Thor could in principle hold the guarding permission itself, which would make some of these
+     * launchable unprivileged. It is not checked: `checkSelfPermission` would have to run per row on
+     * a list that can be several hundred long, and being wrong in this direction costs only an
+     * unnecessary Force Open label on a row that will then succeed. Being wrong in the other
+     * direction costs a plain Open button that throws.
+     */
+    val launchRequiresRoot: Boolean get() = !exported || permission != null
+
+    /**
+     * Whether an explicit override is in force — i.e. whether *anything* (Thor, another tool, the
+     * app itself, the OEM) has written a state for this component.
+     *
+     * This is what "Reset to default" acts on, and it is deliberately blind to who wrote the
+     * override: `getComponentEnabledSetting` records a state, not an author. Thor's own ledger
+     * (`component_overrides`) is the only record of authorship, and it only knows about Thor.
+     */
+    val isOverridden: Boolean get() = hasExplicitState
+
+    /**
+     * The class name without its package prefix, for a Toast.
+     *
+     * `com.foo.bar.baz.ui.settings.SettingsActivity` in a two-line Toast is a package path with the
+     * interesting word off the end; `SettingsActivity` is the word. Substring rather than
+     * `substringAfterLast('.')` on the *package* — a component's class is not always under the app's
+     * own package (a library's `androidx.work.impl.SystemJobService` is declared by the app that
+     * bundles it), so the last dot is the only reliable split.
+     *
+     * Never empty: a class name that ends in a dot, or has none, falls back to the whole string.
+     */
+    val shortName: String
+        get() = className.substringAfterLast('.').ifEmpty { className }
+}
+
+/**
+ * The four component lists of one package, as [ComponentDetail]s.
+ *
+ * A type rather than four parameters because every consumer wants all four together and because
+ * [of] lets the tab loop over [ComponentType.entries] instead of repeating itself four times — which
+ * is what kept the old four-`List<String>` shape from ever gaining a per-row affordance without a
+ * fourfold edit.
+ */
+@Serializable
+@Immutable
+data class ComponentSnapshot(
+    val activities: List<ComponentDetail> = emptyList(),
+    val services: List<ComponentDetail> = emptyList(),
+    val receivers: List<ComponentDetail> = emptyList(),
+    val providers: List<ComponentDetail> = emptyList(),
+) {
+    fun of(type: ComponentType): List<ComponentDetail> = when (type) {
+        ComponentType.ACTIVITY -> activities
+        ComponentType.SERVICE -> services
+        ComponentType.RECEIVER -> receivers
+        ComponentType.PROVIDER -> providers
+    }
+
+    /** Every component of every type, tagged with its section — for counting and reconciliation. */
+    fun all(): List<Pair<ComponentType, ComponentDetail>> =
+        ComponentType.entries.flatMap { type -> of(type).map { type to it } }
+
+    val isEmpty: Boolean
+        get() = activities.isEmpty() && services.isEmpty() &&
+                receivers.isEmpty() && providers.isEmpty()
+}

--- a/app/src/main/java/com/valhalla/thor/domain/model/ComponentOverride.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/ComponentOverride.kt
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * A component Thor switched off, as the ledger remembers it.
+ *
+ * Deliberately *not* a claim about the component's current state. The ledger records what Thor did;
+ * `PackageManager` says what is true now. Where the two disagree — the user re-enabled the component
+ * in Settings, the app re-enabled it itself (which any app may always do for its own components),
+ * an update removed it — the Components tab reports the disagreement and offers to forget the row.
+ * It never re-applies it.
+ *
+ * @param restoreToEnabled what `android:enabled` said when the row was written, which is what
+ * "Restore" puts the component back to. Not always `true`: a component that ships disabled and was
+ * disabled again by Thor must be restored to *disabled*, or Thor has invented a state the app never
+ * had.
+ */
+@Immutable
+data class ComponentOverride(
+    val packageName: String,
+    val className: String,
+    val type: ComponentType,
+    val restoreToEnabled: Boolean,
+    val disabledAt: Long,
+)

--- a/app/src/main/java/com/valhalla/thor/domain/model/DetailedAppInfo.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/DetailedAppInfo.kt
@@ -10,10 +10,15 @@ import kotlinx.serialization.Serializable
 @Immutable
 data class DetailedAppInfo(
     val appInfo: AppInfo,
-    val activities: List<String> = emptyList(),
-    val services: List<String> = emptyList(),
-    val receivers: List<String> = emptyList(),
-    val providers: List<String> = emptyList(),
+    /**
+     * The four component lists.
+     *
+     * Was four `List<String>` of class names. The names alone could be listed and copied and
+     * nothing else, because every question the Components tab now asks of a row — is it exported,
+     * is it switched off, is it guarded by a permission — was thrown away by the mapper one line
+     * after `PackageManager` handed it over.
+     */
+    val components: ComponentSnapshot = ComponentSnapshot(),
     val permissions: List<PermissionDetail> = emptyList(),
     val nativeLibs: List<String> = emptyList(),
     val reqFeatures: List<String> = emptyList(),

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -71,6 +71,13 @@ data class UserPreferences(
     val extensionsUnlocked: Boolean = false,
     val extensionConsentAccepted: Boolean = false,
 
+    // Per-component control (App info → Components). Disabling a component is the one action in Thor
+    // that can break an app without the app ever appearing changed — it stays installed, enabled and
+    // launchable while some part of it silently stops working. The first disable therefore asks once,
+    // and this records that it was answered. Read-only actions (Open, Force open, Stop now) never
+    // consult it; nothing here gates them.
+    val componentControlConsentAccepted: Boolean = false,
+
     // Auto Reinstall Config
     val autoReinstallEnabled: Boolean = false,
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/AppRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/AppRepository.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.domain.repository
 
 import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.ComponentSnapshot
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import kotlinx.coroutines.flow.Flow
 
@@ -26,6 +27,17 @@ interface AppRepository {
      * Fetches heavy details (activities, permissions, services, etc.) dynamically.
      */
     suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo?
+
+    /**
+     * Re-reads just the four component lists.
+     *
+     * Exists so that switching one component off does not have to pay for the whole of
+     * [getDetailedAppInfo] to show the result: that call also hashes the signing certificate, walks
+     * the native library directory and makes two binder calls per requested permission, none of
+     * which a component toggle can have changed. Returns `null` on the same terms as
+     * [getDetailedAppInfo] — the package is gone, or `PackageManager` refused.
+     */
+    suspend fun getComponentDetails(packageName: String): ComponentSnapshot?
 
     // Parser for XAPK/APK installation features
     suspend fun getApkDetails(apkPath: String): AppInfo?

--- a/app/src/main/java/com/valhalla/thor/domain/repository/ComponentOverrideRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/ComponentOverrideRepository.kt
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.repository
+
+import com.valhalla.thor.domain.model.ComponentOverride
+import com.valhalla.thor.domain.model.ComponentType
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Thor's record of the components it switched off.
+ *
+ * Bookkeeping, not enforcement — see [com.valhalla.thor.domain.model.ComponentOverride]. Every
+ * method is scoped to the Android user Thor is running in; the implementation supplies that, the
+ * way [SystemRepository] does for its own per-user commands, so that no caller can forget to.
+ */
+interface ComponentOverrideRepository {
+
+    /** The rows for one package, as a stream so the "N restricted by Thor" header cannot lag. */
+    fun observe(packageName: String): Flow<List<ComponentOverride>>
+
+    /** Every row, for the cross-app restore. */
+    suspend fun getAll(): List<ComponentOverride>
+
+    /**
+     * Record that Thor disabled [className].
+     *
+     * @param restoreToEnabled the component's manifest default **as read right now**, not `true`.
+     */
+    suspend fun record(
+        packageName: String,
+        className: String,
+        type: ComponentType,
+        restoreToEnabled: Boolean,
+    )
+
+    /** Drop one row — after a successful restore, or after the user dismisses a drifted row. */
+    suspend fun forget(packageName: String, className: String)
+
+    /** Drop every row for one package. */
+    suspend fun forgetPackage(packageName: String)
+}

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -136,6 +136,9 @@ interface PreferenceRepository {
     suspend fun setExtensionsUnlocked(unlocked: Boolean)
     suspend fun setExtensionConsentAccepted(accepted: Boolean)
 
+    // --- Component control ---
+    suspend fun setComponentControlConsentAccepted(accepted: Boolean)
+
     // --- Auto Reinstall ---
     suspend fun setAutoReinstallEnabled(enabled: Boolean)
     suspend fun getInstallerArg(): String

--- a/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/SystemRepository.kt
@@ -3,6 +3,7 @@
 
 package com.valhalla.thor.domain.repository
 
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
 import com.valhalla.thor.domain.model.ObbProbe
 
 interface SystemRepository {
@@ -48,6 +49,42 @@ interface SystemRepository {
     suspend fun getAppPaths(packageName: String): Result<List<String>>
     suspend fun grantPermission(packageName: String, permissionName: String): Result<Unit>
     suspend fun revokePermission(packageName: String, permissionName: String): Result<Unit>
+
+    // Per-component control
+    //
+    // Routed through the active gateway like everything else, but with one difference worth stating
+    // once: the fallback chain does not help here. Root, and a Shizuku that was itself started as
+    // root, are the only transports the platform accepts these from — see the block comment on
+    // `SystemGateway`. A device with Shizuku at the shell uid gets a refusal that names the reason,
+    // and the UI is expected to have asked `componentCapability` first so that the refusal is a
+    // backstop rather than the normal path.
+
+    /**
+     * Sets one component's enabled state for the Android user Thor is running in.
+     *
+     * @param state `DEFAULT` removes the override and lets `android:enabled` decide again; it is not
+     * a synonym for `ENABLED`, and for a component that ships disabled it switches it back off.
+     */
+    suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState,
+    ): Result<Unit>
+
+    /**
+     * Launches an activity that an ordinary `startActivity` cannot reach — unexported, or guarded by
+     * a permission Thor does not hold.
+     *
+     * Callers must not route an exported, unguarded activity here. That one needs no privilege at
+     * all, and sending it down this path makes a launch that works on every device fail on most of
+     * them.
+     */
+    suspend fun forceLaunchActivity(packageName: String, className: String): Result<Unit>
+
+    /**
+     * Stops one running service. Transient: nothing stops the app starting it again immediately.
+     */
+    suspend fun stopService(packageName: String, className: String): Result<Unit>
 
     /**
      * Raw shell execution via the active privilege gateway (used by extensions).

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ComponentControlUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ComponentControlUseCase.kt
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.usecase
+
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
+import com.valhalla.thor.domain.model.ComponentDetail
+import com.valhalla.thor.domain.model.ComponentOverride
+import com.valhalla.thor.domain.model.ComponentType
+import com.valhalla.thor.domain.repository.ComponentOverrideRepository
+import com.valhalla.thor.domain.repository.SystemRepository
+import kotlinx.coroutines.flow.Flow
+import org.koin.core.annotation.Factory
+
+/**
+ * Which state to write when the user asks to switch a component **on**.
+ *
+ * Preferring [ComponentEnabledState.DEFAULT] whenever the manifest already says enabled is not
+ * tidiness. An explicit `ENABLED` override is a row in `package-restrictions.xml` that outlives the
+ * app update which removed the component, pins the component on if a later version ships it
+ * disabled on purpose, and reads as a deviation to anything auditing component state. Writing
+ * `default-state` leaves the app exactly as its developer shipped it, with no trace that Thor was
+ * ever here — the correct end state for an undo.
+ *
+ * When the manifest default is *disabled*, `default-state` would switch the component straight back
+ * off, so an explicit [ComponentEnabledState.ENABLED] is the only way to honour the request.
+ */
+fun enableTargetState(manifestDefaultEnabled: Boolean): ComponentEnabledState =
+    if (manifestDefaultEnabled) ComponentEnabledState.DEFAULT else ComponentEnabledState.ENABLED
+
+/**
+ * The per-component verbs, with the ledger kept in step.
+ *
+ * The pairing is the reason this exists rather than the ViewModel calling [SystemRepository]
+ * directly: a disable that is not recorded is a change the user can never find again, and a
+ * recorded disable that never happened is a Restore All that undoes something Thor did not do.
+ * Ordering is deliberate in both directions — **the ledger is written only after the platform call
+ * succeeds, and cleared only after the restoring call succeeds** — so a failure at any point leaves
+ * the ledger describing the world as it is.
+ */
+@Factory
+class ComponentControlUseCase(
+    private val systemRepository: SystemRepository,
+    private val overrides: ComponentOverrideRepository,
+) {
+
+    fun observeOverrides(packageName: String): Flow<List<ComponentOverride>> =
+        overrides.observe(packageName)
+
+    suspend fun allOverrides(): List<ComponentOverride> = overrides.getAll()
+
+    /** Switch [component] off and record it. */
+    suspend fun disable(
+        packageName: String,
+        type: ComponentType,
+        component: ComponentDetail,
+    ): Result<Unit> = systemRepository
+        .setComponentEnabled(packageName, component.className, ComponentEnabledState.DISABLED)
+        .onSuccess {
+            overrides.record(
+                packageName = packageName,
+                className = component.className,
+                type = type,
+                // The manifest default as it stands right now, not `true`: a component that ships
+                // disabled must be restored to disabled or Thor has invented a state the app never
+                // had.
+                restoreToEnabled = component.manifestDefaultEnabled,
+            )
+        }
+
+    /** Switch [component] back on and drop its ledger row. */
+    suspend fun enable(packageName: String, component: ComponentDetail): Result<Unit> =
+        systemRepository
+            .setComponentEnabled(
+                packageName,
+                component.className,
+                enableTargetState(component.manifestDefaultEnabled),
+            )
+            .onSuccess { overrides.forget(packageName, component.className) }
+
+    /**
+     * Remove the override entirely, whatever it was, and drop the ledger row.
+     *
+     * Distinct from [enable]: this is offered for a component whose state somebody *else* set, where
+     * "on" would be Thor asserting a preference rather than stepping out of the way.
+     */
+    suspend fun resetToDefault(packageName: String, className: String): Result<Unit> =
+        systemRepository
+            .setComponentEnabled(packageName, className, ComponentEnabledState.DEFAULT)
+            .onSuccess { overrides.forget(packageName, className) }
+
+    /**
+     * Put every component Thor disabled back the way it found it.
+     *
+     * Each row is restored to its own `restoreToEnabled`, and a row is forgotten only when its own
+     * call succeeds. A partial failure therefore leaves exactly the rows that are still overridden,
+     * which is what makes pressing Restore All again a safe retry rather than a second, different
+     * operation.
+     *
+     * @return the number restored and the number attempted.
+     */
+    suspend fun restoreAll(): RestoreAllOutcome {
+        val rows = overrides.getAll()
+        var restored = 0
+        rows.forEach { row ->
+            val result = systemRepository.setComponentEnabled(
+                row.packageName,
+                row.className,
+                enableTargetState(row.restoreToEnabled),
+            )
+            if (result.isSuccess) {
+                overrides.forget(row.packageName, row.className)
+                restored++
+            }
+        }
+        return RestoreAllOutcome(restored = restored, attempted = rows.size)
+    }
+
+    /** Forget a row without touching the platform — for an override something else already undid. */
+    suspend fun forget(packageName: String, className: String) =
+        overrides.forget(packageName, className)
+
+    suspend fun forceLaunch(packageName: String, className: String): Result<Unit> =
+        systemRepository.forceLaunchActivity(packageName, className)
+
+    suspend fun stopService(packageName: String, className: String): Result<Unit> =
+        systemRepository.stopService(packageName, className)
+}
+
+/**
+ * How Restore All went.
+ *
+ * Two numbers rather than a boolean because "restored 6 of 9" is the only honest report of a partial
+ * run, and a boolean would have to choose between calling that a success and calling it a failure.
+ */
+data class RestoreAllOutcome(val restored: Int, val attempted: Int) {
+    val isComplete: Boolean get() = restored == attempted
+}

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ComponentControlUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ComponentControlUseCase.kt
@@ -47,8 +47,6 @@ class ComponentControlUseCase(
     fun observeOverrides(packageName: String): Flow<List<ComponentOverride>> =
         overrides.observe(packageName)
 
-    suspend fun allOverrides(): List<ComponentOverride> = overrides.getAll()
-
     /** Switch [component] off and record it. */
     suspend fun disable(
         packageName: String,

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -79,6 +81,9 @@ import com.valhalla.thor.presentation.widgets.appHeaderIconGlowInset
 import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.AppClickAction
 import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.ComponentControlBlocker
+import com.valhalla.thor.domain.model.ComponentDetail
+import com.valhalla.thor.domain.model.ComponentType
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.ObbProbe
 import com.valhalla.thor.domain.model.PermissionDetail
@@ -954,6 +959,22 @@ private fun PermissionsTabScreen(permissions: List<PermissionDetail>) {
 
 @Composable
 private fun ComponentsTabScreen(details: DetailedAppInfo) {
+    val packageName = details.appInfo.packageName
+    // Keyed on the package, so opening a second app's details from the same host (the wide-layout
+    // detail pane reuses one host) gets its own instance rather than the previous app's ledger and
+    // in-flight state. Same scoping AppBackupSheet already uses.
+    val viewModel: ComponentControlViewModel = koinViewModel(key = packageName)
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(packageName, details.components) {
+        viewModel.load(packageName, details.components)
+    }
+
+    ObserveAsEvents(viewModel.events) { msg ->
+        Toast.makeText(context, msg.asString(context), Toast.LENGTH_SHORT).show()
+    }
+
     // rememberSaveable so the search query survives rotation / config change.
     var searchQuery by androidx.compose.runtime.saveable.rememberSaveable { mutableStateOf("") }
 
@@ -980,19 +1001,18 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
             )
         )
 
-        val (filteredActivities, filteredServices, filteredReceivers, filteredProviders) =
-            remember(searchQuery, details) {
-                val filter = { items: List<String> ->
-                    if (searchQuery.isEmpty()) items
-                    else items.filter { it.contains(searchQuery, ignoreCase = true) }
-                }
-                ComponentLists(
-                    activities = filter(details.activities),
-                    services = filter(details.services),
-                    receivers = filter(details.receivers),
-                    providers = filter(details.providers)
-                )
+        val filtered = remember(searchQuery, state.snapshot) {
+            val filter = { items: List<ComponentDetail> ->
+                if (searchQuery.isEmpty()) items
+                else items.filter { it.className.contains(searchQuery, ignoreCase = true) }
             }
+            ComponentLists(
+                activities = filter(state.snapshot.activities),
+                services = filter(state.snapshot.services),
+                receivers = filter(state.snapshot.receivers),
+                providers = filter(state.snapshot.providers)
+            )
+        }
 
         // rememberSaveable so the expanded/collapsed sections survive rotation / config changes.
         var activitiesExpanded by androidx.compose.runtime.saveable.rememberSaveable { mutableStateOf(false) }
@@ -1001,7 +1021,6 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
         var providersExpanded by androidx.compose.runtime.saveable.rememberSaveable { mutableStateOf(false) }
 
         val clipboard = LocalClipboard.current
-        val context = LocalContext.current
         val coroutineScope = rememberCoroutineScope()
         val classNameLabel = stringResource(R.string.class_name_label)
         val onCopyClassName: (String) -> Unit = { className ->
@@ -1019,14 +1038,20 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
             ).show()
         }
 
+        ComponentControlBanner(
+            blocker = state.capability.blocker,
+            restrictedCount = state.restrictedCount,
+            onRestoreAll = viewModel::requestRestoreAll
+        )
+
         val activitiesTitle =
-            stringResource(R.string.section_activities_title, filteredActivities.size)
+            stringResource(R.string.section_activities_title, filtered.activities.size)
         val servicesTitle =
-            stringResource(R.string.section_services_title, filteredServices.size)
+            stringResource(R.string.section_services_title, filtered.services.size)
         val receiversTitle =
-            stringResource(R.string.section_receivers_title, filteredReceivers.size)
+            stringResource(R.string.section_receivers_title, filtered.receivers.size)
         val providersTitle =
-            stringResource(R.string.section_providers_title, filteredProviders.size)
+            stringResource(R.string.section_providers_title, filtered.providers.size)
 
         LazyColumn(
             modifier = Modifier
@@ -1035,36 +1060,157 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
         ) {
             componentSection(
                 keyPrefix = "activities",
+                type = ComponentType.ACTIVITY,
                 title = activitiesTitle,
-                items = filteredActivities,
+                items = filtered.activities,
+                state = state,
                 expanded = activitiesExpanded,
                 onToggle = { activitiesExpanded = !activitiesExpanded },
-                onCopy = onCopyClassName
+                onCopy = onCopyClassName,
+                viewModel = viewModel
             )
             componentSection(
                 keyPrefix = "services",
+                type = ComponentType.SERVICE,
                 title = servicesTitle,
-                items = filteredServices,
+                items = filtered.services,
+                state = state,
                 expanded = servicesExpanded,
                 onToggle = { servicesExpanded = !servicesExpanded },
-                onCopy = onCopyClassName
+                onCopy = onCopyClassName,
+                viewModel = viewModel
             )
             componentSection(
                 keyPrefix = "receivers",
+                type = ComponentType.RECEIVER,
                 title = receiversTitle,
-                items = filteredReceivers,
+                items = filtered.receivers,
+                state = state,
                 expanded = receiversExpanded,
                 onToggle = { receiversExpanded = !receiversExpanded },
-                onCopy = onCopyClassName
+                onCopy = onCopyClassName,
+                viewModel = viewModel
             )
             componentSection(
                 keyPrefix = "providers",
+                type = ComponentType.PROVIDER,
                 title = providersTitle,
-                items = filteredProviders,
+                items = filtered.providers,
+                state = state,
                 expanded = providersExpanded,
                 onToggle = { providersExpanded = !providersExpanded },
-                onCopy = onCopyClassName
+                onCopy = onCopyClassName,
+                viewModel = viewModel
             )
+        }
+    }
+
+    state.pendingConsent?.let { pending ->
+        AlertDialog(
+            onDismissRequest = viewModel::onDisclaimerDismissed,
+            title = { Text(stringResource(R.string.component_disclaimer_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.component_disclaimer_message,
+                        pending.component.shortName
+                    )
+                )
+            },
+            confirmButton = {
+                Button(onClick = viewModel::onDisclaimerConfirmed) {
+                    Text(stringResource(R.string.component_disclaimer_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::onDisclaimerDismissed) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+
+    if (state.showRestoreAllConfirm) {
+        AlertDialog(
+            onDismissRequest = viewModel::dismissRestoreAll,
+            title = { Text(stringResource(R.string.component_restore_all_title)) },
+            text = { Text(stringResource(R.string.component_restore_all_message)) },
+            confirmButton = {
+                Button(onClick = viewModel::confirmRestoreAll) {
+                    Text(stringResource(R.string.component_restore_all_action))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissRestoreAll) {
+                    Text(stringResource(R.string.cancel))
+                }
+            }
+        )
+    }
+}
+
+/**
+ * The one-line status strip above the four sections.
+ *
+ * Renders nothing when there is nothing to say — the common case for a rooted device that has not
+ * changed anything yet. When Thor cannot act it explains why *once*, at the top, rather than
+ * repeating a disabled control on every one of several hundred rows; and when Thor has changed
+ * something it says how much and offers the single undo.
+ */
+@Composable
+private fun ComponentControlBanner(
+    blocker: ComponentControlBlocker,
+    restrictedCount: Int,
+    onRestoreAll: () -> Unit
+) {
+    val blockerText = when (blocker) {
+        ComponentControlBlocker.NONE -> null
+        // "Still checking" is not a refusal, and saying so would be wrong a fraction of a second
+        // later. The controls are simply inert until the probe lands.
+        ComponentControlBlocker.NOT_READY -> null
+        ComponentControlBlocker.NO_PRIVILEGE ->
+            stringResource(R.string.component_blocker_no_privilege)
+
+        ComponentControlBlocker.SHIZUKU_NOT_ROOT ->
+            stringResource(R.string.component_blocker_shizuku_not_root)
+
+        ComponentControlBlocker.DHIZUKU_UNSUPPORTED ->
+            stringResource(R.string.component_blocker_dhizuku)
+    }
+
+    if (blockerText == null && restrictedCount == 0) return
+
+    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        if (blockerText != null) {
+            Text(
+                text = blockerText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+        if (restrictedCount > 0) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = androidx.compose.ui.res.pluralStringResource(
+                        R.plurals.component_restricted_count,
+                        restrictedCount,
+                        restrictedCount
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f)
+                )
+                TextButton(onClick = onRestoreAll) {
+                    Text(stringResource(R.string.component_restore_all_action))
+                }
+            }
         }
     }
 }
@@ -1079,11 +1225,14 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
  */
 private fun LazyListScope.componentSection(
     keyPrefix: String,
+    type: ComponentType,
     title: String,
-    items: List<String>,
+    items: List<ComponentDetail>,
+    state: ComponentControlUiState,
     expanded: Boolean,
     onToggle: () -> Unit,
-    onCopy: (String) -> Unit
+    onCopy: (String) -> Unit,
+    viewModel: ComponentControlViewModel
 ) {
     item(key = "$keyPrefix-header", contentType = "component_header") {
         Row(
@@ -1140,9 +1289,9 @@ private fun LazyListScope.componentSection(
                 // Index is part of the key: a package's component list can contain duplicate class
                 // names (PackageManager returns them un-deduped), and a duplicate LazyColumn key
                 // throws IllegalArgumentException and crashes the screen.
-                key = { index, className -> "$keyPrefix-$index-$className" },
+                key = { index, component -> "$keyPrefix-$index-${component.className}" },
                 contentType = { _, _ -> "component" }
-            ) { index, className ->
+            ) { index, component ->
                 val isLast = index == items.lastIndex
                 Box(
                     modifier = Modifier
@@ -1156,22 +1305,13 @@ private fun LazyListScope.componentSection(
                         .padding(horizontal = 16.dp)
                         .padding(bottom = if (isLast) 12.dp else 0.dp)
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable { onCopy(className) }
-                            .padding(vertical = 6.dp, horizontal = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = className,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            fontFamily = firaMonoFontFamily,
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
+                    ComponentRow(
+                        type = type,
+                        component = component,
+                        state = state,
+                        onCopy = onCopy,
+                        viewModel = viewModel
+                    )
                 }
             }
         }
@@ -1179,6 +1319,222 @@ private fun LazyListScope.componentSection(
 
     item(key = "$keyPrefix-spacer") {
         Spacer(modifier = Modifier.height(12.dp))
+    }
+}
+
+/**
+ * One component: its name, what is unusual about it, and what can be done to it.
+ *
+ * The whole row stays tap-to-copy, as it always was — the class name is the reason most people open
+ * this tab, and moving that onto the overflow to make room for the new controls would trade a
+ * one-tap action people already use for one they may never use. The new affordances are additive: a
+ * trailing Open button for activities, and an overflow for everything else.
+ */
+@Composable
+private fun ComponentRow(
+    type: ComponentType,
+    component: ComponentDetail,
+    state: ComponentControlUiState,
+    onCopy: (String) -> Unit,
+    viewModel: ComponentControlViewModel
+) {
+    val context = LocalContext.current
+    var menuExpanded by remember { mutableStateOf(false) }
+    val capability = state.capability
+    val isBusy = state.busyClassName == component.className
+    val isDrifted = state.isDrifted(component)
+    val isThors = state.overrides.containsKey(component.className)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { onCopy(component.className) }
+            .padding(vertical = 6.dp, horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = component.className,
+                style = MaterialTheme.typography.labelSmall,
+                color = if (component.enabled) MaterialTheme.colorScheme.onSurface
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+                fontFamily = firaMonoFontFamily
+            )
+            ComponentBadges(
+                component = component,
+                isThors = isThors,
+                isDrifted = isDrifted
+            )
+        }
+
+        if (isBusy) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .size(16.dp),
+                strokeWidth = 2.dp
+            )
+        } else if (type == ComponentType.ACTIVITY) {
+            val canLaunch = capability.canLaunch(component) && component.enabled
+            TextButton(
+                onClick = { viewModel.launch(context, component) },
+                enabled = canLaunch
+            ) {
+                Text(
+                    text = if (component.launchRequiresRoot)
+                        stringResource(R.string.component_action_force_open)
+                    else stringResource(R.string.component_action_open),
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
+
+        Box {
+            IconButton(
+                onClick = { menuExpanded = true },
+                modifier = Modifier.minimumInteractiveComponentSize()
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.more_vert),
+                    contentDescription = stringResource(
+                        R.string.cd_component_actions,
+                        component.shortName
+                    ),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.component_action_copy)) },
+                    onClick = {
+                        menuExpanded = false
+                        onCopy(component.className)
+                    }
+                )
+                // Offered for an *exported* activity too: an ordinary startActivity still fails when
+                // the target app is frozen or suspended, and the shell route is the way through.
+                if (type == ComponentType.ACTIVITY &&
+                    capability.canForceLaunch &&
+                    !component.launchRequiresRoot
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.component_action_force_open)) },
+                        onClick = {
+                            menuExpanded = false
+                            viewModel.forceLaunch(component)
+                        }
+                    )
+                }
+                if (type == ComponentType.SERVICE && capability.canStopService) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.component_action_stop_now)) },
+                        onClick = {
+                            menuExpanded = false
+                            viewModel.stopService(component)
+                        }
+                    )
+                }
+                if (capability.canSetComponentState) {
+                    if (component.enabled) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.component_action_disable)) },
+                            onClick = {
+                                menuExpanded = false
+                                viewModel.requestDisable(type, component)
+                            }
+                        )
+                    } else {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.component_action_enable)) },
+                            onClick = {
+                                menuExpanded = false
+                                viewModel.enable(component)
+                            }
+                        )
+                    }
+                    if (component.isOverridden) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.component_action_reset)) },
+                            onClick = {
+                                menuExpanded = false
+                                viewModel.resetToDefault(component)
+                            }
+                        )
+                    }
+                }
+                if (isDrifted) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.component_action_forget)) },
+                        onClick = {
+                            menuExpanded = false
+                            viewModel.forget(component)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The chips under a component's name.
+ *
+ * Only what is *unusual* gets a chip. An enabled, exported activity that ships enabled is the
+ * overwhelming majority of rows and carries none — a list where every row is decorated tells the
+ * reader nothing about which rows to look at.
+ */
+@Composable
+private fun ComponentBadges(
+    component: ComponentDetail,
+    isThors: Boolean,
+    isDrifted: Boolean
+) {
+    val chips = buildList {
+        when {
+            // Thor's own row wins over the generic "disabled": it is the one the user can undo, and
+            // saying who did it is the entire point of keeping the ledger.
+            isThors && !component.enabled -> add(
+                stringResource(R.string.component_badge_restricted) to
+                        MaterialTheme.colorScheme.tertiaryContainer
+            )
+
+            isDrifted -> add(
+                stringResource(R.string.component_badge_drift) to
+                        MaterialTheme.colorScheme.secondaryContainer
+            )
+
+            !component.enabled -> add(
+                stringResource(R.string.component_badge_disabled) to
+                        MaterialTheme.colorScheme.errorContainer
+            )
+        }
+        if (!component.exported) {
+            add(
+                stringResource(R.string.component_badge_not_exported) to
+                        MaterialTheme.colorScheme.surfaceContainerHighest
+            )
+        }
+        if (!component.manifestDefaultEnabled) {
+            add(
+                stringResource(R.string.component_badge_off_by_default) to
+                        MaterialTheme.colorScheme.surfaceContainerHighest
+            )
+        }
+    }
+    if (chips.isEmpty()) return
+
+    Row(
+        modifier = Modifier.padding(top = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        chips.forEach { (text, color) ->
+            StatusChip(text = text, color = color)
+        }
     }
 }
 
@@ -1326,10 +1682,10 @@ private fun InfoCard(
 }
 
 private data class ComponentLists(
-    val activities: List<String>,
-    val services: List<String>,
-    val receivers: List<String>,
-    val providers: List<String>
+    val activities: List<ComponentDetail>,
+    val services: List<ComponentDetail>,
+    val receivers: List<ComponentDetail>,
+    val providers: List<ComponentDetail>
 )
 
 /**

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -1024,18 +1024,21 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
         val coroutineScope = rememberCoroutineScope()
         val classNameLabel = stringResource(R.string.class_name_label)
         val onCopyClassName: (String) -> Unit = { className ->
+            // Toast inside the coroutine, after the await — see AppInfoSheet for why. setClipEntry
+            // suspends, so a Toast beside the launch reports a copy that has not happened yet and
+            // may never happen if the scope is cancelled.
             coroutineScope.launch {
                 clipboard.setClipEntry(
                     ClipEntry(
                         android.content.ClipData.newPlainText(classNameLabel, className)
                     )
                 )
+                Toast.makeText(
+                    context,
+                    R.string.toast_copied_class_name,
+                    Toast.LENGTH_SHORT
+                ).show()
             }
-            Toast.makeText(
-                context,
-                (R.string.toast_copied_class_name),
-                Toast.LENGTH_SHORT
-            ).show()
         }
 
         ComponentControlBanner(

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentControlViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentControlViewModel.kt
@@ -97,6 +97,7 @@ class ComponentControlViewModel(
     val events: Flow<UiText> = _events.receiveAsFlow()
 
     private var ledgerJob: Job? = null
+    private var refreshJob: Job? = null
 
     init {
         viewModelScope.launch {
@@ -112,34 +113,48 @@ class ComponentControlViewModel(
      * The ledger collector is cancelled and restarted rather than filtered, because this view model
      * is scoped per package by its Koin key and a second collector on the old package would keep
      * overwriting the state with rows that belong to a screen the user has left.
+     *
+     * **A repeat call for the package already bound still re-reads the snapshot**, and only skips
+     * the state reset and the collector restart. That is what makes drift visible: the ledger is
+     * bookkeeping, so an app update, another root tool or a `pm clear` can re-enable a component
+     * behind Thor's back, and the disagreement is only computable against a *fresh*
+     * `getComponentEnabledSetting`. Returning early on a rebind — which is every reopen of the
+     * sheet — left the row still claiming "Restricted by Thor" until the process was restarted.
      */
     fun load(packageName: String, initial: ComponentSnapshot = ComponentSnapshot()) {
-        if (_uiState.value.packageName == packageName && ledgerJob?.isActive == true) return
-        ledgerJob?.cancel()
-        _uiState.update {
-            ComponentControlUiState(
-                packageName = packageName,
-                // Seeded from the snapshot the detail loader already fetched, so the list renders
-                // on the first frame. Without it the tab would blank itself on every open while a
-                // second, identical PackageManager round-trip ran.
-                isLoading = initial.isEmpty,
-                snapshot = initial,
-                consentAccepted = it.consentAccepted,
-            )
-        }
-        ledgerJob = viewModelScope.launch {
-            componentControl.observeOverrides(packageName).collect { rows ->
-                _uiState.update { it.copy(overrides = rows.associateBy { row -> row.className }) }
+        val alreadyBound = _uiState.value.packageName == packageName && ledgerJob?.isActive == true
+        if (!alreadyBound) {
+            ledgerJob?.cancel()
+            _uiState.update {
+                ComponentControlUiState(
+                    packageName = packageName,
+                    // Seeded from the snapshot the detail loader already fetched, so the list
+                    // renders on the first frame. Without it the tab would blank itself on every
+                    // open while a second, identical PackageManager round-trip ran.
+                    isLoading = initial.isEmpty,
+                    snapshot = initial,
+                    consentAccepted = it.consentAccepted,
+                )
+            }
+            ledgerJob = viewModelScope.launch {
+                componentControl.observeOverrides(packageName).collect { rows ->
+                    _uiState.update { it.copy(overrides = rows.associateBy { row -> row.className }) }
+                }
             }
         }
-        viewModelScope.launch {
+        // Cancelled and restarted so that repeated rebinds cannot stack PackageManager round-trips
+        // whose results then land out of order.
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
             // The capability read awaits the privilege probe; the snapshot is a PackageManager
             // round-trip. Neither depends on the other, but the snapshot is what the list renders,
             // so it lands first and the controls light up a moment later rather than the list
             // waiting on the probe.
             refreshSnapshot(packageName)
             val capability = capabilityProvider.capability()
-            _uiState.update { it.copy(capability = capability) }
+            // Same guard refreshSnapshot carries, for the same reason: a load() for another package
+            // may have landed while the probe was settling.
+            _uiState.update { if (it.packageName != packageName) it else it.copy(capability = capability) }
         }
     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentControlViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentControlViewModel.kt
@@ -1,0 +1,381 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.valhalla.thor.R
+import com.valhalla.thor.data.source.local.ComponentCapabilityProvider
+import com.valhalla.thor.domain.model.ComponentCapability
+import com.valhalla.thor.domain.model.ComponentDetail
+import com.valhalla.thor.domain.model.ComponentOverride
+import com.valhalla.thor.domain.model.ComponentSnapshot
+import com.valhalla.thor.domain.model.ComponentType
+import com.valhalla.thor.domain.repository.AppRepository
+import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.usecase.ComponentControlUseCase
+import com.valhalla.thor.util.UiText
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.KoinViewModel
+import org.koin.core.annotation.Named
+
+/**
+ * A disable the user has been asked to confirm, held while the first-use disclaimer is up.
+ *
+ * The whole request is parked, not just a flag, so the confirm button runs the exact action the user
+ * pressed. Re-deriving it from "the last row tapped" would break the moment a refresh reorders the
+ * list underneath the dialog.
+ */
+@Immutable
+data class PendingComponentDisable(
+    val type: ComponentType,
+    val component: ComponentDetail,
+)
+
+@Immutable
+data class ComponentControlUiState(
+    val packageName: String = "",
+    val isLoading: Boolean = true,
+    val snapshot: ComponentSnapshot = ComponentSnapshot(),
+    val capability: ComponentCapability = ComponentCapability.None,
+    /** Class name → the ledger row, for this package only. */
+    val overrides: Map<String, ComponentOverride> = emptyMap(),
+    /** The component a privileged call is running against, if any. One at a time, by design. */
+    val busyClassName: String? = null,
+    /**
+     * Starts `true` so the disclaimer cannot flash on screen during the first frame, before the
+     * preference has been read. A dialog that appears and vanishes unread is worse than one that
+     * appears a beat late.
+     */
+    val consentAccepted: Boolean = true,
+    val pendingConsent: PendingComponentDisable? = null,
+    val showRestoreAllConfirm: Boolean = false,
+) {
+    /** How many components of *this* package Thor's ledger says it changed. */
+    val restrictedCount: Int get() = overrides.size
+
+    /**
+     * A ledger row whose component is nonetheless enabled right now.
+     *
+     * The ledger is bookkeeping, not a source of truth — an app update, another root tool, or a
+     * `pm clear` can put a component back without telling Thor. Surfacing the disagreement is the
+     * whole reason drift is computed rather than assumed away.
+     */
+    fun isDrifted(component: ComponentDetail): Boolean =
+        overrides.containsKey(component.className) && component.enabled
+}
+
+@KoinViewModel
+class ComponentControlViewModel(
+    private val appRepository: AppRepository,
+    private val componentControl: ComponentControlUseCase,
+    private val capabilityProvider: ComponentCapabilityProvider,
+    private val preferenceRepository: PreferenceRepository,
+    @Named("io") private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ComponentControlUiState())
+    val uiState = _uiState.asStateFlow()
+
+    // Same shape and same reason as AppInfoDetailsViewModel's: a BUFFERED Channel so a message
+    // emitted while the tab's collector is not yet STARTED is delivered rather than dropped.
+    private val _events = Channel<UiText>(Channel.BUFFERED)
+    val events: Flow<UiText> = _events.receiveAsFlow()
+
+    private var ledgerJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            preferenceRepository.userPreferences.collect { prefs ->
+                _uiState.update { it.copy(consentAccepted = prefs.componentControlConsentAccepted) }
+            }
+        }
+    }
+
+    /**
+     * Bind to [packageName]. Safe to call again — the host drives it from a `LaunchedEffect`.
+     *
+     * The ledger collector is cancelled and restarted rather than filtered, because this view model
+     * is scoped per package by its Koin key and a second collector on the old package would keep
+     * overwriting the state with rows that belong to a screen the user has left.
+     */
+    fun load(packageName: String, initial: ComponentSnapshot = ComponentSnapshot()) {
+        if (_uiState.value.packageName == packageName && ledgerJob?.isActive == true) return
+        ledgerJob?.cancel()
+        _uiState.update {
+            ComponentControlUiState(
+                packageName = packageName,
+                // Seeded from the snapshot the detail loader already fetched, so the list renders
+                // on the first frame. Without it the tab would blank itself on every open while a
+                // second, identical PackageManager round-trip ran.
+                isLoading = initial.isEmpty,
+                snapshot = initial,
+                consentAccepted = it.consentAccepted,
+            )
+        }
+        ledgerJob = viewModelScope.launch {
+            componentControl.observeOverrides(packageName).collect { rows ->
+                _uiState.update { it.copy(overrides = rows.associateBy { row -> row.className }) }
+            }
+        }
+        viewModelScope.launch {
+            // The capability read awaits the privilege probe; the snapshot is a PackageManager
+            // round-trip. Neither depends on the other, but the snapshot is what the list renders,
+            // so it lands first and the controls light up a moment later rather than the list
+            // waiting on the probe.
+            refreshSnapshot(packageName)
+            val capability = capabilityProvider.capability()
+            _uiState.update { it.copy(capability = capability) }
+        }
+    }
+
+    private suspend fun refreshSnapshot(packageName: String) {
+        val snapshot = appRepository.getComponentDetails(packageName)
+        _uiState.update {
+            // Guard against a load() for a different package having landed while this was in
+            // flight — the state would otherwise show one app's components under another's name.
+            if (it.packageName != packageName) it
+            // On a null read the previous snapshot is kept, not cleared: a failed re-read after a
+            // successful disable would otherwise empty a list the user is looking at, which reads
+            // as "the disable deleted every component".
+            else it.copy(isLoading = false, snapshot = snapshot ?: it.snapshot)
+        }
+        if (snapshot == null) {
+            _events.send(UiText.StringResource(R.string.failed_to_load_app_details))
+        }
+    }
+
+    /**
+     * Open an activity.
+     *
+     * Two routes, chosen by [ComponentDetail.launchRequiresRoot] rather than by which button was
+     * pressed, so the caller cannot pick the wrong one. An exported, unguarded activity is reachable
+     * with an ordinary `startActivity` and takes it — no privilege, no shell, and the target sees a
+     * normal caller. Anything else needs uid 0 and goes through the gateway.
+     */
+    fun launch(context: Context, component: ComponentDetail) {
+        val packageName = _uiState.value.packageName
+        if (packageName.isEmpty()) return
+        if (!component.launchRequiresRoot) {
+            val result = runCatching {
+                context.startActivity(
+                    Intent().apply {
+                        this.component = ComponentName(packageName, component.className)
+                        // Required: `context` here is the Activity's, but a component-only intent
+                        // into another package still starts a task of its own, and on a Context that
+                        // is not an Activity (the sheet host in a wide layout) the flag is mandatory.
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                )
+            }
+            viewModelScope.launch { reportLaunch(result, component) }
+            return
+        }
+        forceLaunch(component)
+    }
+
+    /**
+     * Open an activity through the privileged shell, whatever its manifest says.
+     *
+     * Offered separately from [launch] because it is also the answer when an *exported* activity
+     * refuses an ordinary launch — a frozen or suspended app, or one whose task the caller is not
+     * allowed to touch.
+     */
+    fun forceLaunch(component: ComponentDetail) {
+        val packageName = _uiState.value.packageName
+        if (packageName.isEmpty()) return
+        runExclusively(component.className) {
+            reportLaunch(componentControl.forceLaunch(packageName, component.className), component)
+        }
+    }
+
+    private suspend fun reportLaunch(result: Result<Unit>, component: ComponentDetail) {
+        result
+            .onSuccess {
+                _events.send(
+                    UiText.StringResource(R.string.component_launched, component.shortName)
+                )
+            }
+            .onFailure { e -> sendFailure(e) }
+    }
+
+    fun stopService(component: ComponentDetail) {
+        val packageName = _uiState.value.packageName
+        if (packageName.isEmpty()) return
+        runExclusively(component.className) {
+            componentControl.stopService(packageName, component.className)
+                .onSuccess {
+                    _events.send(
+                        UiText.StringResource(R.string.component_service_stopped, component.shortName)
+                    )
+                }
+                .onFailure { e -> sendFailure(e) }
+        }
+    }
+
+    /**
+     * Ask to switch a component off.
+     *
+     * Routed through the disclaimer on the first ever disable. The check is here rather than in the
+     * composable so that every entry point to a disable — row menu, and anything added later —
+     * inherits it instead of each host remembering to ask.
+     */
+    fun requestDisable(type: ComponentType, component: ComponentDetail) {
+        if (!_uiState.value.consentAccepted) {
+            _uiState.update {
+                it.copy(pendingConsent = PendingComponentDisable(type, component))
+            }
+            return
+        }
+        performDisable(type, component)
+    }
+
+    fun onDisclaimerConfirmed() {
+        val pending = _uiState.value.pendingConsent ?: return
+        _uiState.update { it.copy(pendingConsent = null) }
+        viewModelScope.launch {
+            // Persisted before the action runs, not after it succeeds: the question asked was "do
+            // you understand what disabling does", and the answer does not become un-given because
+            // this particular component refused.
+            preferenceRepository.setComponentControlConsentAccepted(true)
+        }
+        performDisable(pending.type, pending.component)
+    }
+
+    fun onDisclaimerDismissed() {
+        _uiState.update { it.copy(pendingConsent = null) }
+    }
+
+    private fun performDisable(type: ComponentType, component: ComponentDetail) {
+        val packageName = _uiState.value.packageName
+        if (packageName.isEmpty()) return
+        runExclusively(component.className) {
+            componentControl.disable(packageName, type, component)
+                .onSuccess {
+                    _events.send(
+                        UiText.StringResource(R.string.component_disabled_success, component.shortName)
+                    )
+                    refreshSnapshot(packageName)
+                }
+                .onFailure { e -> sendFailure(e) }
+        }
+    }
+
+    fun enable(component: ComponentDetail) {
+        val packageName = _uiState.value.packageName
+        if (packageName.isEmpty()) return
+        runExclusively(component.className) {
+            componentControl.enable(packageName, component)
+                .onSuccess {
+                    _events.send(
+                        UiText.StringResource(R.string.component_enabled_success, component.shortName)
+                    )
+                    refreshSnapshot(packageName)
+                }
+                .onFailure { e -> sendFailure(e) }
+        }
+    }
+
+    fun resetToDefault(component: ComponentDetail) {
+        val packageName = _uiState.value.packageName
+        if (packageName.isEmpty()) return
+        runExclusively(component.className) {
+            componentControl.resetToDefault(packageName, component.className)
+                .onSuccess {
+                    _events.send(
+                        UiText.StringResource(R.string.component_reset_success, component.shortName)
+                    )
+                    refreshSnapshot(packageName)
+                }
+                .onFailure { e -> sendFailure(e) }
+        }
+    }
+
+    /** Drop a ledger row without touching the platform. Offered for a drifted row. */
+    fun forget(component: ComponentDetail) {
+        val packageName = _uiState.value.packageName
+        if (packageName.isEmpty()) return
+        viewModelScope.launch {
+            componentControl.forget(packageName, component.className)
+            _events.send(
+                UiText.StringResource(R.string.component_forgotten, component.shortName)
+            )
+        }
+    }
+
+    fun requestRestoreAll() {
+        _uiState.update { it.copy(showRestoreAllConfirm = true) }
+    }
+
+    fun dismissRestoreAll() {
+        _uiState.update { it.copy(showRestoreAllConfirm = false) }
+    }
+
+    /**
+     * Undo every component Thor recorded, across every package — not just this one.
+     *
+     * Package-wide would be the smaller promise, but the ledger's reason to exist is that a
+     * component disabled six weeks ago in an app the user has forgotten about is otherwise
+     * unfindable. The confirmation names the total so the scope is not a surprise.
+     */
+    fun confirmRestoreAll() {
+        val packageName = _uiState.value.packageName
+        _uiState.update { it.copy(showRestoreAllConfirm = false) }
+        viewModelScope.launch {
+            val outcome = withContext(ioDispatcher) { componentControl.restoreAll() }
+            _events.send(
+                if (outcome.isComplete) {
+                    UiText.PluralsResource(
+                        R.plurals.component_restore_all_success,
+                        outcome.restored,
+                    )
+                } else {
+                    UiText.StringResource(
+                        R.string.component_restore_all_partial,
+                        outcome.restored,
+                        outcome.attempted,
+                    )
+                }
+            )
+            if (packageName.isNotEmpty()) refreshSnapshot(packageName)
+        }
+    }
+
+    /**
+     * Run one privileged action at a time, marking its row busy for the duration.
+     *
+     * Serialising is not just cosmetic: `pm` and `am` reach the same `PackageManagerService` state,
+     * and two disables racing on one package can interleave into a `package-restrictions.xml` write
+     * that loses one of them. The busy marker also stops a double-tap becoming two disables and two
+     * ledger writes.
+     */
+    private fun runExclusively(className: String, block: suspend () -> Unit) {
+        if (_uiState.value.busyClassName != null) return
+        _uiState.update { it.copy(busyClassName = className) }
+        viewModelScope.launch {
+            try {
+                block()
+            } finally {
+                _uiState.update { it.copy(busyClassName = null) }
+            }
+        }
+    }
+
+    private suspend fun sendFailure(e: Throwable) {
+        _events.send(UiText.StringResource(R.string.error_format, e.message ?: ""))
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentControlViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentControlViewModel.kt
@@ -19,7 +19,9 @@ import com.valhalla.thor.domain.model.ComponentType
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.usecase.ComponentControlUseCase
+import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -377,6 +379,13 @@ class ComponentControlViewModel(
      * and two disables racing on one package can interleave into a `package-restrictions.xml` write
      * that loses one of them. The busy marker also stops a double-tap becoming two disables and two
      * ledger writes.
+     *
+     * The `catch` is load-bearing, not defensive habit. Every verb returns a `Result`, but the
+     * ledger write that follows a successful one happens inside `Result.onSuccess`, which does not
+     * catch — so a Room failure there (`SQLiteFullException`, a disk-I/O error) throws straight out
+     * of the use case. Without a catch that lands in `viewModelScope`'s uncaught handler and takes
+     * the process down, *after* the privileged change already succeeded. Reported like any other
+     * failure instead; `CancellationException` is rethrown so cancellation stays cancellation.
      */
     private fun runExclusively(className: String, block: suspend () -> Unit) {
         if (_uiState.value.busyClassName != null) return
@@ -384,6 +393,11 @@ class ComponentControlViewModel(
         viewModelScope.launch {
             try {
                 block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.e("ComponentControlViewModel", "Component action failed for $className", e)
+                sendFailure(e)
             } finally {
                 _uiState.update { it.copy(busyClassName = null) }
             }

--- a/app/src/main/res/drawable/more_vert.xml
+++ b/app/src/main/res/drawable/more_vert.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M480,800Q447,800 423.5,776.5Q400,753 400,720Q400,687 423.5,663.5Q447,640 480,640Q513,640 536.5,663.5Q560,687 560,720Q560,753 536.5,776.5Q513,800 480,800ZM480,560Q447,560 423.5,536.5Q400,513 400,480Q400,447 423.5,423.5Q447,400 480,400Q513,400 536.5,423.5Q560,447 560,480Q560,513 536.5,536.5Q513,560 480,560ZM480,320Q447,320 423.5,296.5Q400,273 400,240Q400,207 423.5,183.5Q447,160 480,160Q513,160 536.5,183.5Q560,207 560,240Q560,273 536.5,296.5Q513,320 480,320Z" />
+</vector>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -761,4 +761,59 @@
     <string name="cd_move_up">تحريك لأعلى</string>
     <string name="cd_move_down">تحريك لأسفل</string>
 
+    <!-- تبويب المكونات -->
+    <string name="component_action_open">فتح</string>
+    <string name="component_action_force_open">فرض الفتح</string>
+    <string name="component_action_copy">نسخ اسم الفئة</string>
+    <string name="component_action_stop_now">إيقاف الآن</string>
+    <string name="component_action_disable">تعطيل</string>
+    <string name="component_action_enable">تفعيل</string>
+    <string name="component_action_reset">إعادة التعيين إلى الافتراضي</string>
+    <string name="component_action_forget">إيقاف التتبّع</string>
+    <string name="cd_component_actions">إجراءات %1$s</string>
+
+    <string name="component_badge_restricted">مقيَّد بواسطة Thor</string>
+    <string name="component_badge_drift">تغيّر من مكان آخر</string>
+    <string name="component_badge_disabled">معطَّل</string>
+    <string name="component_badge_not_exported">غير مُصدَّر</string>
+    <string name="component_badge_off_by_default">معطَّل افتراضيًا</string>
+
+    <string name="component_blocker_no_privilege">فعِّل Root أو Shizuku لتغيير المكونات.</string>
+    <string name="component_blocker_shizuku_not_root">يتطلب تغيير المكونات تشغيل Shizuku بصلاحية Root. لا يمكن ذلك إذا كان Shizuku يعمل في وضع الصدفة (shell).</string>
+    <string name="component_blocker_dhizuku">لا يستطيع Dhizuku تغيير المكونات الفردية. استخدم Root أو Shizuku في وضع Root.</string>
+    <string name="component_control_requires_root_shizuku">يعمل Shizuku في وضع الصدفة (shell) لا بصلاحية Root. ويتطلب تغيير المكونات صلاحية Root.</string>
+    <string name="component_control_unsupported_dhizuku">لا يستطيع Dhizuku التحكم في المكونات الفردية.</string>
+
+    <string name="component_launched">تم فتح %1$s</string>
+    <string name="component_service_stopped">تم إيقاف %1$s</string>
+    <string name="component_disabled_success">تم تعطيل %1$s</string>
+    <string name="component_enabled_success">تم تفعيل %1$s</string>
+    <string name="component_reset_success">تمت إعادة %1$s إلى الوضع الافتراضي</string>
+    <string name="component_forgotten">تم إيقاف تتبّع %1$s</string>
+
+    <plurals name="component_restricted_count">
+        <item quantity="zero">لا توجد مكونات مقيَّدة بواسطة Thor</item>
+        <item quantity="one">مكوّن واحد مقيَّد بواسطة Thor</item>
+        <item quantity="two">مكوّنان مقيَّدان بواسطة Thor</item>
+        <item quantity="few">%1$d مكونات مقيَّدة بواسطة Thor</item>
+        <item quantity="many">%1$d مكوّنًا مقيَّدًا بواسطة Thor</item>
+        <item quantity="other">%1$d مكوّن مقيَّد بواسطة Thor</item>
+    </plurals>
+    <plurals name="component_restore_all_success">
+        <item quantity="zero">لم تتم استعادة أي مكوّن</item>
+        <item quantity="one">تمت استعادة مكوّن واحد</item>
+        <item quantity="two">تمت استعادة مكوّنين</item>
+        <item quantity="few">تمت استعادة %1$d مكونات</item>
+        <item quantity="many">تمت استعادة %1$d مكوّنًا</item>
+        <item quantity="other">تمت استعادة %1$d مكوّن</item>
+    </plurals>
+    <string name="component_restore_all_partial">تمت استعادة %1$d من %2$d — والباقي ما زال مقيَّدًا</string>
+    <string name="component_restore_all_action">استعادة الكل</string>
+    <string name="component_restore_all_title">استعادة كل المكونات؟</string>
+    <string name="component_restore_all_message">كل مكوّن عطّله Thor — في هذا التطبيق وفي كل التطبيقات الأخرى — سيعود إلى حالته الأصلية كما جاء بها التطبيق. أما المكونات التي غيّرتها أدوات أخرى فتبقى دون تغيير.</string>
+
+    <string name="component_disclaimer_title">تعطيل مكوّن؟</string>
+    <string name="component_disclaimer_message">يبقى %1$s جزءًا من التطبيق، لكنه يتوقف عن العمل فقط. نادرًا ما تتوقع التطبيقات ذلك، لذا قد تتعطل إحدى الميزات دون أي رسالة خطأ، أو قد ينهار التطبيق. ويسجّل Thor كل ما يعطّله حتى تتمكن من التراجع لاحقًا.</string>
+    <string name="component_disclaimer_confirm">تعطيله</string>
+
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -747,7 +747,7 @@
         <item quantity="one">Se restauró %1$d componente</item>
         <item quantity="other">Se restauraron %1$d componentes</item>
     </plurals>
-    <string name="component_restore_all_partial">Se restauraron %1$d de %2$d — el resto siguen restringidos</string>
+    <string name="component_restore_all_partial">Restauración: %1$d de %2$d — el resto sigue restringido</string>
     <string name="component_restore_all_action">Restaurar todo</string>
     <string name="component_restore_all_title">¿Restaurar todos los componentes?</string>
     <string name="component_restore_all_message">Todos los componentes que Thor desactivó — en esta aplicación y en todas las demás — vuelven al estado con el que venían de fábrica. Los componentes cambiados por otras herramientas se quedan tal cual.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -710,4 +710,50 @@
     <string name="cd_move_up">Mover hacia arriba</string>
     <string name="cd_move_down">Mover hacia abajo</string>
 
+    <string name="component_action_open">Abrir</string>
+    <string name="component_action_force_open">Forzar apertura</string>
+    <string name="component_action_copy">Copiar el nombre de la clase</string>
+    <string name="component_action_stop_now">Detener ahora</string>
+    <string name="component_action_disable">Desactivar</string>
+    <string name="component_action_enable">Activar</string>
+    <string name="component_action_reset">Restablecer al valor predeterminado</string>
+    <string name="component_action_forget">Olvidar</string>
+    <string name="cd_component_actions">Acciones para %1$s</string>
+
+    <string name="component_badge_restricted">Restringido por Thor</string>
+    <string name="component_badge_drift">Cambiado en otro sitio</string>
+    <string name="component_badge_disabled">Desactivado</string>
+    <string name="component_badge_not_exported">No exportado</string>
+    <string name="component_badge_off_by_default">Desactivado de forma predeterminada</string>
+
+    <string name="component_blocker_no_privilege">Activa Root o Shizuku para cambiar componentes.</string>
+    <string name="component_blocker_shizuku_not_root">Para cambiar componentes hace falta Shizuku iniciado como root. Un Shizuku en modo shell no puede.</string>
+    <string name="component_blocker_dhizuku">Dhizuku no puede cambiar componentes individuales. Usa Root o un Shizuku en modo root.</string>
+    <string name="component_control_requires_root_shizuku">Shizuku se está ejecutando como shell, no como root. Cambiar componentes requiere root.</string>
+    <string name="component_control_unsupported_dhizuku">Dhizuku no puede controlar componentes individuales.</string>
+
+    <string name="component_launched">Se abrió %1$s</string>
+    <string name="component_service_stopped">Se detuvo %1$s</string>
+    <string name="component_disabled_success">Se desactivó %1$s</string>
+    <string name="component_enabled_success">Se activó %1$s</string>
+    <string name="component_reset_success">%1$s se restableció al valor predeterminado</string>
+    <string name="component_forgotten">Se dejó de hacer seguimiento de %1$s</string>
+
+    <plurals name="component_restricted_count">
+        <item quantity="one">%1$d componente restringido por Thor</item>
+        <item quantity="other">%1$d componentes restringidos por Thor</item>
+    </plurals>
+    <plurals name="component_restore_all_success">
+        <item quantity="one">Se restauró %1$d componente</item>
+        <item quantity="other">Se restauraron %1$d componentes</item>
+    </plurals>
+    <string name="component_restore_all_partial">Se restauraron %1$d de %2$d — el resto siguen restringidos</string>
+    <string name="component_restore_all_action">Restaurar todo</string>
+    <string name="component_restore_all_title">¿Restaurar todos los componentes?</string>
+    <string name="component_restore_all_message">Todos los componentes que Thor desactivó — en esta aplicación y en todas las demás — vuelven al estado con el que venían de fábrica. Los componentes cambiados por otras herramientas se quedan tal cual.</string>
+
+    <string name="component_disclaimer_title">¿Desactivar un componente?</string>
+    <string name="component_disclaimer_message">%1$s sigue formando parte de la aplicación; simplemente deja de ejecutarse. Las aplicaciones rara vez esperan esto, así que una función puede dejar de funcionar sin dar ningún error, o la aplicación puede cerrarse de forma inesperada. Thor registra lo que desactiva para que puedas deshacerlo más tarde.</string>
+    <string name="component_disclaimer_confirm">Desactivarlo</string>
+
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -747,7 +747,7 @@
         <item quantity="one">%1$d composant rétabli</item>
         <item quantity="other">%1$d composants rétablis</item>
     </plurals>
-    <string name="component_restore_all_partial">%1$d composants rétablis sur %2$d — les autres restent restreints</string>
+    <string name="component_restore_all_partial">Rétablissement : %1$d sur %2$d — les autres restent restreints</string>
     <string name="component_restore_all_action">Tout rétablir</string>
     <string name="component_restore_all_title">Rétablir tous les composants ?</string>
     <string name="component_restore_all_message">Chaque composant désactivé par Thor — dans cette application comme dans toutes les autres — retrouve l\'état d\'origine. Les composants modifiés par d\'autres outils ne sont pas touchés.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -710,4 +710,50 @@
     <string name="cd_move_up">Déplacer vers le haut</string>
     <string name="cd_move_down">Déplacer vers le bas</string>
 
+    <string name="component_action_open">Ouvrir</string>
+    <string name="component_action_force_open">Forcer l\'ouverture</string>
+    <string name="component_action_copy">Copier le nom de classe</string>
+    <string name="component_action_stop_now">Arrêter maintenant</string>
+    <string name="component_action_disable">Désactiver</string>
+    <string name="component_action_enable">Activer</string>
+    <string name="component_action_reset">Rétablir la valeur par défaut</string>
+    <string name="component_action_forget">Oublier</string>
+    <string name="cd_component_actions">Actions pour %1$s</string>
+
+    <string name="component_badge_restricted">Restreint par Thor</string>
+    <string name="component_badge_drift">Modifié ailleurs</string>
+    <string name="component_badge_disabled">Désactivé</string>
+    <string name="component_badge_not_exported">Non exporté</string>
+    <string name="component_badge_off_by_default">Désactivé par défaut</string>
+
+    <string name="component_blocker_no_privilege">Activez Root ou Shizuku pour modifier les composants.</string>
+    <string name="component_blocker_shizuku_not_root">La modification des composants nécessite un Shizuku démarré en root. Un Shizuku en mode shell ne le peut pas.</string>
+    <string name="component_blocker_dhizuku">Dhizuku ne peut pas modifier les composants individuels. Utilisez Root ou un Shizuku en mode root.</string>
+    <string name="component_control_requires_root_shizuku">Shizuku fonctionne en mode shell, pas en root. La modification des composants nécessite root.</string>
+    <string name="component_control_unsupported_dhizuku">Dhizuku ne peut pas contrôler les composants individuels.</string>
+
+    <string name="component_launched">%1$s ouvert</string>
+    <string name="component_service_stopped">%1$s arrêté</string>
+    <string name="component_disabled_success">%1$s désactivé</string>
+    <string name="component_enabled_success">%1$s activé</string>
+    <string name="component_reset_success">%1$s rétabli à sa valeur par défaut</string>
+    <string name="component_forgotten">Suivi de %1$s arrêté</string>
+
+    <plurals name="component_restricted_count">
+        <item quantity="one">%1$d composant restreint par Thor</item>
+        <item quantity="other">%1$d composants restreints par Thor</item>
+    </plurals>
+    <plurals name="component_restore_all_success">
+        <item quantity="one">%1$d composant rétabli</item>
+        <item quantity="other">%1$d composants rétablis</item>
+    </plurals>
+    <string name="component_restore_all_partial">%1$d composants rétablis sur %2$d — les autres restent restreints</string>
+    <string name="component_restore_all_action">Tout rétablir</string>
+    <string name="component_restore_all_title">Rétablir tous les composants ?</string>
+    <string name="component_restore_all_message">Chaque composant désactivé par Thor — dans cette application comme dans toutes les autres — retrouve l\'état d\'origine. Les composants modifiés par d\'autres outils ne sont pas touchés.</string>
+
+    <string name="component_disclaimer_title">Désactiver un composant ?</string>
+    <string name="component_disclaimer_message">%1$s reste dans l\'application ; il cesse simplement de s\'exécuter. Les applications s\'y attendent rarement : une fonctionnalité peut cesser de marcher sans erreur, ou l\'application peut planter. Thor enregistre ce qu\'il désactive pour que vous puissiez revenir en arrière plus tard.</string>
+    <string name="component_disclaimer_confirm">Le désactiver</string>
+
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -791,4 +791,58 @@
     <string name="clear_all_caches_requires_usage_access">Shizuku nie może wyczyścić pamięci podręcznej wszystkich aplikacji bez dostępu do danych o użyciu. Androidowi trzeba podać, ile bajtów ma odzyskać, a tylko to uprawnienie pozwala zmierzyć, ile pamięci podręcznej jest. Przyznaj aplikacji Thor dostęp do danych o użyciu w Ustawieniach i spróbuj ponownie.</string>
     <string name="clear_all_caches_unsupported_dhizuku">Dhizuku nie może czyścić pamięci podręcznej. Nie ma powłoki, w której uruchomiłby androidowe czyszczenie pamięci podręcznej, a API Device Owner nie ma odpowiednika. Przełącz się na Root lub Shizuku.</string>
 
+    <!-- Component control (App info → Components).
+         "Force open" is the label for an activity an ordinary launch cannot reach — unexported, or
+         guarded by a permission Thor does not hold. It needs root; the platform grants the waiver to
+         uid 0 alone, so a Shizuku running as shell cannot do it either. -->
+    <string name="component_action_open">Otwórz</string>
+    <string name="component_action_force_open">Wymuś otwarcie</string>
+    <string name="component_action_copy">Kopiuj nazwę klasy</string>
+    <string name="component_action_stop_now">Zatrzymaj teraz</string>
+    <string name="component_action_disable">Wyłącz</string>
+    <string name="component_action_enable">Włącz</string>
+    <string name="component_action_reset">Przywróć stan domyślny</string>
+    <string name="component_action_forget">Zapomnij</string>
+    <string name="cd_component_actions">Akcje dla %1$s</string>
+
+    <string name="component_badge_restricted">Ograniczony przez aplikację Thor</string>
+    <string name="component_badge_drift">Zmieniony gdzie indziej</string>
+    <string name="component_badge_disabled">Wyłączony</string>
+    <string name="component_badge_not_exported">Nieeksportowany</string>
+    <string name="component_badge_off_by_default">Domyślnie wyłączony</string>
+
+    <string name="component_blocker_no_privilege">Włącz Root lub Shizuku, aby zmieniać komponenty.</string>
+    <string name="component_blocker_shizuku_not_root">Zmienianie komponentów wymaga Shizuku uruchomionego jako root. Shizuku w trybie powłoki tego nie potrafi.</string>
+    <string name="component_blocker_dhizuku">Dhizuku nie może zmieniać pojedynczych komponentów. Użyj trybu Root lub Shizuku w trybie root.</string>
+    <string name="component_control_requires_root_shizuku">Shizuku działa jako powłoka, a nie jako root. Zmienianie komponentów wymaga dostępu root.</string>
+    <string name="component_control_unsupported_dhizuku">Dhizuku nie może sterować pojedynczymi komponentami.</string>
+
+    <string name="component_launched">Otwarto %1$s</string>
+    <string name="component_service_stopped">Zatrzymano %1$s</string>
+    <string name="component_disabled_success">Wyłączono %1$s</string>
+    <string name="component_enabled_success">Włączono %1$s</string>
+    <string name="component_reset_success">%1$s — przywrócono stan domyślny</string>
+    <string name="component_forgotten">Przestano śledzić %1$s</string>
+
+    <plurals name="component_restricted_count">
+        <item quantity="one">%1$d komponent ograniczony przez aplikację Thor</item>
+        <item quantity="few">%1$d komponenty ograniczone przez aplikację Thor</item>
+        <item quantity="many">%1$d komponentów ograniczonych przez aplikację Thor</item>
+        <item quantity="other">%1$d komponentu ograniczonego przez aplikację Thor</item>
+    </plurals>
+    <plurals name="component_restore_all_success">
+        <item quantity="one">Przywrócono %1$d komponent</item>
+        <item quantity="few">Przywrócono %1$d komponenty</item>
+        <item quantity="many">Przywrócono %1$d komponentów</item>
+        <item quantity="other">Przywrócono %1$d komponentu</item>
+    </plurals>
+    <string name="component_restore_all_partial">Przywrócono %1$d z %2$d — reszta nadal jest ograniczona</string>
+    <string name="component_restore_all_action">Przywróć wszystkie</string>
+    <string name="component_restore_all_title">Przywrócić wszystkie komponenty?</string>
+    <string name="component_restore_all_message">Każdy komponent wyłączony przez aplikację Thor — w tej aplikacji i we wszystkich pozostałych — wróci do stanu, w jakim został dostarczony. Komponenty zmienione przez inne narzędzia zostaną nietknięte.</string>
+
+    <string name="component_disclaimer_title">Wyłączyć komponent?</string>
+    <string name="component_disclaimer_message">%1$s nadal pozostanie częścią aplikacji; przestanie tylko działać. Aplikacje rzadko się tego spodziewają, więc jakaś funkcja może przestać działać bez żadnego błędu albo aplikacja może ulec awarii. Thor zapisuje, co wyłącza, aby można było to później cofnąć.</string>
+    <string name="component_disclaimer_confirm">Wyłącz go</string>
+
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -578,4 +578,36 @@
     <string name="backup_hub_action_delete">Excluir</string>
     <string name="backup_hub_action_share">Compartilhar</string>
 
+    <!-- Component control. Only the rows where Brazilian usage diverges from values-pt:
+         repor/predefinição → restaurar/padrão, restringido → restrito, aplicação → aplicativo,
+         "está a correr" → "está rodando", "noutro sítio" → "em outro lugar". Everything else in
+         that block — Abrir, Parar agora, Desativar, Ativar, Esquecer, the badges, the Dhizuku
+         blockers — reads the same in both and resolves through values-pt. -->
+    <string name="component_action_force_open">Forçar abertura</string>
+    <string name="component_action_reset">Restaurar padrão</string>
+
+    <string name="component_badge_restricted">Restrito pelo Thor</string>
+    <string name="component_badge_drift">Alterado em outro lugar</string>
+    <string name="component_badge_off_by_default">Desativado por padrão</string>
+
+    <string name="component_control_requires_root_shizuku">O Shizuku está rodando como shell, não como root. Alterar componentes exige root.</string>
+
+    <string name="component_reset_success">%1$s restaurado para o padrão</string>
+
+    <plurals name="component_restricted_count">
+        <item quantity="one">%1$d componente restrito pelo Thor</item>
+        <item quantity="other">%1$d componentes restritos pelo Thor</item>
+    </plurals>
+    <plurals name="component_restore_all_success">
+        <item quantity="one">%1$d componente restaurado</item>
+        <item quantity="other">%1$d componentes restaurados</item>
+    </plurals>
+    <string name="component_restore_all_partial">Restaurados %1$d de %2$d — os demais continuam restritos</string>
+    <string name="component_restore_all_action">Restaurar tudo</string>
+    <string name="component_restore_all_title">Restaurar todos os componentes?</string>
+    <string name="component_restore_all_message">Todos os componentes que o Thor desativou — neste aplicativo e em todos os outros — voltam ao estado original. Os componentes alterados por outras ferramentas ficam intactos.</string>
+
+    <string name="component_disclaimer_message">%1$s continua fazendo parte do aplicativo; apenas deixa de ser executado. Os aplicativos raramente contam com isso, então um recurso pode parar de funcionar sem nenhum erro, ou o aplicativo pode travar. O Thor registra o que desativa para que você possa desfazer depois.</string>
+    <string name="component_disclaimer_confirm">Desativar mesmo assim</string>
+
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -602,7 +602,7 @@
         <item quantity="one">%1$d componente restaurado</item>
         <item quantity="other">%1$d componentes restaurados</item>
     </plurals>
-    <string name="component_restore_all_partial">Restaurados %1$d de %2$d — os demais continuam restritos</string>
+    <string name="component_restore_all_partial">Restauração: %1$d de %2$d — os demais continuam restritos</string>
     <string name="component_restore_all_action">Restaurar tudo</string>
     <string name="component_restore_all_title">Restaurar todos os componentes?</string>
     <string name="component_restore_all_message">Todos os componentes que o Thor desativou — neste aplicativo e em todos os outros — voltam ao estado original. Os componentes alterados por outras ferramentas ficam intactos.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -772,4 +772,54 @@
     <string name="clear_all_caches_requires_usage_access">O Shizuku não consegue limpar a cache de todas as aplicações sem acesso à utilização. É preciso indicar ao Android quantos bytes deve libertar, e só essa permissão consegue medir quanta cache existe. Conceda acesso à utilização ao Thor nas Definições e tente novamente.</string>
     <string name="clear_all_caches_unsupported_dhizuku">O Dhizuku não consegue limpar caches. Não tem shell onde executar a limpeza de cache do Android, e a API de Device Owner não tem equivalente. Mude para Root ou Shizuku.</string>
 
+    <!-- Component control (App info → Components).
+         "Force open" is the label for an activity an ordinary launch cannot reach — unexported, or
+         guarded by a permission Thor does not hold. It needs root; the platform grants the waiver to
+         uid 0 alone, so a Shizuku running as shell cannot do it either. -->
+    <string name="component_action_open">Abrir</string>
+    <string name="component_action_force_open">Forçar a abertura</string>
+    <string name="component_action_copy">Copiar o nome da classe</string>
+    <string name="component_action_stop_now">Parar agora</string>
+    <string name="component_action_disable">Desativar</string>
+    <string name="component_action_enable">Ativar</string>
+    <string name="component_action_reset">Repor a predefinição</string>
+    <string name="component_action_forget">Esquecer</string>
+    <string name="cd_component_actions">Ações para %1$s</string>
+
+    <string name="component_badge_restricted">Restringido pelo Thor</string>
+    <string name="component_badge_drift">Alterado noutro sítio</string>
+    <string name="component_badge_disabled">Desativado</string>
+    <string name="component_badge_not_exported">Não exportado</string>
+    <string name="component_badge_off_by_default">Desativado de origem</string>
+
+    <string name="component_blocker_no_privilege">Ative o Root ou o Shizuku para alterar componentes.</string>
+    <string name="component_blocker_shizuku_not_root">Alterar componentes exige que o Shizuku tenha sido iniciado como root. Um Shizuku em modo shell não consegue.</string>
+    <string name="component_blocker_dhizuku">O Dhizuku não consegue alterar componentes individuais. Use Root ou um Shizuku em modo root.</string>
+    <string name="component_control_requires_root_shizuku">O Shizuku está a correr como shell, não como root. Alterar componentes exige root.</string>
+    <string name="component_control_unsupported_dhizuku">O Dhizuku não consegue controlar componentes individuais.</string>
+
+    <string name="component_launched">%1$s aberto</string>
+    <string name="component_service_stopped">%1$s parado</string>
+    <string name="component_disabled_success">%1$s desativado</string>
+    <string name="component_enabled_success">%1$s ativado</string>
+    <string name="component_reset_success">%1$s reposto na predefinição</string>
+    <string name="component_forgotten">O Thor deixou de acompanhar %1$s</string>
+
+    <plurals name="component_restricted_count">
+        <item quantity="one">%1$d componente restringido pelo Thor</item>
+        <item quantity="other">%1$d componentes restringidos pelo Thor</item>
+    </plurals>
+    <plurals name="component_restore_all_success">
+        <item quantity="one">%1$d componente reposto</item>
+        <item quantity="other">%1$d componentes repostos</item>
+    </plurals>
+    <string name="component_restore_all_partial">Repostos %1$d de %2$d — os restantes continuam restringidos</string>
+    <string name="component_restore_all_action">Repor tudo</string>
+    <string name="component_restore_all_title">Repor todos os componentes?</string>
+    <string name="component_restore_all_message">Todos os componentes que o Thor desativou — nesta aplicação e em todas as outras — voltam ao estado de origem. Os componentes alterados por outras ferramentas ficam intactos.</string>
+
+    <string name="component_disclaimer_title">Desativar o componente?</string>
+    <string name="component_disclaimer_message">%1$s continua a fazer parte da aplicação; apenas deixa de ser executado. As aplicações raramente contam com isso, por isso uma funcionalidade pode deixar de funcionar sem qualquer erro, ou a aplicação pode falhar. O Thor regista o que desativa para que possa desfazer mais tarde.</string>
+    <string name="component_disclaimer_confirm">Desativá-lo</string>
+
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -813,7 +813,7 @@
         <item quantity="one">%1$d componente reposto</item>
         <item quantity="other">%1$d componentes repostos</item>
     </plurals>
-    <string name="component_restore_all_partial">Repostos %1$d de %2$d — os restantes continuam restringidos</string>
+    <string name="component_restore_all_partial">Reposição: %1$d de %2$d — os restantes continuam restringidos</string>
     <string name="component_restore_all_action">Repor tudo</string>
     <string name="component_restore_all_title">Repor todos os componentes?</string>
     <string name="component_restore_all_message">Todos os componentes que o Thor desativou — nesta aplicação e em todas as outras — voltam ao estado de origem. Os componentes alterados por outras ferramentas ficam intactos.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -698,4 +698,48 @@
     <string name="cd_move_up">上移</string>
     <string name="cd_move_down">下移</string>
 
+    <string name="component_action_open">打开</string>
+    <string name="component_action_force_open">强制打开</string>
+    <string name="component_action_copy">复制类名</string>
+    <string name="component_action_stop_now">立即停止</string>
+    <string name="component_action_disable">禁用</string>
+    <string name="component_action_enable">启用</string>
+    <string name="component_action_reset">恢复默认</string>
+    <string name="component_action_forget">不再跟踪</string>
+    <string name="cd_component_actions">%1$s 的操作</string>
+
+    <string name="component_badge_restricted">已被 Thor 限制</string>
+    <string name="component_badge_drift">已在别处更改</string>
+    <string name="component_badge_disabled">已禁用</string>
+    <string name="component_badge_not_exported">未导出</string>
+    <string name="component_badge_off_by_default">默认关闭</string>
+
+    <string name="component_blocker_no_privilege">开启 Root 或 Shizuku 才能更改组件。</string>
+    <string name="component_blocker_shizuku_not_root">更改组件需要以 root 身份启动的 Shizuku。shell 模式的 Shizuku 无法做到。</string>
+    <string name="component_blocker_dhizuku">Dhizuku 无法更改单个组件。请使用 Root 或 root 模式的 Shizuku。</string>
+    <string name="component_control_requires_root_shizuku">Shizuku 正以 shell 身份运行，而非 root。更改组件需要 root 权限。</string>
+    <string name="component_control_unsupported_dhizuku">Dhizuku 无法控制单个组件。</string>
+
+    <string name="component_launched">已打开 %1$s</string>
+    <string name="component_service_stopped">已停止 %1$s</string>
+    <string name="component_disabled_success">已禁用 %1$s</string>
+    <string name="component_enabled_success">已启用 %1$s</string>
+    <string name="component_reset_success">%1$s 已恢复默认</string>
+    <string name="component_forgotten">已停止跟踪 %1$s</string>
+
+    <plurals name="component_restricted_count">
+        <item quantity="other">Thor 已限制 %1$d 个组件</item>
+    </plurals>
+    <plurals name="component_restore_all_success">
+        <item quantity="other">已恢复 %1$d 个组件</item>
+    </plurals>
+    <string name="component_restore_all_partial">已恢复 %2$d 个组件中的 %1$d 个 — 其余仍处于受限状态</string>
+    <string name="component_restore_all_action">全部恢复</string>
+    <string name="component_restore_all_title">恢复所有组件？</string>
+    <string name="component_restore_all_message">Thor 禁用过的每一个组件 — 无论在此应用中还是在其他应用中 — 都会恢复为出厂时的状态。由其他工具更改的组件不会受到影响。</string>
+
+    <string name="component_disclaimer_title">禁用此组件？</string>
+    <string name="component_disclaimer_message">%1$s 仍会保留在应用中，只是不再运行。应用通常不会预料到这种情况，因此某项功能可能会在没有任何错误提示的情况下失效，应用也可能崩溃。Thor 会记录它禁用过的内容，方便你之后撤销。</string>
+    <string name="component_disclaimer_confirm">确认禁用</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -554,6 +554,57 @@
     <string name="cd_collapse">Collapse</string>
     <string name="cd_expand">Expand</string>
     <string name="components_none_declared">None declared</string>
+
+    <!-- Component control (App info → Components).
+         "Force open" is the label for an activity an ordinary launch cannot reach — unexported, or
+         guarded by a permission Thor does not hold. It needs root; the platform grants the waiver to
+         uid 0 alone, so a Shizuku running as shell cannot do it either. -->
+    <string name="component_action_open">Open</string>
+    <string name="component_action_force_open">Force open</string>
+    <string name="component_action_copy">Copy class name</string>
+    <string name="component_action_stop_now">Stop now</string>
+    <string name="component_action_disable">Disable</string>
+    <string name="component_action_enable">Enable</string>
+    <string name="component_action_reset">Reset to default</string>
+    <string name="component_action_forget">Forget</string>
+    <string name="cd_component_actions">Actions for %1$s</string>
+
+    <string name="component_badge_restricted">Restricted by Thor</string>
+    <string name="component_badge_drift">Changed elsewhere</string>
+    <string name="component_badge_disabled">Disabled</string>
+    <string name="component_badge_not_exported">Not exported</string>
+    <string name="component_badge_off_by_default">Off by default</string>
+
+    <string name="component_blocker_no_privilege">Turn on Root or Shizuku to change components.</string>
+    <string name="component_blocker_shizuku_not_root">Changing components needs Shizuku started as root. A shell-mode Shizuku cannot.</string>
+    <string name="component_blocker_dhizuku">Dhizuku cannot change individual components. Use Root or a root-mode Shizuku.</string>
+    <string name="component_control_requires_root_shizuku">Shizuku is running as shell, not root. Changing components needs root.</string>
+    <string name="component_control_unsupported_dhizuku">Dhizuku cannot control individual components.</string>
+
+    <string name="component_launched">Opened %1$s</string>
+    <string name="component_service_stopped">Stopped %1$s</string>
+    <string name="component_disabled_success">Disabled %1$s</string>
+    <string name="component_enabled_success">Enabled %1$s</string>
+    <string name="component_reset_success">%1$s reset to default</string>
+    <string name="component_forgotten">Stopped tracking %1$s</string>
+
+    <plurals name="component_restricted_count">
+        <item quantity="one">%1$d component restricted by Thor</item>
+        <item quantity="other">%1$d components restricted by Thor</item>
+    </plurals>
+    <plurals name="component_restore_all_success">
+        <item quantity="one">Restored %1$d component</item>
+        <item quantity="other">Restored %1$d components</item>
+    </plurals>
+    <string name="component_restore_all_partial" tools:ignore="PluralsCandidate">Restored %1$d of %2$d — the rest are still restricted</string>
+    <string name="component_restore_all_action">Restore all</string>
+    <string name="component_restore_all_title">Restore every component?</string>
+    <string name="component_restore_all_message">Every component Thor disabled — in this app and in every other — goes back to how it shipped. Components changed by other tools are left alone.</string>
+
+    <string name="component_disclaimer_title">Disable a component?</string>
+    <string name="component_disclaimer_message">%1$s stays part of the app; it just stops running. Apps rarely expect this, so a feature may break with no error, or the app may crash. Thor records what it disables so you can undo it later.</string>
+    <string name="component_disclaimer_confirm">Disable it</string>
+
     <string name="section_native_libs_title">Native Libraries (.so)</string>
     <string name="no_native_libs_found">No native libraries found</string>
     <string name="section_req_features_title">Required Features</string>

--- a/app/src/test/java/com/valhalla/thor/data/freezer/BulkFreezeWorkerTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/freezer/BulkFreezeWorkerTest.kt
@@ -3,6 +3,7 @@
 
 package com.valhalla.thor.data.freezer
 
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
 import com.valhalla.thor.domain.model.ObbProbe
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
@@ -189,6 +190,20 @@ private class RecordingSystemRepository(
         unreachable("executeShellCommand")
 
     override suspend fun probeObb(packageName: String): ObbProbe = unreachable("probeObb")
+
+    override suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState,
+    ): Result<Unit> = unreachable("setComponentEnabled")
+
+    override suspend fun forceLaunchActivity(
+        packageName: String,
+        className: String,
+    ): Result<Unit> = unreachable("forceLaunchActivity")
+
+    override suspend fun stopService(packageName: String, className: String): Result<Unit> =
+        unreachable("stopService")
 
     private fun unreachable(name: String): Nothing =
         throw UnsupportedOperationException("$name is not reachable from a bulk freeze worker")

--- a/app/src/test/java/com/valhalla/thor/data/source/local/ComponentCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/ComponentCommandsTest.kt
@@ -291,4 +291,177 @@ class ComponentCommandsTest {
         val failure = requireNotNull(componentCommandFailure(0, "Error: " + "x".repeat(500)))
         assertEquals(200, failure.length)
     }
+
+    /**
+     * `ShellCommand.exec` announces an exception with a header line and puts the exception itself on
+     * the next one, so a plain first-match scan reports "Exception occurred while executing
+     * 'start':" — a sentence that tells the user nothing. The specific markers are searched across
+     * the whole output before the generic one is considered.
+     *
+     * Verbatim stderr from an Android 17 `am start` of an unexported activity at the shell uid.
+     */
+    @Test
+    fun `the specific marker beats the exception header above it`() {
+        val output = """
+            Starting: Intent { cmp=com.google.android.deskclock/com.android.deskclock.ringtone.RingtoneSearchActivity }
+
+            Exception occurred while executing 'start':
+            java.lang.SecurityException: Permission Denial: starting Intent { cmp=com.google.android.deskclock/com.android.deskclock.ringtone.RingtoneSearchActivity } from null (pid=7714, uid=2000) not exported from uid 10175
+            	at com.android.server.wm.ActivityStarter.executeRequest(ActivityStarter.java:1299)
+        """.trimIndent()
+        val failure = requireNotNull(componentCommandFailure(exitCode = 255, output = output))
+        assertTrue("the header was reported instead of the denial", failure.contains("SecurityException"))
+        assertFalse(failure.contains("Exception occurred while executing"))
+    }
+
+    /**
+     * With no marker matching anywhere, the line *after* the header is reported rather than the
+     * header — that is where `ShellCommand.exec` puts the exception, and a bare exception type still
+     * says more than "something happened".
+     */
+    @Test
+    fun `the line after the header is reported in preference to the header`() {
+        val output = """
+            Stopping service: Intent { cmp=com.example.app/.SyncService }
+            Exception occurred while executing 'stopservice':
+            java.lang.NullPointerException
+        """.trimIndent()
+        assertEquals(
+            "java.lang.NullPointerException",
+            componentCommandFailure(exitCode = 255, output = output),
+        )
+    }
+
+    /** …and the header itself when there is no line after it worth reporting. */
+    @Test
+    fun `the header stands alone when only a stack frame follows it`() {
+        val output = """
+            Exception occurred while executing 'stopservice':
+            	at com.android.server.am.ActivityManagerShellCommand.onCommand(AMSC.java:12)
+        """.trimIndent()
+        val failure = requireNotNull(componentCommandFailure(exitCode = 255, output = output))
+        assertTrue(failure.startsWith("Exception occurred while executing"))
+    }
+
+    /**
+     * The failure a "Restore all" hits for a component an app update has removed, verbatim from an
+     * Android 17 `pm default-state`. The message names the component and is the whole point of
+     * reporting a line at all — before `Exception:` was a marker, the user got the header instead.
+     */
+    @Test
+    fun `a missing component names itself`() {
+        val output = """
+
+            Exception occurred while executing 'default-state':
+            java.lang.IllegalArgumentException: Component class com.does.not.Exist does not exist in com.google.android.deskclock
+            	at com.android.server.pm.PackageManagerService.setEnabledSettings(PackageManagerService.java:4257)
+        """.trimIndent()
+        val failure = requireNotNull(componentCommandFailure(exitCode = 255, output = output))
+        assertTrue(failure.contains("IllegalArgumentException"))
+        assertTrue(failure.contains("com.does.not.Exist"))
+    }
+
+    // --- the stopservice verdict ---
+    //
+    // `am stopservice` exits **255 whatever happens**. Verified on an Android 17 emulator for a
+    // service that was stopped, one that was not running, and a component that does not exist,
+    // through both `am` and `cmd activity stop-service`, with and without `--user`. Every one of
+    // them printed `Stopping service: Intent { … }` to stdout, exited 255, and differed only in the
+    // sentence written to stderr. So for this kind the code is not evidence, and the whole verdict
+    // is the marker — which is also why the Shizuku gateway had to stop using `execute()`, whose
+    // stdout-or-stderr contract drops the only line that carries the answer.
+
+    @Test
+    fun `a stopped service is a success despite exit 255`() {
+        assertNull(
+            componentCommandFailure(
+                exitCode = 255,
+                output = "Stopping service: Intent { cmp=com.example.app/.SyncService }\nService stopped",
+                kind = ComponentCommandKind.STOP_SERVICE,
+            )
+        )
+    }
+
+    /**
+     * The most likely outcome of the press, and the one that must not be an error: most services in
+     * a component list are not running when the user is looking at them, and "stop this service" is
+     * satisfied by a service that is already stopped.
+     */
+    @Test
+    fun `a service that was not running is a success`() {
+        assertNull(
+            componentCommandFailure(
+                exitCode = 255,
+                output = "Stopping service: Intent { cmp=com.example.app/.SyncService }\n" +
+                    "Service not stopped: was not running.",
+                kind = ComponentCommandKind.STOP_SERVICE,
+            )
+        )
+    }
+
+    /** The one real failure `ActivityManagerShellCommand` reports, and it has to survive. */
+    @Test
+    fun `an error stopping the service is still a failure`() {
+        val failure = componentCommandFailure(
+            exitCode = 255,
+            output = "Stopping service: Intent { cmp=com.example.app/.SyncService }\n" +
+                "Error stopping service",
+            kind = ComponentCommandKind.STOP_SERVICE,
+        )
+        assertEquals("Error stopping service", failure)
+    }
+
+    /** A refusal reaches the user even though the code it came with is the same 255 as a success. */
+    @Test
+    fun `a security exception on stopservice is a failure`() {
+        val failure = componentCommandFailure(
+            exitCode = 255,
+            output = "Stopping service: Intent { cmp=com.example.app/.SyncService }\n" +
+                "java.lang.SecurityException: Permission Denial",
+            kind = ComponentCommandKind.STOP_SERVICE,
+        )
+        assertNotNull(failure)
+        assertTrue(failure!!.contains("SecurityException"))
+    }
+
+    /**
+     * The echo alone — which is all the Shizuku path could ever see before `executeCombined` — is
+     * *not* a failure. Reading exit 255 as one is exactly the defect: every single "Stop now" press
+     * reported "Stopping service: Intent { … }" as its error message.
+     */
+    @Test
+    fun `the bare intent echo at exit 255 is not a failure`() {
+        assertNull(
+            componentCommandFailure(
+                exitCode = 255,
+                output = "Stopping service: Intent { cmp=com.example.app/.SyncService }",
+                kind = ComponentCommandKind.STOP_SERVICE,
+            )
+        )
+    }
+
+    /**
+     * The exemption is scoped to the stopservice kind and nothing else. The same output judged as a
+     * standard command is a failure, which is what keeps `pm disable` and `am start` — both of which
+     * *do* set a meaningful code — from silently inheriting the exemption.
+     */
+    @Test
+    fun `the standard kind still reads a non-zero exit as a failure`() {
+        assertEquals(
+            "Stopping service: Intent { cmp=com.example.app/.SyncService }",
+            componentCommandFailure(
+                exitCode = 255,
+                output = "Stopping service: Intent { cmp=com.example.app/.SyncService }",
+            )
+        )
+    }
+
+    /** …and the standard kind is what a caller that names no kind gets. */
+    @Test
+    fun `the default kind is standard`() {
+        assertEquals(
+            componentCommandFailure(1, "boom", ComponentCommandKind.STANDARD),
+            componentCommandFailure(1, "boom"),
+        )
+    }
 }

--- a/app/src/test/java/com/valhalla/thor/data/source/local/ComponentCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/ComponentCommandsTest.kt
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The three component commands, and the one function that decides whether one of them worked.
+ *
+ * Same reachable boundary as [PerUserCommandsTest], for the same reason: none of the gateways can be
+ * constructed here, so what is under test is the string a builder produces and the verdict
+ * [componentCommandFailure] returns for an output — never the wiring between them. Those two are
+ * where every defect this feature can have that is *not* a device problem actually lives:
+ *
+ *  - a command that forgets `--user` acts on user 0 from a work profile, and `pm` exits 0 either way;
+ *  - a spec that is not single-quoted loses its `$` to the shell, so an inner-class receiver name
+ *    silently becomes its **outer** class — a different, real component;
+ *  - a verdict taken from the exit code alone reports "Opened" for a launch the system refused.
+ */
+class ComponentCommandsTest {
+
+    private val pkg = "com.example.app"
+    private val cls = "com.example.app.MainActivity"
+
+    /** The `--user <id>` a command names, or null if it names none — which is the bug. */
+    private fun userArgOf(command: String): Int? =
+        Regex("--user (\\d+)").find(command)?.groupValues?.get(1)?.toIntOrNull()
+
+    private fun spec(packageName: String = pkg, className: String = cls): String =
+        requireNotNull(escapedComponentSpecOrNull(packageName, className)) {
+            "$packageName/$className was rejected by the validator"
+        }
+
+    // --- the spec: quoting and validation ---
+
+    /**
+     * The whole reason the spec is escaped before it reaches a builder. `PackageManager` reports an
+     * inner class as `Outer$Inner`; unquoted, the shell expands `$Inner` to the empty string and the
+     * command lands on `com.foo.Outer` — which in a great many apps is a real component of its own.
+     * Single quotes are the only form that makes `$` inert in `sh`.
+     */
+    @Test
+    fun `an inner class keeps its dollar sign`() {
+        val escaped = spec(className = "com.example.app.Widget\$Receiver")
+        assertTrue(
+            "spec was not single-quoted: $escaped",
+            escaped.startsWith("'") && escaped.endsWith("'"),
+        )
+        assertTrue("the dollar sign was lost: $escaped", escaped.contains("Widget\$Receiver"))
+    }
+
+    /** `$` is legal in a class name and must not be what makes the validator refuse. */
+    @Test
+    fun `an inner class is not rejected as implausible`() {
+        assertNotNull(escapedComponentSpecOrNull(pkg, "com.example.app.Widget\$Receiver"))
+    }
+
+    /**
+     * A `$` in the *package* half has no legitimate source, so the wider class pattern must not be
+     * the one applied to it. Keeping the two patterns apart is the point of having two.
+     */
+    @Test
+    fun `a dollar sign in the package half is rejected`() {
+        assertNull(escapedComponentSpecOrNull("com.example\$app", cls))
+    }
+
+    /**
+     * Shell metacharacters are refused outright rather than merely quoted. Quoting alone would be
+     * enough for safety; refusing makes an impossible name visible as a bug instead of as a command
+     * that runs against nothing.
+     */
+    @Test
+    fun `shell metacharacters are refused in either half`() {
+        assertNull(escapedComponentSpecOrNull("com.example.app; rm -rf /", cls))
+        assertNull(escapedComponentSpecOrNull(pkg, "com.example.app.Main; rm -rf /"))
+        assertNull(escapedComponentSpecOrNull(pkg, "com.example.app.Main`id`"))
+    }
+
+    /** The unescaped pair is `pkg/cls` and nothing else — the slash is the separator `pm` wants. */
+    @Test
+    fun `the spec is package slash class`() {
+        assertEquals("$pkg/$cls", componentSpec(pkg, cls))
+    }
+
+    // --- pm enable / disable / default-state ---
+
+    /**
+     * `PackageManagerShellCommand` seeds `UserHandle.USER_SYSTEM` for the enable/disable/default
+     * trio, so a bare command issued from a work profile changes **user 0's** component and exits 0.
+     */
+    @Test
+    fun `every component state command names the user`() {
+        for (state in ComponentState.entries) {
+            assertEquals(
+                "${state.pmVerb} dropped the user",
+                10,
+                userArgOf(setComponentStateCommand(spec(), 10, state)),
+            )
+        }
+    }
+
+    /** The verb has to follow the state, or "disable" enables and the row lies about what happened. */
+    @Test
+    fun `the verb follows the requested state`() {
+        assertTrue(
+            setComponentStateCommand(spec(), 10, ComponentState.DISABLED).startsWith("pm disable ")
+        )
+        assertTrue(
+            setComponentStateCommand(spec(), 10, ComponentState.ENABLED).startsWith("pm enable ")
+        )
+        assertTrue(
+            setComponentStateCommand(spec(), 10, ComponentState.DEFAULT)
+                .startsWith("pm default-state ")
+        )
+    }
+
+    /**
+     * `disable`, never `disable-user`. `DISABLED_USER` is the state Settings writes at *package*
+     * level; reusing it per component would make Thor's rows indistinguishable from a user-disabled
+     * app in `dumpsys package`. `startsWith("pm disable ")` above would still pass for
+     * `pm disable-user` if the trailing space were ever dropped, so this is asserted separately.
+     */
+    @Test
+    fun `disable is the strong state and not disable-user`() {
+        assertFalse(
+            setComponentStateCommand(spec(), 10, ComponentState.DISABLED).contains("disable-user")
+        )
+    }
+
+    /** The escaped spec reaches the command intact — quotes and all. */
+    @Test
+    fun `the command carries the quoted spec`() {
+        val escaped = spec()
+        assertTrue(setComponentStateCommand(escaped, 10, ComponentState.DISABLED).endsWith(escaped))
+    }
+
+    /**
+     * [ComponentEnabledState.DEFAULT] maps to `default-state`, **not** to `enable`. `default-state`
+     * removes the override; `enable` writes one. For a component that ships disabled the two produce
+     * opposite results, which is exactly the case a "reset" is most often used on.
+     */
+    @Test
+    fun `default maps to default-state and not to enable`() {
+        assertEquals(ComponentState.DEFAULT, ComponentEnabledState.DEFAULT.asComponentState())
+        assertEquals(ComponentState.ENABLED, ComponentEnabledState.ENABLED.asComponentState())
+        assertEquals(ComponentState.DISABLED, ComponentEnabledState.DISABLED.asComponentState())
+    }
+
+    // --- am start ---
+
+    @Test
+    fun `starting an activity names the user`() {
+        assertEquals(10, userArgOf(startActivityCommand(spec(), 10)))
+    }
+
+    /** `-n` is what makes the trailing word a component rather than data or a package. */
+    @Test
+    fun `starting an activity passes the component with -n`() {
+        assertTrue(startActivityCommand(spec(), 10).contains("-n ${spec()}"))
+    }
+
+    /**
+     * No action, no category, no flags. An invented `MAIN`/`LAUNCHER` action is visible to the
+     * target through `intent.action`, and several apps branch on it in `onCreate` — the activity the
+     * user asked to see is then not the one they get.
+     */
+    @Test
+    fun `starting an activity invents no action or category`() {
+        val command = startActivityCommand(spec(), 10)
+        assertFalse(command.contains("-a "))
+        assertFalse(command.contains("-c "))
+        assertFalse(command.contains("android.intent.action"))
+    }
+
+    // --- am stopservice ---
+
+    @Test
+    fun `stopping a service names the user`() {
+        assertEquals(10, userArgOf(stopServiceCommand(spec(), 10)))
+    }
+
+    /**
+     * The `-n` here is not cosmetic. `Intent.parseCommandArgs` reads a trailing bare argument as
+     * data or as a package, never as a component, so `am stopservice pkg/cls` builds an intent with
+     * no component, stops nothing, and exits 0 — a silent no-op the UI would report as success.
+     */
+    @Test
+    fun `stopping a service passes the component with -n`() {
+        assertTrue(stopServiceCommand(spec(), 10).contains("-n ${spec()}"))
+    }
+
+    // --- the verdict ---
+
+    /**
+     * The case the whole function exists for: on most releases `am start` prints the refusal and
+     * still exits **0**. Reading the code alone reports a launch that visibly did not happen.
+     */
+    @Test
+    fun `a security exception at exit zero is a failure`() {
+        val output = """
+            Starting: Intent { cmp=com.example.app/.SecretActivity }
+            Security exception: Permission Denial: starting Intent { ... } not exported from uid 10123
+            	at android.os.Parcel.createExceptionOrNull(Parcel.java:3057)
+            	at android.os.Parcel.createException(Parcel.java:3041)
+        """.trimIndent()
+        val failure = componentCommandFailure(exitCode = 0, output = output)
+        assertNotNull("exit 0 hid a refusal", failure)
+        assertTrue(failure!!.contains("Security exception"))
+    }
+
+    /**
+     * Android 14 folds the same refusal into `START_CLASS_NOT_FOUND`, so the marker changes shape
+     * entirely. Missing this one would make the feature report success on every recent release.
+     */
+    @Test
+    fun `the Android 14 class-not-found refusal is a failure`() {
+        val failure = componentCommandFailure(
+            exitCode = 0,
+            output = "Error: Activity class {com.example.app/com.example.app.SecretActivity} does " +
+                "not exist.",
+        )
+        assertNotNull(failure)
+        assertTrue(failure!!.startsWith("Error:"))
+    }
+
+    /**
+     * The single most common repeat press in the feature: opening an activity that is already the
+     * foreground task. `am` calls that a warning and it is a complete success — treating it as a
+     * failure would put an error Toast on the happy path.
+     */
+    @Test
+    fun `a warning that the task was brought forward is a success`() {
+        val output = """
+            Starting: Intent { cmp=com.example.app/.MainActivity }
+            Warning: Activity not started, its current task has been brought to the front
+        """.trimIndent()
+        assertNull(componentCommandFailure(exitCode = 0, output = output))
+    }
+
+    /** Plain success stays success — no marker, no code, no verdict. */
+    @Test
+    fun `a clean start is a success`() {
+        assertNull(
+            componentCommandFailure(
+                exitCode = 0,
+                output = "Starting: Intent { cmp=com.example.app/.MainActivity }",
+            )
+        )
+    }
+
+    /**
+     * The other direction. A non-zero code with nothing recognisable in the output is still a
+     * failure, so the code is checked as well as the text rather than instead of it.
+     */
+    @Test
+    fun `a non-zero exit with no marker is still a failure`() {
+        assertEquals("something went sideways", componentCommandFailure(1, "something went sideways"))
+    }
+
+    /** …and with no output at all, the code itself is the only thing left to report. */
+    @Test
+    fun `a non-zero exit with empty output reports the code`() {
+        assertEquals("exit 137", componentCommandFailure(137, "   \n\n  "))
+    }
+
+    /**
+     * `ShellCommand.exec` prints the whole stack trace on an exception. A Toast is not the place for
+     * forty frames, so the verdict is one line and a bounded one.
+     */
+    @Test
+    fun `the failure is one bounded line and not the stack trace`() {
+        val output = buildString {
+            appendLine("Security exception: Permission Denial")
+            repeat(40) { appendLine("\tat android.os.Parcel.createException(Parcel.java:$it)") }
+        }
+        val failure = requireNotNull(componentCommandFailure(0, output))
+        assertFalse("the stack trace came along", failure.contains("\n"))
+        assertTrue("the line is unbounded", failure.length <= 200)
+    }
+
+    /** A line 200 characters long is not truncated; one longer is. */
+    @Test
+    fun `an overlong failure line is truncated`() {
+        val failure = requireNotNull(componentCommandFailure(0, "Error: " + "x".repeat(500)))
+        assertEquals(200, failure.length)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/source/local/ComponentCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/ComponentCommandsTest.kt
@@ -414,6 +414,37 @@ class ComponentCommandsTest {
     }
 
     /**
+     * The one code a stopservice *must* still read: a negative one, which `am` never returns.
+     * `ShizukuHelper` uses it for a dead binder, a timeout, and a thrown exception, and its output
+     * carries none of the three markers — so "ignore the exit code" taken literally reports a
+     * service Thor never reached as a service it stopped.
+     */
+    @Test
+    fun `a dead transport is a failure even for stopservice`() {
+        assertEquals(
+            "Shizuku binder is null",
+            componentCommandFailure(
+                exitCode = -1,
+                output = "Shizuku binder is null",
+                kind = ComponentCommandKind.STOP_SERVICE,
+            )
+        )
+    }
+
+    /** …and with no output at all there is still a verdict, rather than a silent success. */
+    @Test
+    fun `a silent transport failure still reports for stopservice`() {
+        assertEquals(
+            "exit -1",
+            componentCommandFailure(
+                exitCode = -1,
+                output = "",
+                kind = ComponentCommandKind.STOP_SERVICE,
+            )
+        )
+    }
+
+    /**
      * The asynchronous wording, for a service whose `onDestroy` has not returned yet. It is the
      * third success marker and the only one with no test of its own — without this, deleting it
      * from the list turns every slow stop into an error Toast and the suite stays green.

--- a/app/src/test/java/com/valhalla/thor/data/source/local/ComponentCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/ComponentCommandsTest.kt
@@ -231,6 +231,37 @@ class ComponentCommandsTest {
     }
 
     /**
+     * The output above never arrives alone. `ActivityManagerShellCommand` prints its numeric code
+     * on the line *before* the sentence, and both lines are marked — so a scan that takes the first
+     * matching *line* reports "Error type 3", which names neither the component nor the reason.
+     * Captured verbatim from an API 37 emulator.
+     */
+    @Test
+    fun `the numeric code does not beat the sentence below it`() {
+        val output = """
+            Starting: Intent { cmp=com.example.app/com.example.app.SecretActivity }
+            Error type 3
+            Error: Activity class {com.example.app/com.example.app.SecretActivity} does not exist.
+        """.trimIndent()
+        val failure = componentCommandFailure(exitCode = 1, output = output)
+        assertNotNull(failure)
+        assertTrue(
+            "expected the descriptive line, got: $failure",
+            failure!!.startsWith("Error: Activity class"),
+        )
+    }
+
+    /** …but on its own it is still the only evidence there is, and better than the bare echo. */
+    @Test
+    fun `the numeric code is reported when nothing better is present`() {
+        val output = """
+            Starting: Intent { cmp=com.example.app/.MainActivity }
+            Error type 3
+        """.trimIndent()
+        assertEquals("Error type 3", componentCommandFailure(exitCode = 1, output = output))
+    }
+
+    /**
      * The single most common repeat press in the feature: opening an activity that is already the
      * foreground task. `am` calls that a warning and it is a complete success — treating it as a
      * failure would put an error Toast on the happy path.
@@ -377,6 +408,23 @@ class ComponentCommandsTest {
             componentCommandFailure(
                 exitCode = 255,
                 output = "Stopping service: Intent { cmp=com.example.app/.SyncService }\nService stopped",
+                kind = ComponentCommandKind.STOP_SERVICE,
+            )
+        )
+    }
+
+    /**
+     * The asynchronous wording, for a service whose `onDestroy` has not returned yet. It is the
+     * third success marker and the only one with no test of its own — without this, deleting it
+     * from the list turns every slow stop into an error Toast and the suite stays green.
+     */
+    @Test
+    fun `a service that is still stopping is a success`() {
+        assertNull(
+            componentCommandFailure(
+                exitCode = 255,
+                output = "Stopping service: Intent { cmp=com.example.app/.SyncService }\n" +
+                    "Service stopping",
                 kind = ComponentCommandKind.STOP_SERVICE,
             )
         )

--- a/app/src/test/java/com/valhalla/thor/domain/model/ComponentCapabilityTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/ComponentCapabilityTest.kt
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Which privilege transport may touch an individual component.
+ *
+ * A pure fold over the settled privilege state, and testable here for the same reason the freeze
+ * tier fold is: the *decision* is arithmetic on three values, while the *evidence* — is Shizuku up,
+ * what uid is it — needs a device. Getting the fold wrong is not a cosmetic bug. Every affordance
+ * this feature adds is drawn from it, so an over-optimistic answer paints enabled Force Open and
+ * Disable buttons that throw `SecurityException` on every press, and an over-pessimistic one hides
+ * the whole feature from a rooted user.
+ *
+ * The one asymmetry worth stating: an **unreadable** Shizuku uid resolves to not-capable, which is
+ * the opposite of the fold used when picking a privileged installer. There an unknown uid is
+ * optimistically root because a wrong guess costs a failed install with a clear error. Here a wrong
+ * guess costs a screen full of controls that cannot work.
+ */
+class ComponentCapabilityTest {
+
+    private companion object {
+        const val SHELL_UID = 2000
+    }
+
+    /**
+     * Before the probe settles there is no answer, and "no answer" must not read as "no". The UI
+     * treats [ComponentControlBlocker.NOT_READY] as a transient state and shows no blocker banner
+     * for it — a mode of `ROOT` that has not been confirmed is still not permission to act.
+     */
+    @Test
+    fun `an unsettled probe is not ready in every mode`() {
+        for (mode in PrivilegeMode.entries) {
+            val capability = componentCapability(mode, isReady = false, shizukuUid = ROOT_UID)
+            assertFalse("$mode claimed uid 0 before the probe settled", capability.hasUid0)
+            assertEquals(ComponentControlBlocker.NOT_READY, capability.blocker)
+        }
+    }
+
+    /** The default the UI starts from is that same not-yet-answered state, never a denial. */
+    @Test
+    fun `the default capability is not ready`() {
+        assertEquals(ComponentControlBlocker.NOT_READY, ComponentCapability.None.blocker)
+        assertFalse(ComponentCapability.None.hasUid0)
+    }
+
+    @Test
+    fun `root has uid 0 and no blocker`() {
+        val capability = componentCapability(PrivilegeMode.ROOT, isReady = true, shizukuUid = null)
+        assertTrue(capability.hasUid0)
+        assertEquals(ComponentControlBlocker.NONE, capability.blocker)
+    }
+
+    /**
+     * The case that decides whether the feature works for most Shizuku users. Shizuku started the
+     * ordinary way runs at the shell uid, and `PackageManagerService.setEnabledSetting` refuses
+     * `SHELL_UID` outright for anything with a class name. There is no reflective way past it, so
+     * this must be a blocker and not a "try it and see".
+     */
+    @Test
+    fun `shell-uid Shizuku is blocked and says why`() {
+        val capability =
+            componentCapability(PrivilegeMode.SHIZUKU, isReady = true, shizukuUid = SHELL_UID)
+        assertFalse(capability.hasUid0)
+        assertEquals(ComponentControlBlocker.SHIZUKU_NOT_ROOT, capability.blocker)
+    }
+
+    /** Shizuku started as root is uid 0 and is exactly as capable as root, with no blocker. */
+    @Test
+    fun `root-mode Shizuku is fully capable`() {
+        val capability =
+            componentCapability(PrivilegeMode.SHIZUKU, isReady = true, shizukuUid = ROOT_UID)
+        assertTrue(capability.hasUid0)
+        assertEquals(ComponentControlBlocker.NONE, capability.blocker)
+    }
+
+    /**
+     * An unreadable uid fails **closed**, and reports the shell blocker rather than inventing a
+     * fourth message. From the user's side the remedy is identical: restart Shizuku as root.
+     */
+    @Test
+    fun `an unreadable Shizuku uid fails closed`() {
+        val capability =
+            componentCapability(PrivilegeMode.SHIZUKU, isReady = true, shizukuUid = null)
+        assertFalse(capability.hasUid0)
+        assertEquals(ComponentControlBlocker.SHIZUKU_NOT_ROOT, capability.blocker)
+    }
+
+    /**
+     * Dhizuku is an empty case, not a partial one: `DevicePolicyManager` has no component-enabled
+     * API at all, and a Device Owner's background-activity-launch exemption is not an export waiver.
+     * It gets its own blocker because the remedy is different — switch transports, not restart one.
+     */
+    @Test
+    fun `Dhizuku is unsupported outright`() {
+        val capability =
+            componentCapability(PrivilegeMode.DHIZUKU, isReady = true, shizukuUid = ROOT_UID)
+        assertFalse(capability.hasUid0)
+        assertEquals(ComponentControlBlocker.DHIZUKU_UNSUPPORTED, capability.blocker)
+    }
+
+    /** No transport, and a null mode, are the same answer: nothing is available. */
+    @Test
+    fun `no privilege and no mode both report no privilege`() {
+        for (mode in listOf(PrivilegeMode.NONE, null)) {
+            val capability = componentCapability(mode, isReady = true, shizukuUid = null)
+            assertFalse(capability.hasUid0)
+            assertEquals(ComponentControlBlocker.NO_PRIVILEGE, capability.blocker)
+        }
+    }
+
+    // --- the three verbs, and the one per-row question ---
+
+    /**
+     * The three privileged verbs are one fact wearing three names. Pinning that they move together
+     * is what stops a later "well, Shizuku can *probably* stop an exported service" from being
+     * bolted onto one accessor and quietly disagreeing with the banner the other two drive.
+     */
+    @Test
+    fun `the three privileged verbs all follow uid 0`() {
+        val capable = componentCapability(PrivilegeMode.ROOT, isReady = true, shizukuUid = null)
+        assertTrue(capable.canSetComponentState)
+        assertTrue(capable.canForceLaunch)
+        assertTrue(capable.canStopService)
+
+        val blocked =
+            componentCapability(PrivilegeMode.SHIZUKU, isReady = true, shizukuUid = SHELL_UID)
+        assertFalse(blocked.canSetComponentState)
+        assertFalse(blocked.canForceLaunch)
+        assertFalse(blocked.canStopService)
+    }
+
+    /**
+     * The only question whose answer varies per row. An exported, unguarded activity is launchable
+     * by anybody — Thor with no privilege at all included — which is the whole reason the row shows
+     * "Open" rather than "Force open" for it.
+     */
+    @Test
+    fun `an exported unguarded activity is launchable with no privilege`() {
+        val unprivileged = componentCapability(PrivilegeMode.NONE, isReady = true, shizukuUid = null)
+        assertTrue(unprivileged.canLaunch(component(exported = true, permission = null)))
+    }
+
+    /**
+     * An exported activity behind an `android:permission` fails in exactly the same way an
+     * unexported one does: `ActivityStarter.executeRequest` runs both checks side by side, and
+     * `canAccessUnexportedComponents` — the only waiver — is granted to ROOT and SYSTEM alone. So
+     * "exported" alone is not the predicate, and a row that assumed it would offer a plain Open
+     * button that throws.
+     */
+    @Test
+    fun `an exported but permission-guarded activity still needs uid 0`() {
+        val guarded = component(exported = true, permission = "com.example.SECRET")
+        val unprivileged = componentCapability(PrivilegeMode.NONE, isReady = true, shizukuUid = null)
+        val root = componentCapability(PrivilegeMode.ROOT, isReady = true, shizukuUid = null)
+
+        assertTrue("the predicate collapsed to !exported", guarded.launchRequiresRoot)
+        assertFalse(unprivileged.canLaunch(guarded))
+        assertTrue(root.canLaunch(guarded))
+    }
+
+    @Test
+    fun `an unexported activity needs uid 0`() {
+        val hidden = component(exported = false, permission = null)
+        val unprivileged = componentCapability(PrivilegeMode.NONE, isReady = true, shizukuUid = null)
+        assertFalse(unprivileged.canLaunch(hidden))
+        assertTrue(
+            componentCapability(PrivilegeMode.ROOT, isReady = true, shizukuUid = null)
+                .canLaunch(hidden)
+        )
+    }
+
+    private fun component(exported: Boolean, permission: String?) = ComponentDetail(
+        className = "com.example.app.SomeActivity",
+        exported = exported,
+        enabled = true,
+        manifestDefaultEnabled = true,
+        permission = permission,
+    )
+}

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/ComponentControlUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/ComponentControlUseCaseTest.kt
@@ -1,0 +1,480 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.usecase
+
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
+import com.valhalla.thor.domain.model.ComponentDetail
+import com.valhalla.thor.domain.model.ComponentOverride
+import com.valhalla.thor.domain.model.ComponentType
+import com.valhalla.thor.domain.model.ObbProbe
+import com.valhalla.thor.domain.repository.ComponentOverrideRepository
+import com.valhalla.thor.domain.repository.SystemRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The one place the ledger and the platform have to stay in step.
+ *
+ * The ledger is **bookkeeping, not enforcement** — that was the design decision, and it is what
+ * makes these orderings load-bearing rather than stylistic. Nothing re-applies a row at boot and no
+ * sweep reconciles one later, so a row that exists for a component the platform never disabled is a
+ * lie that survives until somebody presses Restore All and gets told a component was restored that
+ * was never touched. The two invariants:
+ *
+ *  - a row is written **after** the platform call succeeds, never before or unconditionally;
+ *  - a row is dropped **after** the restoring call succeeds, so a failed restore leaves the row
+ *    behind to be retried rather than silently forgetting a component Thor is still holding down.
+ *
+ * The third thing under test is [enableTargetState], which is the difference between "switch it on"
+ * and "put it back". For a component that ships disabled those are opposite outcomes, and getting it
+ * wrong invents a state the app has never been in — an `ENABLED` override on a component the
+ * developer ships off, which then also survives the app update that would have cleared a default.
+ */
+class ComponentControlUseCaseTest {
+
+    private val pkg = "com.example.app"
+
+    // --- enableTargetState: the "put it back" question ---
+
+    /**
+     * A component the manifest already enables must be restored with `default-state`, which
+     * *removes* the override. Writing `ENABLED` instead would leave a real row in
+     * `package-restrictions.xml` that looks identical from the outside but outlives the app update
+     * the developer's own default would not.
+     */
+    @Test
+    fun `a component that ships enabled is restored to default and not to enabled`() {
+        assertEquals(
+            ComponentEnabledState.DEFAULT,
+            enableTargetState(manifestDefaultEnabled = true),
+        )
+    }
+
+    /**
+     * A component that ships **disabled** is the case that makes this a function rather than a
+     * constant. `default-state` would put it straight back to off, so an explicit `ENABLED` is the
+     * only way an "Enable" press does what the label says.
+     */
+    @Test
+    fun `a component that ships disabled is explicitly enabled`() {
+        assertEquals(
+            ComponentEnabledState.ENABLED,
+            enableTargetState(manifestDefaultEnabled = false),
+        )
+    }
+
+    // --- disable: the ledger follows the platform ---
+
+    @Test
+    fun `a successful disable writes the ledger row`() = runTest {
+        val system = FakeSystem()
+        val ledger = FakeLedger()
+        val useCase = ComponentControlUseCase(system, ledger)
+
+        val result = useCase.disable(pkg, ComponentType.SERVICE, component(className = "Sync"))
+
+        assertTrue(result.isSuccess)
+        assertEquals(
+            listOf("setComponentEnabled:$pkg:Sync:DISABLED"),
+            system.calls,
+        )
+        assertEquals(1, ledger.rows.size)
+        assertEquals("Sync", ledger.rows.single().className)
+        assertEquals(ComponentType.SERVICE, ledger.rows.single().type)
+    }
+
+    /**
+     * The invariant that keeps the ledger honest. A row written before the call, or written
+     * regardless of its outcome, claims Thor disabled something it did not — and because nothing
+     * reconciles the ledger later, that claim is permanent.
+     */
+    @Test
+    fun `a failed disable writes no ledger row`() = runTest {
+        val system = FakeSystem(respond = { Result.failure(IllegalStateException("denied")) })
+        val ledger = FakeLedger()
+        val useCase = ComponentControlUseCase(system, ledger)
+
+        val result = useCase.disable(pkg, ComponentType.RECEIVER, component(className = "Boot"))
+
+        assertTrue(result.isFailure)
+        assertTrue("the ledger recorded a disable that never happened", ledger.rows.isEmpty())
+    }
+
+    /**
+     * `restoreToEnabled` records the manifest default **as read at the time**, not `true`. A
+     * component that ships disabled and is disabled again by Thor has to be restored to *disabled*,
+     * and this row is the only thing that will remember that once the component is off and its
+     * effective state no longer says which way it shipped.
+     */
+    @Test
+    fun `the row remembers how the component shipped`() = runTest {
+        val ledger = FakeLedger()
+        val useCase = ComponentControlUseCase(FakeSystem(), ledger)
+
+        useCase.disable(
+            pkg,
+            ComponentType.RECEIVER,
+            component(className = "ShipsOff", manifestDefaultEnabled = false),
+        )
+
+        assertFalse(ledger.rows.single().restoreToEnabled)
+    }
+
+    // --- enable / reset: the ledger follows the platform, in the other direction ---
+
+    @Test
+    fun `a successful enable drops the ledger row`() = runTest {
+        val ledger = FakeLedger(rows = mutableListOf(row("Sync", restoreToEnabled = true)))
+        val system = FakeSystem()
+        val useCase = ComponentControlUseCase(system, ledger)
+
+        val result = useCase.enable(pkg, component(className = "Sync"))
+
+        assertTrue(result.isSuccess)
+        assertEquals(listOf("setComponentEnabled:$pkg:Sync:DEFAULT"), system.calls)
+        assertTrue(ledger.rows.isEmpty())
+    }
+
+    /**
+     * The mirror of the disable invariant, and the more damaging direction of the two: forgetting a
+     * row for a component that is *still disabled* strands it. Nothing re-applies and nothing
+     * reconciles, so Restore All will never see it again and the user has no route back short of
+     * finding the component by hand.
+     */
+    @Test
+    fun `a failed enable keeps the ledger row`() = runTest {
+        val ledger = FakeLedger(rows = mutableListOf(row("Sync", restoreToEnabled = true)))
+        val useCase = ComponentControlUseCase(
+            FakeSystem(respond = { Result.failure(IllegalStateException("denied")) }),
+            ledger,
+        )
+
+        val result = useCase.enable(pkg, component(className = "Sync"))
+
+        assertTrue(result.isFailure)
+        assertEquals(1, ledger.rows.size)
+    }
+
+    /** "Enable" on a component that ships off asks the platform for the explicit state. */
+    @Test
+    fun `enabling a ships-off component asks for ENABLED`() = runTest {
+        val system = FakeSystem()
+        val useCase = ComponentControlUseCase(system, FakeLedger())
+
+        useCase.enable(pkg, component(className = "ShipsOff", manifestDefaultEnabled = false))
+
+        assertEquals(listOf("setComponentEnabled:$pkg:ShipsOff:ENABLED"), system.calls)
+    }
+
+    /**
+     * "Reset to default" is not "enable". It is offered for *any* explicit override, including one
+     * Thor did not write, so it always clears rather than choosing a direction.
+     */
+    @Test
+    fun `reset always asks for DEFAULT`() = runTest {
+        val system = FakeSystem()
+        val ledger = FakeLedger(rows = mutableListOf(row("Sync", restoreToEnabled = false)))
+        val useCase = ComponentControlUseCase(system, ledger)
+
+        useCase.resetToDefault(pkg, "Sync")
+
+        assertEquals(listOf("setComponentEnabled:$pkg:Sync:DEFAULT"), system.calls)
+        assertTrue(ledger.rows.isEmpty())
+    }
+
+    /** Forgetting a drifted row touches the ledger only — the component is somebody else's now. */
+    @Test
+    fun `forget touches the ledger and not the platform`() = runTest {
+        val system = FakeSystem()
+        val ledger = FakeLedger(rows = mutableListOf(row("Sync", restoreToEnabled = true)))
+        val useCase = ComponentControlUseCase(system, ledger)
+
+        useCase.forget(pkg, "Sync")
+
+        assertTrue(system.calls.isEmpty())
+        assertTrue(ledger.rows.isEmpty())
+    }
+
+    // --- restoreAll ---
+
+    @Test
+    fun `restore all restores every row and reports a complete run`() = runTest {
+        val ledger = FakeLedger(
+            rows = mutableListOf(
+                row("Sync", restoreToEnabled = true),
+                row("Boot", restoreToEnabled = false),
+            )
+        )
+        val system = FakeSystem()
+        val useCase = ComponentControlUseCase(system, ledger)
+
+        val outcome = useCase.restoreAll()
+
+        assertEquals(RestoreAllOutcome(restored = 2, attempted = 2), outcome)
+        assertTrue(outcome.isComplete)
+        assertTrue(ledger.rows.isEmpty())
+        assertEquals(
+            listOf(
+                "setComponentEnabled:$pkg:Sync:DEFAULT",
+                "setComponentEnabled:$pkg:Boot:ENABLED",
+            ),
+            system.calls,
+        )
+    }
+
+    /**
+     * A partial run is the interesting one. The rows that failed have to stay — they are still
+     * disabled and this ledger is the only record of that — and the count reported has to be the
+     * number actually restored, not the number tried. The banner says "N restricted by Thor" from
+     * the same rows, so a run that cleared them all regardless would show 0 while N components were
+     * still switched off.
+     */
+    @Test
+    fun `a partial restore keeps the rows it could not restore`() = runTest {
+        val ledger = FakeLedger(
+            rows = mutableListOf(
+                row("Sync", restoreToEnabled = true),
+                row("Boot", restoreToEnabled = true),
+                row("Widget", restoreToEnabled = true),
+            )
+        )
+        val useCase = ComponentControlUseCase(
+            FakeSystem(respond = { call ->
+                if (call.contains(":Boot:")) Result.failure(IllegalStateException("denied"))
+                else Result.success(Unit)
+            }),
+            ledger,
+        )
+
+        val outcome = useCase.restoreAll()
+
+        assertEquals(RestoreAllOutcome(restored = 2, attempted = 3), outcome)
+        assertFalse(outcome.isComplete)
+        assertEquals(listOf("Boot"), ledger.rows.map { it.className })
+    }
+
+    /** An empty ledger is a complete run of nothing, not a failure. */
+    @Test
+    fun `restore all with no rows is complete`() = runTest {
+        val outcome = ComponentControlUseCase(FakeSystem(), FakeLedger()).restoreAll()
+        assertEquals(RestoreAllOutcome(restored = 0, attempted = 0), outcome)
+        assertTrue(outcome.isComplete)
+    }
+
+    /**
+     * Restore All is cross-app by design — the whole point is that a user who disabled components
+     * across a dozen apps has one way back — so it must not filter to the package that happens to be
+     * on screen.
+     */
+    @Test
+    fun `restore all crosses package boundaries`() = runTest {
+        val ledger = FakeLedger(
+            rows = mutableListOf(
+                row("Sync", restoreToEnabled = true, packageName = "com.example.a"),
+                row("Boot", restoreToEnabled = true, packageName = "com.example.b"),
+            )
+        )
+        val system = FakeSystem()
+
+        ComponentControlUseCase(system, ledger).restoreAll()
+
+        assertEquals(
+            listOf(
+                "setComponentEnabled:com.example.a:Sync:DEFAULT",
+                "setComponentEnabled:com.example.b:Boot:DEFAULT",
+            ),
+            system.calls,
+        )
+    }
+
+    // --- pass-throughs ---
+
+    @Test
+    fun `force launch and stop service reach the platform unchanged`() = runTest {
+        val system = FakeSystem()
+        val useCase = ComponentControlUseCase(system, FakeLedger())
+
+        useCase.forceLaunch(pkg, "Secret")
+        useCase.stopService(pkg, "Sync")
+
+        assertEquals(
+            listOf("forceLaunchActivity:$pkg:Secret", "stopService:$pkg:Sync"),
+            system.calls,
+        )
+    }
+
+    /** Neither read-only verb writes a ledger row — only Disable does. */
+    @Test
+    fun `neither force launch nor stop service writes a ledger row`() = runTest {
+        val ledger = FakeLedger()
+        val useCase = ComponentControlUseCase(FakeSystem(), ledger)
+
+        useCase.forceLaunch(pkg, "Secret")
+        useCase.stopService(pkg, "Sync")
+
+        assertTrue(ledger.rows.isEmpty())
+    }
+
+    // --- fixtures ---
+
+    private fun component(
+        className: String,
+        manifestDefaultEnabled: Boolean = true,
+    ) = ComponentDetail(
+        className = className,
+        exported = true,
+        enabled = manifestDefaultEnabled,
+        manifestDefaultEnabled = manifestDefaultEnabled,
+    )
+
+    private fun row(
+        className: String,
+        restoreToEnabled: Boolean,
+        packageName: String = pkg,
+    ) = ComponentOverride(
+        packageName = packageName,
+        className = className,
+        type = ComponentType.SERVICE,
+        restoreToEnabled = restoreToEnabled,
+        disabledAt = 0L,
+    )
+}
+
+/**
+ * The ledger, in memory, with the rows readable.
+ *
+ * A real list rather than a call recorder because every assertion here is about *what is left in
+ * the ledger* after a partly-failed run, which a list of "record"/"forget" strings answers only by
+ * replaying them.
+ */
+private class FakeLedger(
+    val rows: MutableList<ComponentOverride> = mutableListOf(),
+) : ComponentOverrideRepository {
+
+    private val revision = MutableStateFlow(0)
+
+    override fun observe(packageName: String): Flow<List<ComponentOverride>> =
+        revision.map { rows.filter { row -> row.packageName == packageName } }
+
+    override suspend fun getAll(): List<ComponentOverride> = rows.toList()
+
+    override suspend fun record(
+        packageName: String,
+        className: String,
+        type: ComponentType,
+        restoreToEnabled: Boolean,
+    ) {
+        rows.removeAll { it.packageName == packageName && it.className == className }
+        rows += ComponentOverride(packageName, className, type, restoreToEnabled, disabledAt = 0L)
+        revision.value++
+    }
+
+    override suspend fun forget(packageName: String, className: String) {
+        rows.removeAll { it.packageName == packageName && it.className == className }
+        revision.value++
+    }
+
+    override suspend fun forgetPackage(packageName: String) {
+        rows.removeAll { it.packageName == packageName }
+        revision.value++
+    }
+}
+
+/**
+ * Records the three component verbs in order and lets a test decide what each one answers.
+ *
+ * Hand-written for the same reason as the other `SystemRepository` doubles in this source set: there
+ * is no mocking library on `:app`. Everything off the component path throws rather than returning a
+ * benign default, so a use case that starts calling one of them fails loudly here instead of
+ * recording nothing and still passing.
+ */
+private class FakeSystem(
+    private val respond: (String) -> Result<Unit> = { Result.success(Unit) },
+) : SystemRepository {
+
+    val calls = mutableListOf<String>()
+
+    override suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState,
+    ): Result<Unit> = record("setComponentEnabled:$packageName:$className:$state")
+
+    override suspend fun forceLaunchActivity(
+        packageName: String,
+        className: String,
+    ): Result<Unit> = record("forceLaunchActivity:$packageName:$className")
+
+    override suspend fun stopService(packageName: String, className: String): Result<Unit> =
+        record("stopService:$packageName:$className")
+
+    private fun record(call: String): Result<Unit> {
+        calls += call
+        return respond(call)
+    }
+
+    override suspend fun isRootAvailable(): Boolean = unreachable("isRootAvailable")
+    override suspend fun isShizukuAvailable(): Boolean = unreachable("isShizukuAvailable")
+    override suspend fun isDhizukuAvailable(): Boolean = unreachable("isDhizukuAvailable")
+
+    override suspend fun setAppDisabled(packageName: String, isDisabled: Boolean): Result<Unit> =
+        unreachable("setAppDisabled")
+
+    override suspend fun setAppSuspended(packageName: String, isSuspended: Boolean): Result<Unit> =
+        unreachable("setAppSuspended")
+
+    override suspend fun forceStopApp(packageName: String): Result<Unit> =
+        unreachable("forceStopApp")
+
+    override suspend fun clearCache(packageName: String): Result<Long?> = unreachable("clearCache")
+    override suspend fun clearAllCaches(): Result<Long?> = unreachable("clearAllCaches")
+
+    override suspend fun clearAppData(packageName: String): Result<Unit> =
+        unreachable("clearAppData")
+
+    override suspend fun setAppRestricted(
+        packageName: String,
+        isRestricted: Boolean,
+    ): Result<Unit> = unreachable("setAppRestricted")
+
+    override suspend fun uninstallApp(packageName: String): Result<Unit> =
+        unreachable("uninstallApp")
+
+    override suspend fun rebootDevice(reason: String): Result<Unit> = unreachable("rebootDevice")
+
+    override suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit> =
+        unreachable("reinstallAppWithGoogle")
+
+    override suspend fun copyFileWithRoot(
+        sourcePath: String,
+        destinationPath: String,
+    ): Result<Unit> = unreachable("copyFileWithRoot")
+
+    override suspend fun getAppPaths(packageName: String): Result<List<String>> =
+        unreachable("getAppPaths")
+
+    override suspend fun grantPermission(
+        packageName: String,
+        permissionName: String,
+    ): Result<Unit> = unreachable("grantPermission")
+
+    override suspend fun revokePermission(
+        packageName: String,
+        permissionName: String,
+    ): Result<Unit> = unreachable("revokePermission")
+
+    override suspend fun executeShellCommand(command: String): Result<Pair<Int, String?>> =
+        unreachable("executeShellCommand")
+
+    override suspend fun probeObb(packageName: String): ObbProbe = unreachable("probeObb")
+
+    private fun unreachable(name: String): Nothing =
+        throw UnsupportedOperationException("$name is off the component-control path")
+}

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/ComponentControlUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/ComponentControlUseCaseTest.kt
@@ -162,6 +162,26 @@ class ComponentControlUseCaseTest {
         assertEquals(1, ledger.rows.size)
     }
 
+    /**
+     * The third verb with the same `.onSuccess { forget }` contract, and the one whose failure half
+     * was unverified — `disable` and `enable` both had a test for it. A ledger row dropped after a
+     * refused `pm default-state` would strand the component: still overridden, no longer listed, so
+     * "Restore all" can never reach it.
+     */
+    @Test
+    fun `a failed reset keeps the ledger row`() = runTest {
+        val ledger = FakeLedger(rows = mutableListOf(row("Sync", restoreToEnabled = true)))
+        val useCase = ComponentControlUseCase(
+            FakeSystem(respond = { Result.failure(IllegalStateException("denied")) }),
+            ledger,
+        )
+
+        val result = useCase.resetToDefault(pkg, "Sync")
+
+        assertTrue(result.isFailure)
+        assertEquals(1, ledger.rows.size)
+    }
+
     /** "Enable" on a component that ships off asks the platform for the explicit state. */
     @Test
     fun `enabling a ships-off component asks for ENABLED`() = runTest {

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/FreezeAppUseCaseTest.kt
@@ -4,7 +4,9 @@
 package com.valhalla.thor.domain.usecase
 
 import com.valhalla.thor.R
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
 import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.ComponentSnapshot
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.FreezerMode
 import com.valhalla.thor.domain.model.ObbProbe
@@ -94,6 +96,20 @@ private class RecordingSystemRepository : SystemRepository {
         error("off the freeze path")
 
     override suspend fun probeObb(packageName: String): ObbProbe = error("off the freeze path")
+
+    override suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState,
+    ): Result<Unit> = error("off the freeze path")
+
+    override suspend fun forceLaunchActivity(
+        packageName: String,
+        className: String,
+    ): Result<Unit> = error("off the freeze path")
+
+    override suspend fun stopService(packageName: String, className: String): Result<Unit> =
+        error("off the freeze path")
 }
 
 /**
@@ -119,6 +135,9 @@ private class FakeAppRepository(private val details: (String) -> AppInfo?) : App
     override suspend fun updateInstallSizes(sizes: Map<String, Long>) {
         error("off the freeze path")
     }
+
+    override suspend fun getComponentDetails(packageName: String): ComponentSnapshot? =
+        error("off the freeze path")
 }
 
 /**

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.presentation
 
 import android.content.ContextWrapper
+import com.valhalla.thor.domain.gateway.ComponentEnabledState
 import com.valhalla.thor.domain.model.AnimationIntensity
 import com.valhalla.thor.domain.model.AppGridDensity
 import com.valhalla.thor.domain.model.AppInfo
@@ -13,6 +14,7 @@ import com.valhalla.thor.domain.model.BulkOutcome
 import com.valhalla.thor.domain.model.BulkRequest
 import com.valhalla.thor.domain.model.NoOpReason
 import com.valhalla.thor.domain.model.BundleFormat
+import com.valhalla.thor.domain.model.ComponentSnapshot
 import com.valhalla.thor.domain.model.DefaultTab
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.FilterType
@@ -190,6 +192,18 @@ class FakeSystemRepository(private val trace: CallTrace? = null) : SystemReposit
         note("probeObb:$packageName")
         return obbProbe
     }
+
+    override suspend fun setComponentEnabled(
+        packageName: String,
+        className: String,
+        state: ComponentEnabledState
+    ) = record("setComponentEnabled:$packageName:$className:$state")
+
+    override suspend fun forceLaunchActivity(packageName: String, className: String) =
+        record("forceLaunchActivity:$packageName:$className")
+
+    override suspend fun stopService(packageName: String, className: String) =
+        record("stopService:$packageName:$className")
 }
 
 /** Backed by a [MutableStateFlow] so a test can push a rescan mid-run if it needs one. */
@@ -205,6 +219,15 @@ class FakeAppRepository(initialApps: List<AppInfo> = emptyList()) : AppRepositor
      */
     val details = mutableMapOf<String, DetailedAppInfo>()
 
+    /**
+     * Component reads, by package.
+     *
+     * Falls back to whatever [details] already holds for the package, so a test that plants a
+     * `DetailedAppInfo` gets a consistent answer from both reads without saying it twice. `null` —
+     * the read failed — stays reachable by planting neither.
+     */
+    val componentSnapshots = mutableMapOf<String, ComponentSnapshot>()
+
     override fun getAllApps(): Flow<List<AppInfo>> = apps
 
     override suspend fun getAppDetails(packageName: String): AppInfo? =
@@ -212,6 +235,9 @@ class FakeAppRepository(initialApps: List<AppInfo> = emptyList()) : AppRepositor
 
     override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? =
         details[packageName]
+
+    override suspend fun getComponentDetails(packageName: String): ComponentSnapshot? =
+        componentSnapshots[packageName] ?: details[packageName]?.components
 
     override suspend fun getApkDetails(apkPath: String): AppInfo? = null
 
@@ -537,6 +563,10 @@ class FakePreferenceRepository(
 
     override suspend fun setExtensionConsentAccepted(accepted: Boolean) {
         write { it.copy(extensionConsentAccepted = accepted) }
+    }
+
+    override suspend fun setComponentControlConsentAccepted(accepted: Boolean) {
+        write { it.copy(componentControlConsentAccepted = accepted) }
     }
 
     override suspend fun setAutoReinstallEnabled(enabled: Boolean) {

--- a/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/backup/hub/BackupRestoreHubViewModelTest.kt
@@ -4,6 +4,7 @@
 package com.valhalla.thor.presentation.backup.hub
 
 import com.valhalla.thor.domain.model.AppInfo
+import com.valhalla.thor.domain.model.ComponentSnapshot
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.repository.AppRepository
 import com.valhalla.thor.domain.repository.BackupArchiveItem
@@ -52,6 +53,7 @@ class BackupRestoreHubViewModelTest {
         override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? = null
         override suspend fun getApkDetails(apkPath: String): AppInfo? = null
         override suspend fun updateInstallSizes(sizes: Map<String, Long>) = Unit
+        override suspend fun getComponentDetails(packageName: String): ComponentSnapshot? = null
     }
 
     @Before

--- a/docs/superpowers/specs/2026-08-25-component-control-design.md
+++ b/docs/superpowers/specs/2026-08-25-component-control-design.md
@@ -1,0 +1,481 @@
+# Component control in App Info → Components
+
+**Request:** community feature request, relayed by the maintainer — open an activity from the
+component list the way Activity Launcher does; force-open the ones that are not exported; restrict
+services, broadcast receivers and wakelocks the way other root apps do.
+**Date:** 2026-08-25
+**Status:** design approved in chat (Section 1 approved explicitly; Sections 2–5 decided under the
+maintainer's instruction to proceed). Implementation on `feat/component-control`.
+**Branch:** `feat/component-control` → PR against `dev`. No `versionCode` bump (feature branch).
+
+---
+
+## 1. What the request assumed, and what the platform actually does
+
+Four platform facts were verified against raw AOSP sources across `pie-release` …
+`android16-release` (API 28–36) before any design was drawn. Three of them contradict a premise in
+the request, so they are recorded here rather than buried in a commit message.
+
+### 1.1 Launching a non-exported activity needs uid 0. Not "privilege" — uid 0.
+
+`ActivityManager.canAccessUnexportedComponents(uid)` waives the export check for `ROOT_UID` (0) and
+`SYSTEM_UID` (1000) only. The permission that would otherwise buy it, `START_ANY_ACTIVITY`, is
+`protectionLevel="signature"` in every release from Android 9 to 16 **and is not present in
+`packages/Shell/AndroidManifest.xml` in any of them**. `pm grant` refuses it ("not a changeable
+permission type").
+
+Consequence: **Shizuku-over-ADB cannot force-launch a non-exported activity.** Shizuku *started as
+root* runs at uid 0 and can. A Device Owner cannot either — `DevicePolicyManagerService` never
+references `START_ANY_ACTIVITY`; a DO's only activity-launch privilege is an exemption from
+background-activity-launch limits.
+
+The `startActivityAsCaller` back door is also closed: it needs `START_ACTIVITY_AS_CALLER` (also
+signature, also absent from Shell) *and* a non-null `resultTo` activity token, which `cmd activity`
+never has.
+
+### 1.2 Shell cannot change component state at all — this is not new, and not about SELinux
+
+`PackageManagerService` carries a uid-specific carve-out, unchanged from `pie-release` through
+`android16-release`:
+
+```java
+if (callingUid == Process.SHELL_UID
+        && (pkgSetting.getFlags() & ApplicationInfo.FLAG_TEST_ONLY) == 0) {
+    // Shell can only change whole packages between ENABLED and DISABLED_USER states
+    if (className == null
+            && (oldState in {DISABLED_USER, DEFAULT, ENABLED})
+            && (newState in {DISABLED_USER, DEFAULT, ENABLED})) {
+        // allowed
+    } else {
+        throw new SecurityException("Shell cannot change component state for "
+                + packageName + "/" + className + " to " + newState);
+    }
+}
+```
+
+`className == null` is a requirement of the allowed branch. So from a shell uid:
+
+- `pm disable-user <pkg>` — allowed. (This is exactly what Thor's existing Shizuku freeze does; the
+  codebase has been living inside this rule without naming it.)
+- `pm disable <pkg>` — refused. Whole-package `DISABLED` is not in the allowed set.
+- `pm disable-user <pkg>/<cls>` — refused. Any non-null class name is refused.
+
+Shell *does* hold `CHANGE_COMPONENT_ENABLED_STATE` (it is `signature|privileged` and
+`com.android.shell` is platform-signed and privileged), which is why this surprises people. Holding
+the permission is not sufficient; the uid check runs anyway. App Manager encodes the same rule
+client-side, with the comment *"Since Oreo, shell can only disable components of test only apps."*
+
+The reflection fallback Thor uses elsewhere buys nothing here: `IPackageManager
+.setComponentEnabledSetting` arrives at the same check with the same calling uid.
+
+A Device Owner has no route either — `DevicePolicyManager` exposes zero component-enabled APIs
+(`grep -n "ComponentEnabled\|COMPONENT_ENABLED"` over the whole class returns nothing). Its
+whole-app hammers are `setApplicationHidden` and `setPackagesSuspended`, and
+`setUserControlDisabledPackages` is the *opposite* of a restriction — it marks packages protected
+from being disabled or force-stopped.
+
+**Therefore per-component control is uid 0 only:** root, or Shizuku started as root.
+
+### 1.3 Restricting wakelocks through app-ops is a placebo
+
+`PowerManagerService` contains no app-op check anywhere. `Notifier` calls
+`mAppOps.startOpNoThrow(OP_WAKE_LOCK, …)` and **discards the result**, directly beneath a standing
+AOSP comment reading `// XXX need to deal with disabled operations.` When the wakelock carries a
+`WorkSource` the op is not even noted — the `startOpNoThrow` call sits in the `else` branch of
+`if (workSource != null)`.
+
+`OP_WAKE_LOCK` is backed by the `WAKE_LOCK` permission, which is `protectionLevel="normal|instant"`
+and therefore cannot be revoked by permission machinery either. So `appops set <pkg> WAKE_LOCK
+ignore` changes accounting and nothing else.
+
+Genuine partial-wakelock suppression in `PowerManagerService` is uid-level only: cached-process
+state, exclusion from the device-idle allowlist, and Low Power Standby. Per-tag blocking exists
+only as an Xposed hook on `acquireWakeLockInternal` — and even Amplify throttles (one acquire per
+240 s per tag) rather than blocking.
+
+**Wakelock restriction is therefore out of scope for this feature**, and is not merely deferred for
+effort reasons. What *is* achievable, and is a different feature with a different name, is listed in
+§9.
+
+### 1.4 What the state we write actually survives
+
+- Component-level disabled entries are persisted per user in
+  `/data/system/users/<id>/package-restrictions.xml` and **survive reboot and app update** — on
+  replace, PMS prunes only the component names that no longer exist in the new APK
+  (`pkgSetting.restoreComponentSettings`).
+- Whole-*package* state is the opposite: reset to `DEFAULT` on every install/update unless the
+  session opted into `setApplicationEnabledSettingPersistent()` (Android 13+; unconditional reset
+  before that). A Play update silently re-enables a `pm disable-user`d app. Not our problem here,
+  but worth knowing before anyone reasons by analogy from freeze.
+- Clearing app data does **not** reset component state unless the target app itself declared
+  `android:resetEnabledSettingsOnAppDataCleared`. Thor ships a Clear Data action; users will assume
+  otherwise.
+- An app can always re-enable **its own** components — `isCallerTargetApp` is an unconditional
+  allow in PMS. A determined app undoes anything we write, on its next launch. The only mechanism
+  that beats that is Intent Firewall (§9.1), which is not in this cut.
+
+---
+
+## 2. Capability matrix
+
+Keyed on **effective uid**, not on `PrivilegeMode`, because Shizuku has two of them.
+
+| Operation | No privilege | Shizuku @ shell (2000) | Shizuku @ root (0) | Dhizuku (DO) | Root |
+|---|---|---|---|---|---|
+| Open an **exported** activity with no `android:permission` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Open an exported activity **guarded by a permission** Thor lacks | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Force-open a **non-exported** activity | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Enable/disable **one component** | ❌ | ❌ | ✅ | ❌ | ✅ |
+| `am stopservice` on a non-exported service | ❌ | ❌ | ✅ | ❌ | ✅ |
+
+The first row needs no privilege at all: any app may launch an exported activity, and a user tap
+gives Thor a visible window, so background-activity-launch limits do not apply. **"Open" is
+therefore available to every user of Thor, including one with no privilege mode configured** — a
+point worth making because it is the only part of this feature most users can use.
+
+Row 2 is the case every comparable tool except sdex/ActivityManager gets wrong: an *exported*
+activity guarded by an `android:permission` Thor does not hold fails exactly like a non-exported
+one. The predicate is `launchRequiresRoot = !exported || permission != null`.
+
+---
+
+## 3. Scope
+
+**In:**
+
+1. Per-component metadata in the model (exported / effective enabled state / manifest default /
+   guarding permission).
+2. **Open** and **Force Open** on activity rows.
+3. **Disable / Enable / Reset to default** on every component type.
+4. **Stop now** on service rows (transient; `am stopservice`).
+5. A bookkeeping ledger of what Thor disabled, with a per-app **Restore all**.
+
+**Out** (with reasons, so nobody re-derives them): wakelock restriction (§1.3), Intent Firewall
+(§9.1), enforcement/re-apply after update or boot (explicitly chosen against — the ledger is
+bookkeeping), bulk multi-select component operations, per-component labels (§9.3), cross-user
+component state, and any new permission in Thor's manifest.
+
+---
+
+## 4. Data model
+
+### 4.1 `ComponentDetail` replaces `List<String>`
+
+`AppRepositoryImpl.getDetailedAppInfo` already requests `GET_ACTIVITIES | GET_SERVICES |
+GET_RECEIVERS | GET_PROVIDERS | … | MATCH_DISABLED_COMPONENTS | MATCH_DISABLED_UNTIL_USED_COMPONENTS`
+and then discards every attribute at one line:
+
+```kotlin
+val activities = packInfo.activities?.map { it.name } ?: emptyList()
+```
+
+That line is the choke point. It becomes a mapper producing:
+
+```kotlin
+@Serializable @Immutable
+data class ComponentDetail(
+    val className: String,
+    val exported: Boolean,
+    val enabled: Boolean,                 // effective state, right now
+    val manifestDefaultEnabled: Boolean,  // android:enabled
+    val permission: String? = null,       // android:permission guarding entry
+)
+```
+
+Two booleans instead of a four-value enum: `enabled != manifestDefaultEnabled` *is* "somebody
+overrode this" (what Reset-to-default needs to know), and `!manifestDefaultEnabled` is "off by
+design, not by anyone's choice" — a distinction the UI must draw or it invites people to "fix"
+components the developer shipped off deliberately.
+
+### 4.2 Reading effective state costs two binder calls, not N
+
+The obvious route — `getComponentEnabledSetting` per row — is hundreds of binder calls for
+something like GMS. Instead, call `getPackageInfo` **twice**: once with `MATCH_DISABLED_COMPONENTS |
+MATCH_DISABLED_UNTIL_USED_COMPONENTS` (what the code already does) and once without. A component
+present in the first list and absent from the second is effectively not enabled;
+`ComponentInfo.enabled` then says whether that is the manifest's doing or a person's.
+
+`ComponentInfo.enabled` alone cannot answer this: it only ever reports the manifest attribute, never
+the runtime override. That is the trap this avoids.
+
+The diff is computed over a `Set<String>` of class names, because PackageManager returns components
+un-deduped — the existing LazyColumn key comment in `AppInfoDetailsScreen.kt` already documents
+duplicate class names within one package.
+
+State is **current-user only**, matching what `getDetailedAppInfo` does today.
+
+### 4.3 The ledger — `component_overrides`, schema v7
+
+```kotlin
+@Entity(
+    tableName = "component_overrides",
+    primaryKeys = ["packageName", "className", "userId"],
+    indices = [Index("packageName")],
+)
+data class ComponentOverrideEntity(
+    val packageName: String,
+    val className: String,
+    val userId: Int,
+    val componentType: String,      // so a row still renders after the component disappears
+    val restoreToEnabled: Boolean,  // the manifest default captured at write time
+    val disabledAt: Long,
+)
+```
+
+A pure table-add, so an `AutoMigration` like every migration since v2.
+
+`restoreToEnabled` is captured **when the override is written**, because a later app version can
+change the manifest default, and "Restore" has to mean "put it back the way the developer shipped
+it", not "enable it".
+
+`userId` is in the primary key with no precedent to copy — `freezer_apps` and `freeze_profile_apps`
+are package-keyed only — because a restore that targets the wrong user is silent and wrong.
+
+Known risk, stated rather than hidden: **there is no Room migration test anywhere in this repo** and
+`fallbackToDestructiveMigration` is debug-only. A table-add `AutoMigration` is generated and
+schema-validated at build time, so this is as safe as a schema change gets here, but it ships
+without an upgrade test like the six before it.
+
+---
+
+## 5. The privileged seam
+
+Chosen approach: **component-scoped verbs become first-class `SystemGateway` methods**, plus one
+capability value object. The alternative — a separate port off the interface, following the
+`clearCache` / `DataArchiveCapability` precedent — was rejected because it creates a second
+privileged-dispatch mechanism that must re-derive the Root → Shizuku → Dhizuku fallback. Riding the
+generic `executeShellCommand` seam was rejected outright: no reflection fallback, no per-mode
+judgement, and it abandons the codebase's rule that a mutating op is judged by re-reading state
+rather than by an exit code.
+
+### 5.1 New gateway methods
+
+```kotlin
+suspend fun setComponentEnabled(packageName: String, className: String, enabled: Boolean): Result<Unit>
+suspend fun forceLaunchActivity(packageName: String, className: String): Result<Unit>
+suspend fun stopService(packageName: String, className: String): Result<Unit>
+```
+
+**Root** implements all three through new builders in `ComponentCommands.kt`, mirroring the
+`PerUserCommands` contract exactly (internal top-level pure functions, already-escaped package,
+explicit `userId: Int`, escaping done exactly once by the caller):
+
+| Verb | Command |
+|---|---|
+| disable | `pm disable --user N <pkg>/<cls>` |
+| enable, manifest default was **on** | `pm default-state --user N <pkg>/<cls>` |
+| enable, manifest default was **off** | `pm enable --user N <pkg>/<cls>` |
+| force launch | `am start --user N -n <pkg>/<cls>` |
+| stop service | `am stopservice --user N <pkg>/<cls>` |
+
+The enable split matters: restoring a component whose manifest default is *enabled* should remove
+the override entirely (`default-state`) rather than leave a spurious explicit-ENABLED record behind.
+
+**Shizuku** runs the identical commands **only when `Shizuku.getUid() == 0`**, and otherwise returns
+a localized refusal. This is the one place in the codebase where the Shizuku gateway's behaviour
+depends on its own uid, so it is commented with §1.2's reason.
+
+**Dhizuku** always refuses, localized. The refusal follows `DhizukuSystemGateway.clearAllCaches`'s
+pattern (a `UiText` string resource), *not* the two hardcoded-English refusals that also exist in
+the tree.
+
+### 5.2 Judging success
+
+Exit codes are not trusted, per house rule, and here they actively lie:
+
+- `am start` prints `Security exception: …` plus a Java stack trace on **stderr** for a permission
+  denial, and from Android 14 the SecurityException path is deliberately converted to
+  `START_CLASS_NOT_FOUND` so as not to disclose package existence. A background-launch abort is
+  *silent* — `ActivityStarter.getExternalResult` rewrites `START_ABORTED` to `START_SUCCESS`.
+- `am force-stop`'s shell command ends in an unconditional `return 0` (existing precedent for why
+  Thor re-reads state).
+
+So:
+
+- `setComponentEnabled` is judged by re-reading `getComponentEnabledSetting(ComponentName)` and
+  comparing against what was asked for. That read needs no permission.
+- `forceLaunchActivity` and `stopService` cannot be judged by re-reading anything, so they are
+  judged by exit code **plus** an output scan for the known failure shapes, and the resulting error
+  is mapped to a human sentence (§7).
+
+### 5.3 `ComponentCapability` — one place that answers "can this mode do this"
+
+The repo currently spells "mode X can't do this" **eight different ways**, only one of which
+(`FreezePolicy.uninstallFreezeFallbackAllowed`) is an exhaustive `when (PrivilegeMode)` that a new
+mode would break the build on. This feature adds a ninth idiom unless it is consolidated, so:
+
+```kotlin
+enum class ComponentControlBlocker { NONE, NOT_READY, NO_PRIVILEGE, SHIZUKU_NOT_ROOT, DHIZUKU }
+
+data class ComponentCapability(
+    val canForceLaunch: Boolean,
+    val canSetComponentState: Boolean,
+    val canStopService: Boolean,
+    val blocker: ComponentControlBlocker,
+)
+
+fun componentCapability(mode: PrivilegeMode?, isReady: Boolean, shizukuUid: Int?): ComponentCapability
+```
+
+A pure function in `domain/`, exhaustive over `PrivilegeMode`, therefore JVM-testable — the
+`FreezePolicy` template. Reading Shizuku's uid is not JVM-testable (`rikka.shizuku.Shizuku`'s static
+init builds a Binder and throws "not mocked"), so the uid is *passed in* by a thin data-layer
+provider rather than read inside the pure function.
+
+`NOT_READY` is a distinct blocker because `HomeViewModel` already shows the *preferred* mode while
+`isReady == false`; a capability that collapses "not ready yet" into "not capable" would tell a root
+user during cold start that they cannot do something they can.
+
+---
+
+## 6. UX
+
+### 6.1 The row
+
+Today a component row is the fully-qualified class name in Fira Mono, with the whole row clickable
+to copy. It gains a leading state marker, optional badges, an optional trailing action, and an
+overflow:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ● com.example.app.ui.MainActivity              [ Open ]  ⋮   │
+│ ○ com.example.app.ui.DebugActivity   NOT EXPORTED  [Force] ⋮ │
+│ ⊘ com.example.app.sync.SyncService    DISABLED           ⋮   │
+│ ◌ com.example.app.ui.LegacyActivity   OFF BY DEFAULT     ⋮   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Row click keeps its current meaning (copy the class name) so nothing existing is taken away.
+
+**Overflow contents**, by type and capability:
+
+- Copy class name — always.
+- Disable / Enable — every type, when `canSetComponentState`.
+- Reset to default — only when `enabled != manifestDefaultEnabled`.
+- Stop now — services only, when `canStopService`.
+- When the capability is missing, the destructive items are **replaced by one muted, non-clickable
+  line naming the blocker** ("Needs root — Shizuku over ADB cannot change component state"), rather
+  than shown as dead controls. Dead switches teach people the feature is broken; a sentence teaches
+  them what to change. `NOT_READY` shows "Checking privileges…" instead.
+
+### 6.2 Force Open is visibly different from Open
+
+Non-exported and permission-guarded activities get a distinct label and a distinct colour, following
+sdex, which highlights them. Thor does **not** copy sdex's decision to *hide* non-exported
+activities behind an opt-in dialog: this list already shows every component, and hiding them would
+be a regression on the surface's existing purpose.
+
+### 6.3 First-use disclaimer
+
+The first time a user changes any component state, a one-time dialog explains that disabling
+components can break the app, that the app can undo it by itself, and that Thor keeps a list to
+restore from. Acceptance persists through the existing preferences seam. This is Activity Launcher's
+proven pattern, minus its hard-exit-on-decline behaviour (declining simply cancels the action).
+
+### 6.4 Restore all
+
+When the ledger holds rows for the current package, the Components tab header shows
+`N restricted by Thor · Restore all`. Restoring walks the ledger and applies `restoreToEnabled`.
+
+Honesty requirement, borrowed verbatim from App Manager's documentation: **Thor only tracks what
+Thor changed.** A component disabled by another tool shows as disabled but is not in the ledger, and
+Restore all does not touch it. The UI says so rather than implying total knowledge.
+
+---
+
+## 7. Errors
+
+Every failure travels through `AppInfoDetailsViewModel`'s existing events `Channel` → Toast, as
+`UiText`, with `UiTextException` for the translated cases — the established plumbing, no new bus.
+
+Raw exception text is never shown. Activity Launcher's failure path is literally
+`Toast(… + ": " + e)` and it is the anti-pattern this feature is measured against. The known shapes
+are mapped:
+
+| Observed | Shown |
+|---|---|
+| `Security exception:` / `not exported` | "Android refused: this activity is private to *App*." |
+| `does not exist` / `START_CLASS_NOT_FOUND` | "That component no longer exists in this app." |
+| `unable to resolve Intent` | "Nothing on this device can open that." |
+| Odin `JOB_NOT_EXECUTED` (-1) | The existing transport-failure string. |
+| Anything else | Existing `R.string.error_format` fallback. |
+
+After any state change the row is refreshed from the **observed** state, never optimistically from
+the command's return.
+
+---
+
+## 8. Testing
+
+JVM (the gate that runs in CI):
+
+- `ComponentCommandsTest` — mirrors `PerUserCommandsTest`: every builder pinned as a whole string,
+  and the reflective sweep that fails any builder not varying with the user id.
+- `ComponentCapabilityTest` — exhaustive over `PrivilegeMode`, both Shizuku uids, and `isReady =
+  false`. The `FreezePolicy` test is the template.
+- Use-case and ViewModel tests asserting against `FakeSystemRepository.calls` — the ordered list of
+  commands that reached the privilege layer — not against the returned `Result`, because a gate that
+  refuses *after* the command was issued satisfies a `Result` assertion while the component is
+  already disabled.
+- `SystemRepositorySurfaceTest` updated for the three new methods.
+
+Device:
+
+- Unprivileged **Open** and the capability gating are testable on any emulator.
+- The root paths need uid 0. An `android-30/google_apis` AVD gives `adb root` (a root *shell*), but
+  Thor's root gateway needs `su` reachable from an **app** uid, which an AOSP emulator image does
+  not provide. A Magisk-patched AVD is attempted; if it does not come up, the root paths are
+  verified by the maintainer on physical hardware and this document is updated with the result
+  rather than the feature being claimed as verified.
+
+---
+
+## 9. Deliberately not in this cut
+
+### 9.1 Intent Firewall
+
+App Manager blocks activities, services and broadcasts by writing XML to `/data/system/ifw` — alive
+in AOSP `main` today, hot-reloaded by a `FileObserver` ~250 ms after a write, surviving reboot, app
+update and even uninstall, and **undetectable by the target app**, which is a real advantage given
+§1.4's note that an app can re-enable its own components. It is rejected for v1 because it means a
+raw write into `/data/system` (root-only in practice — App Manager's capability check is literally a
+writability probe), it has no `<provider>` tag so providers need a second mechanism and the UI then
+has to explain which one is in force per row, and its behaviour under KernelSU/APatch SELinux
+policy and on OEM ROMs is unverified. Worth doing later; not worth doubling the surface now.
+
+### 9.2 Wakelocks, honestly
+
+Per §1.3 the app-op is a placebo. The achievable, shell-capable (therefore Shizuku-capable) levers
+are `cmd deviceidle whitelist -<pkg>`, `am set-standby-bucket <pkg> restricted`, and force-stop —
+which genuinely drops the package's alarms and cancels its jobs via `ACTION_PACKAGE_RESTARTED`. Per-tag
+blocking would need Thor's own Xposed module (Strombringer) hooking
+`PowerManagerService.acquireWakeLockInternal`. That is a separate feature with a separate name, and
+promising "restrict wakelocks" through app-ops would be shipping a lie.
+
+### 9.3 Component labels
+
+Activity Launcher shows human-readable labels. Doing so means a resource lookup per component into
+another app's assets — 600+ for a large system app — and a taller row on a surface that is
+deliberately monospaced class names. The cheap subset, if it is ever wanted, is launcher activities
+only: one extra `queryIntentActivities` call, no per-row cost.
+
+### 9.4 Bulk
+
+The multi-select seam already exists (`MultiSelectToolBox` → `MultiAppAction` → the exhaustive
+`MultiAppAffirmationDialog` `when` → `performLoggedMultiAction`) and "disable all receivers of these
+12 apps" would ride it. The primitive lands first; the bulk verb is a follow-up that costs one
+sealed-interface entry.
+
+---
+
+## 10. Risks
+
+1. **Root-only means most users get only "Open".** That is the platform's decision, not ours, but it
+   should be said plainly in the release notes rather than discovered.
+2. **A disabled component can be re-enabled by the app itself** (§1.4). The ledger will then show a
+   row whose real state has drifted. The UI reads state live on every load, so drift is *visible*;
+   it is not silently corrected.
+3. **No Room migration test** (§4.3).
+4. **Disabling a provider can break other apps**, not just this one. Providers are in scope because
+   excluding them would be arbitrary, but the disclaimer names this case.
+5. **OEM ROM divergence** on `pm`'s component syntax is unverified beyond AOSP.


### PR DESCRIPTION
Closes the long-standing "let me control components" request: the Components tab in App Info stops being a read-only list and becomes a set of controls, gated by what the active privilege transport can actually do.

Design spec: `docs/superpowers/specs/2026-08-25-component-control-design.md`.

## What you can do now

| Component | Action | Needs |
|---|---|---|
| Activity, exported & unguarded | **Open** | nothing |
| Activity, not exported or permission-guarded | **Force open** | uid 0 |
| Activity, exported | **Force open** (overflow) — the shell route still works when the app is frozen or suspended | uid 0 |
| Service | **Stop now** (transient) | uid 0 |
| Service / Receiver / Activity | **Disable** and **Enable** (persistent) | uid 0 |
| Anywhere | **Restore all** — every component Thor disabled, in every app, back to how it shipped | uid 0 |

Every row also offers **Copy class name**, which needs nothing.

## Which privilege gets what

`ComponentCapability` stores exactly one fact — **does the transport execute at uid 0** — because every privileged verb here collapses onto it:

- **Setting component state** is uid 0 only. `PackageManagerService.setEnabledSetting` carves out `Process.SHELL_UID` for *package*-level changes and explicitly rejects a non-null class name. Reaching `IPackageManager.setComponentEnabledSetting` by reflection hits the same check with the same uid, so there is no fallback.
- **Force-launching** is uid 0 only. `ActivityManager.canAccessUnexportedComponents` waives export and permission checks for `ROOT_UID` and `SYSTEM_UID` alone. `START_ANY_ACTIVITY` is `signature` and the Shell package does not declare it in any release from 9 to 16.
- **Stopping a service** is uid 0 only *here*. `ActiveServices.retrieveServiceLocked` would let any uid stop an **exported** service, so a shell-uid Shizuku could stop some of them — that narrower path is deliberately not offered, because a "Stop" that silently does nothing on half the rows is worse than one that is honestly absent.

So: **root** and **Shizuku started as root** get everything; **shell-uid Shizuku** and **Dhizuku** get the read-only list plus Open on exported activities, under a banner that says why. Dhizuku is not a partial case but an empty one — `DevicePolicyManager` has no component-enabled API at all.

Per the design decision on the issue, Thor **never** touches `Settings.Secure.assistant` and never asks for `WRITE_SECURE_SETTINGS`; force launch stays root-only rather than borrowing the assistant-method trick.

## The ledger is bookkeeping, not policy

`component_overrides` (Room v7, `AutoMigration(6, 7)`, one new table, no existing column touched) records what Thor disabled so it can offer Restore All and flag drift. **PackageManager stays the source of truth.** There is no boot receiver and no re-apply sweep: if another tool re-enables a component, Thor reports it as *"Changed elsewhere"* rather than fighting for it. A restore that fails on one row leaves that row in the ledger and reports `Restored N of M`.

## Verification

Driven end to end on `emulator-5556` (API 37 / SDK 37 userdebug AVD, Shizuku's own server started at uid 0 so `hasUid0 = true` exercises the privileged path through `ShizukuSystemGateway`):

- Open on an exported activity, with and without privilege
- Force open disabled on a non-exported activity when not uid 0
- Stop now on a **running** service and on a **not-running** one — both report honestly
- Disable on a broadcast receiver → `dumpsys package` shows it under `disabledComponents`
- Drift: external `pm default-state` → the row flips from "Restricted by Thor" to "Changed elsewhere" without a process restart
- Restore all, **partial** (`Restored 3 of 4 — the rest are still restricted`, failing row survives in the ledger) and **complete** (`Restored 2 components`, ledger empty, no PM overrides left)
- Both blocker banners: shell-uid Shizuku → *"Changing components needs Shizuku started as root."*; no transport → *"Turn on Root or Shizuku to change components."*

`:app:testStoreDebugUnitTest --rerun-tasks` → **1721 tests, 0 failures, 0 errors**. `:app:lintStoreRelease` → 8 issues, all Hint, identical to the committed baseline.

## Three platform traps worth knowing

1. **`am stopservice` exits 255 in every case, success included.** The only discriminator is stderr: `Service stopped` / `Service not stopped: was not running.` / `Error stopping service`. Hence `ComponentCommandKind.STOP_SERVICE`, which reads markers alone and ignores the exit code.
2. **On SDK 37 `am` writes the outcome to stderr and only an echo to stdout.** `ShizukuHelper.execute` returns `stdout.ifBlank { stderr }`, so the outcome was invisible — `executeCombined` was added alongside it. `execute`'s contract is unchanged for its several dozen existing callers.
3. **`ComponentInfo.enabled` is the manifest `android:enabled` attribute**, never the effective state, so `componentSnapshotOf` calls `getComponentEnabledSetting` per component.

Strings are translated into all eight in-app locales.

**Do not merge** — @trinadhthatakula will merge after a physical rooted-device test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-component controls in App Info for enabling, disabling, resetting, launching, stopping, and forgetting components.
  * Added detailed status information for activities, services, receivers, and providers, including state and restriction badges.
  * Added restore-all support for components disabled by Thor.
  * Added capability guidance based on available privilege access, with clear unsupported-action messages.
  * Added a confirmation disclaimer before disabling components.
* **Localization**
  * Added translations for component controls and messages in Arabic, Chinese, English, French, Polish, Portuguese, and Spanish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->