### PR TITLE
fix(freezer): a watchlist write that fails must not take the process

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
+++ b/app/src/main/java/com/valhalla/thor/data/launcher/FreezerShortcutManager.kt
@@ -82,6 +82,39 @@ class FreezerShortcutManager(
         }
     }
 
+    /**
+     * `scope.launch` for the fire-and-forget port methods, with the throw caught where the caller
+     * cannot reach it.
+     *
+     * A view-model-side guard is worthless for these: the method returns the moment
+     * [CoroutineScope.launch] schedules the body, so the caller's `try`/`catch` — or
+     * `launchGuarded`'s — has already completed successfully by the time the body runs. The throw
+     * then surfaces on [scope], which is `SupervisorJob() + ioDispatcher` with **no**
+     * `CoroutineExceptionHandler`: a `SupervisorJob` stops a failing child from cancelling its
+     * siblings, not from being *reported*, so it goes on to Android's default uncaught handler and
+     * ends the process. That is the same reasoning [rebuildPinnedIcons] already carries; this hoists
+     * it so every launch in this class is covered by one rule instead of one of five being right.
+     *
+     * Everything routed through here is a best-effort launcher cosmetic — an icon repaint, a pin
+     * request the platform never confirms anyway — so continuing is the correct answer. It is not a
+     * silent one at the layer that matters: [ShortcutManagerCompat.requestPinShortcut] only ever
+     * reports the *accept*, so there is nothing a caller could have been told about a refusal even
+     * if the throw could reach it. Logged rather than surfaced for that reason, and because a
+     * `Context` is all this class has — no channel, no UI.
+     */
+    private fun launchSafely(what: String, block: suspend () -> Unit) {
+        scope.launch {
+            try {
+                block()
+            } catch (e: CancellationException) {
+                // Never swallowed: this only arrives when the process-lifetime scope itself dies.
+                throw e
+            } catch (e: Exception) {
+                Logger.e("FreezerShortcut", "$what failed", e)
+            }
+        }
+    }
+
     override fun isPinSupported(): Boolean =
         ShortcutManagerCompat.isRequestPinShortcutSupported(context)
 
@@ -89,7 +122,9 @@ class FreezerShortcutManager(
      *  (grey while frozen, full colour while enabled). Runs off the caller's thread — the icon
      *  decode is heavy — so any surface (dialog, details, freezer) can call this directly. */
     override fun pinAppShortcut(packageName: String, label: String) {
-        scope.launch { pinAppShortcutSuspend(packageName, label) }
+        launchSafely("pinning a shortcut for $packageName") {
+            pinAppShortcutSuspend(packageName, label)
+        }
     }
 
     /** Suspending pin so bulk callers can pin sequentially instead of spawning N concurrent bitmap
@@ -105,7 +140,9 @@ class FreezerShortcutManager(
     /** Update an already-pinned per-app shortcut so its icon reflects the app's current state.
      *  No-op if no such shortcut exists. Call after any freeze/unfreeze of the package. */
     override fun refreshAppShortcut(packageName: String) {
-        scope.launch { updateShortcutIcon(packageName) }
+        launchSafely("repainting the shortcut icon for $packageName") {
+            updateShortcutIcon(packageName)
+        }
     }
 
     /** Ask the launcher to pin a Freeze-all / Unfreeze-all action shortcut. */
@@ -118,7 +155,11 @@ class FreezerShortcutManager(
     /** Publish (or remove) the Freeze-all + Unfreeze-all long-press dynamic shortcuts. */
     fun syncDynamicShortcuts(enabled: Boolean) {
         // Binder IPC — called from Main (cold-start + Settings); keep it off the caller's thread.
-        scope.launch {
+        //
+        // Guarded for the same reason as the two above, and this one is the worst of the three to
+        // leave bare: a cold-start caller means a throw here is a crash *on launch*, before the
+        // user has touched anything.
+        launchSafely(if (enabled) "publishing the bulk shortcuts" else "removing the bulk shortcuts") {
             if (enabled) {
                 ShortcutManagerCompat.setDynamicShortcuts(
                     context,
@@ -191,6 +232,11 @@ class FreezerShortcutManager(
             // binder-death RuntimeException would otherwise escape to Android's default
             // uncaught handler and kill the process — and would also terminate the collector
             // for the rest of the process lifetime. Log and continue.
+            //
+            // Kept *inside* the collected body rather than folded into [launchSafely], which now
+            // covers the other launches in this class: the guard has to sit inside `collect` for
+            // the collector to survive its own failure. Wrapping the launch instead would stop the
+            // crash and still leave every pinned icon stale until the process restarts.
             Logger.e("FreezerShortcut", "pinned icon rebuild failed", e)
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/LaunchGuarded.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/LaunchGuarded.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * `viewModelScope.launch` that reports a throw instead of taking the process with it.
@@ -41,14 +43,30 @@ import kotlinx.coroutines.launch
  * tests (no `testOptions.unitTests.isReturnDefaultValues`), so a log call would throw inside the very
  * guard that exists to stop throws, in every test that drives one of these view models.
  *
+ * That ban is on *this file* touching `android.util.Log`, not on a call site logging from its
+ * [onFailure]. The freezer handlers all open with `Logger.e`, which is safe for a reason this file
+ * cannot rely on for itself: `Logger` gates every level on `Logger.isDebug`, a `var` defaulting to
+ * `false` that only `ThorApplication` and `ThorRootService` ever set, so under JVM tests it stays
+ * false and `Log` is never reached. A bare `Log.e` at a call site would be the same hazard as one
+ * here.
+ *
  * [CancellationException] is rethrown rather than reported: it is structured concurrency's own
  * signal, raised when the view model is cleared or when [ViewModel] scope children are cancelled, and
  * swallowing it would break cancellation rather than report a failure.
+ *
+ * [context] exists because the freezer watchlist call sites this guard was extended to cover in
+ * `fix/freezer-bookkeeping-crashes` are `viewModelScope.launch(ioDispatcher)`, not bare launches.
+ * Without it, adopting the guard would silently move their Room writes and privileged shell calls
+ * onto `Dispatchers.Main.immediate` — a correctness regression bought with a crash fix, and one
+ * nothing would have failed on, because Room's own suspend DAO functions dispatch internally and
+ * would keep working. It is first in the list to match [launch]'s own signature, and defaults to
+ * [EmptyCoroutineContext] so the backup, export and passphrase call sites are unchanged.
  */
 internal fun ViewModel.launchGuarded(
+    context: CoroutineContext = EmptyCoroutineContext,
     onFailure: (Throwable) -> Unit = {},
     block: suspend CoroutineScope.() -> Unit,
-): Job = viewModelScope.launch {
+): Job = viewModelScope.launch(context) {
     try {
         coroutineScope(block)
     } catch (cancellation: CancellationException) {

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -18,8 +18,11 @@ import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.usecase.FreezeAppUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.presentation.launchGuarded
+import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
-import com.valhalla.thor.util.UiTextException
+import com.valhalla.thor.util.asUiText
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -99,6 +102,57 @@ class AppInfoDetailsViewModel(
     private val _events = Channel<UiText>(Channel.BUFFERED)
     val events: Flow<UiText> = _events.receiveAsFlow()
 
+    /**
+     * The same toast channel every action below already reports through, reached from a non-suspend
+     * caller.
+     *
+     * `launchGuarded` hands its `onFailure` a plain `(Throwable) -> Unit`, so `send` — which
+     * suspends — is out of reach there, and the guards would otherwise have no way to say anything
+     * at all. `trySend` is not a weaker promise here: the channel is `BUFFERED`, so it only declines
+     * once 64 messages are sitting undelivered, which describes a screen nobody is collecting rather
+     * than a report that got lost. Inside a coroutine keep using `_events.send`, whose backpressure
+     * is the right behaviour there.
+     *
+     * Named `tryEmitToast` rather than `emitToast` to match `FreezerViewModel`, where the two names
+     * are two different functions: `emitToast` there is a suspending `send` and `tryEmitToast` is the
+     * `trySend`. Calling this one `emitToast` gave the same name to opposite delivery guarantees
+     * across two files that are read together, in a class where both spellings compile.
+     */
+    private fun tryEmitToast(text: UiText) {
+        _events.trySend(text)
+    }
+
+    /**
+     * Watchlist membership for the three places that only *display* it.
+     *
+     * Room reports a failed query by throwing — `SQLiteDiskIOException` on a failing disk,
+     * `SQLiteFullException` on a full one, `SQLiteDatabaseCorruptException` on a damaged file — and
+     * `FreezerRepositoryImpl` is a pass-through that does not catch, so before this existed a
+     * membership read on a bad disk reached the thread's default handler and killed the process on a
+     * tap that was only ever going to decide which way a toggle points.
+     *
+     * Degrading to "not in the freezer" is the fallback
+     * `AppListViewModel.observeFreezerMembership` already chose for the same read — its `Flow.catch`
+     * says so in as many words — and the two surfaces should not disagree. It is also the harmless
+     * direction: the toggle then offers to *add* an app that may already be tracked, and a duplicate
+     * add is the mistake with no consequence, whereas defaulting the other way would hide an
+     * untracked frozen app behind a control that claims it is already handled. Nothing is toasted —
+     * this read is a passenger on a detail load or on a force-stop / clear-cache refresh that
+     * otherwise succeeded, and an error toast there would blame the action the user actually took.
+     *
+     * [CancellationException] is rethrown rather than degraded: a sheet dismissed mid-read is not a
+     * database failure, and swallowing it would publish "not in the freezer" into a view model that
+     * is being cleared.
+     */
+    private suspend fun isInFreezer(packageName: String): Boolean = try {
+        freezerRepository.contains(packageName)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Logger.e("AppInfoDetailsViewModel", "freezer membership read for $packageName failed", e)
+        false
+    }
+
     fun loadAppDetails(packageName: String) {
         _uiState.update {
             it.copy(
@@ -121,7 +175,11 @@ class AppInfoDetailsViewModel(
                 val rootProbe = async { systemRepository.isRootAvailable() }
                 val shizukuProbe = async { systemRepository.isShizukuAvailable() }
                 val dhizukuProbe = async { systemRepository.isDhizukuAvailable() }
-                val freezer = freezerRepository.contains(packageName)
+                // [isInFreezer], not the repository directly: this read is one input to a load the
+                // user asked for, and a Room throw here would take the whole detail sheet — probes,
+                // manifest, components and all — down with the process. Falling back to "not in the
+                // freezer" costs the freezer toggle its accuracy and nothing else.
+                val freezer = isInFreezer(packageName)
                 Triple(
                     rootProbe.await(),
                     shizukuProbe.await(),
@@ -169,7 +227,15 @@ class AppInfoDetailsViewModel(
     // viewModelScope coroutine, so launching again was redundant and could let concurrent refreshes
     // complete out of order. Called directly => it serializes within the caller's coroutine.
     private suspend fun refreshDetails(packageName: String) {
-        val inFreezer = withContext(ioDispatcher) { freezerRepository.contains(packageName) }
+        // The membership read is guarded inside [isInFreezer] rather than at this function's call
+        // sites, and that is the whole reason the helper exists. Seven coroutines call this —
+        // toggleFreezerState, toggleSuspendState, forceStopApp, clearCache, clearData, addToFreezer
+        // and addOrRemoveFromFreezer — and in every one of them the action the user asked for has
+        // already succeeded by the time it runs. Guarding per call site would mean four more functions
+        // needing an `onFailure` that invents something to say about a force-stop or a clear-cache
+        // that worked, over a failure in a refresh the user never asked for. Degrading the read once,
+        // here, fixes all seven at the same point and says nothing, which is the correct amount.
+        val inFreezer = withContext(ioDispatcher) { isInFreezer(packageName) }
         val details = appRepository.getDetailedAppInfo(packageName)
         if (details != null) {
             _uiState.update {
@@ -182,15 +248,51 @@ class AppInfoDetailsViewModel(
     }
 
     fun toggleFreezerState(packageName: String, appName: String?, freeze: Boolean) {
-        viewModelScope.launch {
+        // Raised the instant the freeze / unfreeze returns success and lowered again the moment the
+        // user has been told about it, so the guard below can tell the two failures apart. Everything
+        // inside `onSuccess` runs *after* an irreversible privileged call and none of it reports by
+        // returning: refreshAppShortcut goes to ShortcutManagerCompat, refreshDetails to the package
+        // manager. `Result.onSuccess` is a plain inline lambda and catches nothing, so a throw in
+        // there used to walk straight out of the launch and end the process.
+        var appliedButUnannounced = false
+        launchGuarded(
+            onFailure = { e ->
+                Logger.e(
+                    "AppInfoDetailsViewModel",
+                    "toggling the frozen state of $packageName failed",
+                    e
+                )
+                // Lead with what is true of the app. The freeze or unfreeze really did happen, and a
+                // bare "Error: …" on top of it reads as "your action failed" over an app that is
+                // demonstrably frozen — the one thing this must not say. The throw still gets
+                // reported straight after, because a watchlist or shortcut that did not keep up is
+                // something the user is entitled to know about.
+                if (appliedButUnannounced) {
+                    tryEmitToast(
+                        UiText.StringResource(
+                            if (freeze) R.string.frozen_success else R.string.unfrozen_success,
+                            appName ?: packageName
+                        )
+                    )
+                }
+                // [asUiText], the same unwrap the `Result.onFailure` branch below makes. The two
+                // paths don't carry the same refusals today — FreezeAppUseCase *returns* its tier
+                // refusal rather than throwing it, so a refusal lands there and not here — but a
+                // `throw` added anywhere in this block surfaces through this handler instead, and
+                // two sites unwrapping the same type by hand is the asymmetry that shows up as an
+                // empty error toast. Hence one function, called from both.
+                tryEmitToast(e.asUiText())
+            }
+        ) {
             // Freezing goes through FreezeAppUseCase so the BLOCKED tier is enforced below this
             // view model rather than by AppRiskDialog declining to render a confirm button.
             // Unfreezing keeps the raw call: it must never be blocked.
             val result = if (freeze) freezeAppUseCase(packageName)
             else manageAppUseCase.setAppDisabled(packageName, false)
             result.onSuccess {
+                appliedButUnannounced = true
                 appShortcuts.refreshAppShortcut(packageName)
-                val inFreezer = withContext(ioDispatcher) { freezerRepository.contains(packageName) }
+                val inFreezer = withContext(ioDispatcher) { isInFreezer(packageName) }
                 if (freeze && !inFreezer) {
                     // Don't auto-add — prompt the user to add it to the Freezer instead.
                     _uiState.update { it.copy(freezerPrompt = FreezerPrompt(packageName, appName)) }
@@ -198,16 +300,15 @@ class AppInfoDetailsViewModel(
                     val msgRes = if (freeze) R.string.frozen_success else R.string.unfrozen_success
                     _uiState.update { it.copy(isInFreezer = inFreezer) }
                     _events.send(UiText.StringResource(msgRes, appName ?: packageName))
+                    // Told. A later throw must not repeat this toast on its way out.
+                    appliedButUnannounced = false
                 }
                 // Refresh detail only — no privilege re-probe, no loader flash.
                 refreshDetails(packageName)
             }.onFailure { e ->
-                // A UiTextException already carries the message to show (the tier refusal) and
-                // has a null `message`, which error_format would render as a bare "Error: ".
-                _events.send(
-                    if (e is UiTextException) e.uiText
-                    else UiText.StringResource(R.string.error_format, e.message ?: "")
-                )
+                // The tier refusal arrives here as a UiTextException, which carries its message in
+                // `uiText` and leaves `message` null — see [asUiText].
+                _events.send(e.asUiText())
             }
         }
     }
@@ -271,7 +372,24 @@ class AppInfoDetailsViewModel(
      * reach it, so refusing here would stand between the user and their own frozen app.
      */
     fun addToFreezer(packageName: String) {
-        viewModelScope.launch {
+        launchGuarded(
+            // Nothing here can fail the user's freeze, because the freeze is already done — the
+            // prompt only exists because [toggleFreezerState]'s `onSuccess` raised it. What a full
+            // or failing disk costs is the watchlist row, which leaves the app frozen and untracked:
+            // the very state the prompt was offering to fix. So the report is `error_format` and
+            // nothing more. There is no existing string for "it is frozen, Thor just could not write
+            // it down", and this branch is not allowed to add one — eight in-app locales, six
+            // coupling sites — so the throw is reported plainly rather than dressed up in a claim.
+            //
+            // The prompt is deliberately left standing and `isInFreezer` deliberately left false:
+            // no row was written, so false is the truth, and a prompt still on screen makes the
+            // retry one more tap — the same call FreezerViewModel.removeFromFreezer makes when it
+            // keeps a failed package selected.
+            onFailure = { e ->
+                Logger.e("AppInfoDetailsViewModel", "adding $packageName to the freezer failed", e)
+                tryEmitToast(e.asUiText())
+            }
+        ) {
             withContext(ioDispatcher) { freezerRepository.add(packageName) }
             _uiState.update { it.copy(freezerPrompt = null, isInFreezer = true) }
             refreshDetails(packageName)
@@ -283,7 +401,51 @@ class AppInfoDetailsViewModel(
     }
 
     fun addOrRemoveFromFreezer(packageName: String) {
-        viewModelScope.launch(ioDispatcher) {
+        // Raised the moment the restore below reports success. Past that point the app really is
+        // running again, and everything left — the Room delete, the shortcut, the refresh — is Thor
+        // writing down what already happened. A guard that could not tell the two apart would answer
+        // a successful unfreeze with a bare "Error: …", which every user reads as "it didn't
+        // unfreeze" about an app they can see in their launcher.
+        var restored = false
+        launchGuarded(
+            // context, not a bare launch: this coroutine was `viewModelScope.launch(ioDispatcher)`
+            // and both the Room calls and the privileged restore below have to stay off the main
+            // thread. Dropping it would move them onto Dispatchers.Main.immediate and nothing would
+            // fail, because Room's suspend DAO functions dispatch internally.
+            context = ioDispatcher,
+            onFailure = { e ->
+                Logger.e(
+                    "AppInfoDetailsViewModel",
+                    "toggling freezer membership for $packageName failed",
+                    e
+                )
+                if (restored) {
+                    // Two facts, in the order they matter. The app is unfrozen — say so — and then
+                    // say that something threw, because the watchlist row this was meant to drop is
+                    // still there and the toggle above is still showing it. No existing string says
+                    // "unfrozen, but the record survived" and adding one is out of the question here
+                    // (eight in-app locales, six coupling sites), so the two halves are reported as
+                    // the two facts they are rather than compressed into a claim that would be false
+                    // either way round.
+                    //
+                    // `unfrozen_success`, which is *not* the string the success path ends on — that
+                    // one sends the `removed_from_freezer_success` plural, a claim about the row,
+                    // which is the exact thing that did not happen here. Because the two strings
+                    // differ, `restored` is deliberately left raised after its toast rather than
+                    // lowered the way `toggleFreezerState`'s `appliedButUnannounced` is: there is no
+                    // duplicate to suppress, and a throw from a statement appended below would
+                    // otherwise report a bare "Error: …" over an app the user can see running.
+                    val appName = _uiState.value.detailedInfo?.appInfo?.appName ?: packageName
+                    tryEmitToast(UiText.StringResource(R.string.unfrozen_success, appName))
+                }
+                tryEmitToast(e.asUiText())
+            }
+        ) {
+            // Deliberately the repository and not [isInFreezer]: this read picks between two
+            // opposite actions rather than feeding a label, so degrading it to "not in the freezer"
+            // would answer a Remove tap by trying to Add. Failing loudly through the guard above is
+            // the honest answer, and `restored` is still false there, so it reports as the plain
+            // error it is — nothing has happened to the app at this point.
             val currentlyIn = freezerRepository.contains(packageName)
             if (currentlyIn) {
                 // Removing always restores, the same as FreezerViewModel.removeFromFreezer and
@@ -301,12 +463,25 @@ class AppInfoDetailsViewModel(
                 else manageAppUseCase.forceUnfreeze(packageName))
                     .onFailure { e ->
                         _events.send(UiText.StringResource(R.string.error_format, e.message ?: ""))
-                        return@launch
+                        return@launchGuarded
                     }
-                freezerRepository.remove(packageName)
+                // From here on the app is running again and cannot be un-run. Everything below is
+                // bookkeeping, and the guard reports it as such.
+                restored = true
+                // Grey the launcher shortcut *before* dropping the row, matching
+                // AppListViewModel.toggleFreezerMembership — see the comment there for the argument.
+                // Short version: a pinned shortcut can only ever be greyed, never removed, so both
+                // orders leave residue on a throw and the question is which residue is worse. A greyed
+                // shortcut for an app still on the watchlist costs a launcher tile until the next tap;
+                // a dropped row with a live shortcut leaves the launcher able to drive a freeze for an
+                // app Thor is no longer tracking.
                 appShortcuts.disableAppShortcut(packageName)
+                freezerRepository.remove(packageName)
                 // refreshDetails re-reads membership, but only when details are loaded — set it here
-                // too so the toggle also flips before the first load lands.
+                // too so the toggle also flips before the first load lands. After the delete, never
+                // before it, so the toggle describes the database at every point: claiming "not in
+                // Freezer" over a row that is still there invites a second tap that re-adds nothing
+                // and reports success.
                 _uiState.update { it.copy(isInFreezer = false) }
                 refreshDetails(packageName)
                 _events.send(UiText.PluralsResource(R.plurals.removed_from_freezer_success, 1))
@@ -318,8 +493,11 @@ class AppInfoDetailsViewModel(
                 val app = _uiState.value.detailedInfo?.appInfo
                 if (app == null || app.freezeTier == FreezeTier.BLOCKED) {
                     _events.send(UiText.StringResource(R.string.error_unsafe_skipped))
-                    return@launch
+                    return@launchGuarded
                 }
+                // Unlike the branch above, this one freezes nothing — the watchlist row is the whole
+                // action. So a throw here really is a failed action and `restored` is still false,
+                // which is exactly how the guard reports it: one plain error, no success claim.
                 freezerRepository.add(packageName)
                 _uiState.update { it.copy(isInFreezer = true) }
                 _events.send(UiText.StringResource(R.string.added_to_freezer_success))

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -39,10 +39,11 @@ import com.valhalla.thor.domain.usecase.GetAppDetailsUseCase
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
 import com.valhalla.thor.presentation.freezer.FreezerPrompt
+import com.valhalla.thor.presentation.launchGuarded
 import com.valhalla.thor.util.AppScanRevision
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
-import com.valhalla.thor.util.UiTextException
+import com.valhalla.thor.util.asUiText
 import com.valhalla.thor.util.bulkResultMessage
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -497,7 +498,25 @@ class AppListViewModel(
     }
 
     fun freezeApp(packageName: String, appName: String?, freeze: Boolean) {
-        viewModelScope.launch {
+        // `launchGuarded`, not a bare `launch`, because of the freezer read inside `onSuccess`
+        // below. `Result.onSuccess` catches nothing — its lambda is a plain inline lambda — so a
+        // Room throw from `contains()` (SQLiteFullException, SQLiteDiskIOException,
+        // SQLiteDatabaseCorruptException) walks straight out of it, out of the launch, and into the
+        // thread's default handler, because `:app` installs no `CoroutineExceptionHandler`. One
+        // freeze on a full disk was process death.
+        //
+        // The report here is deliberately unadorned. Everything on this path that can fail in a way
+        // worth naming already names itself: both privileged calls return a `Result` and the
+        // `onFailure` branch renders it, and the freezer read degrades on its own rather than
+        // aborting (see below). What is left to reach this handler is an unexpected throw with
+        // nothing to add to it, so it is shown as-is instead of being dressed up as a claim about
+        // what did or did not happen to the app.
+        launchGuarded(
+            onFailure = { e ->
+                Logger.e("AppListViewModel", "freeze toggle for $packageName failed", e)
+                _events.trySend(AppListEvent.ShowMessage(e.asUiText()))
+            }
+        ) {
             // Freezing goes through FreezeAppUseCase so the BLOCKED tier is enforced below this
             // view model rather than by AppRiskDialog declining to render a confirm button.
             // Unfreezing keeps the raw call: it must never be blocked.
@@ -517,8 +536,30 @@ class AppListViewModel(
                 }
 
                 if (freeze) {
-                    val inFreezer = withContext(ioDispatcher) {
-                        freezerRepository.contains(packageName)
+                    // "Not in the freezer" is the safe answer when the read fails — the same
+                    // fallback observeFreezerMembership's `catch` takes, for the same reason. The
+                    // app is already frozen by the time this runs, and all this Boolean decides is
+                    // whether to offer to track it. Guessing `true` would leave a frozen app off
+                    // the watchlist without a word, which is the stranding this feature exists to
+                    // prevent; guessing `false` costs at worst one prompt for an app already on it,
+                    // and `FreezerDao.insert` is `OnConflictStrategy.IGNORE`, so confirming that
+                    // prompt is a no-op rather than a duplicate row. Caught here rather than left
+                    // to the guard above because the guard can only abandon the block — and
+                    // abandoning it here would drop the freeze report the user is owed for a
+                    // freeze that succeeded.
+                    val inFreezer = try {
+                        withContext(ioDispatcher) {
+                            freezerRepository.contains(packageName)
+                        }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Logger.e(
+                            "AppListViewModel",
+                            "freezer membership read for $packageName failed",
+                            e
+                        )
+                        false
                     }
                     if (!inFreezer) {
                         _events.send(
@@ -545,14 +586,9 @@ class AppListViewModel(
                     )
                 }
             }.onFailure { e ->
-                // A UiTextException already carries the message to show (the tier refusal) and
-                // has a null `message`, which error_format would render as a bare "Error: ".
-                _events.send(
-                    AppListEvent.ShowMessage(
-                        if (e is UiTextException) e.uiText
-                        else UiText.StringResource(R.string.error_format, e.message ?: "")
-                    )
-                )
+                // The tier refusal arrives here as a UiTextException, which carries its message in
+                // `uiText` and leaves `message` null — see [asUiText].
+                _events.send(AppListEvent.ShowMessage(e.asUiText()))
             }
         }
     }
@@ -568,7 +604,26 @@ class AppListViewModel(
      * Unfreeze-all reaches it. Refusing here would strand a frozen app off the list it belongs on.
      */
     fun addToFreezer(packageName: String) {
-        viewModelScope.launch(ioDispatcher) {
+        launchGuarded(
+            // `ioDispatcher` passed through rather than dropped: this is a Room write, and letting
+            // it default to `Dispatchers.Main.immediate` would move it to the main thread without
+            // anything failing to say so, because Room's suspend DAO functions dispatch internally
+            // and would keep working.
+            context = ioDispatcher,
+            // The app is *already frozen* when this runs — the prompt this confirms only appears
+            // after [freezeApp] succeeded — so a failed insert has undone nothing. What is lost is
+            // the row that makes a frozen app recoverable: gone from the freezer screen and out of
+            // Unfreeze-all's reach, which iterates the watchlist. That is worth reporting, but it
+            // is emphatically not "the freeze failed", and no existing string says "it is frozen,
+            // Thor just could not write it down" — one Room failure is not worth an English-only
+            // ninth string across eight locales. So the throw is reported verbatim instead: on the
+            // failures that actually reach here (a full disk, a failing one) its message names the
+            // disk, which is the part the user can act on.
+            onFailure = { e ->
+                Logger.e("AppListViewModel", "adding $packageName to the freezer failed", e)
+                _events.trySend(AppListEvent.ShowMessage(e.asUiText()))
+            }
+        ) {
             freezerRepository.add(packageName)
             _events.send(
                 AppListEvent.ShowMessage(UiText.StringResource(R.string.added_to_freezer_success))
@@ -594,7 +649,52 @@ class AppListViewModel(
      * before the gate existed can always be taken back off.
      */
     fun toggleFreezerMembership(packageName: String) {
-        viewModelScope.launch(ioDispatcher) {
+        // Non-null once the restore has come back successful, holding the label to report it with.
+        // `onFailure` is not suspend and cannot re-derive which side of the irreversible step a
+        // throw landed on, and the two sides mean opposite things: before the restore nothing has
+        // happened to the app and a Room throw means the tap did nothing, while after it the app
+        // really is thawed and only Thor's record of it is missing. Reporting both the same way
+        // would tell a user whose app just came back that the unfreeze failed.
+        var unfrozenLabel: String? = null
+        launchGuarded(
+            // `ioDispatcher` passed through rather than dropped: this body runs the three watchlist
+            // calls *and* the privileged restore, and the default context would put all four on
+            // `Dispatchers.Main.immediate` with nothing failing to report it.
+            context = ioDispatcher,
+            // All three Room calls in this body report by throwing, and the delete is the one that
+            // matters: it runs after `restoreApp`/`forceUnfreeze` has already succeeded, so an
+            // escaping throw used to land between the irreversible act and the record of it — and
+            // then kill the process, leaving exactly the frozen-but-untracked stranding this
+            // method's KDoc promises to prevent, arrived at from the other direction.
+            onFailure = { e ->
+                Logger.e("AppListViewModel", "freezer membership toggle for $packageName failed", e)
+                val unfrozen = unfrozenLabel
+                if (unfrozen != null) {
+                    // Two facts, in the order they matter, the same as
+                    // AppInfoDetailsViewModel.addOrRemoveFromFreezer — the other surface that takes an
+                    // app off the watchlist, and one that must not answer the same failure
+                    // differently. The restore returned success, so the app is enabled and
+                    // unsuspended, and saying so first is the only claim here that is certainly true;
+                    // a bare "Error: …" on its own would read as "the unfreeze failed" over an app the
+                    // user can see running.
+                    //
+                    // Then the throw, rather than stopping at the good news. The undropped row is
+                    // survivable — it keeps the app on the freezer screen and inside Unfreeze-all's
+                    // reach, and the next tap retries the delete after a restore that is by then a
+                    // no-op — but "survivable" is not "not worth mentioning": whatever broke the
+                    // delete is a failing disk, and that is the part the user can act on.
+                    _events.trySend(
+                        AppListEvent.ShowMessage(
+                            UiText.StringResource(R.string.unfrozen_success, unfrozen)
+                        )
+                    )
+                }
+                // Nothing has happened to the app on the other side of the restore — the membership
+                // read that chooses the branch, or the insert that only ever adds a row (adding never
+                // freezes) — so on that path this is the whole report.
+                _events.trySend(AppListEvent.ShowMessage(e.asUiText()))
+            }
+        ) {
             if (freezerRepository.contains(packageName)) {
                 // Restore before dropping the row, and before reporting success. The privileged call
                 // is the only step that can fail and the Room delete is durable, so removing first
@@ -615,15 +715,17 @@ class AppListViewModel(
                             UiText.StringResource(R.string.error_format, e.message ?: "")
                         )
                     )
-                    return@launch
+                    return@launchGuarded
                 }
-                freezerRepository.remove(packageName)
-                // Pinned launcher shortcuts can't be removed silently, only greyed out — leaving a
-                // live shortcut for an app no longer in the freezer would let it drive a freeze
-                // from the launcher.
-                appShortcuts.disableAppShortcut(packageName)
+                // Latched between the privileged call and the durable one, which is the only place
+                // it can be right: past here the app is thawed whatever the rest of this block does.
+                unfrozenLabel = app?.appName ?: packageName
                 // Same optimistic local patch freezeApp does, so the row stops reading as frozen
-                // without waiting for a full rescan.
+                // without waiting for a full rescan. Ordered ahead of the two steps that can throw,
+                // because it cannot: it is a CAS over two `List.map`s, touching neither Room nor the
+                // shortcut service. Left behind them, a throw from either would skip it and leave the
+                // list drawing the app as frozen while the guard above says "Unfrozen X" — the screen
+                // contradicting its own toast, on the one path where the toast is certainly true.
                 _rawState.update { state ->
                     fun restore(list: List<AppInfo>) = list.map {
                         if (it.packageName == packageName) it.copy(enabled = true, isSuspended = false)
@@ -634,6 +736,18 @@ class AppListViewModel(
                         allSystemApps = restore(state.allSystemApps)
                     )
                 }
+                // Pinned launcher shortcuts can't be removed silently, only greyed out — leaving a
+                // live shortcut for an app no longer in the freezer would let it drive a freeze
+                // from the launcher.
+                //
+                // Before the delete, not after, so that invariant survives a throw in either step.
+                // Both orders can fail, and the question is only which residue is worse: greying a
+                // shortcut for an app still on the watchlist costs the launcher tile until the next
+                // tap re-runs a restore that is by then a no-op, whereas dropping the row first and
+                // then failing to grey the shortcut leaves precisely the live-shortcut-for-an-
+                // untracked-app the comment above exists to forbid.
+                appShortcuts.disableAppShortcut(packageName)
+                freezerRepository.remove(packageName)
                 _events.send(
                     AppListEvent.ShowMessage(
                         UiText.PluralsResource(R.plurals.removed_from_freezer_success, 1)
@@ -655,7 +769,7 @@ class AppListViewModel(
                     _events.send(
                         AppListEvent.ShowMessage(UiText.StringResource(R.string.error_unsafe_skipped))
                     )
-                    return@launch
+                    return@launchGuarded
                 }
                 freezerRepository.add(packageName)
                 _events.send(

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -30,9 +30,10 @@ import com.valhalla.thor.domain.repository.PrivilegeStateProvider
 import com.valhalla.thor.domain.usecase.FreezeAppUseCase
 import com.valhalla.thor.domain.usecase.GetInstalledAppsUseCase
 import com.valhalla.thor.domain.usecase.ManageAppUseCase
+import com.valhalla.thor.presentation.launchGuarded
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
-import com.valhalla.thor.util.UiTextException
+import com.valhalla.thor.util.asUiText
 import com.valhalla.thor.util.bulkResultMessage
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -277,10 +278,12 @@ class FreezerViewModel(
                             failures += e
                             return@forEach
                         }
-                    freezerRepository.remove(pkg)
                     // Pinned shortcuts can only be greyed, never removed — leaving a live one for an
                     // app no longer in the freezer would let the launcher drive a freeze from it.
+                    // Before the delete, not after, so that holds even when one of the two throws:
+                    // see AppListViewModel.toggleFreezerMembership for the full argument.
                     appShortcuts.disableAppShortcut(pkg)
+                    freezerRepository.remove(pkg)
                     succeeded += pkg
                 } catch (e: CancellationException) {
                     throw e
@@ -382,14 +385,16 @@ class FreezerViewModel(
                             )
                             return@launch
                         }
-                    freezerRepository.remove(packageName)
+                    // Shortcut first, then the row — the same order as the bulk path above and
+                    // AppListViewModel.toggleFreezerMembership.
                     appShortcuts.disableAppShortcut(packageName)
+                    freezerRepository.remove(packageName)
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 Logger.e("FreezeViewModel", "toggling watchlist membership for $packageName", e)
-                emitToast(UiText.StringResource(R.string.error_format, e.message ?: ""))
+                emitToast(e.asUiText())
             }
         }
     }
@@ -591,8 +596,35 @@ class FreezerViewModel(
      * and is what lets Unfreeze-all reach it.
      */
     fun addToFreezer(packageName: String) {
-        viewModelScope.launch(ioDispatcher) {
+        // [launchGuarded], not the [runProfileWrite] helper thirty lines up, even though both catch
+        // the same class of Room throw. That helper is about *profile* writes: its reason to exist
+        // is the `@StringRes constraintMessage` naming which constraint the write could trip, and a
+        // watchlist insert can trip neither of the two it was written for — `FreezerDao.insert` is
+        // `OnConflictStrategy.IGNORE`, so re-adding a tracked app is a no-op rather than a
+        // SQLiteConstraintException, and its "that name is already taken" branch is unreachable
+        // nonsense here. It is also `suspend`, so it cannot close the hole that is actually open:
+        // the crash is the unguarded *coroutine*, and only something owning the `launch` catches
+        // what escapes it.
+        //
+        // `context = ioDispatcher` because adopting the guard must not quietly move the Room write
+        // onto Main — nothing would fail if it did, since Room's suspend DAO functions dispatch
+        // internally.
+        launchGuarded(
+            context = ioDispatcher,
+            onFailure = { e ->
+                // The freeze already happened: this prompt is only raised after one succeeded, per
+                // the doc above. What failed is Thor's record of it, so the toast must not say the
+                // freeze did — the app is frozen and simply untracked, which means `Unfreeze all`
+                // will not reach it until the row is added again. No existing string says that
+                // sentence and a new one is eight locales of debt, so report the throw plainly
+                // rather than invent a claim about the action.
+                Logger.e("FreezeViewModel", "adding $packageName to the freezer failed", e)
+                tryEmitToast(e.asUiText())
+            }
+        ) {
             freezerRepository.add(packageName)
+            // After the write, never before: "Added to Freezer" emitted first would be the only
+            // thing the user is told about a row that then failed to land.
             emitToast(UiText.StringResource(R.string.added_to_freezer_success))
         }
     }
@@ -623,12 +655,9 @@ class FreezerViewModel(
                     }
                 }
                 .onFailure { e ->
-                    // A UiTextException already carries the message to show (the tier refusal)
-                    // and has a null `message`, which error_format renders as a bare "Error: ".
-                    emitToast(
-                        if (e is UiTextException) e.uiText
-                        else UiText.StringResource(R.string.error_format, e.message ?: "")
-                    )
+                    // The tier refusal arrives here as a UiTextException, which carries its message
+                    // in `uiText` and leaves `message` null — see [asUiText].
+                    emitToast(e.asUiText())
                 }
         }
     }
@@ -659,6 +688,33 @@ class FreezerViewModel(
     // --- Feedback ---
 
     private suspend fun emitToast(text: UiText) = _events.send(FreezerEvent.ShowToast(text))
+
+    /**
+     * [emitToast] from somewhere that cannot suspend.
+     *
+     * [launchGuarded]'s `onFailure` is declared `(Throwable) -> Unit`, not a suspending function, so
+     * `send` is simply not callable there — the handler does run inside the guard's `catch`, and so
+     * inside the coroutine, but a plain lambda offers no suspension point to use it from. The channel
+     * is `Channel.BUFFERED`, so `trySend` only refuses once 64 events are queued with nothing
+     * collecting them, and a dropped error toast in that state is a far smaller loss than the process
+     * death this whole guard exists to prevent.
+     *
+     * The refusal is logged rather than dropped on the floor, because this view model is created
+     * eagerly by `MainScreen` and so can accumulate events long before the Freezer tab is ever
+     * opened. Worth being exact about what that buys, though: `Logger` gates every level on
+     * `Logger.isDebug`, which `ThorApplication` sets to `BuildConfig.DEBUG ||
+     * BuildConfig.PRIVILEGE_TRACE`, so on the builds users run the line is not emitted either. The
+     * log is a bug-report aid for a `PRIVILEGE_TRACE` build, not a promise that the message survives
+     * in release. Making a refused toast visible to a user with nothing collecting the channel would
+     * need a different mechanism than a toast, and 64 queued undelivered events is not a state worth
+     * one.
+     */
+    private fun tryEmitToast(text: UiText) {
+        val delivered = _events.trySend(FreezerEvent.ShowToast(text)).isSuccess
+        if (!delivered) {
+            Logger.e("FreezeViewModel", "dropped a freezer toast: the event channel refused it")
+        }
+    }
 
     private fun observePreferences() {
         viewModelScope.launch {
@@ -716,16 +772,57 @@ class FreezerViewModel(
      * the user chose.
      */
     fun addAppsToFreezer(packageNames: List<String>) {
-        viewModelScope.launch(ioDispatcher) {
-            packageNames.forEach { pkg ->
-                freezerRepository.add(pkg)
+        launchGuarded(
+            context = ioDispatcher,
+            // The per-item catch below is what stops one package abandoning the rest, so this outer
+            // net only ever sees a throw from *outside* the loop — the report itself. It still says
+            // something, because an import that reports nothing at all is indistinguishable from an
+            // import that did nothing.
+            onFailure = { e ->
+                Logger.e("FreezeViewModel", "reporting the disabled-apps import failed", e)
+                tryEmitToast(e.asUiText())
             }
-            emitToast(
-                UiText.PluralsResource(
-                    R.plurals.added_to_freezer_count_success,
-                    packageNames.size
-                )
-            )
+        ) {
+            var succeeded = 0
+            val failures = mutableListOf<Throwable>()
+            packageNames.forEach { pkg ->
+                // Inside the loop, per package, exactly as [removeFromFreezer]'s guard is: N inserts
+                // are N chances for a full or failing disk to throw, and a guard around the whole
+                // loop would let the first one lose every package after it — the user's entire
+                // import gone to one row. [launchGuarded] cannot serve as this per-item guard: it
+                // starts a coroutine, which would turn an ordered walk into N concurrent writes and
+                // have the report below read its counts before any of them landed.
+                try {
+                    freezerRepository.add(pkg)
+                    succeeded++
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Logger.e("FreezeViewModel", "importing $pkg into the freezer failed", e)
+                    failures += e
+                }
+            }
+            // `succeeded`, not `packageNames.size`: the old count was the size of the request, so it
+            // announced "Added 12 apps to Freezer" over an import where not one row had landed.
+            //
+            // A partial import reports *both* facts, in two toasts, rather than collapsing to the
+            // error. There is no "Added x/y (z failed)" string to mirror [removeFromFreezer]'s third
+            // branch — the only string of that shape says *Removed*, which over an import would tell
+            // the user the opposite of what happened, and minting one costs eight locales — but
+            // suppressing the count entirely was the worse half of that trade: 11 of 12 rows landing
+            // read as a total failure, over a screen that was about to show all 11. So the count goes
+            // out when there is one, and the throw goes out after it, which is the same
+            // two-facts-in-order convention `AppInfoDetailsViewModel`'s guards use for the same
+            // succeeded-then-threw shape.
+            if (succeeded > 0) {
+                emitToast(UiText.PluralsResource(R.plurals.added_to_freezer_count_success, succeeded))
+            }
+            if (failures.isNotEmpty()) {
+                // Say what the database said. Every app in this list was already disabled before the
+                // import — that is the dialog's whole precondition — so a failure here costs
+                // watchlist rows, not the freeze.
+                emitToast(UiText.StringResource(R.string.error_format, failures.first().message ?: ""))
+            }
         }
     }
 
@@ -733,11 +830,52 @@ class FreezerViewModel(
 
     fun isPinSupported(): Boolean = appShortcuts.isPinSupported()
 
+    /**
+     * All three pin entry points below are guarded for the same reason the watchlist writes above
+     * are, and it is the same defect rather than a related one: `ShortcutManagerCompat` reports by
+     * throwing — `IllegalStateException` from a background caller, `IllegalArgumentException` on a
+     * malformed id, and whatever the launcher's own binder raises — and `:app` installs no
+     * `CoroutineExceptionHandler`, so a bare `launch` around one of these made a failed pin request
+     * process death.
+     *
+     * Which throws *reach* this guard is a property of the port method, not of the guard, and the
+     * three below are deliberately the three that throw into their caller:
+     * [AppShortcutController.pinAppShortcutSuspend] suspends, and `pinBulkShortcut` /
+     * `disableAppShortcut` run on the caller's thread. The two fire-and-forget members —
+     * `pinAppShortcut` and `refreshAppShortcut` — hand their body to `FreezerShortcutManager`'s own
+     * `SupervisorJob` scope and return, so no caller-side guard can ever see their failure; they are
+     * caught in `FreezerShortcutManager.launchSafely` instead, which is also the only place that can
+     * cover their non-view-model callers (`AutoFreezeManager`, `FreezerLaunchActivity`,
+     * `ThorApplication`). [pinAppToLauncher] therefore calls the *suspending* pin rather than the
+     * fire-and-forget one, so a refusal the user is waiting on still becomes a message.
+     *
+     * `context = defaultDispatcher`, never the [ioDispatcher] the watchlist sites use: these decode
+     * and rasterize bitmaps, which is why they were on Default to begin with, and adopting the guard
+     * must not quietly re-file CPU work onto the IO pool any more than it may move Room onto Main.
+     *
+     * Reported through [tryEmitToast] with `error_format` rather than silently: a pin the user asked
+     * for and did not get is worth a line, and inventing a "couldn't pin that shortcut" string costs
+     * eight locales for a failure this rare.
+     */
+    private fun launchPin(what: String, block: suspend () -> Unit) {
+        launchGuarded(
+            context = defaultDispatcher,
+            onFailure = { e ->
+                Logger.e("FreezeViewModel", "pinning $what to the launcher failed", e)
+                tryEmitToast(e.asUiText())
+            }
+        ) { block() }
+    }
+
     fun pinAppToLauncher(app: AppInfo) {
         if (app.isSystem) return // v1: user apps only
         // Grayscale icon decode + binder pin request — keep it off Main to avoid jank.
-        viewModelScope.launch(defaultDispatcher) {
-            appShortcuts.pinAppShortcut(app.packageName, app.appName ?: app.packageName)
+        //
+        // The suspending pin, not the fire-and-forget one: `launchPin` is already off Main, which is
+        // the only thing `pinAppShortcut` buys, and it swallows the outcome into the manager's scope
+        // where this guard cannot see it. Same call the bulk loop below makes, for the same reason.
+        launchPin(app.packageName) {
+            appShortcuts.pinAppShortcutSuspend(app.packageName, app.appName ?: app.packageName)
         }
     }
 
@@ -745,20 +883,47 @@ class FreezerViewModel(
         // Pin sequentially (suspending) off Main: a rapid loop of the fire-and-forget pinAppShortcut
         // would spawn N concurrent bitmap decodes + binder pin requests and risk OOM / overwhelming
         // the shortcut service. A small gap keeps the per-shortcut system prompts orderly too.
-        viewModelScope.launch(defaultDispatcher) {
+        launchPin("every freezer app") {
+            var refused: Throwable? = null
             _uiState.value.freezerApps
                 .filter { !it.isSystem }
                 .forEach {
-                    appShortcuts.pinAppShortcutSuspend(it.packageName, it.appName ?: it.packageName)
+                    // Per app, so one launcher refusing a single shortcut does not abandon the rest
+                    // of the run — the same per-item isolation [addAppsToFreezer]'s loop has, and for
+                    // the same reason. The outer guard then only ever sees a throw from outside the
+                    // loop.
+                    try {
+                        appShortcuts.pinAppShortcutSuspend(
+                            it.packageName,
+                            it.appName ?: it.packageName
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Logger.e("FreezeViewModel", "pinning ${it.packageName} failed", e)
+                        // Kept for one line after the loop. Isolating the failure must not also hide
+                        // it: `Logger` is gated on `Logger.isDebug`, false in every build users run,
+                        // so catching per app and only logging meant a run in which the launcher
+                        // refused *every* shortcut reported nothing at all — no toast, no logcat —
+                        // against a [launchPin] doc that promises a pin the user asked for and did
+                        // not get is worth a line. First throw only, and no count: they are the same
+                        // refusal repeated, N lines would bury each other, and a "%d shortcuts could
+                        // not be pinned" sentence needs a string that does not exist in any of the
+                        // eight locales.
+                        if (refused == null) refused = e
+                    }
                     delay(100)
                 }
+            // Rethrown rather than reported here, so the one place that formats a pin failure stays
+            // [launchPin]'s `onFailure` instead of becoming two places that must agree.
+            refused?.let { throw it }
         }
     }
 
     fun pinBulkShortcut(freeze: Boolean) {
         // Rasterizes a 216x216 tile bitmap + issues a binder pin request; keep it off Main
         // to avoid click-time jank, matching pinAppToLauncher / pinAllToLauncher.
-        viewModelScope.launch(defaultDispatcher) {
+        launchPin(if (freeze) "Freeze all" else "Unfreeze all") {
             appShortcuts.pinBulkShortcut(
                 if (freeze) FreezerShortcutContract.ACTION_FREEZE_ALL
                 else FreezerShortcutContract.ACTION_UNFREEZE_ALL

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -695,7 +695,40 @@ class MainViewModel(
                             val result = manageAppUseCase.uninstallApp(action.appInfo.packageName)
                             if (result.isSuccess) {
                                 addLog(UiText.StringResource(R.string.log_uninstall_success))
-                                freezerRepository.add(action.appInfo.packageName)
+                                // The uninstall above has already happened and nothing here can undo
+                                // it; this row is only Thor's record of it. Room reports a full or
+                                // failing disk by throwing (SQLiteFullException,
+                                // SQLiteDiskIOException), `FreezerRepositoryImpl` is a pass-through
+                                // that does not catch, and `:app` installs no
+                                // CoroutineExceptionHandler — so unguarded, an uninstall ends in
+                                // process death *after* it succeeded, with the logger left open and
+                                // never completed and a ✔ line as the user's last sight of it.
+                                // `MultiAppAction.Uninstall` had the identical hole and is guarded
+                                // the same way; the two are the same bug at the single- and
+                                // batch-app entry points, not one special case.
+                                //
+                                // Losing the row is not cosmetic either: the watchlist entry is the
+                                // handle the Freezer unfreezes from (`pm install-existing`), and
+                                // `importableDisabledApps` deliberately refuses to offer an
+                                // uninstalled package back, so there is no second route that would
+                                // pick this app up later.
+                                //
+                                // Reported as an error line and not as a failed uninstall, because
+                                // the uninstall did not fail — the "✔ Uninstall successful" line
+                                // directly above stands, and `triggerSupportPromptIfNeeded` below
+                                // still runs for the same reason.
+                                try {
+                                    freezerRepository.add(action.appInfo.packageName)
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    Logger.e(
+                                        "MainViewModel",
+                                        "uninstalled ${action.appInfo.packageName}, but adding it to the freezer failed",
+                                        e
+                                    )
+                                    addLog(UiText.StringResource(R.string.log_error, e.message ?: ""))
+                                }
                                 triggerSupportPromptIfNeeded()
                             } else {
                                 addLog(UiText.StringResource(R.string.log_priv_uninstall_failed))
@@ -857,21 +890,74 @@ class MainViewModel(
                     manageAppUseCase.clearCache(it.packageName).map { }
                 }
 
-                is MultiAppAction.Uninstall -> performLoggedMultiAction(
-                    UiText.StringResource(R.string.log_uninstalling_batch),
-                    action.appList
-                ) { appInfo ->
-                    if (appInfo.packageName == BuildConfig.APPLICATION_ID) {
-                        // Same reasoning as the Kill branch, with a worse ending: this one succeeds.
-                        Result.failure(UiTextException(UiText.StringResource(R.string.error_self_skipped)))
-                    } else if (appInfo.freezeTier == FreezeTier.BLOCKED) {
-                        Result.failure(UiTextException(UiText.StringResource(R.string.error_unsafe_skipped)))
-                    } else {
-                        val result = manageAppUseCase.uninstallApp(appInfo.packageName)
-                        if (result.isSuccess && appInfo.isSystem) {
-                            freezerRepository.add(appInfo.packageName)
+                is MultiAppAction.Uninstall -> {
+                    // The uninstalls this batch could not write down. Collected and reported once at
+                    // the end rather than per app: what lands here is a full or failing disk, so it
+                    // repeats for every system app in the selection, and N copies of it spliced
+                    // between the step lines and their results would bury the per-app transcript the
+                    // batch exists to produce.
+                    val unrecorded = mutableListOf<Throwable>()
+                    performLoggedMultiAction(
+                        UiText.StringResource(R.string.log_uninstalling_batch),
+                        action.appList
+                    ) { appInfo ->
+                        if (appInfo.packageName == BuildConfig.APPLICATION_ID) {
+                            // Same reasoning as the Kill branch, with a worse ending: this one succeeds.
+                            Result.failure(UiTextException(UiText.StringResource(R.string.error_self_skipped)))
+                        } else if (appInfo.freezeTier == FreezeTier.BLOCKED) {
+                            Result.failure(UiTextException(UiText.StringResource(R.string.error_unsafe_skipped)))
+                        } else {
+                            val result = manageAppUseCase.uninstallApp(appInfo.packageName)
+                            if (result.isSuccess && appInfo.isSystem) {
+                                // Guarded here rather than around `block(app)` in
+                                // [performLoggedMultiAction], even though a throw out of `block` is
+                                // process death for all six actions routed through that helper and
+                                // not just this one — after N system apps are already gone, with the
+                                // partial-progress line and `finishLogger` never reached.
+                                //
+                                // The helper has exactly one way to describe an app: the Result this
+                                // lambda hands back, and it prints " -> Failed" for anything that is
+                                // not a success. Catching there would therefore have to report an
+                                // uninstall that really happened as one that did not, in the batch's
+                                // own transcript — a lie on the record, which is worse than the crash
+                                // it replaces. Only Thor's bookkeeping is missing, so `result` is
+                                // still returned as the success it is and the shortfall is said once,
+                                // separately, below.
+                                try {
+                                    freezerRepository.add(appInfo.packageName)
+                                } catch (e: CancellationException) {
+                                    throw e
+                                } catch (e: Exception) {
+                                    Logger.e(
+                                        "MainViewModel",
+                                        "uninstalled ${appInfo.packageName}, but adding it to the freezer failed",
+                                        e
+                                    )
+                                    unrecorded += e
+                                }
+                            }
+                            result
                         }
-                        result
+                    }
+                    // After the batch rather than inside it: every app's own result and the
+                    // "Operation Complete" line are already printed, so this reads as a closing fact
+                    // about the run instead of interrupting a step, and the dialog auto-scrolls on
+                    // each new line so it is what the user ends up looking at.
+                    //
+                    // One line carrying the first throw's message — the answer
+                    // `FreezerViewModel.removeFromFreezer` gives in its `1 ->` branch, and
+                    // deliberately *not* what it does past one. That function has a third branch for
+                    // the many-failure case (`removed_from_freezer_partial_failure`, "Removed x/y
+                    // (z failed)"), and there is no import- or uninstall-shaped string of that form:
+                    // a "%d apps were uninstalled but not recorded" sentence would need one that does
+                    // not exist, and adding it means eight locales carrying an English-only entry
+                    // that lint will not report — so the count is dropped rather than half-
+                    // translated. They are the same disk error repeated in any case, and the
+                    // " -> Success" lines above are what keep this from reading as a failed
+                    // uninstall. The per-app `Logger.e` is debug-only, so the transcript is the whole
+                    // record here; what it does not preserve is *which* apps lost their row.
+                    unrecorded.firstOrNull()?.let { failure ->
+                        addLog(UiText.StringResource(R.string.log_error, failure.message ?: ""))
                     }
                 }
 

--- a/app/src/main/java/com/valhalla/thor/util/UiText.kt
+++ b/app/src/main/java/com/valhalla/thor/util/UiText.kt
@@ -9,6 +9,7 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import com.valhalla.thor.R
 
 sealed class UiText {
     data class DynamicString(val value: String) : UiText()
@@ -87,3 +88,26 @@ sealed class UiText {
 }
 
 class UiTextException(val uiText: UiText) : Exception()
+
+/**
+ * The message to show for a throw, whichever kind of throw it is.
+ *
+ * Exists because [UiTextException] carries its rendered message in [UiTextException.uiText] and
+ * leaves `message` null, so `error_format` applied to one renders a bare "Error: " — a toast that
+ * tells the user something failed and nothing else. Every handler that formats an exception therefore
+ * has to ask, and the ones that forgot were not distinguishable by reading them: the omission only
+ * surfaces at runtime, on a refusal, as an empty error.
+ *
+ * A function rather than the same `if` repeated at each catch, because the repetition is what let the
+ * sites drift apart in the first place — the freezer surfaces had it in three places and not in six,
+ * and which behaviour you got depended on which screen you tapped.
+ *
+ * Covers both ways a refusal reaches a handler, since a surface can see either. A tier refusal is
+ * *returned* — `FreezeAppUseCase` wraps it in a failed `Result` rather than throwing it — and reaches
+ * `Result.onFailure`; anything else that goes wrong in the same block is *thrown* and reaches the
+ * `launchGuarded` catch instead. Two sites unwrapping the same type by hand is what produced the
+ * empty-toast asymmetry, so both go through here.
+ */
+fun Throwable.asUiText(): UiText =
+    if (this is UiTextException) uiText
+    else UiText.StringResource(R.string.error_format, message ?: "")

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -47,6 +47,7 @@ import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.domain.repository.UsageAccessGate
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -57,6 +58,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import java.io.File
 import java.nio.file.Files
+import kotlin.coroutines.ContinuationInterceptor
 
 // Hand-written fakes, matching the rest of the suite — no mocking library. The point of a
 // privileged-action fake is that the *call it was asked to make* is the assertion, so these record
@@ -233,8 +235,27 @@ class FakeAppRepository(initialApps: List<AppInfo> = emptyList()) : AppRepositor
     override suspend fun getAppDetails(packageName: String): AppInfo? =
         apps.value.firstOrNull { it.packageName == packageName }
 
-    override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? =
-        details[packageName]
+    private val detailFailures = mutableMapOf<String, Throwable>()
+
+    /**
+     * Make the detail read of [packageName] raise, as the package manager does.
+     *
+     * `getDetailedAppInfo` funnels into `PackageManager`, which reports by throwing — `DeadObjectException`
+     * when `system_server` restarts under it, `NameNotFoundException` when the app is uninstalled
+     * between the tap and the read. It is the seam `AppInfoDetailsViewModel.refreshDetails` cannot
+     * degrade the way it degrades the watchlist read, and so the only remaining collaborator that can
+     * throw *after* a freeze or unfreeze has already been applied — which is the case worth pinning,
+     * because that is where a bare "Error: …" would tell a user their action failed over an app that is
+     * demonstrably frozen.
+     */
+    fun failDetailsWith(packageName: String, error: Throwable) {
+        detailFailures[packageName] = error
+    }
+
+    override suspend fun getDetailedAppInfo(packageName: String): DetailedAppInfo? {
+        detailFailures[packageName]?.let { throw it }
+        return details[packageName]
+    }
 
     override suspend fun getComponentDetails(packageName: String): ComponentSnapshot? =
         componentSnapshots[packageName] ?: details[packageName]?.components
@@ -260,8 +281,22 @@ class FakeFreezerRepository(
     val added = mutableListOf<String>()
     val removed = mutableListOf<String>()
 
+    /**
+     * The dispatcher each write actually ran on, keyed the same way as [trace].
+     *
+     * Recorded because nothing else in the suite can see it. Every view model here is built with one
+     * dispatcher injected everywhere, so a `launchGuarded(context = ioDispatcher)` that silently
+     * lost its context would pass every test — and losing it is not a hypothetical: the production
+     * comments at those call sites all say the same thing, that Room's suspend DAO functions
+     * dispatch internally, so a write left on `Dispatchers.Main.immediate` keeps working and nothing
+     * fails to say so. The only way to catch it is to inject a *distinct* dispatcher and ask the
+     * write which one it woke up on.
+     */
+    val ranOn = mutableMapOf<String, ContinuationInterceptor?>()
+
     private val addFailures = mutableMapOf<String, Throwable>()
     private val removeFailures = mutableMapOf<String, Throwable>()
+    private val containsFailures = mutableMapOf<String, Throwable>()
 
     /**
      * Make the write of [packageName] raise.
@@ -278,11 +313,26 @@ class FakeFreezerRepository(
         removeFailures[packageName] = error
     }
 
+    /**
+     * As [failAddWith], for the membership *read*.
+     *
+     * Worth a seam of its own even though nothing is written: Room raises
+     * `SQLiteDiskIOException`/`SQLiteFullException` out of a `SELECT` as readily as out of an
+     * `INSERT`, and the read is the more dangerous of the two here because it runs on paths that had
+     * not touched the database yet — opening a details sheet, or deciding which way a toggle points.
+     * A caller that treats "the query threw" as "not in the freezer" is making a claim, and only a
+     * throwing read can tell whether it makes the right one.
+     */
+    fun failContainsWith(packageName: String, error: Throwable) {
+        containsFailures[packageName] = error
+    }
+
     override fun getAll(): Flow<List<String>> = packages.map { it.toList() }
 
     override suspend fun getAllPackageNames(): List<String> = packages.value.toList()
 
     override suspend fun add(packageName: String) {
+        ranOn["freezer.add:$packageName"] = currentCoroutineContext()[ContinuationInterceptor]
         addFailures[packageName]?.let { throw it }
         added += packageName
         trace?.add("freezer.add:$packageName")
@@ -290,6 +340,7 @@ class FakeFreezerRepository(
     }
 
     override suspend fun remove(packageName: String) {
+        ranOn["freezer.remove:$packageName"] = currentCoroutineContext()[ContinuationInterceptor]
         // Before the bookkeeping: a delete that raised deleted nothing, so [removed] stays the
         // list of rows that actually went.
         removeFailures[packageName]?.let { throw it }
@@ -307,7 +358,14 @@ class FakeFreezerRepository(
         packages.update { it - packageNames }
     }
 
-    override suspend fun contains(packageName: String): Boolean = packageName in packages.value
+    // Deliberately not traced, unlike [add] and [remove]. Tests call `contains` directly as a
+    // precondition assertion — `FreezerViewModelTest` does it twice inside a test that then asserts
+    // the trace by exact list equality — so recording it here would make the assertion depend on how
+    // many times the *test* happened to look, which is not a property of the code under test.
+    override suspend fun contains(packageName: String): Boolean {
+        containsFailures[packageName]?.let { throw it }
+        return packageName in packages.value
+    }
 }
 
 /**
@@ -826,7 +884,18 @@ class FakeAppShortcutController(
     val pinned = mutableListOf<String>()
     val pinnedBulkActions = mutableListOf<String>()
 
+    /**
+     * Failures the *port* absorbed instead of handing to its caller — see [pinAppShortcut].
+     *
+     * Recorded rather than dropped so a test can still say "the launcher refused and the caller was
+     * not told", which is a claim about the seam and not merely an absence.
+     */
+    val absorbedFailures = mutableListOf<Throwable>()
+
     private val disableFailures = mutableMapOf<String, Throwable>()
+    private val pinFailures = mutableMapOf<String, Throwable>()
+    private val refreshFailures = mutableMapOf<String, Throwable>()
+    private var bulkPinFailure: Throwable? = null
 
     /**
      * Make disabling [packageName]'s shortcut raise, as `ShortcutManagerCompat` does — it reports a
@@ -836,27 +905,81 @@ class FakeAppShortcutController(
         disableFailures[packageName] = error
     }
 
+    /**
+     * As [failDisableWith], for a *pin* request.
+     *
+     * The pin path raises for reasons the disable path does not — the launcher declining the request
+     * outright, and the rate limit that `ShortcutManagerCompat` enforces per app per interval — and it
+     * is the one a user reaches by asking for many shortcuts at once, which is exactly the shape where
+     * one refusal must not cost the whole run.
+     *
+     * Keyed on the package, so it covers both pin members — but only [pinAppShortcutSuspend] raises
+     * it at the caller; the fire-and-forget [pinAppShortcut] absorbs it, as in production.
+     */
+    fun failPinWith(packageName: String, error: Throwable) {
+        pinFailures[packageName] = error
+    }
+
+    /** As [failPinWith], for the one bulk tile, which has no package to key on. */
+    fun failBulkPinWith(error: Throwable) {
+        bulkPinFailure = error
+    }
+
+    /**
+     * As [failDisableWith], for the refresh — but note that this failure never reaches the caller.
+     *
+     * `refreshAppShortcut` is fire-and-forget, so setting this asserts the opposite of what the other
+     * hooks do: that a stale launcher icon is *not* reported to whoever asked for the freeze, and is
+     * absorbed by the port instead. See [refreshAppShortcut] for why, and [absorbedFailures] for
+     * where it lands. For a genuine post-success throw in `toggleFreezerState`, use
+     * `FakeFreezerRepository.failContainsWith` — the watchlist read at the same point in that method
+     * does raise into its caller.
+     */
+    fun failRefreshWith(packageName: String, error: Throwable) {
+        refreshFailures[packageName] = error
+    }
+
     override fun disableAppShortcut(packageName: String) {
         disableFailures[packageName]?.let { throw it }
         disabled += packageName
         trace?.add("shortcut.disable:$packageName")
     }
 
+    /**
+     * Absorbs its failure rather than raising it, because that is what the real one does.
+     *
+     * `FreezerShortcutManager.refreshAppShortcut` hands the work to the manager's own
+     * `SupervisorJob` scope and returns the moment it is *scheduled*, so the throw arrives after the
+     * caller's frame — and therefore after any `try`/`catch` or `launchGuarded` around the call —
+     * has already completed successfully. `FreezerShortcutManager.launchSafely` is the only frame
+     * that can see it, which is also the only place that covers the callers that are not view models
+     * at all (`AutoFreezeManager`, `FreezerLaunchActivity`, `ThorApplication`).
+     *
+     * A fake that threw here would make every caller-side guard around this method look
+     * load-bearing while catching nothing in production — the exact mistake the sweep in
+     * `fix/freezer-bookkeeping-crashes` made first time round, green tests and all. [absorbedFailures]
+     * keeps the refusal assertable without lying about who gets told.
+     */
     override fun refreshAppShortcut(packageName: String) {
+        refreshFailures[packageName]?.let { absorbedFailures += it; return }
         refreshed += packageName
     }
 
     override fun isPinSupported(): Boolean = pinSupported
 
+    /** Fire-and-forget, so it absorbs rather than raises — see [refreshAppShortcut]. */
     override fun pinAppShortcut(packageName: String, label: String) {
+        pinFailures[packageName]?.let { absorbedFailures += it; return }
         pinned += packageName
     }
 
     override suspend fun pinAppShortcutSuspend(packageName: String, label: String) {
+        pinFailures[packageName]?.let { throw it }
         pinned += packageName
     }
 
     override fun pinBulkShortcut(action: String) {
+        bulkPinFailure?.let { throw it }
         pinnedBulkActions += action
     }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModelTest.kt
@@ -3,6 +3,7 @@
 
 package com.valhalla.thor.presentation.appList
 
+import com.valhalla.thor.R
 import com.valhalla.thor.domain.model.DetailedAppInfo
 import com.valhalla.thor.domain.model.ObbFile
 import com.valhalla.thor.domain.model.ObbProbe
@@ -24,6 +25,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -357,5 +359,244 @@ class AppInfoDetailsViewModelTest {
         runCurrent()
 
         assertEquals(ObbProbe.None, vm.uiState.value.obbProbe)
+    }
+
+    // --- The Room throws that used to be process death (fix/freezer-bookkeeping-crashes) ---
+    //
+    // This file had no `try`, no `catch` and no `runCatching` anywhere in it before that branch, and
+    // every watchlist call in it sat in a bare `viewModelScope.launch`. Room reports a full or failing
+    // disk by *throwing*, `FreezerRepositoryImpl` is a pass-through that does not catch, and `:app`
+    // installs no `CoroutineExceptionHandler` — so opening this sheet on a bad disk killed the app.
+    //
+    // Each test below removes one guard's reason to exist. Without the guard they do not merely
+    // assert wrongly, they take the test runner's coroutine with them, which is the correct shape for
+    // a pin on a crash.
+
+    /**
+     * The two-facts case, and the one worth getting right: something throws *after* the freeze has
+     * already succeeded.
+     *
+     * The detail read is the seam, and picking it took some elimination. `refreshAppShortcut` runs
+     * first and looks like the obvious candidate, but it is fire-and-forget — it returns as soon as
+     * its body is scheduled on `FreezerShortcutManager`'s own scope, so its throw arrives after this
+     * frame is gone and no guard here could ever see it. The watchlist read next to it is wrapped in
+     * `isInFreezer`, which deliberately degrades to false. That leaves `refreshDetails`' package
+     * manager call, which reports a dead `system_server` or a package that vanished mid-tap by
+     * throwing and has nothing to degrade to — so it is the one remaining collaborator that can land
+     * a throw between the act and the report of it.
+     *
+     * A bare "Error: …" there would tell a user whose app is demonstrably frozen that their action
+     * failed, so the guard leads with the truth and then names the throw.
+     */
+    @Test
+    fun `a freeze that succeeds then throws says so before naming the failure`() = runTest {
+        loaded(userApp("a", enabled = true))
+        appRepository.failDetailsWith("a", IllegalStateException("package manager died"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.toggleFreezerState("a", freeze = true, appName = "App A")
+        runCurrent()
+
+        assertEquals(
+            "the freeze really happened, so that is the first thing said",
+            listOf(
+                UiText.StringResource(R.string.frozen_success, "App A"),
+                UiText.StringResource(R.string.error_format, "package manager died")
+            ),
+            seen
+        )
+    }
+
+    /**
+     * And the shortcut refresh's own failure, which by design reaches nobody.
+     *
+     * Worth pinning precisely because the fix here first tried to report it: a guard around
+     * [AppShortcutController.refreshAppShortcut] catches nothing, so the freeze is announced exactly
+     * once and the stale launcher icon is absorbed by `FreezerShortcutManager.launchSafely`. If this
+     * test ever starts seeing a second event, the port has grown a throw its callers were not written
+     * for.
+     */
+    @Test
+    fun `a launcher icon that will not repaint is not the user's problem`() = runTest {
+        loaded(userApp("a", enabled = true))
+        freezer.add("a") // already tracked, so the freeze reports rather than prompting
+        shortcuts.failRefreshWith("a", IllegalStateException("shortcut rate limit exceeded"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.toggleFreezerState("a", freeze = true, appName = "App A")
+        runCurrent()
+
+        assertEquals(
+            UiText.StringResource(R.string.frozen_success, "App A"),
+            seen.single()
+        )
+        assertEquals(
+            "the refusal went to the port's own guard, not to the screen",
+            1,
+            shortcuts.absorbedFailures.size
+        )
+    }
+
+    /** The same shape on the removal path: restore succeeded, the row would not go. */
+    @Test
+    fun `a removal whose delete raises still reports the unfreeze`() = runTest {
+        loaded(userApp("a", enabled = false))
+        freezer.add("a")
+        freezer.failRemoveWith("a", IllegalStateException("disk is full"))
+        val vm = viewModel()
+        vm.loadAppDetails("a")
+        runCurrent()
+        val seen = events(vm)
+
+        vm.addOrRemoveFromFreezer("a")
+        runCurrent()
+
+        assertEquals(
+            "the app is back — say that, then say the record did not keep up",
+            listOf(
+                UiText.StringResource(R.string.unfrozen_success, "a"),
+                UiText.StringResource(R.string.error_format, "disk is full")
+            ),
+            seen
+        )
+        assertTrue("and the row is still there, so the next tap can retry it", freezer.contains("a"))
+    }
+
+    /**
+     * The other side of the same guard: a throw *before* anything irreversible.
+     *
+     * Adding to the watchlist freezes nothing, so a failed insert really is a failed action and there
+     * is no success to lead with. One plain error, and no claim about the app.
+     */
+    @Test
+    fun `an add that raises is reported as the plain failure it is`() = runTest {
+        loaded(userApp("a"))
+        freezer.failAddWith("a", IllegalStateException("disk is full"))
+        val vm = viewModel()
+        vm.loadAppDetails("a")
+        runCurrent()
+        val seen = events(vm)
+
+        vm.addOrRemoveFromFreezer("a")
+        runCurrent()
+
+        assertEquals(
+            listOf(UiText.StringResource(R.string.error_format, "disk is full")),
+            seen
+        )
+        // Filtered rather than `isEmpty`: the `loadAppDetails` above leaves the three privilege
+        // probes in `calls`, so "nothing was done to the app" has to be said about the calls that
+        // would actually do something to it.
+        assertTrue(
+            "nothing was done to the app — adding a row never freezes",
+            system.calls.none { it.startsWith("setAppDisabled") || it.startsWith("setAppSuspended") }
+        )
+        assertTrue("and no row landed", freezer.added.isEmpty())
+    }
+
+    /**
+     * [AppInfoDetailsViewModel.addToFreezer] — the prompt's own confirm, which is a different method
+     * from the toggle above and had no test at all.
+     *
+     * It only ever runs after a freeze already succeeded, so the insert raising costs the watchlist
+     * row and nothing else: the app stays frozen and stops being tracked, which is precisely the
+     * state the prompt appeared to offer a way out of. Two things therefore have to survive the
+     * throw — the prompt, so the retry is one more tap, and `isInFreezer` staying false, because no
+     * row was written and the sheet's toggle would otherwise claim one was.
+     *
+     * The prompt outliving the failure is load-bearing on this surface in a way it is not on the
+     * others: `AppInfoDetailsScreen.kt` leaves dismissal to the view model, where `AppListScreen`
+     * and `FreezerScreen` clear their own prompt state as the dialog goes. Whatever this method
+     * leaves in `freezerPrompt` is what the user sees.
+     */
+    @Test
+    fun `a prompt confirm whose insert raises keeps the prompt and stays untracked`() = runTest {
+        loaded(userApp("a", enabled = true))
+        freezer.failAddWith("a", IllegalStateException("disk is full"))
+        val vm = viewModel()
+        vm.loadAppDetails("a")
+        runCurrent()
+        val seen = events(vm)
+
+        // The only way the prompt is raised: a freeze that lands on an app not yet tracked.
+        vm.toggleFreezerState("a", freeze = true, appName = "App A")
+        runCurrent()
+        assertNotNull("precondition: the freeze raised the prompt", vm.uiState.value.freezerPrompt)
+        assertTrue("precondition: and it said so by prompting, not by toasting", seen.isEmpty())
+
+        vm.addToFreezer("a")
+        runCurrent()
+
+        assertEquals(
+            "the freeze is not re-announced and the failure is not dressed up as one",
+            listOf(UiText.StringResource(R.string.error_format, "disk is full")),
+            seen
+        )
+        assertNotNull(
+            "the prompt stands, so the retry is one tap — this screen has no other dismissal",
+            vm.uiState.value.freezerPrompt
+        )
+        assertFalse("no row landed, so the sheet must not claim one", vm.uiState.value.isInFreezer)
+        assertTrue(freezer.added.isEmpty())
+    }
+
+    /**
+     * The membership read that picks between two opposite actions, which is deliberately *not*
+     * degraded the way the display read is.
+     *
+     * `isInFreezer` answers "not in the freezer" when the query throws, which is right for a label.
+     * It would be wrong here: it would answer a Remove tap by trying to Add. So this one reads the
+     * repository directly and lets the guard report it — nothing has happened to the app, and that is
+     * exactly what the user is told.
+     */
+    @Test
+    fun `a membership read that raises refuses to guess which action was meant`() = runTest {
+        loaded(userApp("a", enabled = false))
+        freezer.add("a")
+        freezer.failContainsWith("a", IllegalStateException("disk I O error"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.addOrRemoveFromFreezer("a")
+        runCurrent()
+
+        assertEquals(
+            listOf(UiText.StringResource(R.string.error_format, "disk I O error")),
+            seen
+        )
+        assertTrue("no restore, and no add: the tap did nothing", system.calls.isEmpty())
+        // Deliberately not `freezer.contains("a")`: that is the very call rigged to raise here, so
+        // asserting through it would throw out of the test body and report as a failure of the code
+        // under test. `removed` says the same thing without asking the broken question.
+        assertTrue("the row is untouched", freezer.removed.isEmpty())
+    }
+
+    /**
+     * And the display read, which *is* degraded — the case that must not be turned into an error.
+     *
+     * This read is a passenger on a detail load the user asked for. Failing it loudly would blame the
+     * load for a database fault, and crashing on it was the original bug: the sheet could not be
+     * opened at all. It degrades to "not tracked" and says nothing, matching
+     * `AppListViewModel.observeFreezerMembership`'s `Flow.catch`.
+     */
+    @Test
+    fun `a failed membership read leaves the detail load standing and silent`() = runTest {
+        loaded(userApp("a"))
+        freezer.add("a")
+        freezer.failContainsWith("a", IllegalStateException("disk I O error"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.loadAppDetails("a")
+        runCurrent()
+
+        assertNotNull("the details themselves landed", vm.uiState.value.detailedInfo)
+        assertFalse(
+            "degraded to not-tracked, which offers to add rather than hiding an untracked app",
+            vm.uiState.value.isInFreezer
+        )
+        assertTrue("and the load is not blamed for the database's fault", seen.isEmpty())
     }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
@@ -34,9 +34,11 @@ import com.valhalla.thor.presentation.FakeStorageStatsProvider
 import com.valhalla.thor.presentation.FakeSystemRepository
 import com.valhalla.thor.presentation.FakeUsageAccessGate
 import com.valhalla.thor.presentation.MainDispatcherRule
+import com.valhalla.thor.presentation.freezer.FreezerPrompt
 import com.valhalla.thor.presentation.userApp
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.util.bulkResultMessage
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -91,11 +93,29 @@ class AppListViewModelTest {
     private lateinit var privilege: FakePrivilegeStateProvider
     private lateinit var fileStore: FakeAppBundleFileStore
 
+    /**
+     * Hoisted out of [viewModel] so the watchlist tests at the bottom can rig it to raise and read
+     * back what it was asked to do. It was built inline while nothing needed either.
+     */
+    private lateinit var shortcuts: FakeAppShortcutController
+
+    /**
+     * The three fakes' calls in one ordered list, as `FreezerViewModelTest` keeps one.
+     *
+     * `system.calls`, `freezer.removed` and `shortcuts.disabled` each say what happened to them;
+     * none of them says what happened *first*, and the membership toggle's contract is almost entirely
+     * ordering — restore before the row goes, the shortcut retired before the row it belongs to. On
+     * the happy path the per-fake lists are identical whichever way round those ran.
+     */
+    private lateinit var trace: MutableList<String>
+
     @Before
     fun setUp() {
+        trace = mutableListOf()
         appRepository = FakeAppRepository()
-        system = FakeSystemRepository()
-        freezer = FakeFreezerRepository()
+        system = FakeSystemRepository(trace)
+        freezer = FakeFreezerRepository(trace = trace)
+        shortcuts = FakeAppShortcutController(trace = trace)
         privilege = FakePrivilegeStateProvider()
         fileStore = FakeAppBundleFileStore()
     }
@@ -116,7 +136,10 @@ class AppListViewModelTest {
         intensity: AnimationIntensity = AnimationIntensity.MEDIUM,
         filterType: FilterType = FilterType.Source,
         permissions: FakePermissionRepository = FakePermissionRepository(),
-        installedApps: FakeInstalledAppsPermissionGate = FakeInstalledAppsPermissionGate()
+        installedApps: FakeInstalledAppsPermissionGate = FakeInstalledAppsPermissionGate(),
+        // Overridable so one test can inject a dispatcher that is *not* the main one and check that
+        // a Room write reached it. Defaults to the main one, as every other test wants.
+        ioDispatcher: CoroutineDispatcher = mainDispatcherRule.dispatcher
     ): AppListViewModel {
         val prefs = FakePreferenceRepository(
             UserPreferences(animationIntensity = intensity, appFilterType = filterType)
@@ -136,7 +159,7 @@ class AppListViewModelTest {
             freezeAppUseCase = FreezeAppUseCase(appRepository, manageAppUseCase),
             preferenceRepository = prefs,
             freezerRepository = freezer,
-            appShortcuts = FakeAppShortcutController(),
+            appShortcuts = shortcuts,
             appRepository = appRepository,
             permissionRepository = permissions,
             storageStats = FakeStorageStatsProvider(),
@@ -149,7 +172,7 @@ class AppListViewModelTest {
                 mainDispatcherRule.dispatcher
             ),
             defaultDispatcher = mainDispatcherRule.dispatcher,
-            ioDispatcher = mainDispatcherRule.dispatcher
+            ioDispatcher = ioDispatcher
         )
         backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.uiState.collect {} }
         return vm
@@ -787,6 +810,229 @@ class AppListViewModelTest {
         assertEquals(
             listOf(AppListEvent.ShowMessage(UiText.StringResource(R.string.export_list_empty))),
             events
+        )
+    }
+
+    // --- The watchlist writes that used to be process death (fix/freezer-bookkeeping-crashes) ---
+    //
+    // Five of this view model's six watchlist calls sat in bare `viewModelScope.launch`es. Room
+    // reports a full or failing disk by throwing, `FreezerRepositoryImpl` does not catch, and `:app`
+    // installs no `CoroutineExceptionHandler`, so one freeze on a bad disk ended the process. Only
+    // `observeFreezerMembership` was covered, by a `Flow.catch`.
+    //
+    // Without their guards these do not fail an assertion, they kill the test's coroutine — which is
+    // the right way for a crash pin to read.
+
+    /** Collects one-off events for the duration of the test, as the screen does. */
+    private fun TestScope.freezerEvents(vm: AppListViewModel): List<AppListEvent> {
+        val seen = mutableListOf<AppListEvent>()
+        backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.events.collect { seen += it } }
+        return seen
+    }
+
+    /**
+     * The read inside `Result.onSuccess`, which is where this file's sharpest instance lived:
+     * `onSuccess`'s lambda is a plain inline lambda and catches nothing, so a throw from the freezer
+     * read walked straight out of it and out of the launch.
+     *
+     * It degrades to "not tracked" rather than aborting, and the reason is the freeze that already
+     * succeeded: abandoning the block would drop the report the user is owed for it. Guessing the
+     * other way would hide a frozen app off the watchlist, and `FreezerDao.insert` is
+     * `OnConflictStrategy.IGNORE`, so the prompt costs a no-op at worst.
+     */
+    @Test
+    fun `a freeze whose membership read raises still finishes and offers to track the app`() =
+        runTest {
+            appRepository.apps.value = listOf(userApp("a", enabled = true))
+            freezer.failContainsWith("a", IllegalStateException("disk I O error"))
+            val vm = viewModel()
+            runCurrent()
+            val seen = freezerEvents(vm)
+
+            vm.freezeApp("a", appName = "App A", freeze = true)
+            runCurrent()
+
+            assertEquals(
+                "the freeze itself went through — the read is a passenger on it",
+                listOf("setAppDisabled:a:true"),
+                system.calls.filter { it.startsWith("setAppDisabled") }
+            )
+            assertEquals(
+                "and the run finishes with the prompt rather than a crash",
+                listOf(AppListEvent.ShowFreezerPrompt(FreezerPrompt("a", "App A"))),
+                seen
+            )
+        }
+
+    /** The prompt's own confirmation, on the disk that would not take the row. */
+    @Test
+    fun `an add that raises is reported rather than killing the process`() = runTest {
+        appRepository.apps.value = listOf(userApp("a", enabled = false))
+        freezer.failAddWith("a", IllegalStateException("disk is full"))
+        val vm = viewModel()
+        runCurrent()
+        val seen = freezerEvents(vm)
+
+        vm.addToFreezer("a")
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                AppListEvent.ShowMessage(
+                    UiText.StringResource(R.string.error_format, "disk is full")
+                )
+            ),
+            seen
+        )
+    }
+
+    /**
+     * The delete that lands *after* the restore, which is the bookkeeping inversion this branch is
+     * named for: the app really is thawed and only Thor's record of it failed.
+     *
+     * Reporting that as a bare "Error: …" would tell a user whose app just came back that the unfreeze
+     * failed, so the guard leads with the true half. It does not stop there: the failure follows, in
+     * its own message, because the row surviving is a state the user can see on the freezer screen and
+     * would otherwise have no account of. Two messages rather than one is the point — the tap did two
+     * things and they did not agree, and either message alone is a half-truth.
+     *
+     * The same pair, in the same order, as `AppInfoDetailsViewModel.addOrRemoveFromFreezer`; the two
+     * surfaces are reachable from the same app row and must not describe one outcome two ways.
+     */
+    @Test
+    fun `a delete that raises after the restore reports the unfreeze and then the failure`() = runTest {
+        appRepository.apps.value = listOf(userApp("a", enabled = false))
+        freezer.add("a")
+        freezer.failRemoveWith("a", IllegalStateException("disk is full"))
+        // LOW, so the settle delay is ZERO and the scan lands under `runCurrent` — the app has to be
+        // resolvable in `_rawState` for this test to be about the patch rather than about the
+        // unresolvable-package fallback.
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+        val seen = freezerEvents(vm)
+
+        vm.toggleFreezerMembership("a")
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                AppListEvent.ShowMessage(UiText.StringResource(R.string.unfrozen_success, "a")),
+                AppListEvent.ShowMessage(UiText.StringResource(R.string.error_format, "disk is full"))
+            ),
+            seen
+        )
+        assertTrue("the row is still there for the next tap to retry", freezer.contains("a"))
+        assertTrue(
+            "and the list agrees with the toast rather than still drawing the app as frozen",
+            vm.uiState.value.allUserApps.single { it.packageName == "a" }.enabled
+        )
+    }
+
+    /**
+     * The ordering the two steps after the restore have to keep, which no per-fake list can show.
+     *
+     * The shortcut is retired *before* the row goes. Both steps can throw and the question is only
+     * which residue is worse: greying a shortcut for an app still on the watchlist costs the launcher
+     * tile until the next tap, whereas dropping the row first and then failing to grey the shortcut
+     * leaves a live freeze-from-the-launcher route for an app Thor no longer tracks.
+     */
+    @Test
+    fun `the shortcut is retired before the row it belongs to`() = runTest {
+        appRepository.apps.value = listOf(userApp("a", enabled = false))
+        freezer.add("a")
+        // LOW for the same reason as above: the resolved path runs `restoreApp`, the fallback runs
+        // `forceUnfreeze`, and the order under test is only interesting on the one the screen takes.
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+        trace.clear() // the scaffolding above is not part of the run
+
+        vm.toggleFreezerMembership("a")
+        runCurrent()
+
+        assertEquals(listOf("a"), freezer.removed)
+        assertEquals(listOf("a"), shortcuts.disabled)
+        assertTrue(
+            "the restore comes first — the row is the handle it would be retried from: $trace",
+            trace.indexOfFirst { it.startsWith("setAppDisabled") } <
+                trace.indexOf("shortcut.disable:a")
+        )
+        assertTrue(
+            "and the shortcut goes before the row, not after it: $trace",
+            trace.indexOf("shortcut.disable:a") < trace.indexOf("freezer.remove:a")
+        )
+    }
+
+    /**
+     * The guard's other arm — a throw *before* the irreversible step, where `unfrozenLabel` is still
+     * null and there is no success to lead with.
+     *
+     * The membership read is the seam and it is the first thing the body does, so nothing has been
+     * asked of the app when it raises. Both halves matter. One plain error, because prefixing it with
+     * `unfrozen_success` here would announce a thaw that never happened; and no privileged call at
+     * all, because the read is what picks between restoring and adding — a caller that degraded it to
+     * "not tracked" would answer this tap by freezing the app instead.
+     */
+    @Test
+    fun `a membership read that raises reports plainly and touches nothing`() = runTest {
+        appRepository.apps.value = listOf(userApp("a", enabled = false))
+        freezer.add("a")
+        freezer.failContainsWith("a", IllegalStateException("database is locked"))
+        val vm = viewModel(AnimationIntensity.LOW)
+        runCurrent()
+        val seen = freezerEvents(vm)
+
+        vm.toggleFreezerMembership("a")
+        runCurrent()
+
+        assertEquals(
+            "no unfrozen_success in front of it — the app was never touched",
+            listOf(
+                AppListEvent.ShowMessage(
+                    UiText.StringResource(R.string.error_format, "database is locked")
+                )
+            ),
+            seen
+        )
+        // Filtered rather than `isEmpty`: the initial load leaves its privilege probes in `calls`.
+        assertTrue(
+            "and nothing was asked of the app, in either direction",
+            system.calls.none { it.startsWith("setAppDisabled") || it.startsWith("setAppSuspended") }
+        )
+        // `getAllPackageNames`, not `contains`: the read under test is the one that is rigged to
+        // throw, so asking it would fail the test from the assertion rather than from the code.
+        assertTrue("the row is untouched", freezer.getAllPackageNames().contains("a"))
+        assertTrue(freezer.removed.isEmpty())
+        assertTrue(shortcuts.disabled.isEmpty())
+    }
+
+    /**
+     * That the watchlist writes reach the injected `ioDispatcher` and not the main thread.
+     *
+     * Every other test in the suite passes `mainDispatcherRule.dispatcher` in as both dispatchers, so
+     * a `launchGuarded` that dropped its `context =` argument would be invisible to all of them —
+     * and the production comments at those call sites say why it would also be invisible on device:
+     * Room's suspend DAO functions dispatch internally, so a write left on
+     * `Dispatchers.Main.immediate` keeps working and nothing fails to say so. A distinct dispatcher
+     * is the only thing that can tell the two apart.
+     *
+     * Sharing `testScheduler` keeps `runCurrent()` in charge of both, so this stays a statement about
+     * which dispatcher the body ran on rather than about timing.
+     */
+    @Test
+    fun `the watchlist write runs on the io dispatcher, not on main`() = runTest {
+        val io = StandardTestDispatcher(testScheduler, name = "io")
+        appRepository.apps.value = listOf(userApp("a", enabled = false))
+        val vm = viewModel(AnimationIntensity.LOW, ioDispatcher = io)
+        runCurrent()
+
+        vm.addToFreezer("a")
+        runCurrent()
+
+        assertEquals(listOf("a"), freezer.added)
+        assertEquals(
+            "the insert woke up on the injected dispatcher: ${freezer.ranOn}",
+            io,
+            freezer.ranOn["freezer.add:a"]
         )
     }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/freezer/FreezerViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/freezer/FreezerViewModelTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -154,12 +155,15 @@ class FreezerViewModelTest {
         assertEquals(listOf("a", "b"), shortcuts.disabled)
         // The ordering itself, which is the whole fix and which the lists above cannot show: the
         // row goes only after the app is back, one package finished before the next is started.
+        // Within a package the shortcut is greyed before the row goes — a pinned shortcut can only
+        // be disabled, never deleted, so the reverse order can leave a live launcher entry for an
+        // app that is no longer in the freezer.
         assertEquals(
             listOf(
                 "setAppSuspended:a:false", "setAppDisabled:a:false",
-                "freezer.remove:a", "shortcut.disable:a",
+                "shortcut.disable:a", "freezer.remove:a",
                 "setAppSuspended:b:false", "setAppDisabled:b:false",
-                "freezer.remove:b", "shortcut.disable:b"
+                "shortcut.disable:b", "freezer.remove:b"
             ),
             trace
         )
@@ -288,7 +292,10 @@ class FreezerViewModelTest {
             runCurrent()
 
             assertEquals("c ran after the throw", listOf("a", "c"), freezer.removed)
-            assertEquals(listOf("a", "c"), shortcuts.disabled)
+            // b's shortcut was greyed before its delete raised, and that is the order on purpose:
+            // a greyed shortcut over a surviving row is a launcher entry the next refresh restores,
+            // where a live shortcut over a deleted row is one the launcher can freeze from.
+            assertEquals(listOf("a", "b", "c"), shortcuts.disabled)
             assertTrue("the row whose delete raised is still there", freezer.contains("b"))
             assertEquals(
                 UiText.StringResource(R.string.error_format, "database is locked"),
@@ -342,15 +349,16 @@ class FreezerViewModelTest {
     }
 
     /**
-     * The launcher step raising, which is the one failure that lands after the row is already gone.
+     * The launcher step raising, which is what the shortcut-before-row ordering is chosen for.
      *
-     * It counts as a failure even so. The alternative — treating the package as removed because the
-     * part that mattered worked — would hide a stale live shortcut, and a live shortcut for an app
-     * no longer in the freezer is a route back into freezing it from the launcher. Reporting is the
-     * cheap side to be wrong on: the app is thawed and the row is gone, so nothing is stranded.
+     * A pinned shortcut can only be greyed, never deleted, so the row is the only end of this pair
+     * the app can still take back. Greying it first means a launcher that refuses stops the delete:
+     * the row and the shortcut are both still live, which is the state the user started in and the
+     * one a retry can act on. The reverse order cannot be retried into consistency — the row is
+     * gone, so nothing lists the app, and the live shortcut is still a route back into freezing it.
      */
     @Test
-    fun `a shortcut that will not be disabled is still reported, though the row has gone`() =
+    fun `a shortcut that will not be disabled keeps the row rather than orphaning it`() =
         runTest {
             freezer.add("a")
             shortcuts.failDisableWith("a", IllegalStateException("shortcut rate limit exceeded"))
@@ -362,11 +370,12 @@ class FreezerViewModelTest {
             runCurrent()
 
             assertEquals(
-                "the restore ran and the row went — the invariant held all the way through",
+                "the restore ran, and it is the launcher step after it that raised",
                 listOf("setAppSuspended:a:false", "setAppDisabled:a:false"),
                 system.calls
             )
-            assertEquals(listOf("a"), freezer.removed)
+            assertTrue("the row outlives the shortcut that would not be greyed", freezer.contains("a"))
+            assertTrue("so there is no delete to undo", freezer.removed.isEmpty())
             assertEquals(
                 UiText.StringResource(R.string.error_format, "shortcut rate limit exceeded"),
                 seen.onlyToast()
@@ -433,7 +442,9 @@ class FreezerViewModelTest {
                 system.calls
             )
             assertTrue("the throw left the row in place", freezer.contains("a"))
-            assertTrue(shortcuts.disabled.isEmpty())
+            // Greyed before the delete raised, the same order as the multi-select path — see
+            // `a shortcut that will not be disabled keeps the row rather than orphaning it`.
+            assertEquals(listOf("a"), shortcuts.disabled)
             assertEquals(
                 UiText.StringResource(R.string.error_format, "database is locked"),
                 seen.onlyToast()
@@ -550,7 +561,7 @@ class FreezerViewModelTest {
                 listOf(
                     "setAppSuspended:a:true", "freezer.add:a",
                     "setAppSuspended:a:false", "setAppDisabled:a:false",
-                    "freezer.remove:a", "shortcut.disable:a"
+                    "shortcut.disable:a", "freezer.remove:a"
                 ),
                 trace
             )
@@ -725,6 +736,239 @@ class FreezerViewModelTest {
                 FreezerEvent.ShowToast(UiText.StringResource(R.string.profile_nothing_to_do))
             ),
             seen
+        )
+    }
+
+    // --- The watchlist writes that were still unguarded (fix/freezer-bookkeeping-crashes) ---
+    //
+    // Everything above pins `removeFromFreezer` and `toggleManaged`, which have caught their own Room
+    // throws since GH#310. The two functions below did not, three hundred lines away in the same
+    // file, and `:app` installs no `CoroutineExceptionHandler` — so a full or failing disk turned one
+    // tap into process death. These pin the guard, and each one fails by *crashing the test* rather
+    // than by a wrong assertion if the guard is removed, which is the honest shape for this defect.
+
+    /**
+     * The snackbar's "add it to the Freezer?" confirmation, on a disk that will not take the row.
+     *
+     * The freeze has already happened when this runs — the prompt is only raised after one succeeded
+     * — so the toast must not claim the freeze failed. It reports the throw and nothing else.
+     */
+    @Test
+    fun `an add that raises is reported rather than taking the process with it`() = runTest {
+        freezer.failAddWith("a", IllegalStateException("disk is full"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.addToFreezer("a")
+        runCurrent()
+
+        assertFalse("the row never landed", freezer.contains("a"))
+        assertEquals(
+            "and the failure is named, not swallowed and not dressed up as a failed freeze",
+            UiText.StringResource(R.string.error_format, "disk is full"),
+            seen.onlyToast()
+        )
+    }
+
+    /**
+     * The import-already-disabled dialog with one row in the batch refusing.
+     *
+     * Two claims, and the second is the one that was wrong even after the crash was fixed. Per-item
+     * isolation first: the guard sits *inside* the loop, exactly as [removeFromFreezer]'s does, so one
+     * throw cannot cost the user every package behind it in the list.
+     *
+     * Then the counting. A batch that lands 2 of 3 rows used to report the throw alone, which reads as
+     * a total failure over a screen that is about to list both survivors — so the count goes out too.
+     * There is no "Added x/y (z failed)" string to say it in one line and minting one costs eight
+     * locales, so it is two events: what landed, then what threw.
+     */
+    @Test
+    fun `a partial import reports what landed as well as what threw`() = runTest {
+        freezer.failAddWith("b", IllegalStateException("disk is full"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.addAppsToFreezer(listOf("a", "b", "c"))
+        runCurrent()
+
+        assertEquals("c ran after the throw", listOf("a", "c"), freezer.added)
+        assertEquals(
+            "both facts, in the order they matter",
+            listOf(
+                FreezerEvent.ShowToast(
+                    UiText.PluralsResource(R.plurals.added_to_freezer_count_success, 2)
+                ),
+                FreezerEvent.ShowToast(
+                    UiText.StringResource(R.string.error_format, "disk is full")
+                )
+            ),
+            seen
+        )
+    }
+
+    /**
+     * What the count is actually counting, which is *not* rows the table gained.
+     *
+     * `FreezerDao.insert` is `OnConflictStrategy.IGNORE`, so re-importing a package that is already
+     * tracked is a write that succeeds and changes nothing. The run tallies writes that did not
+     * throw, so it says two over a selection of two while the table grows by one — and that is the
+     * right answer to give: both apps are on the watchlist when the toast appears, which is the only
+     * thing the user asked for. The number diverges from the selection on failures, not on
+     * duplicates; `a partial import reports what landed as well as what threw` is where that
+     * divergence is pinned.
+     */
+    @Test
+    fun `a duplicate in the import still counts, because an ignored insert is not a failure`() =
+        runTest {
+            freezer.add("a")
+            val vm = viewModel()
+            val seen = events(vm)
+
+            vm.addAppsToFreezer(listOf("a", "b"))
+            runCurrent()
+
+            assertEquals(
+                UiText.PluralsResource(R.plurals.added_to_freezer_count_success, 2),
+                seen.onlyToast()
+            )
+            assertEquals(
+                "both writes were made, including the one the DAO ignores",
+                listOf("a", "a", "b"),
+                freezer.added
+            )
+            assertEquals(
+                "but the table only gained one row, so the toast is not counting those",
+                listOf("a", "b"),
+                freezer.getAllPackageNames().sorted()
+            )
+        }
+
+    /**
+     * The import's cancellation rethrow, matching [removeFromFreezer]'s.
+     *
+     * `CancellationException` is an `Exception`, so the per-item catch would swallow it and keep
+     * walking a list for a screen that is gone. It has to be rethrown ahead of the general catch, and
+     * then reach the guard, which rethrows it too rather than toasting it.
+     */
+    @Test
+    fun `a cancelled import stops rather than reporting itself`() = runTest {
+        freezer.failAddWith("b", CancellationException("the screen went away"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.addAppsToFreezer(listOf("a", "b", "c"))
+        runCurrent()
+
+        assertEquals("what landed before the cancellation still counts", listOf("a"), freezer.added)
+        assertTrue("nothing is reported, because there is nobody left to report to", seen.isEmpty())
+    }
+
+    /**
+     * The launcher pins, which are the same defect class as the watchlist writes and were swept with
+     * them: `ShortcutManagerCompat` reports a refused or rate-limited request by throwing, and all
+     * three pin entry points were bare launches.
+     *
+     * Two assertions, and they pull against each other on purpose. The per-app isolation is the first
+     * — "pin every freezer app" losing the rest of the list to one launcher refusal would be a second
+     * bug wearing the fix's clothes. But isolating the failure must not also bury it: `Logger` is
+     * gated on `Logger.isDebug`, which is false in every build a user runs, so catching per app and
+     * only logging meant a run in which the launcher refused every single shortcut said nothing at all.
+     * One line for the run, however many rows refused.
+     *
+     * The `runCurrent()` after `advanceUntilIdle()` is load-bearing, and this is the only test in the
+     * file that needs it: the toast is emitted from the *last* foreground task, and `advanceUntilIdle`
+     * calls it a day once the foreground queue drains, leaving the `backgroundScope` collector's
+     * resumption unrun. Measured, not guessed — `seen` is `[]` on the line after `advanceUntilIdle` and
+     * holds the toast on the line after `runCurrent`. Which also means the assertion this test used to
+     * carry, `assertTrue(seen.isEmpty())`, was true of the harness rather than of the code, and would
+     * have stayed green against the reporting this test now demands.
+     */
+    @Test
+    fun `a pin that raises is reported and does not abandon the rest of the run`() = runTest {
+        appRepository.apps.value = listOf(userApp("a"), userApp("b"), userApp("c"))
+        listOf("a", "b", "c").forEach { freezer.add(it) }
+        shortcuts.failPinWith("b", IllegalStateException("shortcut rate limit exceeded"))
+        val vm = viewModel()
+        val seen = events(vm)
+        runCurrent()
+
+        vm.pinAllToLauncher()
+        advanceUntilIdle() // the loop spaces its pin requests with delay(100)
+        runCurrent() // and the closing toast lands in the last of those tasks — see the KDoc
+
+        assertEquals("c is pinned after b raised", listOf("a", "c"), shortcuts.pinned)
+        assertEquals(
+            "and the refusal is still reported, once, after the run",
+            UiText.StringResource(R.string.error_format, "shortcut rate limit exceeded"),
+            seen.onlyToast()
+        )
+    }
+
+    /** Two refusals, one line: they are the same refusal repeated, and N toasts would bury each other. */
+    @Test
+    fun `a run the launcher refuses outright is reported once, not per app`() = runTest {
+        appRepository.apps.value = listOf(userApp("a"), userApp("b"), userApp("c"))
+        listOf("a", "b", "c").forEach { freezer.add(it) }
+        listOf("a", "b", "c").forEach {
+            shortcuts.failPinWith(it, IllegalStateException("shortcut rate limit exceeded"))
+        }
+        val vm = viewModel()
+        val seen = events(vm)
+        runCurrent()
+
+        vm.pinAllToLauncher()
+        advanceUntilIdle()
+        runCurrent() // as above: the closing toast lands in the last foreground task
+
+        assertTrue("nothing was pinned", shortcuts.pinned.isEmpty())
+        assertEquals(
+            "one line for the run",
+            UiText.StringResource(R.string.error_format, "shortcut rate limit exceeded"),
+            seen.onlyToast()
+        )
+    }
+
+    /**
+     * The single pin, which is the one the fix got wrong first time round.
+     *
+     * `pinAppToLauncher` used to call the fire-and-forget `pinAppShortcut`, whose body runs on
+     * `FreezerShortcutManager`'s own scope — so the `launchPin` guard wrapped around it completed
+     * successfully before the refusal existed, and could not have reported it however well written it
+     * was. It calls `pinAppShortcutSuspend` now, which throws into the guard; the guard is already off
+     * Main, which was the fire-and-forget variant's only purpose.
+     */
+    @Test
+    fun `a single pin the launcher refuses reaches the user`() = runTest {
+        shortcuts.failPinWith("a", IllegalStateException("launcher refused the request"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.pinAppToLauncher(userApp("a"))
+        advanceUntilIdle()
+
+        assertEquals(
+            UiText.StringResource(R.string.error_format, "launcher refused the request"),
+            seen.onlyToast()
+        )
+        assertTrue(
+            "and it was not quietly absorbed by the port instead",
+            shortcuts.absorbedFailures.isEmpty()
+        )
+    }
+
+    /** And the single-shortcut path, where the throw has nowhere to go but the guard. */
+    @Test
+    fun `a bulk shortcut pin that raises is reported rather than killing the process`() = runTest {
+        shortcuts.failBulkPinWith(IllegalStateException("launcher refused the request"))
+        val vm = viewModel()
+        val seen = events(vm)
+
+        vm.pinBulkShortcut(freeze = true)
+        runCurrent()
+
+        assertEquals(
+            UiText.StringResource(R.string.error_format, "launcher refused the request"),
+            seen.onlyToast()
         )
     }
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
@@ -396,6 +396,91 @@ class MainViewModelTest {
         assertTrue(freezer.added.isEmpty())
     }
 
+    /**
+     * The watchlist write that used to be process death (fix/freezer-bookkeeping-crashes).
+     *
+     * The uninstall has already happened when this runs and nothing can undo it. Room reports a full
+     * or failing disk by throwing, `FreezerRepositoryImpl` does not catch, and `:app` installs no
+     * `CoroutineExceptionHandler` — so unguarded, the row that makes a system app recoverable took
+     * the process with it *after* the uninstall succeeded, leaving the logger open, never completed,
+     * and a ✔ line as the user's last sight of it.
+     *
+     * Without the guard this does not fail an assertion, it kills the test's coroutine.
+     */
+    @Test
+    fun `a system uninstall Thor cannot write down still closes its log`() = runTest {
+        freezer.failAddWith("com.sys", IllegalStateException("disk is full"))
+        val vm = viewModel()
+
+        vm.onAppAction(AppClickAction.Uninstall(systemApp("com.sys")))
+        advanceUntilIdle()
+
+        val logs = vm.uiState.value.loggerState.logs
+        // The uninstall did not fail, so the line that says it worked stands — and the shortfall is
+        // named separately rather than rewriting that line into a failure.
+        assertTrue(
+            "the successful uninstall is still on the record: $logs",
+            logs.contains(UiText.StringResource(R.string.log_uninstall_success))
+        )
+        assertTrue(
+            "and the disk is named: $logs",
+            logs.contains(UiText.StringResource(R.string.log_error, "disk is full"))
+        )
+        // The half that was process death: the run reaching its end at all.
+        assertTrue("the logger completed", vm.uiState.value.loggerState.isComplete)
+    }
+
+    /**
+     * The same hole at the batch entry point, which is what makes this a class and not a special
+     * case. The middle app's row is the one that fails, so the test also pins that the run does not
+     * abandon the apps behind it.
+     *
+     * **Two** failures, not one, and with different messages. One failure cannot tell a collapsed
+     * report from a per-app one — both print the line once — so `assertEquals(1, …)` would have been
+     * a statement about the rig rather than about the code. Distinct messages then say which of the
+     * two survived: the production code takes `unrecorded.firstOrNull()`, so the second app's error
+     * must be absent, not merely un-repeated.
+     */
+    @Test
+    fun `a batch uninstall carries on past a row it cannot write and reports it once`() = runTest {
+        freezer.failAddWith("com.b", IllegalStateException("disk is full"))
+        freezer.failAddWith("com.c", IllegalStateException("database is locked"))
+        val vm = viewModel()
+
+        vm.onMultiAppAction(
+            MultiAppAction.Uninstall(
+                listOf(systemApp("com.a"), systemApp("com.b"), systemApp("com.c"))
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            "all three are uninstalled — the throw is bookkeeping, not the act",
+            listOf("uninstallApp:com.a", "uninstallApp:com.b", "uninstallApp:com.c"),
+            system.calls
+        )
+        assertEquals("and the one that could be written down was", listOf("com.a"), freezer.added)
+        val logs = vm.uiState.value.loggerState.logs
+        assertEquals(
+            "one closing line, not one per app: it is the same disk each time",
+            1,
+            logs.count { it == UiText.StringResource(R.string.log_error, "disk is full") }
+        )
+        assertEquals(
+            "and it is the first throw's message that survives, not the last: $logs",
+            0,
+            logs.count { it == UiText.StringResource(R.string.log_error, "database is locked") }
+        )
+        // Where the line sits, which is the reason it is collected instead of printed in place: it
+        // closes the run rather than interrupting a step, and the dialog auto-scrolls to it.
+        assertTrue(
+            "the shortfall is reported after the batch finishes, not spliced into it: $logs",
+            logs.indexOf(UiText.StringResource(R.string.log_op_complete)) <
+                logs.indexOf(UiText.StringResource(R.string.log_error, "disk is full"))
+        )
+        assertTrue("the logger completed", vm.uiState.value.loggerState.isComplete)
+    }
+
     @Test
     fun `a debuggable app that fails to reinstall is reported as debuggable, not as a raw error`() = runTest {
         system.failWith("reinstallAppWithGoogle:com.debuggable", RuntimeException("INSTALL_FAILED"))


### PR DESCRIPTION
Closes the crash class reported on #436.

## The defect

Room reports a failed write by **throwing**. `FreezerRepositoryImpl` is a bare pass-through, and `:app` installs no `CoroutineExceptionHandler`. So a watchlist call in a bare `viewModelScope.launch` is process death from one tap on a full disk — **16 of the 21 call sites**, across `FreezerViewModel`, `AppListViewModel`, `AppInfoDetailsViewModel` and `MainViewModel`.

Ten of the sixteen threw *after* an irreversible privileged call had already succeeded, which is the worse half: the app really is frozen (or thawed) and the process dies between the act and the record of it.

`presentation/LaunchGuarded.kt`'s `launchGuarded` already existed, its KDoc already named this exact defect, and four backup/export view models already used it. All four freezer ones used it zero times.

## What changed

**1. The guards.** Every watchlist call site now runs under `launchGuarded`, and each handler distinguishes the two sides of the irreversible step:

- **before** it — nothing happened to the app, so one plain error;
- **after** it — the app really did change and only the bookkeeping is missing, so the report leads with the true half (`frozen_success` / `unfrozen_success`) and *then* names the throw.

Two messages rather than one. Either alone is a half-truth: a bare `Error: …` over an app the user can see running reads as "the unfreeze failed", and stopping at the good news hides a failing disk the user can act on. No new string — there is nothing that says "it worked, Thor could not write it down", and adding one means eight in-app locales carrying an English-only entry that lint will not report.

**2. The port, not just its callers.** `FreezerShortcutManager.pinAppShortcut`, `refreshAppShortcut` and `syncDynamicShortcuts` are fire-and-forget — `scope.launch { … }` on the manager's own `SupervisorJob`. They return when the body is merely *scheduled*, so the caller's guard has already completed successfully by the time the body throws. **No view-model guard could ever have caught these**, and the first version of this sweep wrongly added ones that looked like they did.

They now route through a `launchSafely` helper, which is also the only guard `AutoFreezeManager`, `FreezerLaunchActivity` and `ThorApplication` ever get. `FreezerViewModel.pinAppToLauncher` switches to `pinAppShortcutSuspend` so its outcome reaches the guard that reports it.

`rebuildPinnedIcons`' inner `catch` is deliberately left alone — that guard has to sit *inside* `collect` for the collector to survive its own failure.

**3. Shortcut before row, at all four surfaces.** A pinned shortcut can only be greyed, never deleted, so the row is the only end of that pair the app can take back. Greying first means a launcher that refuses stops the delete and leaves a state a retry can act on; the reverse order leaves a live freeze-from-the-launcher route for an app Thor no longer tracks. Four sites now agree, where three said one thing and one said the other.

**4. `Throwable.asUiText()`.** `UiTextException` carries its message in `uiText` and leaves `message` null, so `error_format` applied to one renders a bare `Error: `. Eight handlers asked, six did not, and which behaviour you got depended on which screen you tapped. One function now, called from both the `catch` and the `Result.onFailure` side of each surface — the two paths carry different refusals today (`FreezeAppUseCase` *returns* its tier refusal rather than throwing it) but either can grow the other's.

## Verification

- `:app:testFossDebugUnitTest --rerun-tasks` — **1762 tests, 0 failures** (counts from `build/test-results/**/*.xml`).
- `:app:lintStoreRelease` — 8 Hints, unchanged from baseline.
- **Every new guard mutation-checked.** Reintroducing each defect (guard removed, `context = ioDispatcher` dropped, the second event dropped, `pinAppShortcutSuspend` reverted to the fire-and-forget pin) fails exactly the test written for it and nothing else. The four ordering tests were proved the same way — flipping the production order failed them.

Two harness defects fixed on the way, both of which had been hiding real coverage gaps:

- `FakeAppShortcutController`'s fire-and-forget members now **absorb** their rigged failures instead of raising them, and record them in `absorbedFailures`. A double that throws where production swallows makes a worthless guard look load-bearing — which is exactly what let the first, wrong version of this sweep pass its tests.
- `FakeFreezerRepository` now records which dispatcher each write woke up on. Every view model in the suite is built with one dispatcher injected everywhere, so a dropped `context =` was invisible to all 1762 tests — and invisible on device too, because Room's suspend DAO functions dispatch internally and a write left on `Dispatchers.Main.immediate` keeps working without anything failing to say so.

New coverage for four previously untested paths: `AppInfoDetailsViewModel.addToFreezer` (the prompt's confirm, which had no test at all), `AppListViewModel.toggleFreezerMembership`'s pre-restore arm, dispatcher preservation, and the launcher-refuses-outright run. Two existing tests were vacuous and are now not: `MainViewModelTest`'s collapsed-report assertion rigged only one failure (so `assertEquals(1, …)` could not distinguish collapsed from per-app), and the import-count test compared 2 against 2.

## Not in scope

- **`AppListViewModel.freezeApp` reads a stale `isSuspended`** off the list snapshot rather than re-reading it. Pre-existing on `dev`, unrelated to this class, and it wants its own PR.
- `AppInfoDetailsViewModel.isInFreezer` **degrades to `false`** when the Room read throws rather than propagating. That is right for a label and wrong for a decision, and the two call sites already pick correctly — but the name says nothing about it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for freezing, unfreezing, watchlist updates, imports, and shortcut operations.
  - Displays clearer success and failure feedback, including partial-operation results.
  - Prevents background shortcut or storage failures from crashing the app.
  - Uninstall operations now complete safely even when bookkeeping cannot be saved.
  - Bulk actions continue processing remaining apps after individual failures.
  - Preserves cancellation behavior and maintains accurate app and freezer state during failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->