### PR TITLE
fix(freezer): the review follow-ups PR #437 left behind

### DIFF
--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModel.kt
@@ -468,13 +468,31 @@ class AppInfoDetailsViewModel(
                 // From here on the app is running again and cannot be un-run. Everything below is
                 // bookkeeping, and the guard reports it as such.
                 restored = true
+                // The same optimistic patch AppListViewModel.toggleFreezerMembership applies, and for
+                // the same reason: past this line the app is thawed, and both statements below can
+                // throw. Left behind them a throw would skip it, leaving the sheet drawing the `frozen`
+                // chip over an app the guard has just toasted as unfrozen — the screen contradicting
+                // its own toast on the one path where the toast is certainly true.
+                //
+                // Stated here rather than left to refreshDetails, which re-reads through the package
+                // manager and races the enable: the new state is not always visible to
+                // getDetailedAppInfo immediately (FreezerLaunchActivity retries ~10×150ms for exactly
+                // that), whereas a restoreApp that returned success is knowledge.
+                _uiState.update { state ->
+                    state.copy(
+                        detailedInfo = state.detailedInfo?.let {
+                            it.copy(appInfo = it.appInfo.copy(enabled = true, isSuspended = false))
+                        }
+                    )
+                }
                 // Grey the launcher shortcut *before* dropping the row, matching
                 // AppListViewModel.toggleFreezerMembership — see the comment there for the argument.
                 // Short version: a pinned shortcut can only ever be greyed, never removed, so both
-                // orders leave residue on a throw and the question is which residue is worse. A greyed
-                // shortcut for an app still on the watchlist costs a launcher tile until the next tap;
-                // a dropped row with a live shortcut leaves the launcher able to drive a freeze for an
-                // app Thor is no longer tracking.
+                // orders leave residue on a throw and the question is which residue is worse. Greying
+                // first keeps the pair consistent and the removal retryable; dropping the row first
+                // and then failing to grey leaves an orphaned live shortcut for an app that is no
+                // longer on the watchlist, and no route back to it — the freezer screen no longer
+                // lists the app, so the toggle that would retry the disable is gone.
                 appShortcuts.disableAppShortcut(packageName)
                 freezerRepository.remove(packageName)
                 // refreshDetails re-reads membership, but only when details are loaded — set it here

--- a/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/appList/AppListViewModel.kt
@@ -736,16 +736,25 @@ class AppListViewModel(
                         allSystemApps = restore(state.allSystemApps)
                     )
                 }
-                // Pinned launcher shortcuts can't be removed silently, only greyed out — leaving a
-                // live shortcut for an app no longer in the freezer would let it drive a freeze
-                // from the launcher.
+                // Grey the shortcut before dropping the row. A pinned shortcut can only be disabled,
+                // never removed — `disableShortcuts` is the whole of what the app gets — so both
+                // orders leave residue when their second step throws, and the only question is which
+                // residue the user can get out of.
                 //
-                // Before the delete, not after, so that invariant survives a throw in either step.
-                // Both orders can fail, and the question is only which residue is worse: greying a
-                // shortcut for an app still on the watchlist costs the launcher tile until the next
-                // tap re-runs a restore that is by then a no-op, whereas dropping the row first and
-                // then failing to grey the shortcut leaves precisely the live-shortcut-for-an-
-                // untracked-app the comment above exists to forbid.
+                // Greying first: the disable throws, the row survives, the app is still listed in the
+                // freezer, so the same toggle retries the whole pair and the guard above has already
+                // said what failed. Row first: the delete lands, the disable throws, and the app is
+                // gone from the freezer screen — which is the surface that would have retried the
+                // disable. What is left is an orphaned live shortcut and no route back to it.
+                //
+                // Note what that orphan does *not* do, because an earlier version of this comment had
+                // it backwards. A per-app shortcut carries ACTION_LAUNCH, and
+                // FreezerLaunchActivity.launchApp answers it with forceUnfreeze-then-start, so a stale
+                // one thaws an app — it cannot freeze one. And it is not self-healing either: a
+                // shortcut greyed by `disableShortcuts` shows `shortcut_no_longer_frozen` instead of
+                // firing, so the way back is a fresh "Add to home screen", not the next tap. The cost
+                // of getting this order wrong is a launcher tile that outlives the watchlist row it
+                // was made for, not a freeze nobody asked for.
                 appShortcuts.disableAppShortcut(packageName)
                 freezerRepository.remove(packageName)
                 _events.send(

--- a/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/freezer/FreezerViewModel.kt
@@ -278,10 +278,11 @@ class FreezerViewModel(
                             failures += e
                             return@forEach
                         }
-                    // Pinned shortcuts can only be greyed, never removed — leaving a live one for an
-                    // app no longer in the freezer would let the launcher drive a freeze from it.
-                    // Before the delete, not after, so that holds even when one of the two throws:
-                    // see AppListViewModel.toggleFreezerMembership for the full argument.
+                    // Pinned shortcuts can only be greyed, never removed, so a throw between these two
+                    // leaves residue whichever order they run in. Greying first is the order whose
+                    // residue the user can still act on: the row survives, so the app stays listed and
+                    // the same action retries the pair. See AppListViewModel.toggleFreezerMembership
+                    // for the full argument, including what an orphaned shortcut does and does not do.
                     appShortcuts.disableAppShortcut(pkg)
                     freezerRepository.remove(pkg)
                     succeeded += pkg

--- a/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/main/MainViewModel.kt
@@ -35,6 +35,7 @@ import com.valhalla.thor.util.AppLocale
 import com.valhalla.thor.util.Logger
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.util.UiTextException
+import com.valhalla.thor.util.asUiText
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
@@ -588,8 +589,9 @@ class MainViewModel(
                 .onFailure { e ->
                     Logger.e("MainViewModel", "clearAllCaches failed", e)
                     _uiState.update { it.copy(cacheClear = null) }
-                    val errorText = if (e is UiTextException) e.uiText else UiText.DynamicString(e.message ?: "")
-                    _effect.send(MainSideEffect.Message(UiText.StringResource(R.string.error_format, errorText)))
+                    // Same unwrap the freezer surfaces use: a UiTextException already carries a whole
+                    // sentence, so wrapping it in `error_format` would read "Error: Skipped: …".
+                    _effect.send(MainSideEffect.Message(e.asUiText()))
                 }
         }
     }
@@ -631,12 +633,12 @@ class MainViewModel(
                         if (result.isSuccess) {
                             _effect.send(MainSideEffect.LaunchApp(app.packageName))
                         } else {
+                            // asUiText, not `.message`: a refusal arrives as a UiTextException whose
+                            // message is null, which renders as a bare "Error: ".
                             _effect.send(
                                 MainSideEffect.Message(
-                                    UiText.StringResource(
-                                        R.string.error_format,
-                                        result.exceptionOrNull()?.message ?: ""
-                                    )
+                                    result.exceptionOrNull()?.asUiText()
+                                        ?: UiText.StringResource(R.string.error_format, "")
                                 )
                             )
                         }
@@ -1304,15 +1306,7 @@ class MainViewModel(
                     triggerSupportPromptIfNeeded()
                 }
                 .onFailure { e ->
-                    val errorText = if (e is UiTextException) e.uiText else UiText.DynamicString(e.message ?: "")
-                    _effect.send(
-                        MainSideEffect.Message(
-                            UiText.StringResource(
-                                R.string.error_format,
-                                errorText
-                            )
-                        )
-                    )
+                    _effect.send(MainSideEffect.Message(e.asUiText()))
                 }
         else {
             _effect.send(MainSideEffect.Message(UiText.StringResource(R.string.error_app_info_missing)))

--- a/app/src/main/java/com/valhalla/thor/util/UiText.kt
+++ b/app/src/main/java/com/valhalla/thor/util/UiText.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.valhalla.thor.R
@@ -63,17 +64,23 @@ sealed class UiText {
         }
 
         @Composable
-        fun resolve(): String = pluralStringResource(resId, quantity, *formatArgs)
+        fun resolve(): String =
+            if (formatArgs.any { it is UiText }) resolve(LocalContext.current)
+            else pluralStringResource(resId, quantity, *formatArgs)
 
         fun resolve(context: Context): String =
-            context.resources.getQuantityString(resId, quantity, *formatArgs)
+            context.resources.getQuantityString(resId, quantity, *formatArgs.resolved(context))
     }
 
     @Composable
     fun asString(): String {
         return when (this) {
             is DynamicString -> value
-            is StringResource -> stringResource(resId, *args)
+            // Delegating rather than mapping the args in place: resolving a nested [UiText] means
+            // calling the @Composable overload from inside a `map` lambda, which is not composable.
+            is StringResource ->
+                if (args.any { it is UiText }) asString(LocalContext.current)
+                else stringResource(resId, *args)
             is PluralsResource -> resolve()
         }
     }
@@ -81,11 +88,42 @@ sealed class UiText {
     fun asString(context: Context): String {
         return when (this) {
             is DynamicString -> value
-            is StringResource -> context.getString(resId, *args)
+            is StringResource -> context.getString(resId, *args.resolved(context))
             is PluralsResource -> resolve(context)
         }
     }
 }
+
+/**
+ * Renders any [UiText] sitting in a format-argument list before it reaches `String.format`.
+ *
+ * `error_format` and `log_failed` are both `%1$s`, and a view model composing one of them has no
+ * `Context` with which to render an inner [UiText.StringResource] — so the inner message has to
+ * travel *as* a `UiText` and can only be resolved at the point of display, which is here.
+ *
+ * Without this, `String.format` falls back to `toString()` on the argument.
+ * [UiText.DynamicString] is a data class, so the user reads `Error: DynamicString(value=…)`;
+ * [UiText.StringResource] declares none, so they read
+ * `Error: com.valhalla.thor.util.UiText$StringResource@…`, which minification shortens without
+ * making it any more meaningful. Both were reachable from the Apps tab's quick actions.
+ *
+ * Returns `this` untouched in the overwhelmingly common no-nesting case, so the allocation only
+ * happens where it is needed.
+ */
+private fun Array<out Any>.resolved(context: Context): Array<out Any> =
+    resolvedWith { it.asString(context) }
+
+/**
+ * [resolved] with the rendering step handed in, which is the whole of it that a unit test can reach.
+ *
+ * `asString(Context)` cannot be called from a JVM unit test — this module has no Robolectric, so
+ * every `android.content.Context` member throws "not mocked" — and the mapping is the part that can
+ * silently regress to `toString()`. Splitting it out means the array walk is pinned by a test even
+ * though its one production caller is not.
+ */
+internal fun Array<out Any>.resolvedWith(render: (UiText) -> String): Array<out Any> =
+    if (none { it is UiText }) this
+    else map { if (it is UiText) render(it) else it }.toTypedArray()
 
 class UiTextException(val uiText: UiText) : Exception()
 

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppInfoDetailsViewModelTest.kt
@@ -439,10 +439,19 @@ class AppInfoDetailsViewModelTest {
         )
     }
 
-    /** The same shape on the removal path: restore succeeded, the row would not go. */
+    /**
+     * The same shape on the removal path: restore succeeded, the row would not go.
+     *
+     * Also the only pin this surface has on the order of the two steps after the restore. The other
+     * three removal surfaces pin it with a shared `CallTrace`; this file has none, so without the
+     * `disabled` assertion below, swapping `disableAppShortcut` and `remove` back to row-first ships
+     * green across the whole suite.
+     */
     @Test
     fun `a removal whose delete raises still reports the unfreeze`() = runTest {
-        loaded(userApp("a", enabled = false))
+        // appName distinct from the package, so the label expression is pinned too — `?: packageName`
+        // and bare `packageName` are indistinguishable when userApp() leaves appName null.
+        loaded(userApp("a", enabled = false, appName = "App A"))
         freezer.add("a")
         freezer.failRemoveWith("a", IllegalStateException("disk is full"))
         val vm = viewModel()
@@ -456,12 +465,24 @@ class AppInfoDetailsViewModelTest {
         assertEquals(
             "the app is back — say that, then say the record did not keep up",
             listOf(
-                UiText.StringResource(R.string.unfrozen_success, "a"),
+                UiText.StringResource(R.string.unfrozen_success, "App A"),
                 UiText.StringResource(R.string.error_format, "disk is full")
             ),
             seen
         )
         assertTrue("and the row is still there, so the next tap can retry it", freezer.contains("a"))
+        assertEquals(
+            "the shortcut is greyed before the row is dropped, so a row-first order fails here",
+            listOf("a"),
+            shortcuts.disabled
+        )
+        // The screen must not contradict the toast it just showed. `refreshDetails` never runs on
+        // this path — the delete throws first — so the only thing that can clear the `frozen` chip is
+        // the optimistic patch taken the moment `restoreApp` reported success.
+        assertTrue(
+            "the sheet shows the app running, as the toast says it is",
+            vm.uiState.value.detailedInfo?.appInfo?.enabled == true
+        )
     }
 
     /**

--- a/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/appList/AppListViewModelTest.kt
@@ -901,7 +901,11 @@ class AppListViewModelTest {
      */
     @Test
     fun `a delete that raises after the restore reports the unfreeze and then the failure`() = runTest {
-        appRepository.apps.value = listOf(userApp("a", enabled = false))
+        // A distinct appName, not the default null: `unfrozenLabel` is `app?.appName ?: packageName`,
+        // so with the default the two branches of that elvis both produce "a" and collapsing it to
+        // bare `packageName` would ship green — putting com.google.android.gm in the toast where
+        // Gmail belongs.
+        appRepository.apps.value = listOf(userApp("a", enabled = false, appName = "App A"))
         freezer.add("a")
         freezer.failRemoveWith("a", IllegalStateException("disk is full"))
         // LOW, so the settle delay is ZERO and the scan lands under `runCurrent` — the app has to be
@@ -916,7 +920,7 @@ class AppListViewModelTest {
 
         assertEquals(
             listOf(
-                AppListEvent.ShowMessage(UiText.StringResource(R.string.unfrozen_success, "a")),
+                AppListEvent.ShowMessage(UiText.StringResource(R.string.unfrozen_success, "App A")),
                 AppListEvent.ShowMessage(UiText.StringResource(R.string.error_format, "disk is full"))
             ),
             seen
@@ -932,9 +936,10 @@ class AppListViewModelTest {
      * The ordering the two steps after the restore have to keep, which no per-fake list can show.
      *
      * The shortcut is retired *before* the row goes. Both steps can throw and the question is only
-     * which residue is worse: greying a shortcut for an app still on the watchlist costs the launcher
-     * tile until the next tap, whereas dropping the row first and then failing to grey the shortcut
-     * leaves a live freeze-from-the-launcher route for an app Thor no longer tracks.
+     * which residue the user can act on: greying first keeps the row, so the app stays listed in the
+     * freezer and the same toggle retries the pair, whereas dropping the row first and then failing to
+     * grey leaves an orphaned live shortcut for an app that is no longer listed anywhere that could
+     * retry the disable.
      */
     @Test
     fun `the shortcut is retired before the row it belongs to`() = runTest {

--- a/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/main/MainViewModelTest.kt
@@ -666,15 +666,16 @@ class MainViewModelTest {
 
         // UiTextException carries the whole message and has a null `message`, so the generic branch
         // would render it as "Error: " with nothing after the colon.
+        //
+        // The carried message alone, with no `error_format` around it. This assertion used to expect
+        // that StringResource nested *inside* error_format, which was the defect and not the fix:
+        // String.format has no idea what a UiText is, so it called toString(), and the message this
+        // test is named after reached the user as
+        // "Error: com.valhalla.thor.util.UiText$StringResource@4f2a1c" — obfuscated further in
+        // release. Unwrapped it is also the right sentence, a refusal being one already: prefixing it
+        // would read "Error: Skipped: …".
         assertEquals(
-            listOf(
-                MainSideEffect.Message(
-                    UiText.StringResource(
-                        R.string.error_format,
-                        UiText.StringResource(R.string.error_unsafe_skipped)
-                    )
-                )
-            ),
+            listOf(MainSideEffect.Message(UiText.StringResource(R.string.error_unsafe_skipped))),
             effects
         )
     }
@@ -821,13 +822,14 @@ class MainViewModelTest {
         assertNull(vm.uiState.value.cacheClear)
         // The whole effect, not just its arity: a success message is also one effect, and the point
         // of this path is that the reason reaches the user rather than a silent sheet close.
+        //
+        // The reason goes in as a String. It used to go in as a DynamicString, and DynamicString is a
+        // data class, so String.format's toString() fallback turned the sentence that "says why" into
+        // "Error: DynamicString(value=no privileged gateway)".
         assertEquals(
             listOf(
                 MainSideEffect.Message(
-                    UiText.StringResource(
-                        R.string.error_format,
-                        UiText.DynamicString("no privileged gateway")
-                    )
+                    UiText.StringResource(R.string.error_format, "no privileged gateway")
                 )
             ),
             effects

--- a/app/src/test/java/com/valhalla/thor/util/UiTextTest.kt
+++ b/app/src/test/java/com/valhalla/thor/util/UiTextTest.kt
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.util
+
+import com.valhalla.thor.R
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * The two decisions [UiText] makes that do not need a `Context`.
+ *
+ * Same split as `LocalePolicyTest`, and for the same reason: there is no Robolectric here, so
+ * `asString(Context)` and the `@Composable` overload cannot be called at all from a JVM test. What
+ * they delegate to can be, so the delegation targets are what get asserted — [resolvedWith] for the
+ * format-argument walk and [asUiText] for the unwrap.
+ *
+ * What that leaves unpinned, deliberately and on the record: that `asString` actually *calls*
+ * `resolved`. Only the compiler checks that.
+ */
+class UiTextTest {
+
+    @Test
+    fun `an argument list with nothing nested is handed back untouched`() {
+        val args = arrayOf<Any>("disk is full", 3)
+
+        // Same instance, not merely an equal one: the no-nesting case is every existing caller, and
+        // it should not pay an allocation to find that out.
+        assertSame(args, args.resolvedWith { error("must not render anything") })
+    }
+
+    @Test
+    fun `a nested UiText is rendered and everything around it keeps its place`() {
+        val args = arrayOf<Any>(1, UiText.DynamicString("Operation not permitted"), "tail")
+
+        val resolved = args.resolvedWith { (it as UiText.DynamicString).value }
+
+        // The middle slot is the whole point: left to String.format it arrives as
+        // "DynamicString(value=Operation not permitted)", because DynamicString is a data class.
+        assertArrayEquals(arrayOf<Any>(1, "Operation not permitted", "tail"), resolved)
+    }
+
+    @Test
+    fun `every nested UiText is rendered, not just the first`() {
+        val args = arrayOf<Any>(UiText.DynamicString("a"), UiText.DynamicString("b"))
+
+        val resolved = args.resolvedWith { (it as UiText.DynamicString).value + "!" }
+
+        assertArrayEquals(arrayOf<Any>("a!", "b!"), resolved)
+    }
+
+    /**
+     * The unwrap that gave this helper its name: a [UiTextException] carries its message in
+     * [UiTextException.uiText] and leaves `message` null, so formatting one into `error_format`
+     * renders a bare "Error: " and tells the user nothing.
+     */
+    @Test
+    fun `a UiTextException reports the text it carries, not an empty error`() {
+        val carried = UiText.StringResource(R.string.error_self_skipped)
+
+        assertEquals(carried, UiTextException(carried).asUiText())
+    }
+
+    @Test
+    fun `any other throwable reports its message through error_format`() {
+        assertEquals(
+            UiText.StringResource(R.string.error_format, "disk is full"),
+            IllegalStateException("disk is full").asUiText()
+        )
+    }
+
+    @Test
+    fun `a throwable with no message still produces a well-formed UiText`() {
+        assertEquals(
+            UiText.StringResource(R.string.error_format, ""),
+            IllegalStateException().asUiText()
+        )
+    }
+}

--- a/web/src/pages/features.mdx
+++ b/web/src/pages/features.mdx
@@ -304,8 +304,9 @@ Some details worth knowing:
   the home screen too. They carry their own coloured tiles — blue for freeze, orange for unfreeze —
   so they are not mistaken for an app.
 - **Remove an app from the watchlist** and its shortcut is greyed out and deactivated, because
-  Android will not let an app delete a shortcut you pinned. A live shortcut for an app Thor no
-  longer manages could otherwise still drive a freeze from your home screen.
+  Android will not let an app delete a shortcut you pinned. Greying it is as far as Thor can go, and
+  it is the honest signal: left live, that shortcut would go on thawing and launching an app the
+  Freezer no longer manages. Tapping it now says **No longer frozen** instead.
 - **Turning the feature on** is a single switch in Settings, **Add Freezer to launcher**, and it
   needs a privilege engine, since the whole point is unfreezing on tap.
 


### PR DESCRIPTION
#437 was merged without human review. Reviewing the merged diff afterwards turned up five defects. Four are fixed here; the fifth is a factual correction to something #437 asserted, which I cannot fix in its commit message, so it is stated below.

## The user-visible one

`AppInfoDetailsViewModel.addOrRemoveFromFreezer` set `restored = true`, then ran `disableAppShortcut` and `freezerRepository.remove` — both of which can throw — with the only state writes behind them. On a throw, the two-facts guard toasts "unfrozen" (true: the restore already happened) while the sheet keeps drawing the `frozen` chip. The screen contradicts its own toast on the one path where the toast is certainly right.

Fixed by patching `enabled`/`isSuspended` the moment the restore returns success — the same optimistic write `AppListViewModel.toggleFreezerMembership` already does. Deliberately not by hoisting `refreshDetails`: that re-reads through the package manager and races the enable, which is why `FreezerLaunchActivity` retries it ~10×150ms. A `restoreApp` that returned success is knowledge; the re-read is a question that sometimes gets the old answer.

## A `UiText` used as a format argument

`error_format` and `log_failed` are both `%1$s`. Passing a `UiText` into one hands `String.format` an object it knows nothing about, so it calls `toString()`:

- `DynamicString` is a data class → **`Error: DynamicString(value=no privileged gateway)`**
- `StringResource` declares no `toString` → **`Error: com.valhalla.thor.util.UiText$StringResource@4f2a1c`**, which minification shortens without improving

Both were reachable from the Apps tab's quick actions. Fixed by resolving nested `UiText` before formatting, plus routing the two `MainViewModel` handlers that hand-rolled the `UiTextException` unwrap through `asUiText()`. The two `log_failed` sites keep their nesting on purpose — they need the `✘ Failed:` prefix, and the resolution alone is enough for them.

**Two existing tests asserted the garbled shape**, including one named *"a refusal carrying its own message is shown as that message, not as a bare error"* — which asserted the form that was neither. That is why the bug survived a green suite. Both now assert what reaches the user.

## The correction: #437's ordering rationale is backwards

#437 justified greying the shortcut before dropping the watchlist row by claiming a leftover live shortcut "could still drive a freeze from the launcher". It cannot. A per-app freezer shortcut carries `ACTION_LAUNCH` (`FreezerShortcutManager.kt:348`), and `FreezerLaunchActivity.launchApp` answers it with force-unfreeze-then-start. **A stale live shortcut thaws an app; it never freezes one.** A greyed one shows `shortcut_no_longer_frozen` rather than firing, so recovery is a fresh "Add to home screen", not "the next tap".

The ordering flip is still correct — greying first leaves residue the user can act on, so the pair stays retryable — but for that reason, not the stated hazard. Corrected at all five code sites and at `web/src/pages/features.mdx:306`, where the claim was published. (`docs/site-content/` carries the same text but is gitignored, so it is local-only; `faq.mdx` was already accurate.)

## Verification

- **1768 tests, 0 failures** — 1762 plus six new `UiTextTest` cases, counted from `build/test-results/**/*.xml`, not the log line.
- `lintStoreRelease` unchanged at its 8 Hints (5× VectorPath, 3× AndroidGradlePluginVersion).
- No new string resources, so none of the eight locales regress.

## Known gap

`UiTextTest` pins `resolvedWith` and `asUiText` — everything the fix decides that does not need a `Context`. It cannot pin that `asString` actually *calls* `resolved`: there is no Robolectric in this module, so `asString(Context)` cannot be invoked from a JVM test at all. Only the compiler checks that edge, and the test file says so on the record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored apps now immediately appear enabled and unsuspended after leaving the Freezer.
  - Disabled shortcuts now show “No longer frozen” instead of triggering freeze-related actions.
  - Error messages are displayed more accurately, preserving specific failure details.

- **Documentation**
  - Updated shortcut behavior documentation to reflect the restoration experience.

- **Tests**
  - Expanded coverage for app restoration, shortcut handling, error messages, and nested text formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->