### PR TITLE
fix(components): answer the three review findings on the disable path

### DIFF
--- a/app/src/androidTest/java/com/valhalla/thor/presentation/appList/DontAskAgainRowTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/presentation/appList/DontAskAgainRowTest.kt
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.percentOffset
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.valhalla.thor.R
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * What the component disclaimer's "don't ask again this session" option announces.
+ *
+ * The same defect [SettingsSwitchRow][com.valhalla.thor.presentation.settings.SettingsSwitchRow] was
+ * fixed for, on a row written afterwards: `Modifier.clickable` around a `Checkbox` whose own handler
+ * is null contributes an on-click action and no *state*, so between the two nodes nothing carries
+ * ticked-or-not and a screen reader offers "double tap to activate" over an option whose value it
+ * never says.
+ *
+ * Worth asserting on this row in particular rather than trusting the pattern. It is the one control
+ * in Thor that turns *off* a warning — the disclaimer standing between a mis-tap and a component
+ * disabled inside an app that goes on looking perfectly healthy. A user who cannot hear the box's
+ * state can silence that warning for the session without knowing they did.
+ */
+@RunWith(AndroidJUnit4::class)
+class DontAskAgainRowTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<ComponentActivity>()
+
+    private val reported = mutableListOf<Boolean>()
+
+    /** Read off the activity rather than hardcoded, so the eight locales cannot break the lookup. */
+    private val label: String
+        get() = rule.activity.getString(R.string.component_disclaimer_dont_ask_session)
+
+    private fun setRow(checked: Boolean) = rule.setContent {
+        DontAskAgainRow(checked = checked, onCheckedChange = { reported += it })
+    }
+
+    private val hasCheckboxRole = SemanticsMatcher.expectValue(
+        SemanticsProperties.Role,
+        Role.Checkbox
+    )
+
+    /** The two facts `clickable` plus a silenced `Checkbox` lost between them: which control, and its state. */
+    @Test
+    fun theRowAnnouncesItselfAsACheckboxAndSaysItIsTicked() {
+        setRow(checked = true)
+
+        rule.onNodeWithText(label).assert(hasCheckboxRole).assertIsOn()
+    }
+
+    /** And unticked, so that "on" above is a reading rather than a constant. */
+    @Test
+    fun anUntickedRowSaysOff() {
+        setRow(checked = false)
+
+        rule.onNodeWithText(label).assert(hasCheckboxRole).assertIsOff()
+    }
+
+    /**
+     * The option is offered once.
+     *
+     * A live `onCheckedChange` on the `Checkbox` would carry its own toggle semantics, making two
+     * toggleable nodes for one option — a screen reader walks past it twice and reads the label on
+     * only one of them. The null handler is what prevents that, and this is the assertion that it
+     * holds.
+     */
+    @Test
+    fun thereIsExactlyOneControlToFind() {
+        setRow(checked = false)
+
+        assertEquals(1, rule.onAllNodes(isToggleable()).fetchSemanticsNodes().size)
+    }
+
+    /** Tapping an unticked row asks to silence the disclaimer. */
+    @Test
+    fun tappingAnUntickedRowAsksForTrue() {
+        setRow(checked = false)
+
+        rule.onNodeWithText(label).performClick()
+
+        assertEquals(listOf(true), reported)
+    }
+
+    /**
+     * And a ticked row asks for **false** — the value the user wants, not the one in force.
+     *
+     * The direction matters because the caller assigns the reported value straight to its state. An
+     * implementation that reported the current value instead would make the box impossible to untick,
+     * which on this row means a consent the user tried to withdraw and could not.
+     */
+    @Test
+    fun tappingATickedRowAsksForFalse() {
+        setRow(checked = true)
+
+        rule.onNodeWithText(label).performClick()
+
+        assertEquals(listOf(false), reported)
+    }
+
+    /**
+     * A tap that lands on the box itself still counts once.
+     *
+     * The null handler stops the `Checkbox` consuming the pointer, so the tap falls through to the
+     * row. Give the box a handler back and this is the test that fails, because one tap toggles
+     * twice — once in the box, once in the row underneath it — and the option ends where it started.
+     */
+    @Test
+    fun aTapOnTheBoxItselfTogglesOnce() {
+        setRow(checked = false)
+
+        rule.onNodeWithText(label).performTouchInput {
+            click(percentOffset(0.04f, 0.5f))
+        }
+        rule.waitForIdle()
+
+        assertEquals(listOf(true), reported)
+    }
+}

--- a/app/src/androidTest/java/com/valhalla/thor/presentation/appList/DontAskAgainRowTest.kt
+++ b/app/src/androidTest/java/com/valhalla/thor/presentation/appList/DontAskAgainRowTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.click
@@ -17,6 +18,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.percentOffset
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.valhalla.thor.R
 import org.junit.Assert.assertEquals
@@ -114,6 +116,22 @@ class DontAskAgainRowTest {
         rule.onNodeWithText(label).performClick()
 
         assertEquals(listOf(false), reported)
+    }
+
+    /**
+     * The row is big enough to hit.
+     *
+     * The other half of the trade material3 makes here: `Checkbox` applies
+     * `minimumInteractiveComponentSize()` **only while `onCheckedChange != null`**, so the null
+     * handler that fixes the announcement also gives up the 48dp target the box was reserving. A
+     * `toggleable` row is the standard fix for the semantics and silently swaps WCAG 4.1.2 for 2.5.8
+     * unless the row asks for the height back.
+     */
+    @Test
+    fun theTouchTargetIsAtLeast48dp() {
+        setRow(checked = false)
+
+        rule.onNodeWithText(label).assertHeightIsAtLeast(48.dp)
     }
 
     /**

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -200,10 +200,6 @@ class PreferenceRepositoryImpl(
         val EXTENSIONS_UNLOCKED = booleanPreferencesKey("extensions_unlocked")
         val EXTENSION_CONSENT_ACCEPTED = booleanPreferencesKey("extension_consent_accepted")
 
-        // Component control
-        val COMPONENT_CONTROL_CONSENT_ACCEPTED =
-            booleanPreferencesKey("component_control_consent_accepted")
-
         // Auto Reinstall
         val AUTO_REINSTALL_ENABLED = booleanPreferencesKey("auto_reinstall_enabled")
 
@@ -412,14 +408,6 @@ class PreferenceRepositoryImpl(
     override suspend fun setExtensionConsentAccepted(accepted: Boolean) {
         context.dataStore.guardedWrite(SETTINGS_STORE) {
             it[Keys.EXTENSION_CONSENT_ACCEPTED] = accepted
-        }
-    }
-
-    // --- Component control ---
-
-    override suspend fun setComponentControlConsentAccepted(accepted: Boolean) {
-        context.dataStore.guardedWrite(SETTINGS_STORE) {
-            it[Keys.COMPONENT_CONTROL_CONSENT_ACCEPTED] = accepted
         }
     }
 
@@ -670,8 +658,6 @@ internal fun Preferences.toUserPreferences(
         appGridDensity = appGridDensity,
         extensionsUnlocked = prefs[Keys.EXTENSIONS_UNLOCKED] ?: false,
         extensionConsentAccepted = prefs[Keys.EXTENSION_CONSENT_ACCEPTED] ?: false,
-        componentControlConsentAccepted =
-            prefs[Keys.COMPONENT_CONTROL_CONSENT_ACCEPTED] ?: false,
         autoReinstallEnabled = prefs[Keys.AUTO_REINSTALL_ENABLED] ?: false,
         exportDirUri = prefs[Keys.EXPORT_DIR_URI],
         appInfoActionsOrder = AppInfoActionId.fromSavedNamesOrDefault(

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -71,13 +71,6 @@ data class UserPreferences(
     val extensionsUnlocked: Boolean = false,
     val extensionConsentAccepted: Boolean = false,
 
-    // Per-component control (App info → Components). Disabling a component is the one action in Thor
-    // that can break an app without the app ever appearing changed — it stays installed, enabled and
-    // launchable while some part of it silently stops working. The first disable therefore asks once,
-    // and this records that it was answered. Read-only actions (Open, Force open, Stop now) never
-    // consult it; nothing here gates them.
-    val componentControlConsentAccepted: Boolean = false,
-
     // Auto Reinstall Config
     val autoReinstallEnabled: Boolean = false,
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -136,9 +136,6 @@ interface PreferenceRepository {
     suspend fun setExtensionsUnlocked(unlocked: Boolean)
     suspend fun setExtensionConsentAccepted(accepted: Boolean)
 
-    // --- Component control ---
-    suspend fun setComponentControlConsentAccepted(accepted: Boolean)
-
     // --- Auto Reinstall ---
     suspend fun setAutoReinstallEnabled(enabled: Boolean)
     suspend fun getInstallerArg(): String

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ComponentControlUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ComponentControlUseCase.kt
@@ -29,6 +29,28 @@ fun enableTargetState(manifestDefaultEnabled: Boolean): ComponentEnabledState =
     if (manifestDefaultEnabled) ComponentEnabledState.DEFAULT else ComponentEnabledState.ENABLED
 
 /**
+ * The outcome of a verb that changes the platform *and* writes the ledger.
+ *
+ * Two fields rather than one [Result] because the two halves can disagree, and collapsing them
+ * loses the only case that matters: **the privileged change went through and the record of it did
+ * not.** Chaining the ledger write inside `Result.onSuccess` collapsed exactly that way — that block
+ * does not catch, so a Room failure (`SQLiteFullException`, a disk-I/O error) threw out through the
+ * `Result` and the caller reported a failure for a component that was, in fact, already off.
+ *
+ * The platform is the source of truth, so [platform] alone decides whether the *action* succeeded.
+ * [ledgerError] is a second, quieter fact about Thor's bookkeeping, and only [disable] has to say it
+ * out loud: an unrecorded disable is invisible to Restore All. For the restoring verbs a failed
+ * ledger delete leaves a row whose component is enabled, which the UI already surfaces on its own as
+ * drift — "Changed elsewhere", with Forget offered — so there is nothing extra to tell the user.
+ */
+data class ComponentActionOutcome(
+    val platform: Result<Unit>,
+    val ledgerError: Throwable? = null,
+) {
+    val isPlatformSuccess: Boolean get() = platform.isSuccess
+}
+
+/**
  * The per-component verbs, with the ledger kept in step.
  *
  * The pairing is the reason this exists rather than the ViewModel calling [SystemRepository]
@@ -37,6 +59,10 @@ fun enableTargetState(manifestDefaultEnabled: Boolean): ComponentEnabledState =
  * Ordering is deliberate in both directions — **the ledger is written only after the platform call
  * succeeds, and cleared only after the restoring call succeeds** — so a failure at any point leaves
  * the ledger describing the world as it is.
+ *
+ * Every ledger touch is wrapped. The repository hands Room calls straight through, so each one can
+ * throw on a full or damaged database; unwrapped, that throw either took the process down (the
+ * verbs the ViewModel launched bare) or was misreported as the platform call failing.
  */
 @Factory
 class ComponentControlUseCase(
@@ -52,9 +78,11 @@ class ComponentControlUseCase(
         packageName: String,
         type: ComponentType,
         component: ComponentDetail,
-    ): Result<Unit> = systemRepository
-        .setComponentEnabled(packageName, component.className, ComponentEnabledState.DISABLED)
-        .onSuccess {
+    ): ComponentActionOutcome {
+        val platform = systemRepository
+            .setComponentEnabled(packageName, component.className, ComponentEnabledState.DISABLED)
+        if (platform.isFailure) return ComponentActionOutcome(platform)
+        val ledger = runCatching {
             overrides.record(
                 packageName = packageName,
                 className = component.className,
@@ -65,16 +93,20 @@ class ComponentControlUseCase(
                 restoreToEnabled = component.manifestDefaultEnabled,
             )
         }
+        return ComponentActionOutcome(platform, ledger.exceptionOrNull())
+    }
 
     /** Switch [component] back on and drop its ledger row. */
-    suspend fun enable(packageName: String, component: ComponentDetail): Result<Unit> =
-        systemRepository
-            .setComponentEnabled(
+    suspend fun enable(packageName: String, component: ComponentDetail): ComponentActionOutcome =
+        restoring(
+            systemRepository.setComponentEnabled(
                 packageName,
                 component.className,
                 enableTargetState(component.manifestDefaultEnabled),
-            )
-            .onSuccess { overrides.forget(packageName, component.className) }
+            ),
+            packageName,
+            component.className,
+        )
 
     /**
      * Remove the override entirely, whatever it was, and drop the ledger row.
@@ -82,10 +114,24 @@ class ComponentControlUseCase(
      * Distinct from [enable]: this is offered for a component whose state somebody *else* set, where
      * "on" would be Thor asserting a preference rather than stepping out of the way.
      */
-    suspend fun resetToDefault(packageName: String, className: String): Result<Unit> =
-        systemRepository
-            .setComponentEnabled(packageName, className, ComponentEnabledState.DEFAULT)
-            .onSuccess { overrides.forget(packageName, className) }
+    suspend fun resetToDefault(packageName: String, className: String): ComponentActionOutcome =
+        restoring(
+            systemRepository
+                .setComponentEnabled(packageName, className, ComponentEnabledState.DEFAULT),
+            packageName,
+            className,
+        )
+
+    /** Drop the row for a component the platform call just put back, if it did. */
+    private suspend fun restoring(
+        platform: Result<Unit>,
+        packageName: String,
+        className: String,
+    ): ComponentActionOutcome {
+        if (platform.isFailure) return ComponentActionOutcome(platform)
+        val ledger = runCatching { overrides.forget(packageName, className) }
+        return ComponentActionOutcome(platform, ledger.exceptionOrNull())
+    }
 
     /**
      * Put every component Thor disabled back the way it found it.
@@ -94,6 +140,14 @@ class ComponentControlUseCase(
      * call succeeds. A partial failure therefore leaves exactly the rows that are still overridden,
      * which is what makes pressing Restore All again a safe retry rather than a second, different
      * operation.
+     *
+     * A row counts as restored only when **both** halves land. Counting a successful platform call
+     * whose ledger delete failed would report "restored 3 of 3" while a row was still sitting in the
+     * table telling the screen that 1 component is still restricted — a completion message the
+     * user's own screen contradicts. Under-reporting instead keeps the two consistent, and the row
+     * that stays behind makes the next press retry it; `setComponentEnabled` is idempotent, so a
+     * retry on an already-restored component is free. Each delete is wrapped so that one unwritable
+     * row cannot abort the sweep over all the others.
      *
      * @return the number restored and the number attempted.
      */
@@ -106,17 +160,23 @@ class ComponentControlUseCase(
                 row.className,
                 enableTargetState(row.restoreToEnabled),
             )
-            if (result.isSuccess) {
-                overrides.forget(row.packageName, row.className)
+            if (result.isSuccess &&
+                runCatching { overrides.forget(row.packageName, row.className) }.isSuccess
+            ) {
                 restored++
             }
         }
         return RestoreAllOutcome(restored = restored, attempted = rows.size)
     }
 
-    /** Forget a row without touching the platform — for an override something else already undid. */
-    suspend fun forget(packageName: String, className: String) =
-        overrides.forget(packageName, className)
+    /**
+     * Forget a row without touching the platform — for an override something else already undid.
+     *
+     * Returns a [Result] rather than throwing: the caller launches this from the UI, and a Room
+     * failure escaping into `viewModelScope` is an uncaught exception, which is process death.
+     */
+    suspend fun forget(packageName: String, className: String): Result<Unit> =
+        runCatching { overrides.forget(packageName, className) }
 
     suspend fun forceLaunch(packageName: String, className: String): Result<Unit> =
         systemRepository.forceLaunchActivity(packageName, className)

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -66,6 +67,7 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -1125,28 +1127,10 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
                             pending.component.shortName
                         )
                     )
-                    // The whole row toggles, not just the box: a 20dp target inside a dialog is
-                    // below the 48dp minimum, and the label is the part the eye goes to.
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(MaterialTheme.shapes.small)
-                            .clickable { dontAskAgain = !dontAskAgain },
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Checkbox(
-                            checked = dontAskAgain,
-                            // Null so the row's click is the single source of the toggle; a handler
-                            // here would make the box independently clickable and able to disagree
-                            // with the row on a fast double-tap.
-                            onCheckedChange = null,
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(
-                            text = stringResource(R.string.component_disclaimer_dont_ask_session),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
+                    DontAskAgainRow(
+                        checked = dontAskAgain,
+                        onCheckedChange = { dontAskAgain = it },
+                    )
                 }
             },
             confirmButton = {
@@ -1734,6 +1718,53 @@ private data class ComponentLists(
  * through `android.text.format.Formatter.formatShortFileSize(context, …)` and therefore has always
  * read its locale off the Context.
  */
+/**
+ * The "don't ask again this session" option on the component disclaimer.
+ *
+ * The whole row toggles, not just the box: a 20dp target inside a dialog is below the 48dp minimum,
+ * and the label is the part the eye goes to.
+ *
+ * `toggleable` rather than `clickable`, for the reason [FixStoreSheet][com.valhalla.thor.presentation.main.FixStoreSheet]'s
+ * row and [SettingsSwitchRow][com.valhalla.thor.presentation.settings.SettingsSwitchRow] both state:
+ * `clickable` contributes an on-click action and no *state*, and the box's own handler has to be null
+ * or the two nodes can disagree on a fast double-tap — so between them nothing would announce whether
+ * the option is ticked. `Role.Checkbox` is what puts the state in the announcement.
+ *
+ * That matters more here than on a selection row. This box decides whether the warning in this very
+ * dialog stops appearing, so a screen-reader user who cannot hear its state can silence the one
+ * warning standing between a mis-tap and an app that is broken while still looking healthy — without
+ * knowing they did it.
+ *
+ * Extracted from the dialog rather than left inline so the semantics are assertable; the dialog needs
+ * a bound view model, this needs nothing.
+ */
+@Composable
+internal fun DontAskAgainRow(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.small)
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                role = Role.Checkbox,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Null: the row above owns the toggle. A live handler here would be a second semantics node,
+        // and a second thing to disagree with the row.
+        Checkbox(checked = checked, onCheckedChange = null)
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = stringResource(R.string.component_disclaimer_dont_ask_session),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
 private fun formatTime(timestamp: Long, context: Context): String {
     if (timestamp == 0L) return context.getString(R.string.not_available)
     return try {

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -1746,6 +1747,12 @@ internal fun DontAskAgainRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            // Asked for explicitly, because the null handler above gives it up: material3's
+            // `Checkbox` applies `minimumInteractiveComponentSize()` only while `onCheckedChange`
+            // is non-null, so the fix for the announcement silently traded WCAG 4.1.2 for 2.5.8 —
+            // measured at 24dp, exactly half the minimum. Widening the row to full width only ever
+            // fixed the horizontal axis.
+            .heightIn(min = 48.dp)
             .clip(MaterialTheme.shapes.small)
             .toggleable(
                 value = checked,

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -1109,19 +1110,47 @@ private fun ComponentsTabScreen(details: DetailedAppInfo) {
     }
 
     state.pendingConsent?.let { pending ->
+        // Keyed on the component so the tick does not carry over from a dialog the user dismissed
+        // onto the next component they pick — a silenced disclaimer would then be a decision made
+        // for a different component than the one shown.
+        var dontAskAgain by remember(pending.component.className) { mutableStateOf(false) }
         AlertDialog(
             onDismissRequest = viewModel::onDisclaimerDismissed,
             title = { Text(stringResource(R.string.component_disclaimer_title)) },
             text = {
-                Text(
-                    stringResource(
-                        R.string.component_disclaimer_message,
-                        pending.component.shortName
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text(
+                        stringResource(
+                            R.string.component_disclaimer_message,
+                            pending.component.shortName
+                        )
                     )
-                )
+                    // The whole row toggles, not just the box: a 20dp target inside a dialog is
+                    // below the 48dp minimum, and the label is the part the eye goes to.
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.small)
+                            .clickable { dontAskAgain = !dontAskAgain },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = dontAskAgain,
+                            // Null so the row's click is the single source of the toggle; a handler
+                            // here would make the box independently clickable and able to disagree
+                            // with the row on a fast double-tap.
+                            onCheckedChange = null,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = stringResource(R.string.component_disclaimer_dont_ask_session),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
             },
             confirmButton = {
-                Button(onClick = viewModel::onDisclaimerConfirmed) {
+                Button(onClick = { viewModel.onDisclaimerConfirmed(dontAskAgain) }) {
                     Text(stringResource(R.string.component_disclaimer_confirm))
                 }
             },

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentConsentSession.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentConsentSession.kt
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import org.koin.core.annotation.Single
+
+/**
+ * Whether the component-disable disclaimer has been silenced **for this launch of Thor**.
+ *
+ * Disabling a component is the one action in Thor that can break an app without the app ever
+ * appearing changed — it stays installed, enabled and launchable while some part of it silently
+ * stops working. The disclaimer is the only warning the user gets, so it asks **every time** by
+ * default, and silencing it is opt-in per session rather than a permanent answer.
+ *
+ * Deliberately not persisted, and that is the whole design:
+ *
+ * - **A permanent "don't ask again" disarms the warning forever** on the strength of one tap that
+ *   may have been a mis-tap. A session is long enough to cover the real use case — one sitting spent
+ *   trimming several apps — and short enough that the warning comes back for the next one.
+ * - **Nothing to read means nothing to wait for.** A persisted flag has to be loaded before the gate
+ *   can be evaluated, which leaves a window where the answer is *unknown*; the previous version of
+ *   this gate defaulted that window to "accepted" and so skipped the disclaimer entirely if a
+ *   disable was requested before DataStore had emitted. An in-memory flag that starts `false` cannot
+ *   have that bug: unknown does not exist, and the default is to ask.
+ * - **No clock.** A 24-hour or calendar-day window would have to trust the device clock and time
+ *   zone, both of which can move under it.
+ *
+ * A `@Single` rather than state on the ViewModel because [ComponentControlViewModel] is keyed per
+ * package: holding the flag there would re-ask for every app the user opens, which is the annoyance
+ * the checkbox exists to prevent. Process death clears it, which is exactly the intended lifetime.
+ *
+ * The extension-manager consent is a different decision and stays persisted — that one is a
+ * grant-and-forget liability acknowledgement for a whole feature, not a per-action warning.
+ */
+@Single
+class ComponentConsentSession {
+
+    /** True once the user has ticked "don't ask again" and confirmed, until the process dies. */
+    var isDisclaimerSilenced: Boolean = false
+        private set
+
+    fun silenceForSession() {
+        isDisclaimerSilenced = true
+    }
+}

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentControlViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/ComponentControlViewModel.kt
@@ -17,7 +17,7 @@ import com.valhalla.thor.domain.model.ComponentOverride
 import com.valhalla.thor.domain.model.ComponentSnapshot
 import com.valhalla.thor.domain.model.ComponentType
 import com.valhalla.thor.domain.repository.AppRepository
-import com.valhalla.thor.domain.repository.PreferenceRepository
+import com.valhalla.thor.domain.usecase.ComponentActionOutcome
 import com.valhalla.thor.domain.usecase.ComponentControlUseCase
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
@@ -58,12 +58,6 @@ data class ComponentControlUiState(
     val overrides: Map<String, ComponentOverride> = emptyMap(),
     /** The component a privileged call is running against, if any. One at a time, by design. */
     val busyClassName: String? = null,
-    /**
-     * Starts `true` so the disclaimer cannot flash on screen during the first frame, before the
-     * preference has been read. A dialog that appears and vanishes unread is worse than one that
-     * appears a beat late.
-     */
-    val consentAccepted: Boolean = true,
     val pendingConsent: PendingComponentDisable? = null,
     val showRestoreAllConfirm: Boolean = false,
 ) {
@@ -86,7 +80,7 @@ class ComponentControlViewModel(
     private val appRepository: AppRepository,
     private val componentControl: ComponentControlUseCase,
     private val capabilityProvider: ComponentCapabilityProvider,
-    private val preferenceRepository: PreferenceRepository,
+    private val consentSession: ComponentConsentSession,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -100,14 +94,6 @@ class ComponentControlViewModel(
 
     private var ledgerJob: Job? = null
     private var refreshJob: Job? = null
-
-    init {
-        viewModelScope.launch {
-            preferenceRepository.userPreferences.collect { prefs ->
-                _uiState.update { it.copy(consentAccepted = prefs.componentControlConsentAccepted) }
-            }
-        }
-    }
 
     /**
      * Bind to [packageName]. Safe to call again — the host drives it from a `LaunchedEffect`.
@@ -135,7 +121,6 @@ class ComponentControlViewModel(
                     // open while a second, identical PackageManager round-trip ran.
                     isLoading = initial.isEmpty,
                     snapshot = initial,
-                    consentAccepted = it.consentAccepted,
                 )
             }
             ledgerJob = viewModelScope.launch {
@@ -247,12 +232,18 @@ class ComponentControlViewModel(
     /**
      * Ask to switch a component off.
      *
-     * Routed through the disclaimer on the first ever disable. The check is here rather than in the
-     * composable so that every entry point to a disable — row menu, and anything added later —
-     * inherits it instead of each host remembering to ask.
+     * Routed through the disclaimer **every time**, unless the user has silenced it for this session.
+     * The check is here rather than in the composable so that every entry point to a disable — row
+     * menu, and anything added later — inherits it instead of each host remembering to ask.
+     *
+     * Reading a plain in-memory flag is what makes this correct rather than merely convenient: there
+     * is no load to await, so there is no window in which the answer is unknown and no default to
+     * choose for that window. The previous version read a persisted preference and defaulted the
+     * unread state to *accepted*, which skipped the disclaimer outright for a disable requested
+     * before DataStore had emitted.
      */
     fun requestDisable(type: ComponentType, component: ComponentDetail) {
-        if (!_uiState.value.consentAccepted) {
+        if (!consentSession.isDisclaimerSilenced) {
             _uiState.update {
                 it.copy(pendingConsent = PendingComponentDisable(type, component))
             }
@@ -261,15 +252,16 @@ class ComponentControlViewModel(
         performDisable(type, component)
     }
 
-    fun onDisclaimerConfirmed() {
+    /**
+     * @param dontAskAgain the checkbox on the dialog — silence the disclaimer until Thor is killed.
+     */
+    fun onDisclaimerConfirmed(dontAskAgain: Boolean) {
         val pending = _uiState.value.pendingConsent ?: return
         _uiState.update { it.copy(pendingConsent = null) }
-        viewModelScope.launch {
-            // Persisted before the action runs, not after it succeeds: the question asked was "do
-            // you understand what disabling does", and the answer does not become un-given because
-            // this particular component refused.
-            preferenceRepository.setComponentControlConsentAccepted(true)
-        }
+        // Recorded before the action runs, not after it succeeds: the question asked was "do you
+        // understand what disabling does", and the answer does not become un-given because this
+        // particular component refused.
+        if (dontAskAgain) consentSession.silenceForSession()
         performDisable(pending.type, pending.component)
     }
 
@@ -281,14 +273,21 @@ class ComponentControlViewModel(
         val packageName = _uiState.value.packageName
         if (packageName.isEmpty()) return
         runExclusively(component.className) {
-            componentControl.disable(packageName, type, component)
-                .onSuccess {
-                    _events.send(
-                        UiText.StringResource(R.string.component_disabled_success, component.shortName)
+            val outcome = componentControl.disable(packageName, type, component)
+            report(
+                outcome = outcome,
+                packageName = packageName,
+                // The one place the ledger's failure has to be said out loud. The component is off
+                // either way, but with no row to find it by, Restore All will never offer it back.
+                success = if (outcome.ledgerError == null) {
+                    UiText.StringResource(R.string.component_disabled_success, component.shortName)
+                } else {
+                    UiText.StringResource(
+                        R.string.component_disabled_unrecorded,
+                        component.shortName
                     )
-                    refreshSnapshot(packageName)
-                }
-                .onFailure { e -> sendFailure(e) }
+                },
+            )
         }
     }
 
@@ -296,14 +295,14 @@ class ComponentControlViewModel(
         val packageName = _uiState.value.packageName
         if (packageName.isEmpty()) return
         runExclusively(component.className) {
-            componentControl.enable(packageName, component)
-                .onSuccess {
-                    _events.send(
-                        UiText.StringResource(R.string.component_enabled_success, component.shortName)
-                    )
-                    refreshSnapshot(packageName)
-                }
-                .onFailure { e -> sendFailure(e) }
+            report(
+                outcome = componentControl.enable(packageName, component),
+                packageName = packageName,
+                success = UiText.StringResource(
+                    R.string.component_enabled_success,
+                    component.shortName
+                ),
+            )
         }
     }
 
@@ -311,14 +310,38 @@ class ComponentControlViewModel(
         val packageName = _uiState.value.packageName
         if (packageName.isEmpty()) return
         runExclusively(component.className) {
-            componentControl.resetToDefault(packageName, component.className)
-                .onSuccess {
-                    _events.send(
-                        UiText.StringResource(R.string.component_reset_success, component.shortName)
-                    )
-                    refreshSnapshot(packageName)
-                }
-                .onFailure { e -> sendFailure(e) }
+            report(
+                outcome = componentControl.resetToDefault(packageName, component.className),
+                packageName = packageName,
+                success = UiText.StringResource(
+                    R.string.component_reset_success,
+                    component.shortName
+                ),
+            )
+        }
+    }
+
+    /**
+     * Announce a verb's result, letting the **platform** decide whether it worked.
+     *
+     * A ledger failure is not a failed action: the component really did change state. For the
+     * restoring verbs it is not even worth a message, because a row left behind on an enabled
+     * component is drift, and the list already labels that "Changed elsewhere" and offers Forget.
+     * Logged rather than shown, so the cause is still recoverable from a bug report.
+     */
+    private suspend fun report(
+        outcome: ComponentActionOutcome,
+        packageName: String,
+        success: UiText,
+    ) {
+        outcome.ledgerError?.let { e ->
+            Logger.e(TAG, "Ledger write failed after a successful component change", e)
+        }
+        if (outcome.isPlatformSuccess) {
+            _events.send(success)
+            refreshSnapshot(packageName)
+        } else {
+            outcome.platform.exceptionOrNull()?.let { sendFailure(it) }
         }
     }
 
@@ -326,11 +349,14 @@ class ComponentControlViewModel(
     fun forget(component: ComponentDetail) {
         val packageName = _uiState.value.packageName
         if (packageName.isEmpty()) return
-        viewModelScope.launch {
+        launchReporting(component.className) {
             componentControl.forget(packageName, component.className)
-            _events.send(
-                UiText.StringResource(R.string.component_forgotten, component.shortName)
-            )
+                .onSuccess {
+                    _events.send(
+                        UiText.StringResource(R.string.component_forgotten, component.shortName)
+                    )
+                }
+                .onFailure { e -> sendFailure(e) }
         }
     }
 
@@ -352,7 +378,7 @@ class ComponentControlViewModel(
     fun confirmRestoreAll() {
         val packageName = _uiState.value.packageName
         _uiState.update { it.copy(showRestoreAllConfirm = false) }
-        viewModelScope.launch {
+        launchReporting("restoreAll") {
             val outcome = withContext(ioDispatcher) { componentControl.restoreAll() }
             _events.send(
                 if (outcome.isComplete) {
@@ -373,6 +399,33 @@ class ComponentControlViewModel(
     }
 
     /**
+     * Launch on [viewModelScope] with the failure path every action on this screen needs.
+     *
+     * The `catch` is load-bearing, not defensive habit. `viewModelScope` installs no exception
+     * handler, so anything that escapes a `launch` block reaches the thread's default handler and
+     * **takes the process down**. Every verb here reaches Room or a privileged shell, either of which
+     * can throw, and a crash is the one outcome worse than a failed disable — it loses the whole
+     * screen while leaving whatever already happened in place.
+     *
+     * Every launch in this class goes through here for that reason. The two that did not — Forget
+     * and Restore All — were each one `SQLiteFullException` away from killing Thor from a tap.
+     * `CancellationException` is rethrown so cancellation stays cancellation rather than being
+     * reported to the user as an error.
+     */
+    private fun launchReporting(tag: String, block: suspend () -> Unit) {
+        viewModelScope.launch {
+            try {
+                block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.e(TAG, "Component action failed for $tag", e)
+                sendFailure(e)
+            }
+        }
+    }
+
+    /**
      * Run one privileged action at a time, marking its row busy for the duration.
      *
      * Serialising is not just cosmetic: `pm` and `am` reach the same `PackageManagerService` state,
@@ -380,24 +433,16 @@ class ComponentControlViewModel(
      * that loses one of them. The busy marker also stops a double-tap becoming two disables and two
      * ledger writes.
      *
-     * The `catch` is load-bearing, not defensive habit. Every verb returns a `Result`, but the
-     * ledger write that follows a successful one happens inside `Result.onSuccess`, which does not
-     * catch — so a Room failure there (`SQLiteFullException`, a disk-I/O error) throws straight out
-     * of the use case. Without a catch that lands in `viewModelScope`'s uncaught handler and takes
-     * the process down, *after* the privileged change already succeeded. Reported like any other
-     * failure instead; `CancellationException` is rethrown so cancellation stays cancellation.
+     * The marker is cleared in a `finally` that only touches a [MutableStateFlow], which is why it
+     * is safe here: it never suspends, so it still runs when the scope is cancelled mid-action. A
+     * suspending cleanup in that position would silently not run on exactly that path.
      */
     private fun runExclusively(className: String, block: suspend () -> Unit) {
         if (_uiState.value.busyClassName != null) return
         _uiState.update { it.copy(busyClassName = className) }
-        viewModelScope.launch {
+        launchReporting(className) {
             try {
                 block()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Logger.e("ComponentControlViewModel", "Component action failed for $className", e)
-                sendFailure(e)
             } finally {
                 _uiState.update { it.copy(busyClassName = null) }
             }
@@ -406,5 +451,9 @@ class ComponentControlViewModel(
 
     private suspend fun sendFailure(e: Throwable) {
         _events.send(UiText.StringResource(R.string.error_format, e.message ?: ""))
+    }
+
+    private companion object {
+        const val TAG = "ComponentControlViewModel"
     }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -815,5 +815,7 @@
     <string name="component_disclaimer_title">تعطيل مكوّن؟</string>
     <string name="component_disclaimer_message">يبقى %1$s جزءًا من التطبيق، لكنه يتوقف عن العمل فقط. نادرًا ما تتوقع التطبيقات ذلك، لذا قد تتعطل إحدى الميزات دون أي رسالة خطأ، أو قد ينهار التطبيق. ويسجّل Thor كل ما يعطّله حتى تتمكن من التراجع لاحقًا.</string>
     <string name="component_disclaimer_confirm">تعطيله</string>
+    <string name="component_disclaimer_dont_ask_session">لا تسأل مرة أخرى في هذه الجلسة</string>
+    <string name="component_disabled_unrecorded">تم تعطيل %1$s، لكن Thor لم يتمكن من تسجيل هذا التعطيل، لذا لن تشمله ميزة استعادة الكل</string>
 
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -755,5 +755,7 @@
     <string name="component_disclaimer_title">¿Desactivar un componente?</string>
     <string name="component_disclaimer_message">%1$s sigue formando parte de la aplicación; simplemente deja de ejecutarse. Las aplicaciones rara vez esperan esto, así que una función puede dejar de funcionar sin dar ningún error, o la aplicación puede cerrarse de forma inesperada. Thor registra lo que desactiva para que puedas deshacerlo más tarde.</string>
     <string name="component_disclaimer_confirm">Desactivarlo</string>
+    <string name="component_disclaimer_dont_ask_session">No volver a preguntar en esta sesión</string>
+    <string name="component_disabled_unrecorded">Se desactivó %1$s, pero Thor no pudo registrar el cambio: Restaurar todo no lo incluirá</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -755,5 +755,7 @@
     <string name="component_disclaimer_title">Désactiver un composant ?</string>
     <string name="component_disclaimer_message">%1$s reste dans l\'application ; il cesse simplement de s\'exécuter. Les applications s\'y attendent rarement : une fonctionnalité peut cesser de marcher sans erreur, ou l\'application peut planter. Thor enregistre ce qu\'il désactive pour que vous puissiez revenir en arrière plus tard.</string>
     <string name="component_disclaimer_confirm">Le désactiver</string>
+    <string name="component_disclaimer_dont_ask_session">Ne plus demander pendant cette session</string>
+    <string name="component_disabled_unrecorded">Thor n\'a pas pu enregistrer la désactivation de %1$s : Tout rétablir ne la proposera pas</string>
 
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -844,5 +844,7 @@
     <string name="component_disclaimer_title">Wyłączyć komponent?</string>
     <string name="component_disclaimer_message">%1$s nadal pozostanie częścią aplikacji; przestanie tylko działać. Aplikacje rzadko się tego spodziewają, więc jakaś funkcja może przestać działać bez żadnego błędu albo aplikacja może ulec awarii. Thor zapisuje, co wyłącza, aby można było to później cofnąć.</string>
     <string name="component_disclaimer_confirm">Wyłącz go</string>
+    <string name="component_disclaimer_dont_ask_session">Nie pytaj ponownie w tej sesji</string>
+    <string name="component_disabled_unrecorded">Wyłączono %1$s, ale Thor nie zdołał tego zapisać — Przywróć wszystkie tego nie obejmie</string>
 
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -609,5 +609,6 @@
 
     <string name="component_disclaimer_message">%1$s continua fazendo parte do aplicativo; apenas deixa de ser executado. Os aplicativos raramente contam com isso, então um recurso pode parar de funcionar sem nenhum erro, ou o aplicativo pode travar. O Thor registra o que desativa para que você possa desfazer depois.</string>
     <string name="component_disclaimer_confirm">Desativar mesmo assim</string>
+    <string name="component_disabled_unrecorded">O Thor não conseguiu registrar a desativação de %1$s — Restaurar tudo não vai incluí-la</string>
 
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -821,5 +821,7 @@
     <string name="component_disclaimer_title">Desativar o componente?</string>
     <string name="component_disclaimer_message">%1$s continua a fazer parte da aplicação; apenas deixa de ser executado. As aplicações raramente contam com isso, por isso uma funcionalidade pode deixar de funcionar sem qualquer erro, ou a aplicação pode falhar. O Thor regista o que desativa para que possa desfazer mais tarde.</string>
     <string name="component_disclaimer_confirm">Desativá-lo</string>
+    <string name="component_disclaimer_dont_ask_session">Não perguntar novamente nesta sessão</string>
+    <string name="component_disabled_unrecorded">O Thor não conseguiu registar a desativação de %1$s — Repor tudo não a incluirá</string>
 
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -741,5 +741,7 @@
     <string name="component_disclaimer_title">禁用此组件？</string>
     <string name="component_disclaimer_message">%1$s 仍会保留在应用中，只是不再运行。应用通常不会预料到这种情况，因此某项功能可能会在没有任何错误提示的情况下失效，应用也可能崩溃。Thor 会记录它禁用过的内容，方便你之后撤销。</string>
     <string name="component_disclaimer_confirm">确认禁用</string>
+    <string name="component_disclaimer_dont_ask_session">本次会话不再询问</string>
+    <string name="component_disabled_unrecorded">已禁用 %1$s，但 Thor 未能记录此次更改——“全部恢复”不会包含它</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -604,6 +604,8 @@
     <string name="component_disclaimer_title">Disable a component?</string>
     <string name="component_disclaimer_message">%1$s stays part of the app; it just stops running. Apps rarely expect this, so a feature may break with no error, or the app may crash. Thor records what it disables so you can undo it later.</string>
     <string name="component_disclaimer_confirm">Disable it</string>
+    <string name="component_disclaimer_dont_ask_session">Don\'t ask again this session</string>
+    <string name="component_disabled_unrecorded">Disabled %1$s, but Thor could not record the change — Restore all will not include it</string>
 
     <string name="section_native_libs_title">Native Libraries (.so)</string>
     <string name="no_native_libs_found">No native libraries found</string>

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/ComponentControlUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/ComponentControlUseCaseTest.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -80,7 +82,8 @@ class ComponentControlUseCaseTest {
 
         val result = useCase.disable(pkg, ComponentType.SERVICE, component(className = "Sync"))
 
-        assertTrue(result.isSuccess)
+        assertTrue(result.isPlatformSuccess)
+        assertNull("a clean run reported a ledger error", result.ledgerError)
         assertEquals(
             listOf("setComponentEnabled:$pkg:Sync:DISABLED"),
             system.calls,
@@ -103,7 +106,7 @@ class ComponentControlUseCaseTest {
 
         val result = useCase.disable(pkg, ComponentType.RECEIVER, component(className = "Boot"))
 
-        assertTrue(result.isFailure)
+        assertTrue(result.platform.isFailure)
         assertTrue("the ledger recorded a disable that never happened", ledger.rows.isEmpty())
     }
 
@@ -137,7 +140,7 @@ class ComponentControlUseCaseTest {
 
         val result = useCase.enable(pkg, component(className = "Sync"))
 
-        assertTrue(result.isSuccess)
+        assertTrue(result.isPlatformSuccess)
         assertEquals(listOf("setComponentEnabled:$pkg:Sync:DEFAULT"), system.calls)
         assertTrue(ledger.rows.isEmpty())
     }
@@ -158,7 +161,7 @@ class ComponentControlUseCaseTest {
 
         val result = useCase.enable(pkg, component(className = "Sync"))
 
-        assertTrue(result.isFailure)
+        assertTrue(result.platform.isFailure)
         assertEquals(1, ledger.rows.size)
     }
 
@@ -178,7 +181,7 @@ class ComponentControlUseCaseTest {
 
         val result = useCase.resetToDefault(pkg, "Sync")
 
-        assertTrue(result.isFailure)
+        assertTrue(result.platform.isFailure)
         assertEquals(1, ledger.rows.size)
     }
 
@@ -220,6 +223,87 @@ class ComponentControlUseCaseTest {
 
         assertTrue(system.calls.isEmpty())
         assertTrue(ledger.rows.isEmpty())
+    }
+
+    // --- the ledger failing is not the platform failing ---
+
+    /**
+     * The inversion this outcome type exists to prevent.
+     *
+     * Chaining the ledger write inside `Result.onSuccess` meant a Room failure threw out through the
+     * `Result`, so the caller reported a *failed disable* for a component that was already off. The
+     * user is then told nothing happened, retries, and gets the same error — while the component has
+     * been disabled the whole time.
+     */
+    @Test
+    fun `a ledger failure does not turn a successful disable into a failure`() = runTest {
+        val system = FakeSystem()
+        val ledger = FakeLedger(writeFailure = IllegalStateException("database or disk is full"))
+        val useCase = ComponentControlUseCase(system, ledger)
+
+        val result = useCase.disable(pkg, ComponentType.SERVICE, component(className = "Sync"))
+
+        assertTrue("the platform call succeeded and must be reported as such", result.isPlatformSuccess)
+        assertNotNull("the lost record has to be reported separately", result.ledgerError)
+        assertEquals(listOf("setComponentEnabled:$pkg:Sync:DISABLED"), system.calls)
+        assertTrue("nothing could be written, so there is no row", ledger.rows.isEmpty())
+    }
+
+    /** Same for the restoring direction, where the leftover row shows up as drift in the UI. */
+    @Test
+    fun `a ledger failure does not turn a successful enable into a failure`() = runTest {
+        val ledger = FakeLedger(
+            rows = mutableListOf(row("Sync", restoreToEnabled = true)),
+            writeFailure = IllegalStateException("disk I/O error"),
+        )
+        val useCase = ComponentControlUseCase(FakeSystem(), ledger)
+
+        val result = useCase.enable(pkg, component(className = "Sync"))
+
+        assertTrue(result.isPlatformSuccess)
+        assertNotNull(result.ledgerError)
+        assertEquals("the row survives, which the UI reads as drift", 1, ledger.rows.size)
+    }
+
+    /** A ledger write that throws must be reported, not thrown — the caller launches this from the UI. */
+    @Test
+    fun `forget reports a ledger failure rather than throwing`() = runTest {
+        val useCase = ComponentControlUseCase(
+            FakeSystem(),
+            FakeLedger(
+                rows = mutableListOf(row("Sync", restoreToEnabled = true)),
+                writeFailure = IllegalStateException("disk I/O error"),
+            ),
+        )
+
+        val result = useCase.forget(pkg, "Sync")
+
+        assertTrue(result.isFailure)
+    }
+
+    /**
+     * One unwritable row must not abort the sweep, and must not be counted as restored.
+     *
+     * Counting it would report "restored 2 of 2" while a row was still in the table telling the
+     * screen a component is restricted — a completion message the user's own screen contradicts.
+     */
+    @Test
+    fun `restore all under-reports a row whose ledger delete failed`() = runTest {
+        val system = FakeSystem()
+        val useCase = ComponentControlUseCase(
+            system,
+            FakeLedger(
+                rows = mutableListOf(row("Sync", restoreToEnabled = true)),
+                writeFailure = IllegalStateException("database or disk is full"),
+            ),
+        )
+
+        val outcome = useCase.restoreAll()
+
+        assertEquals("the platform call was still made", 1, system.calls.size)
+        assertEquals(0, outcome.restored)
+        assertEquals(1, outcome.attempted)
+        assertFalse("an unforgettable row cannot be a complete run", outcome.isComplete)
     }
 
     // --- restoreAll ---
@@ -376,6 +460,15 @@ class ComponentControlUseCaseTest {
  */
 private class FakeLedger(
     val rows: MutableList<ComponentOverride> = mutableListOf(),
+    /**
+     * Makes every write throw, standing in for the database being full or damaged.
+     *
+     * The real repository hands Room calls straight through, so this is not a hypothetical: `upsert`
+     * and `delete` can both throw `SQLiteFullException` or a disk-I/O error, and the production code
+     * used to let that throw travel out through a `Result` the caller read as the *platform* call
+     * having failed.
+     */
+    private val writeFailure: Throwable? = null,
 ) : ComponentOverrideRepository {
 
     private val revision = MutableStateFlow(0)
@@ -391,12 +484,14 @@ private class FakeLedger(
         type: ComponentType,
         restoreToEnabled: Boolean,
     ) {
+        writeFailure?.let { throw it }
         rows.removeAll { it.packageName == packageName && it.className == className }
         rows += ComponentOverride(packageName, className, type, restoreToEnabled, disabledAt = 0L)
         revision.value++
     }
 
     override suspend fun forget(packageName: String, className: String) {
+        writeFailure?.let { throw it }
         rows.removeAll { it.packageName == packageName && it.className == className }
         revision.value++
     }

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -565,10 +565,6 @@ class FakePreferenceRepository(
         write { it.copy(extensionConsentAccepted = accepted) }
     }
 
-    override suspend fun setComponentControlConsentAccepted(accepted: Boolean) {
-        write { it.copy(componentControlConsentAccepted = accepted) }
-    }
-
     override suspend fun setAutoReinstallEnabled(enabled: Boolean) {
         write { it.copy(autoReinstallEnabled = enabled) }
     }

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/ComponentControlViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/ComponentControlViewModelTest.kt
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.appList
+
+import com.valhalla.thor.data.source.local.ComponentCapabilityProvider
+import com.valhalla.thor.domain.model.ComponentDetail
+import com.valhalla.thor.domain.model.ComponentOverride
+import com.valhalla.thor.domain.model.ComponentSnapshot
+import com.valhalla.thor.domain.model.ComponentType
+import com.valhalla.thor.domain.model.PrivilegeMode
+import com.valhalla.thor.domain.model.PrivilegeState
+import com.valhalla.thor.domain.repository.ComponentOverrideRepository
+import com.valhalla.thor.domain.usecase.ComponentControlUseCase
+import com.valhalla.thor.presentation.FakeAppRepository
+import com.valhalla.thor.presentation.FakePrivilegeStateProvider
+import com.valhalla.thor.presentation.FakeSystemRepository
+import com.valhalla.thor.presentation.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The disclaimer gate on [ComponentControlViewModel].
+ *
+ * Worth its own suite because the gate guards the one action in Thor that can break an app while
+ * leaving every visible sign of health intact — the component stays installed, the app stays enabled
+ * and launchable, and some part of it simply stops working. The warning is the only thing standing
+ * between a mis-tap and that outcome, so *when it is skipped* is a behaviour, not a detail.
+ *
+ * The suite is possible at all because the gate stopped being a persisted preference. When the
+ * answer lived in DataStore the only way to drive it was a real preference flow, and the unread
+ * window in between — which defaulted to *accepted*, and so skipped the disclaimer outright — was
+ * exactly the state a test could not pin down. A plain in-memory flag has no such window: it starts
+ * at "ask", and every move away from that is an explicit user action, which is what is asserted
+ * here.
+ *
+ * Both halves are checked each time, because each alone can pass while the gate is broken:
+ * `pendingConsent` says the disclaimer was raised, and the calls reaching [FakeSystemRepository] say
+ * whether the disable itself went through. A test that only looked for a null `pendingConsent`
+ * would be equally happy with a `requestDisable` that quietly did nothing.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ComponentControlViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `the disclaimer is raised for a disable in a fresh session`() = runTest {
+        val fixture = Fixture()
+
+        fixture.viewModel.requestDisable(ComponentType.SERVICE, component("Sync"))
+
+        assertNotNull(
+            "a fresh session must ask before disabling anything",
+            fixture.viewModel.uiState.value.pendingConsent,
+        )
+        assertEquals("the component was disabled before the user answered", emptyList<String>(), fixture.disables)
+    }
+
+    @Test
+    fun `confirming runs the disable that was parked`() = runTest {
+        val fixture = Fixture()
+
+        fixture.viewModel.requestDisable(ComponentType.SERVICE, component("Sync"))
+        fixture.viewModel.onDisclaimerConfirmed(dontAskAgain = false)
+
+        assertNull(fixture.viewModel.uiState.value.pendingConsent)
+        assertEquals(listOf("setComponentEnabled:$PKG:Sync:DISABLED"), fixture.disables)
+    }
+
+    /**
+     * The default, and the reason the checkbox exists rather than the confirm button implying it.
+     *
+     * Confirming *is* consent for the component in front of the user; it is not consent for every
+     * component after it. Treating one tap as a standing answer is what the persisted flag did, and
+     * it did it permanently.
+     */
+    @Test
+    fun `confirming without ticking the box asks again next time`() = runTest {
+        val fixture = Fixture()
+
+        fixture.viewModel.requestDisable(ComponentType.SERVICE, component("Sync"))
+        fixture.viewModel.onDisclaimerConfirmed(dontAskAgain = false)
+        fixture.viewModel.requestDisable(ComponentType.RECEIVER, component("Boot"))
+
+        assertNotNull(
+            "an unticked confirm silenced the disclaimer anyway",
+            fixture.viewModel.uiState.value.pendingConsent,
+        )
+        assertEquals(
+            "the second component went off without being asked about",
+            listOf("setComponentEnabled:$PKG:Sync:DISABLED"),
+            fixture.disables,
+        )
+    }
+
+    @Test
+    fun `ticking the box silences the disclaimer for the rest of the session`() = runTest {
+        val fixture = Fixture()
+
+        fixture.viewModel.requestDisable(ComponentType.SERVICE, component("Sync"))
+        fixture.viewModel.onDisclaimerConfirmed(dontAskAgain = true)
+        fixture.viewModel.requestDisable(ComponentType.RECEIVER, component("Boot"))
+
+        assertNull(
+            "the box was ticked, so the second disable must not stop to ask",
+            fixture.viewModel.uiState.value.pendingConsent,
+        )
+        assertEquals(
+            listOf("setComponentEnabled:$PKG:Sync:DISABLED", "setComponentEnabled:$PKG:Boot:DISABLED"),
+            fixture.disables,
+        )
+    }
+
+    /**
+     * The silence is *session*-scoped, and the session outlives the ViewModel on purpose.
+     *
+     * [ComponentControlViewModel] is scoped per package by its Koin key, so a flag held on the
+     * ViewModel would re-ask for every app the user opened — the annoyance the checkbox is there to
+     * prevent. Sharing the one session instance is what makes a single tick cover a whole sitting.
+     */
+    @Test
+    fun `the silence spans the packages of one session`() = runTest {
+        val session = ComponentConsentSession()
+
+        Fixture(session).viewModel.also {
+            it.requestDisable(ComponentType.SERVICE, component("Sync"))
+            it.onDisclaimerConfirmed(dontAskAgain = true)
+        }
+        // A second view model over a second package, as opening another app's sheet builds.
+        val next = Fixture(session, packageName = OTHER_PKG)
+        next.viewModel.requestDisable(ComponentType.RECEIVER, component("Boot"))
+
+        assertNull(
+            "the tick did not carry to the next package",
+            next.viewModel.uiState.value.pendingConsent,
+        )
+        assertEquals(listOf("setComponentEnabled:$OTHER_PKG:Boot:DISABLED"), next.disables)
+    }
+
+    /**
+     * And it does not outlive the process, which is the whole difference from the persisted flag.
+     *
+     * A fresh [ComponentConsentSession] is what a relaunch produces, since nothing reads the answer
+     * back from disk.
+     */
+    @Test
+    fun `the silence does not survive a new session`() = runTest {
+        Fixture().viewModel.also {
+            it.requestDisable(ComponentType.SERVICE, component("Sync"))
+            it.onDisclaimerConfirmed(dontAskAgain = true)
+        }
+
+        val relaunched = Fixture()
+        relaunched.viewModel.requestDisable(ComponentType.SERVICE, component("Sync"))
+
+        assertNotNull(
+            "a silenced session leaked across a restart",
+            relaunched.viewModel.uiState.value.pendingConsent,
+        )
+        assertEquals(emptyList<String>(), relaunched.disables)
+    }
+
+    /** Dismissing drops the parked request; it must not fall through to the disable. */
+    @Test
+    fun `dismissing the disclaimer clears the parked request without disabling`() = runTest {
+        val fixture = Fixture()
+
+        fixture.viewModel.requestDisable(ComponentType.SERVICE, component("Sync"))
+        fixture.viewModel.onDisclaimerDismissed()
+
+        assertNull(fixture.viewModel.uiState.value.pendingConsent)
+        assertEquals("a dismissal disabled the component anyway", emptyList<String>(), fixture.disables)
+
+        fixture.viewModel.requestDisable(ComponentType.SERVICE, component("Sync"))
+        assertNotNull(
+            "a dismissal must not count as an answer",
+            fixture.viewModel.uiState.value.pendingConsent,
+        )
+    }
+
+    /** Confirming with nothing parked is a no-op, not a disable of whatever was last seen. */
+    @Test
+    fun `confirming with no parked request does nothing`() = runTest {
+        val fixture = Fixture()
+
+        fixture.viewModel.onDisclaimerConfirmed(dontAskAgain = true)
+
+        assertNull(fixture.viewModel.uiState.value.pendingConsent)
+        assertEquals(emptyList<String>(), fixture.disables)
+    }
+
+    /**
+     * A bound view model over a stubbed package.
+     *
+     * `load()` is called because [ComponentControlViewModel.performDisable] needs a package name to
+     * act on, and without one every disable would return early — leaving the "went through" half of
+     * each assertion unable to fail. The privilege state is a ready **root** one specifically: a
+     * ready *Shizuku* state would send [ComponentCapabilityProvider] to read `Shizuku.getUid()`,
+     * whose static initialiser builds a Binder and cannot load in a JVM test.
+     */
+    private class Fixture(
+        session: ComponentConsentSession = ComponentConsentSession(),
+        val packageName: String = PKG,
+    ) {
+        val system = FakeSystemRepository()
+
+        val viewModel = ComponentControlViewModel(
+            appRepository = FakeAppRepository().apply {
+                componentSnapshots[packageName] = SNAPSHOT
+            },
+            componentControl = ComponentControlUseCase(system, FakeLedger()),
+            capabilityProvider = ComponentCapabilityProvider(
+                FakePrivilegeStateProvider(
+                    PrivilegeState(root = true, active = PrivilegeMode.ROOT, isReady = true)
+                )
+            ),
+            consentSession = session,
+            ioDispatcher = UnconfinedTestDispatcher(),
+        ).apply { load(packageName, SNAPSHOT) }
+
+        /** The component writes that actually reached the privilege layer, in order. */
+        val disables: List<String>
+            get() = system.calls.filter { it.startsWith("setComponentEnabled:") }
+    }
+
+    /** Enough of a ledger to run the use case; the rows themselves are asserted in its own suite. */
+    private class FakeLedger : ComponentOverrideRepository {
+
+        private val rows = mutableListOf<ComponentOverride>()
+        private val revision = MutableStateFlow(0)
+
+        override fun observe(packageName: String): Flow<List<ComponentOverride>> =
+            revision.map { rows.filter { row -> row.packageName == packageName } }
+
+        override suspend fun getAll(): List<ComponentOverride> = rows.toList()
+
+        override suspend fun record(
+            packageName: String,
+            className: String,
+            type: ComponentType,
+            restoreToEnabled: Boolean,
+        ) {
+            rows += ComponentOverride(packageName, className, type, restoreToEnabled, disabledAt = 0L)
+            revision.value++
+        }
+
+        override suspend fun forget(packageName: String, className: String) {
+            rows.removeAll { it.packageName == packageName && it.className == className }
+            revision.value++
+        }
+
+        override suspend fun forgetPackage(packageName: String) {
+            rows.removeAll { it.packageName == packageName }
+            revision.value++
+        }
+    }
+
+    private companion object {
+        const val PKG = "com.example.app"
+        const val OTHER_PKG = "com.example.other"
+
+        val SNAPSHOT = ComponentSnapshot(
+            services = listOf(component("Sync")),
+            receivers = listOf(component("Boot")),
+        )
+
+        fun component(className: String) = ComponentDetail(
+            className = className,
+            exported = true,
+            enabled = true,
+            manifestDefaultEnabled = true,
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to #435. CodeRabbit posted three findings on `ComponentControlViewModel` that were not read before that PR merged — this is them, checked against the merged code and answered.

All three were still valid. One of them turned out to be worse than reported.

## 1. A tap could kill the process

`forget` and Restore All each launched bare on `viewModelScope`, which installs **no** exception handler. Both open with a raw Room call, so a `SQLiteFullException` from either reached the thread's default handler and took Thor down — losing the whole screen while leaving whatever had already happened in place.

What makes this worth saying plainly: **this defect was already found and fixed once in this same class**, in `runExclusively`, and was never swept across its siblings. Two launches were left. Every launch in the class now routes through one `launchReporting`, which rethrows `CancellationException` and reports everything else, so there is no longer a second path to sweep.

## 2. A full database made a successful disable report "failed"

`overrides.record` ran inside `Result.onSuccess`, which does not catch. The component was genuinely disabled and the user was told the disable failed — the worst combination, because the obvious response is to try again.

`ComponentActionOutcome` now carries the platform result and the ledger error separately:

- **the platform decides whether the action worked.** A ledger failure is not a failed disable.
- the ledger error is logged in every case, so it survives into a bug report.
- it is shown to the user in exactly one place — a disable whose row was not written, via `component_disabled_unrecorded`, because that is the only case where the failure changes what the user can do next: with no row, **Restore all will never offer that component back**. For the restoring verbs a leftover row is drift, and the list already labels that "Changed elsewhere" and offers Forget.

`restoreAll` counts a row only when both halves land, so it under-reports rather than claiming "3 of 3 restored" while the screen still says 1 component is restricted. The leftover row makes the next press a retry, and `setComponentEnabled` is idempotent.

**CodeRabbit's suggested remedy — compensate or roll back the disable — was not taken.** The ledger is bookkeeping, not policy: PackageManager is the source of truth and Thor never re-applies a row. Re-enabling a component because Thor's own notebook was full would undo what the user asked for in order to fix something they did not, and it adds a failure mode of its own (the rollback can fail too, and then what?). Honest reporting is the smaller promise and the true one.

## 3. The consent gate was fail-open — and the default bought nothing

`consentAccepted` defaulted to `true` while DataStore was still loading, so a disable requested in that window skipped the disclaimer entirely. On inspection it was worse than the finding said: the flag was read in exactly one place and **nothing in the UI rendered it**, so the "avoid a flash of the dialog" reasoning the default rested on described a hazard that could not occur. It was a fail-open default in exchange for nothing.

Rather than pick a safer default for the unknown window, the window is gone: consent is a synchronous in-memory flag with no load to await.

### Consent now lasts one session, and only if asked for

Per the owner's call, and it changes the gate's shape:

- the disclaimer is raised for **every** disable by default,
- the dialog carries a **"Don't ask again this session"** checkbox, and confirming *without* ticking it is consent for that component only,
- ticking it silences the disclaimer until Thor's process dies. Nothing is persisted — no DataStore key, no timestamp, no clock or timezone to be wrong about.

A permanent don't-ask would disarm, on one possibly-mis-tapped checkbox, the only warning standing between a mis-tap and an app that is broken while every visible sign of health stays intact. A session is the longest scope that still expires on its own.

It lives in a `@Single` (`ComponentConsentSession`) rather than in the view model, because `ComponentControlViewModel` is keyed per package — view-model-local state would re-ask for every app opened, which is the annoyance the checkbox exists to remove.

**The extension disclaimer is untouched.** That one is a grant-and-forget liability acknowledgement for a whole feature, not a per-action warning, and it stays persisted.

The `componentControlConsentAccepted` preference is removed end to end: field, interface method, DataStore key, setter and flow mapping. Deleting the `init` collect also removed a fourth latent crash site — `userPreferences` has no `.catch`, so a DataStore read error in that collector was another uncaught throw on `viewModelScope`.

## Tests

`ComponentControlViewModelTest` is new — 8 tests on the consent gate, which is the follow-up #435 recorded as out of scope *because* the gate depended on DataStore. Making consent a synchronous injectable is what made it testable.

Each test asserts both halves, because either alone passes while the gate is broken: `pendingConsent` says the disclaimer was raised, and the calls reaching `FakeSystemRepository` say whether the disable actually went through. A test that only looked for a null `pendingConsent` would be equally happy with a `requestDisable` that quietly did nothing.

Covered: the disclaimer is raised in a fresh session; confirming runs the parked disable; confirming *without* ticking asks again; ticking silences the rest of the session; the silence spans packages (a second view model over a second package); the silence does **not** survive a new session; dismissing clears the request without disabling; confirming with nothing parked is a no-op.

`ComponentControlUseCaseTest` gained 4 tests for the ledger-vs-platform split, driven by a `FakeLedger` that can be told to throw: a ledger failure does not turn a successful disable or enable into a failure; `forget` reports a Room failure rather than throwing; Restore All under-reports a row whose delete failed.

| | |
|---|---|
| `:app:testStoreDebugUnitTest` | **1739 tests, 0 failures, 0 errors** (1727 → +4 use case, +8 view model) |
| `:app:lintStoreRelease` | **8 issues, all Hint** — 3 `AndroidGradlePluginVersion`, 5 `VectorPath`. Unchanged from baseline. |

Counts parsed from `build/test-results/**/*.xml`, not the Gradle log line.

Strings added in all 8 locales. `component_disabled_unrecorded` is phrased impersonally in every one (`Se desactivó`, `Wyłączono`, `تم تعطيل`) — a first draft put gender agreement on the `%1$s` placeholder, which is the same locale defect fixed in the previous review round.

## Not verified on device

The three fixes are reached only by a Room failure (a full or damaged database), which is not a state I can produce on the owner's device without deliberately filling it. The consent gate is unit-tested and the disable path itself was verified on a rooted physical device in #435.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a session-only “Don’t ask again” option for component-disable warnings.
  * Added warnings when disabled components cannot be included in “Restore all.”
  * Added translations for the new messages across supported languages.

* **Bug Fixes**
  * Improved component action feedback by distinguishing system-action success from recording failures.
  * Prevented recording failures from interrupting other restore operations.
  * Ensured restore counts include only successfully restored and recorded components.
  * Improved accessibility semantics for the session-only option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->