### PR TITLE
docs(follow-ups): exact lint id, and every source set the :app fix touched

### DIFF
--- a/web/public/follow-ups-report.html
+++ b/web/public/follow-ups-report.html
@@ -1060,7 +1060,7 @@
           </div>
         </div>
 
-        <!-- Pick 4: Static Analysis :app SyntheticAccessors -->
+        <!-- Pick 4: Static Analysis :app SyntheticAccessor -->
         <div class="action-card">
           <span class="rank-badge">#4 SHIPPED 2026-08-26</span>
           <div class="card-top">
@@ -1072,10 +1072,10 @@
             <span class="meta-chip">Rot prevention, not DEX optimization</span>
           </div>
           <p class="card-body">
-            Closed by widening 15 declarations from <code>private</code> to <code>internal</code> and enabling the check in <code>app/lint.xml</code>, following <code>:bypass</code> (Band A #12). Two corrections to this card's original claim, both measured: the count was <strong>62 findings from 14 declarations</strong>, not 43 — and the <strong>APK payoff was overstated by ~20x</strong>. The release dex holds 21 <code>access$</code> methods out of 30,682 against 3,563 in debug, so R8 had already inlined nearly all of them; the fix removed <strong>3</strong>. Worth doing to stop the count rotting, not as a 64K-limit lever.
+            Closed by widening 15 declarations from <code>private</code> to <code>internal</code> and enabling the check in <code>app/lint.xml</code>, following <code>:bypass</code> (Band A #12). The 15 are <strong>11 in <code>main</code>, 3 in the <code>store</code> flavour and 1 in test sources</strong> — that last one reported by neither <code>lintStoreRelease</code> nor a failing build, so it is invisible to CI. Two corrections to this card's original claim, both measured: the count was <strong>62 findings from 14 declarations</strong> (the 15th is the test one), not 43 — and the <strong>APK payoff was overstated by ~20x</strong>. The release dex holds 21 <code>access$</code> methods out of 30,682 against 3,563 in debug, so R8 had already inlined nearly all of them; the fix removed <strong>3</strong>. Worth doing to stop the count rotting, not as a 64K-limit lever.
           </p>
           <div class="card-footer">
-            <span>Target: <code>app/src/main/java</code>, <code>app/lint.xml</code></span>
+            <span>Target: <code>app/lint.xml</code>, <code>app/src/main</code>, <code>app/src/store</code>, <code>app/src/test</code></span>
             <strong style="color: var(--primary);">Static Analysis</strong>
           </div>
         </div>
@@ -1426,7 +1426,7 @@
       },
       {
         id: "synthetic_app",
-        title: "Static Analysis: SyntheticAccessors in :app (62, not 43)",
+        title: "Static Analysis: SyntheticAccessor in :app (62 findings, not 43)",
         doc: "static-analysis-switched-off-by-default.md",
         files: "app/lint.xml, app/src/main/java/**/*.kt, app/src/store/**, app/src/test/**",
         status: "shipped",


### PR DESCRIPTION
Addresses the two CodeRabbit findings left on #441 after it merged. Both were verified against the
merged state (`b2e05f89`) before changing anything, both are still valid, and both sit in the same
card of `web/public/follow-ups-report.html`.

## 1. The title pluralised the lint issue id

```diff
- title: "Static Analysis: SyntheticAccessors in :app (62, not 43)",
+ title: "Static Analysis: SyntheticAccessor in :app (62 findings, not 43)",
```

`app/lint.xml` enables `SyntheticAccessor`; the report's own `solution` field quotes
`<issue id="SyntheticAccessor" …/>` correctly one line below. Module and count text are preserved, as
the finding asked. The `<!-- Pick 4: … -->` marker comment above the card carried the same plural and
is fixed too — those comments are what the live ranking is read from, so an inexact id there costs a
grep.

## 2. The footer under-stated the target by two source sets

```diff
- <span>Target: <code>app/src/main/java</code>, <code>app/lint.xml</code></span>
+ <span>Target: <code>app/lint.xml</code>, <code>app/src/main</code>, <code>app/src/store</code>, <code>app/src/test</code></span>
```

Counted from the merge diff rather than from memory:

```
app/src/main   11   (8 files)
app/src/store   3   BillingProcessorImpl.kt
app/src/test    1   BackupAppsUseCaseTest.kt
                --
                15
```

So `app/src/store` and `app/src/test` were both missing, and 4 of the 15 declarations were
unrepresented. These are genuinely in scope — not intentionally excluded — so I took the finding's
first branch rather than its "state that it is production-only" alternative. The JS entry's `files:`
field already listed all four paths; the human-readable footer did not, and the footer is the half a
reader actually sees. They now agree.

The card body picks up the same 11/3/1 split, because the test-source declaration is the one worth
naming out loud: no lint variant this repo runs turns it red (`lintStoreRelease` does not report it;
the debug variants print it as `Warning:` and still succeed despite `warningsAsErrors`), so a reader
would otherwise reasonably assume it was never there.

## Verification

- 1 `<script>` block, `node --check` clean on it.
- Zero occurrences of `SyntheticAccessors` left in the file; 4 of the exact id remain.
- Every tag type (`div span p h4 strong code script section`) balances at the same open/close delta as
  `HEAD` — the two `<code>` pairs and one `<strong>` pair I added are matched, and the line count is
  unchanged at 2112.
- `web/dist/` carries the same stale plural but is **untracked** build output (`git ls-files web/dist`
  is empty), so nothing to change there.

Nothing outside this card needed the same correction: `docs/follow-ups/README.md` row 12 and the
`static-analysis-switched-off-by-default.md` sections already name the `store` source set and the test
hits explicitly.

Docs-only, `web/` only — no `versionCode` bump, and `dev` only stages the site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “SyntheticAccessor” label in the Pick 4 report.
  * Updated the static-analysis summary with accurate source-distribution details and target paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->