### PR TITLE
docs(components): say which rows a partial Restore all leaves behind

### DIFF
--- a/app/src/main/java/com/valhalla/thor/domain/repository/ComponentOverrideRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/ComponentOverrideRepository.kt
@@ -19,7 +19,9 @@ interface ComponentOverrideRepository {
     /** The rows for one package, as a stream so the "N restricted by Thor" header cannot lag. */
     fun observe(packageName: String): Flow<List<ComponentOverride>>
 
-    /** Every row, for the cross-app restore. */
+    /**
+     * Every row **for that user**, for the cross-app restore — which is not the same as device-wide.
+     */
     suspend fun getAll(): List<ComponentOverride>
 
     /**

--- a/app/src/main/java/com/valhalla/thor/domain/usecase/ComponentControlUseCase.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/usecase/ComponentControlUseCase.kt
@@ -136,10 +136,12 @@ class ComponentControlUseCase(
     /**
      * Put every component Thor disabled back the way it found it.
      *
-     * Each row is restored to its own `restoreToEnabled`, and a row is forgotten only when its own
-     * call succeeds. A partial failure therefore leaves exactly the rows that are still overridden,
-     * which is what makes pressing Restore All again a safe retry rather than a second, different
-     * operation.
+     * Each row is restored to its own `restoreToEnabled`, and a row is forgotten only when **both**
+     * its platform call and its ledger delete succeed. A partial failure therefore leaves exactly the
+     * rows that did not fully complete, which is what makes pressing Restore All again a safe retry
+     * rather than a second, different operation. That set is wider than "the components still
+     * disabled": one the platform put back whose row could not be deleted stays behind too, and the
+     * next press restores an already-restored component, which costs nothing.
      *
      * A row counts as restored only when **both** halves land. Counting a successful platform call
      * whose ledger delete failed would report "restored 3 of 3" while a row was still sitting in the

--- a/app/src/test/java/com/valhalla/thor/domain/usecase/ComponentControlUseCaseTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/usecase/ComponentControlUseCaseTest.kt
@@ -334,11 +334,12 @@ class ComponentControlUseCaseTest {
     }
 
     /**
-     * A partial run is the interesting one. The rows that failed have to stay — they are still
-     * disabled and this ledger is the only record of that — and the count reported has to be the
-     * number actually restored, not the number tried. The banner says "N restricted by Thor" from
-     * the same rows, so a run that cleared them all regardless would show 0 while N components were
-     * still switched off.
+     * A partial run is the interesting one. The row that stays behind here failed at the platform, so
+     * it really is still disabled and this ledger is the only record of that — but that is one of two
+     * ways to survive the sweep, and `restore all under-reports a row whose ledger delete failed`
+     * covers the other. Either way the count reported has to be the number actually restored, not the
+     * number tried. The banner says "N restricted by Thor" from the same rows, so a run that cleared
+     * them all regardless would show 0 while N components were still switched off.
      */
     @Test
     fun `a partial restore keeps the rows it could not restore`() = runTest {


### PR DESCRIPTION
Closes the loop on a review finding from #439. The web copy was fixed there; this fixes the source it was copied from.

## The defect

`ComponentControlUseCase.restoreAll()`'s KDoc contradicted itself across two paragraphs:

- **Para 1** — "A partial failure therefore leaves exactly the rows that are **still overridden**"
- **Para 2**, nine lines down — correctly explains that a row also survives when the **platform call succeeded and only the ledger delete failed**

Those describe different sets. A component the platform put back, whose row could not be deleted, is *not* still overridden — it is enabled and still in the table. The set that stays behind is "the rows that did not fully complete", which is wider.

Para 1 is the sentence I copied into `web/src/pages/{faq,features}.mdx` as "the rows that are still switched off". Review caught it on the site; the KDoc it came from was left as-is, so this removes the source.

## Also

- The comment on `a partial restore keeps the rows it could not restore` described the platform-failure path as though it were the only way to survive the sweep. The other path already has a test — `restore all under-reports a row whose ledger delete failed` — so the comment now names it. **No new test needed; coverage was already there.**
- `ComponentOverrideRepository.getAll()`'s one-liner said "Every row". The interface KDoc above it already scopes every method to the Android user Thor runs in, but "Every row" reads absolute at the call site, and reading it that way is how "device-wide" got published. Now says "Every row **for that user**".

## Scope

Comments only — no behaviour change, no new strings, no resources.

**Deliberately not included:** `component_restore_all_partial` reads "Restored %1\$d of %2\$d — the rest are still restricted", which carries the same imprecision. It is defensible as written, because Thor's own banner counts those rows as restricted and so the message matches what the screen shows. Changing it means a translation pass across all eight locales, which does not belong in a comment-only PR.

## Verification

`:app:testFossDebugUnitTest --rerun-tasks --tests ComponentControlUseCaseTest` — **21 tests, 0 failures, 0 errors** (counted from the JUnit XML).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that component-override results apply to the current Android user and support cross-app restoration.
  * Documented that restoration records are retained when platform restoration or cleanup fails and are retried during subsequent “Restore All” operations.
  * Clarified restore-count behavior for partially completed restorations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->