### PR TITLE
fix(strings): a partial Restore All must not claim the rest are still off

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -805,7 +805,7 @@
         <item quantity="many">تمت استعادة %1$d مكوّنًا</item>
         <item quantity="other">تمت استعادة %1$d مكوّن</item>
     </plurals>
-    <string name="component_restore_all_partial">تمت استعادة %1$d من %2$d — والباقي ما زال مقيَّدًا</string>
+    <string name="component_restore_all_partial">تمت استعادة %1$d من %2$d — حاول مرة أخرى لاستعادة الباقي</string>
     <string name="component_restore_all_action">استعادة الكل</string>
     <string name="component_restore_all_title">استعادة كل المكونات؟</string>
     <string name="component_restore_all_message">كل مكوّن عطّله Thor — في هذا التطبيق وفي كل التطبيقات الأخرى — سيعود إلى حالته الأصلية كما جاء بها التطبيق. أما المكونات التي غيّرتها أدوات أخرى فتبقى دون تغيير.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -745,7 +745,7 @@
         <item quantity="one">Se restauró %1$d componente</item>
         <item quantity="other">Se restauraron %1$d componentes</item>
     </plurals>
-    <string name="component_restore_all_partial">Restauración: %1$d de %2$d — el resto sigue restringido</string>
+    <string name="component_restore_all_partial">Restauración: %1$d de %2$d — inténtalo de nuevo para restaurar el resto</string>
     <string name="component_restore_all_action">Restaurar todo</string>
     <string name="component_restore_all_title">¿Restaurar todos los componentes?</string>
     <string name="component_restore_all_message">Todos los componentes que Thor desactivó — en esta aplicación y en todas las demás — vuelven al estado con el que venían de fábrica. Los componentes cambiados por otras herramientas se quedan tal cual.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -745,7 +745,7 @@
         <item quantity="one">%1$d composant rétabli</item>
         <item quantity="other">%1$d composants rétablis</item>
     </plurals>
-    <string name="component_restore_all_partial">Rétablissement : %1$d sur %2$d — les autres restent restreints</string>
+    <string name="component_restore_all_partial">Rétablissement : %1$d sur %2$d — réessayez pour rétablir les autres</string>
     <string name="component_restore_all_action">Tout rétablir</string>
     <string name="component_restore_all_title">Rétablir tous les composants ?</string>
     <string name="component_restore_all_message">Chaque composant désactivé par Thor — dans cette application comme dans toutes les autres — retrouve l\'état d\'origine. Les composants modifiés par d\'autres outils ne sont pas touchés.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -834,7 +834,7 @@
         <item quantity="many">Przywrócono %1$d komponentów</item>
         <item quantity="other">Przywrócono %1$d komponentu</item>
     </plurals>
-    <string name="component_restore_all_partial">Przywrócono %1$d z %2$d — reszta nadal jest ograniczona</string>
+    <string name="component_restore_all_partial">Przywrócono %1$d z %2$d — spróbuj ponownie, aby przywrócić resztę</string>
     <string name="component_restore_all_action">Przywróć wszystkie</string>
     <string name="component_restore_all_title">Przywrócić wszystkie komponenty?</string>
     <string name="component_restore_all_message">Każdy komponent wyłączony przez aplikację Thor — w tej aplikacji i we wszystkich pozostałych — wróci do stanu, w jakim został dostarczony. Komponenty zmienione przez inne narzędzia zostaną nietknięte.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -602,7 +602,7 @@
         <item quantity="one">%1$d componente restaurado</item>
         <item quantity="other">%1$d componentes restaurados</item>
     </plurals>
-    <string name="component_restore_all_partial">Restauração: %1$d de %2$d — os demais continuam restritos</string>
+    <string name="component_restore_all_partial">Restauração: %1$d de %2$d — tente novamente para restaurar os demais</string>
     <string name="component_restore_all_action">Restaurar tudo</string>
     <string name="component_restore_all_title">Restaurar todos os componentes?</string>
     <string name="component_restore_all_message">Todos os componentes que o Thor desativou — neste aplicativo e em todos os outros — voltam ao estado original. Os componentes alterados por outras ferramentas ficam intactos.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -811,7 +811,7 @@
         <item quantity="one">%1$d componente reposto</item>
         <item quantity="other">%1$d componentes repostos</item>
     </plurals>
-    <string name="component_restore_all_partial">Reposição: %1$d de %2$d — os restantes continuam restringidos</string>
+    <string name="component_restore_all_partial">Reposição: %1$d de %2$d — tente novamente para repor os restantes</string>
     <string name="component_restore_all_action">Repor tudo</string>
     <string name="component_restore_all_title">Repor todos os componentes?</string>
     <string name="component_restore_all_message">Todos os componentes que o Thor desativou — nesta aplicação e em todas as outras — voltam ao estado de origem. Os componentes alterados por outras ferramentas ficam intactos.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -731,7 +731,7 @@
     <plurals name="component_restore_all_success">
         <item quantity="other">已恢复 %1$d 个组件</item>
     </plurals>
-    <string name="component_restore_all_partial">已恢复 %2$d 个组件中的 %1$d 个 — 其余仍处于受限状态</string>
+    <string name="component_restore_all_partial">已恢复 %2$d 个组件中的 %1$d 个 — 请重试以恢复其余组件</string>
     <string name="component_restore_all_action">全部恢复</string>
     <string name="component_restore_all_title">恢复所有组件？</string>
     <string name="component_restore_all_message">Thor 禁用过的每一个组件 — 无论在此应用中还是在其他应用中 — 都会恢复为出厂时的状态。由其他工具更改的组件不会受到影响。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -594,7 +594,16 @@
         <item quantity="one">Restored %1$d component</item>
         <item quantity="other">Restored %1$d components</item>
     </plurals>
-    <string name="component_restore_all_partial" tools:ignore="PluralsCandidate">Restored %1$d of %2$d — the rest are still restricted</string>
+    <!--
+      "try again", not "the rest are still restricted": a row survives Restore All in two ways, and
+      only one of them leaves the component switched off. The other is a platform call that succeeded
+      whose ledger delete failed — that component is back on, and if it belongs to the app on screen
+      the refresh that follows this message relabels its row "Changed elsewhere", so the old wording
+      contradicted the very screen it appeared over. Naming the state is wrong for half the set;
+      naming the remedy is true for both, because the row that stayed behind is what makes the next
+      press a retry and setComponentEnabled is idempotent. See ComponentControlUseCase.restoreAll.
+    -->
+    <string name="component_restore_all_partial" tools:ignore="PluralsCandidate">Restored %1$d of %2$d — try again to finish the rest</string>
     <string name="component_restore_all_action">Restore all</string>
     <string name="component_restore_all_title">Restore every component?</string>
     <string name="component_restore_all_message">Every component Thor disabled — in this app and in every other — goes back to how it shipped. Components changed by other tools are left alone.</string>


### PR DESCRIPTION
Closes followup 1b from the component-control review: the partial Restore All message named the
wrong set, and it was left alone in #440 on a premise that turns out not to hold.

## The defect

```
Restored %1$d of %2$d — the rest are still restricted
```

A row survives `ComponentControlUseCase.restoreAll()` in **two** ways, and the KDoc there (corrected
in #440) says so:

1. the platform call failed — the component really is still disabled;
2. the platform call **succeeded** and only the ledger delete failed — the component is **back on**,
   but its row stays so the next press retries the delete.

The string asserted case 1 for both.

## Why the "it agrees with the screen" defence fails

#440 deferred this because Thor's own **N restricted by Thor** count is drawn from those same
surviving rows, so the message looked consistent with the screen. Checking the screen rather than
assuming it:

- `ComponentControlUiState.isDrifted` is `overrides.containsKey(className) && component.enabled`;
- `confirmRestoreAll()` calls `refreshSnapshot(packageName)` immediately after sending this event.

So a case-2 row belonging to the app on screen is relabelled **Changed elsewhere** a moment after the
message appears. The wording contradicted the very screen it was supposed to agree with. (The header
count does still include it — `restrictedCount` is `overrides.size` — which is deliberate and
documented: under-reporting keeps the count and the row's own badge from disagreeing about progress.)

## The wording

```
Restored %1$d of %2$d — try again to finish the rest
```

Naming the **remedy** is true for both halves of the set, and it is the affordance `restoreAll` was
designed around: the row that stayed behind is what makes the next press a retry rather than a
second, different operation, and `setComponentEnabled` is idempotent, so retrying an
already-restored component costs nothing. It also matches the house retry phrasing already in
`strings.xml` (`export_job_cleanup_busy`, `suspend_owned_by_other_privilege`).

A rationale comment sits above the string, because the next person to read it will otherwise
"correct" it back to naming a state.

## Translations

All **eight** in-app locales, each following its own file's existing verb for the action and its own
retry phrasing rather than a literal calque:

| locale | new value |
|---|---|
| `values` | Restored %1$d of %2$d — try again to finish the rest |
| `ar` | تمت استعادة %1$d من %2$d — حاول مرة أخرى لاستعادة الباقي |
| `es` | Restauración: %1$d de %2$d — inténtalo de nuevo para restaurar el resto |
| `fr` | Rétablissement : %1$d sur %2$d — réessayez pour rétablir les autres |
| `pl` | Przywrócono %1$d z %2$d — spróbuj ponownie, aby przywrócić resztę |
| `pt` | Reposição: %1$d de %2$d — tente novamente para repor os restantes |
| `pt-rBR` | Restauração: %1$d de %2$d — tente novamente para restaurar os demais |
| `zh-rCN` | 已恢复 %2$d 个组件中的 %1$d 个 — 请重试以恢复其余组件 |

`pt` keeps *repor/Reposição* against `pt-rBR`'s *restaurar/Restauração*, `fr` keeps *rétablir* to
match `component_restore_all_success`, and `zh-rCN` keeps its swapped placeholder order and the
file's own ` — ` convention (18 other strings there use it).

Side benefit: the reword removes a plural-agreement problem the old text had in every language with
gendered or case-marked adjectives — "the rest **are restricted**" had to agree with a count the
string cannot see, which is why `es`/`pt`/`pt-rBR` had each picked a different singular/plural
compromise.

## Verification

- Placeholder sets compared with ElementTree, not by eye: `['1$', '2$']` in all eight, and every file
  still parses.
- `:app:lintStoreRelease` — **0 errors, 0 warnings**, 9 hints (pre-existing vector hints). Run
  separately from the debug variant; four lint variants in one invocation OOMs the Kotlin backend.
- `:app:lintFossDebug` — **0 errors, 0 warnings**, 12 hints. Run because
  `lintStoreRelease` alone does not cover every source set, and translation checks are the point here.
- No test asserts this string's text, and no doc quotes it: `web/src/pages/{faq,features}.mdx` already
  describe the partial run correctly ("exactly the rows that did not fully complete"), so nothing else
  needed correcting.

No `versionCode` bump — component control is still unreleased on `dev`, and the notes belong to the
`chore(release)` commit that spends **1952**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated partial component-restore messages to tell users to try again to restore the remaining components.
  * Applied clearer wording across English, Arabic, Chinese, French, Polish, Portuguese, and Brazilian Portuguese translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->