### PR TITLE
fix(installer): make the install-time permission grant opt-in (#445)

### DIFF
--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -439,6 +439,7 @@ class DhizukuSystemGateway(
                 ),
                 userId = thorUserId,
                 canDowngrade = canDowngrade,
+                grantAllPermissions = preferenceRepository.shouldGrantAllPermissionsOnInstall(),
                 installerArg = installerArg,
             )
         )

--- a/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/DhizukuSystemGateway.kt
@@ -424,7 +424,11 @@ class DhizukuSystemGateway(
      * process `pm` runs in; the missing `--user` is interpreted by `PackageManagerService`, which
      * neither knows nor cares who invoked the command.
      */
-    override suspend fun installApp(apkPath: String, canDowngrade: Boolean): Result<Unit> {
+    override suspend fun installApp(
+        apkPath: String,
+        canDowngrade: Boolean,
+        grantAllPermissions: Boolean?,
+    ): Result<Unit> {
         val installerArg = preferenceRepository.getInstallerArg()
 
         // Through the same session builder as every other install in the app — see the note on
@@ -439,7 +443,10 @@ class DhizukuSystemGateway(
                 ),
                 userId = thorUserId,
                 canDowngrade = canDowngrade,
-                grantAllPermissions = preferenceRepository.shouldGrantAllPermissionsOnInstall(),
+                // Caller's answer if it has one, saved setting otherwise — never `== true`, which
+                // would read "no answer" as "no" and override a user who turned the setting on.
+                grantAllPermissions = grantAllPermissions
+                    ?: preferenceRepository.shouldGrantAllPermissionsOnInstall(),
                 installerArg = installerArg,
             )
         )

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1182,12 +1182,20 @@ class RootSystemGateway(
         return runCommand(uninstallCommand(escapedPackage, thorUserId))
     }
 
-    override suspend fun installApp(apkPath: String, canDowngrade: Boolean): Result<Unit> {
-        return installViaSession(listOf(apkPath), canDowngrade)
+    override suspend fun installApp(
+        apkPath: String,
+        canDowngrade: Boolean,
+        grantAllPermissions: Boolean?,
+    ): Result<Unit> {
+        return installViaSession(listOf(apkPath), canDowngrade, grantAllPermissions)
     }
 
-    suspend fun installMultipleApks(apkPaths: List<String>, canDowngrade: Boolean): Result<Unit> {
-        return installViaSession(apkPaths, canDowngrade)
+    suspend fun installMultipleApks(
+        apkPaths: List<String>,
+        canDowngrade: Boolean,
+        grantAllPermissions: Boolean? = null,
+    ): Result<Unit> {
+        return installViaSession(apkPaths, canDowngrade, grantAllPermissions)
     }
 
     /**
@@ -1211,7 +1219,8 @@ class RootSystemGateway(
      */
     private suspend fun installViaSession(
         apkPaths: List<String>,
-        canDowngrade: Boolean
+        canDowngrade: Boolean,
+        grantAllPermissions: Boolean?,
     ): Result<Unit> {
         if (apkPaths.isEmpty()) {
             return Result.failure(Exception("No APK paths provided for install"))
@@ -1231,7 +1240,11 @@ class RootSystemGateway(
                 apks = staged,
                 userId = thorUserId,
                 canDowngrade = canDowngrade,
-                grantAllPermissions = preferenceRepository.shouldGrantAllPermissionsOnInstall(),
+                // The caller's answer if it has one, the saved setting otherwise. Not
+                // `grantAllPermissions == true`: that would read a missing answer as "no" and
+                // override a user who had turned the setting on.
+                grantAllPermissions = grantAllPermissions
+                    ?: preferenceRepository.shouldGrantAllPermissionsOnInstall(),
                 installerArg = preferenceRepository.getInstallerArg(),
             )
         )

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1231,6 +1231,7 @@ class RootSystemGateway(
                 apks = staged,
                 userId = thorUserId,
                 canDowngrade = canDowngrade,
+                grantAllPermissions = preferenceRepository.shouldGrantAllPermissionsOnInstall(),
                 installerArg = preferenceRepository.getInstallerArg(),
             )
         )

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -500,7 +500,11 @@ class ShizukuSystemGateway(
      * exited 0, the mirror image of the `DELETE_ALL_USERS` trap `uninstallCommand` documents. Every
      * other privileged command in this gateway already named a user; the install path did not.
      */
-    override suspend fun installApp(apkPath: String, canDowngrade: Boolean): Result<Unit> {
+    override suspend fun installApp(
+        apkPath: String,
+        canDowngrade: Boolean,
+        grantAllPermissions: Boolean?,
+    ): Result<Unit> {
         val installerArg = preferenceRepository.getInstallerArg()
 
         // Through the same session builder as every other install in the app. This override has no
@@ -513,7 +517,10 @@ class ShizukuSystemGateway(
             apks = listOf(SessionApk(path = apkPath, sizeBytes = file.length(), name = file.name)),
             userId = thorUserId,
             canDowngrade = canDowngrade,
-            grantAllPermissions = preferenceRepository.shouldGrantAllPermissionsOnInstall(),
+            // Caller's answer if it has one, saved setting otherwise — never `== true`, which
+            // would read "no answer" as "no" and override a user who turned the setting on.
+            grantAllPermissions = grantAllPermissions
+                ?: preferenceRepository.shouldGrantAllPermissionsOnInstall(),
             installerArg = installerArg,
         )
 

--- a/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/ShizukuSystemGateway.kt
@@ -513,6 +513,7 @@ class ShizukuSystemGateway(
             apks = listOf(SessionApk(path = apkPath, sizeBytes = file.length(), name = file.name)),
             userId = thorUserId,
             canDowngrade = canDowngrade,
+            grantAllPermissions = preferenceRepository.shouldGrantAllPermissionsOnInstall(),
             installerArg = installerArg,
         )
 

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -68,7 +68,7 @@ class AppAnalyzerImpl(
         //
         // That copy is also the ONE read of the caller's URI: the install runs off this file,
         // so a hostile provider cannot serve a clean APK to the sheet the user approves and
-        // spyware to the `pm install -r -g` that follows. See StagedPackage.
+        // spyware to the privileged install that follows. See StagedPackage.
         val bundleFile = File(stagingDir, "staged_$token")
         val apkFile = File(context.cacheDir, "analysis_$token.apk")
 

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -658,6 +658,7 @@ class InstallerRepositoryImpl(
         eventBus.emit(InstallState.Installing(0.5f))
 
         val installerArg = preferenceRepository.getInstallerArg()
+        val grantAll = preferenceRepository.shouldGrantAllPermissionsOnInstall()
 
         return try {
             // The shell rung, and normally the one that decides the outcome: the PackageInstaller
@@ -699,6 +700,7 @@ class InstallerRepositoryImpl(
                 },
                 userId = thorUserId,
                 canDowngrade = canDowngrade,
+                grantAllPermissions = grantAll,
                 installerArg = installerArg,
             )
             val result = ShizukuHelper.execute(integrityGuardedInstall(digests, command))
@@ -745,6 +747,7 @@ class InstallerRepositoryImpl(
         eventBus.emit(InstallState.Installing(0.5f))
 
         val installerArg = preferenceRepository.getInstallerArg()
+        val grantAll = preferenceRepository.shouldGrantAllPermissionsOnInstall()
 
         return try {
             // Same rung, same seed, same fix as installWithShizuku above — and the same pairing
@@ -769,6 +772,7 @@ class InstallerRepositoryImpl(
                 },
                 userId = thorUserId,
                 canDowngrade = canDowngrade,
+                grantAllPermissions = grantAll,
                 installerArg = installerArg,
             )
             val result = DhizukuHelper.execute(integrityGuardedInstall(digests, command))
@@ -809,6 +813,15 @@ class InstallerRepositoryImpl(
 
         eventBus.emit(InstallState.Parsing)
 
+        // No install-time permission grant here, and deliberately not wired to
+        // `UserPreferences.grantAllPermissionsOnInstall` either. `SessionParams` exposes no public
+        // way to ask for one — the shell's `-g` is `INSTALL_GRANT_ALL_REQUESTED_PERMISSIONS`, a bit
+        // in the hidden `installFlags` field — and a session created with a flag the caller is not
+        // allowed to set fails outright rather than degrading, so reaching for it would turn a
+        // convenience toggle into an install that stops working. This rung has never granted
+        // anything and is not the rung GH#445 was about; it is the *fallback*, reached only when the
+        // shell rung above returns false. Consequence worth knowing: with the toggle on, a package
+        // that lands here comes up ungranted, the same as with it off.
         val params = PackageInstaller.SessionParams(
             PackageInstaller.SessionParams.MODE_FULL_INSTALL
         )
@@ -1161,8 +1174,11 @@ internal fun writeEntriesWithinBudget(
  * The Shizuku/Dhizuku rungs have to stage into shared storage (see installWithShizuku), where on
  * API 28-29 — minSdk is 28, and Android/data was not sandboxed until 11 — any app holding
  * WRITE_EXTERNAL_STORAGE can watch the directory with a FileObserver and swap base.apk before
- * `pm` reads it. `pm install -r -g` would then install the attacker's package, silently and with
- * every runtime permission granted, while the sheet showed the app the user actually picked.
+ * `pm` reads it. The session would then install the attacker's package, silently — and, if the user
+ * has turned `grantAllPermissionsOnInstall` on, with every runtime permission already granted —
+ * while the sheet showed the app the user actually picked. Note which half of that this guard is
+ * for: turning the grant off narrows the blast radius, it does not close the swap, so the check
+ * still has to run on every install regardless of what the toggle says.
  *
  * Running the check inside the same shell invocation is the point: doing it from Thor's process
  * would put a binder round trip and a process spawn between the check and the read. A window

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -120,6 +120,7 @@ class InstallerRepositoryImpl(
         uri: Uri,
         mode: InstallMode,
         canDowngrade: Boolean,
+        grantAllPermissions: Boolean?,
     ) =
         withContext(ioDispatcher) {
             try {
@@ -144,13 +145,13 @@ class InstallerRepositoryImpl(
 
                 when (mode) {
                     InstallMode.ROOT -> {
-                        installWithRoot(staged, canDowngrade)
+                        installWithRoot(staged, canDowngrade, grantAllPermissions)
                     }
 
                     InstallMode.SHIZUKU -> {
                         // 1. Try Shell command first
                         val shellSuccess = try {
-                            installWithShizuku(staged, canDowngrade)
+                            installWithShizuku(staged, canDowngrade, grantAllPermissions)
                         } catch (e: Throwable) {
                             if (e is CancellationException) throw e
                             // A refusal is a verdict about the archive, not a failure of this rung.
@@ -208,7 +209,7 @@ class InstallerRepositoryImpl(
                     InstallMode.DHIZUKU -> {
                         // 1. Try Shell command first
                         val shellSuccess = try {
-                            installWithDhizuku(staged, canDowngrade)
+                            installWithDhizuku(staged, canDowngrade, grantAllPermissions)
                         } catch (e: Throwable) {
                             if (e is CancellationException) throw e
                             if (e is InstallRefusedException) throw e
@@ -586,6 +587,7 @@ class InstallerRepositoryImpl(
     private suspend fun installWithRoot(
         staged: StagedPackage,
         canDowngrade: Boolean,
+        grantAllPermissions: Boolean?,
     ) {
         eventBus.emit(InstallState.Installing(0f))
 
@@ -607,10 +609,12 @@ class InstallerRepositoryImpl(
             // because they have to stage into shared storage; the session paths read the staged
             // file directly and never expose it at all. Those are all four write paths.
             val apkPaths = tempFiles.map { it.file.absolutePath }
+            // The gateway resolves a null against the saved setting; this rung has no reason to
+            // resolve it first, and doing so would put a second copy of that rule in the app.
             val result = if (apkPaths.size == 1) {
-                rootGateway.installApp(apkPaths[0], canDowngrade)
+                rootGateway.installApp(apkPaths[0], canDowngrade, grantAllPermissions)
             } else {
-                rootGateway.installMultipleApks(apkPaths, canDowngrade)
+                rootGateway.installMultipleApks(apkPaths, canDowngrade, grantAllPermissions)
             }
 
             if (result.isSuccess) {
@@ -629,7 +633,11 @@ class InstallerRepositoryImpl(
         }
     }
 
-    private suspend fun installWithShizuku(staged: StagedPackage, canDowngrade: Boolean): Boolean {
+    private suspend fun installWithShizuku(
+        staged: StagedPackage,
+        canDowngrade: Boolean,
+        grantAllPermissions: Boolean?,
+    ): Boolean {
         eventBus.emit(InstallState.Installing(0f))
 
         // Shared storage, because the *shell* has to be able to read these files: uid 2000 cannot
@@ -658,7 +666,12 @@ class InstallerRepositoryImpl(
         eventBus.emit(InstallState.Installing(0.5f))
 
         val installerArg = preferenceRepository.getInstallerArg()
-        val grantAll = preferenceRepository.shouldGrantAllPermissionsOnInstall()
+        // The caller's answer for this one install if it gave one — the portable installer's
+        // checkbox — and the saved setting otherwise. Not `grantAllPermissions == true`: a missing
+        // answer means "nobody was asked", which is not the same as "the user said no", and
+        // collapsing the two would override anyone who had turned the setting on.
+        val grantAll = grantAllPermissions
+            ?: preferenceRepository.shouldGrantAllPermissionsOnInstall()
 
         return try {
             // The shell rung, and normally the one that decides the outcome: the PackageInstaller
@@ -722,7 +735,11 @@ class InstallerRepositoryImpl(
         }
     }
 
-    private suspend fun installWithDhizuku(staged: StagedPackage, canDowngrade: Boolean): Boolean {
+    private suspend fun installWithDhizuku(
+        staged: StagedPackage,
+        canDowngrade: Boolean,
+        grantAllPermissions: Boolean?,
+    ): Boolean {
         eventBus.emit(InstallState.Installing(0f))
 
         // Shared storage for the same reason as the Shizuku path, and guarded the same way — but
@@ -747,7 +764,9 @@ class InstallerRepositoryImpl(
         eventBus.emit(InstallState.Installing(0.5f))
 
         val installerArg = preferenceRepository.getInstallerArg()
-        val grantAll = preferenceRepository.shouldGrantAllPermissionsOnInstall()
+        // Same resolution rule as installWithShizuku above, and the same reason for it.
+        val grantAll = grantAllPermissions
+            ?: preferenceRepository.shouldGrantAllPermissionsOnInstall()
 
         return try {
             // Same rung, same seed, same fix as installWithShizuku above — and the same pairing
@@ -813,15 +832,16 @@ class InstallerRepositoryImpl(
 
         eventBus.emit(InstallState.Parsing)
 
-        // No install-time permission grant here, and deliberately not wired to
-        // `UserPreferences.grantAllPermissionsOnInstall` either. `SessionParams` exposes no public
-        // way to ask for one — the shell's `-g` is `INSTALL_GRANT_ALL_REQUESTED_PERMISSIONS`, a bit
-        // in the hidden `installFlags` field — and a session created with a flag the caller is not
-        // allowed to set fails outright rather than degrading, so reaching for it would turn a
-        // convenience toggle into an install that stops working. This rung has never granted
-        // anything and is not the rung GH#445 was about; it is the *fallback*, reached only when the
-        // shell rung above returns false. Consequence worth knowing: with the toggle on, a package
-        // that lands here comes up ungranted, the same as with it off.
+        // No install-time permission grant here, and deliberately wired to neither
+        // `UserPreferences.grantAllPermissionsOnInstall` nor the portable installer's per-install
+        // checkbox, which is the same answer arriving by a different route. `SessionParams` exposes
+        // no public way to ask for one — the shell's `-g` is
+        // `INSTALL_GRANT_ALL_REQUESTED_PERMISSIONS`, a bit in the hidden `installFlags` field — and
+        // a session created with a flag the caller is not allowed to set fails outright rather than
+        // degrading, so reaching for it would turn a convenience toggle into an install that stops
+        // working. This rung has never granted anything and is not the rung GH#445 was about; it is
+        // the *fallback*, reached only when the shell rung above returns false. Consequence worth
+        // knowing: with the box ticked, a package that lands here comes up ungranted anyway.
         val params = PackageInstaller.SessionParams(
             PackageInstaller.SessionParams.MODE_FULL_INSTALL
         )

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -205,6 +205,10 @@ class PreferenceRepositoryImpl(
         // Auto Reinstall
         val AUTO_REINSTALL_ENABLED = booleanPreferencesKey("auto_reinstall_enabled")
 
+        // Installing
+        val GRANT_ALL_PERMISSIONS_ON_INSTALL =
+            booleanPreferencesKey("grant_all_permissions_on_install")
+
         // Customization
         val APP_INFO_ACTIONS_ORDER = stringPreferencesKey("app_info_actions_order")
         val HIDDEN_APP_INFO_ACTIONS = stringSetPreferencesKey("hidden_app_info_actions")
@@ -420,6 +424,15 @@ class PreferenceRepositoryImpl(
     override suspend fun getInstallerArg(): String {
         return if (userPreferences.first().autoReinstallEnabled) " -i com.android.vending" else ""
     }
+
+    override suspend fun setGrantAllPermissionsOnInstall(enabled: Boolean) {
+        context.dataStore.guardedWrite(SETTINGS_STORE) {
+            it[Keys.GRANT_ALL_PERMISSIONS_ON_INSTALL] = enabled
+        }
+    }
+
+    override suspend fun shouldGrantAllPermissionsOnInstall(): Boolean =
+        userPreferences.first().grantAllPermissionsOnInstall
 
     // --- Customization ---
 
@@ -661,6 +674,7 @@ internal fun Preferences.toUserPreferences(
         extensionsUnlocked = prefs[Keys.EXTENSIONS_UNLOCKED] ?: false,
         extensionConsentAccepted = prefs[Keys.EXTENSION_CONSENT_ACCEPTED] ?: false,
         autoReinstallEnabled = prefs[Keys.AUTO_REINSTALL_ENABLED] ?: false,
+        grantAllPermissionsOnInstall = prefs[Keys.GRANT_ALL_PERMISSIONS_ON_INSTALL] ?: false,
         exportDirUri = prefs[Keys.EXPORT_DIR_URI],
         appInfoActionsOrder = AppInfoActionId.fromSavedNamesOrDefault(
             prefs[Keys.APP_INFO_ACTIONS_ORDER]?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/InstallSessionCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/InstallSessionCommands.kt
@@ -86,8 +86,12 @@ internal const val SESSION_COMMIT_FAILED_EXIT_CODE = 103
  *   `USER_SYSTEM` plus `INSTALL_ALL_USERS` — installing on every user of the device, and exiting 0.
  * @param canDowngrade adds `-d`. Permissive only, so it is opt-in.
  * @param grantAllPermissions adds `-g`, granting every runtime permission the package declares at
- *   install time without asking the user. **Default `false`, and every caller must pass the user's
- *   answer explicitly rather than lean on that default.** It was unconditional until GH#445: an app
+ *   install time without asking the user. **Required, with no default**, so that a caller cannot
+ *   omit the user's answer: this used to say "every caller must pass it explicitly" and leave a
+ *   `false` default in the signature, which is a rule a reviewer enforces rather than the compiler.
+ *   The safe direction is not the point — a caller that silently takes `false` ignores a user who
+ *   turned the setting on, which is the same shape of unasked decision, pointing the other way. It
+ *   was unconditional until GH#445: an app
  *   installed through Thor came up with location, contacts and microphone already granted, which is
  *   neither what the platform installer does nor anything the UI said was happening. `-r` on its own
  *   does not touch permissions already granted, so an update keeps what the user had chosen —
@@ -104,7 +108,7 @@ internal fun installViaSessionCommand(
     apks: List<SessionApk>,
     userId: Int,
     canDowngrade: Boolean = false,
-    grantAllPermissions: Boolean = false,
+    grantAllPermissions: Boolean,
     installerArg: String = "",
 ): String {
     require(apks.isNotEmpty()) { "installViaSessionCommand needs at least one APK" }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/InstallSessionCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/InstallSessionCommands.kt
@@ -85,8 +85,17 @@ internal const val SESSION_COMMIT_FAILED_EXIT_CODE = 103
  *   `UserHandle.USER_ALL` and, if the option loop never sees a `--user`, creates the session with
  *   `USER_SYSTEM` plus `INSTALL_ALL_USERS` — installing on every user of the device, and exiting 0.
  * @param canDowngrade adds `-d`. Permissive only, so it is opt-in.
+ * @param grantAllPermissions adds `-g`, granting every runtime permission the package declares at
+ *   install time without asking the user. **Default `false`, and every caller must pass the user's
+ *   answer explicitly rather than lean on that default.** It was unconditional until GH#445: an app
+ *   installed through Thor came up with location, contacts and microphone already granted, which is
+ *   neither what the platform installer does nor anything the UI said was happening. `-r` on its own
+ *   does not touch permissions already granted, so an update keeps what the user had chosen —
+ *   dropping `-g` costs nothing on the update path and only stops the silent grant on the new-install
+ *   one.
  * @param installerArg the attribution flag, e.g. `" -i com.android.vending"`, with or without its
- *   leading space. Re-spaced here so it cannot fuse onto the preceding `-g`.
+ *   leading space. Re-spaced here so it cannot fuse onto the flag before it — which used to be a
+ *   constant `-g` and is now `-g` or `-r`, so the hazard did not go away with the constant.
  * @return a script whose exit code is 0 on success, or one of
  *   [SESSION_CREATE_FAILED_EXIT_CODE] / [SESSION_WRITE_FAILED_EXIT_CODE] /
  *   [SESSION_COMMIT_FAILED_EXIT_CODE], with the `pm` output on stderr.
@@ -95,17 +104,19 @@ internal fun installViaSessionCommand(
     apks: List<SessionApk>,
     userId: Int,
     canDowngrade: Boolean = false,
+    grantAllPermissions: Boolean = false,
     installerArg: String = "",
 ): String {
     require(apks.isNotEmpty()) { "installViaSessionCommand needs at least one APK" }
 
     val downgrade = if (canDowngrade) " -d" else ""
+    val grant = if (grantAllPermissions) " -g" else ""
     val installer = installerArg.trim().let { if (it.isEmpty()) "" else " $it" }
 
     val sb = StringBuilder()
     sb.append("(\n")
     sb.append("set -o pipefail\n")
-    sb.append("CREATE_OUT=\$(pm install-create -r -g").append(installer)
+    sb.append("CREATE_OUT=\$(pm install-create -r").append(grant).append(installer)
         .append(" --user ").append(userId).append(downgrade).append(" 2>&1)\n")
     // install-create prints "Success: created install session [<id>]".
     sb.append("SID=\$(printf '%s\\n' \"\$CREATE_OUT\" | sed -n 's/.*\\[\\([0-9]*\\)\\].*/\\1/p')\n")

--- a/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/shizuku/ShizukuReflector.kt
@@ -362,9 +362,20 @@ class ShizukuReflector(
      *
      * @param apkPath Absolute path to the APK file.
      * @param canDowngrade Whether to allow downgrade.
+     * @param grantAllPermissions Whether to hand the package every runtime permission it declares,
+     *   at install time, without asking — `pm install-create -g`, the GH#445 flag. Required, with
+     *   no default, and that is the point: this class is a reflection layer with no
+     *   `PreferenceRepository` and no `suspend` to read one from, so it cannot resolve the question
+     *   itself. A default here would answer it silently for whoever calls this first. There is no
+     *   such caller yet, so the cost of requiring an answer is zero and the cost of defaulting is
+     *   an install that quietly disagrees with the user's setting.
      * @return true if installation command exited with 0 (Success).
      */
-    fun installPackage(apkPath: String, canDowngrade: Boolean = false): Boolean {
+    fun installPackage(
+        apkPath: String,
+        canDowngrade: Boolean = false,
+        grantAllPermissions: Boolean,
+    ): Boolean {
         return try {
             val file = File(apkPath)
             val command = installViaSessionCommand(
@@ -373,6 +384,7 @@ class ShizukuReflector(
                 ),
                 userId = thorUserId,
                 canDowngrade = canDowngrade,
+                grantAllPermissions = grantAllPermissions,
             )
             val result = Shizuku.execute(command)
             result.first == 0

--- a/app/src/main/java/com/valhalla/thor/domain/gateway/SystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/gateway/SystemGateway.kt
@@ -24,7 +24,18 @@ interface SystemGateway {
 
     // Advanced
     suspend fun uninstallApp(packageName: String): Result<Unit>
-    suspend fun installApp(apkPath: String, canDowngrade: Boolean = false): Result<Unit>
+    /**
+     * @param grantAllPermissions the answer for THIS install to "grant every runtime permission
+     *   the package declares, without asking" (`pm install-create -g`, GH#445). `null` — the
+     *   default — means "no answer for this install, use the saved setting", which is what every
+     *   caller that has no user in front of it wants. Deliberately not defaulting to `false`: that
+     *   would silently override a user who had turned the setting on.
+     */
+    suspend fun installApp(
+        apkPath: String,
+        canDowngrade: Boolean = false,
+        grantAllPermissions: Boolean? = null,
+    ): Result<Unit>
     suspend fun reinstallAppWithGoogle(packageName: String): Result<Unit>
     suspend fun grantPermission(packageName: String, permissionName: String): Result<Unit>
     suspend fun revokePermission(packageName: String, permissionName: String): Result<Unit>

--- a/app/src/main/java/com/valhalla/thor/domain/model/StagedPackage.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/StagedPackage.kt
@@ -13,8 +13,10 @@ import java.io.File
  * device, and in a privileged install mode there is no OS confirmation dialog. Reading that URI
  * twice — once to build the sheet the user approves, once to install — lets the provider serve
  * two different files: a clean APK for the "4 permissions" the sheet shows, spyware for the
- * `pm install -r -g` that follows. So the bytes the user was shown are the bytes that get
- * installed, and the URI is never opened again.
+ * privileged install that follows. So the bytes the user was shown are the bytes that get
+ * installed, and the URI is never opened again. Whether that install also *grants* those
+ * permissions is now the user's `grantAllPermissionsOnInstall` answer (GH#445) and does not change
+ * the argument here: the sheet is a claim about what the substituted APK would be free to ask for.
  *
  * @param file app-private copy of the input. It OUTLIVES the analysis that produced it — whoever
  *   asked for the analysis owns it and must delete it on every exit path (installed, failed,

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -87,6 +87,13 @@ data class UserPreferences(
      *
      * Turning it on is a convenience for the person restoring a hundred apps at once and re-granting
      * each by hand. It reaches only the shell rung; see `installViaSessionCommand`.
+     *
+     * This is the *default*, not the last word. The portable installer shows a checkbox seeded from
+     * this value that the user may flip for one install, and that answer never comes back here — a
+     * decision about one APK must not quietly become the rule for every install after it. Which way
+     * round matters: an install with no answer of its own reads this field, so a caller that has
+     * nobody to ask passes `null` rather than `false`. See
+     * `InstallerRepository.installPackage`'s `grantAllPermissions`.
      */
     val grantAllPermissionsOnInstall: Boolean = false,
 

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -74,6 +74,22 @@ data class UserPreferences(
     // Auto Reinstall Config
     val autoReinstallEnabled: Boolean = false,
 
+    /**
+     * Whether a privileged install hands the package every runtime permission it declares, without
+     * asking — `pm install-create -g`, the same thing `adb install -g` does.
+     *
+     * Off, and off is the only safe default: `-g` was unconditional until GH#445, so an app
+     * installed through Thor started with location, contacts, microphone and the rest already
+     * granted, in a build whose whole selling point is that the user decides what an app may do. The
+     * platform's own installer never does this, so the grant was invisible — nothing in the UI said
+     * it had happened, and the only place it showed up was the app's own permission screen after the
+     * fact.
+     *
+     * Turning it on is a convenience for the person restoring a hundred apps at once and re-granting
+     * each by hand. It reaches only the shell rung; see `installViaSessionCommand`.
+     */
+    val grantAllPermissionsOnInstall: Boolean = false,
+
     // Export destination (persisted SAF tree URI; null = default Downloads/Thor)
     val exportDirUri: String? = null,
 

--- a/app/src/main/java/com/valhalla/thor/domain/repository/InstallerRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/InstallerRepository.kt
@@ -27,11 +27,20 @@ interface InstallerRepository {
      *   to another installer app rather than installing anything itself (that app does its own
      *   read and shows its own confirmation, so the read-once rule is not ours to enforce there —
      *   and a private staging path is not something another app could open anyway).
+     * @param grantAllPermissions the answer for THIS install to "grant every runtime permission
+     *   the package declares, without asking" — `pm install-create -g`, the GH#445 flag. `null`,
+     *   the default, means "no answer for this install, use the saved setting"; that is what every
+     *   caller with no user in front of it wants, and it is why this is nullable rather than
+     *   defaulting to `false` — a `false` default would silently override a user who had turned the
+     *   setting on. The portable installer passes a concrete value because it shows the user a
+     *   checkbox, seeded from the setting, that they may flip for one install without the setting
+     *   changing underneath them. Reaches only the shell rungs; see `installViaSessionCommand`.
      */
     suspend fun installPackage(
         staged: StagedPackage,
         uri: Uri,
         mode: InstallMode,
-        canDowngrade: Boolean = false
+        canDowngrade: Boolean = false,
+        grantAllPermissions: Boolean? = null,
     )
 }

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -140,6 +140,20 @@ interface PreferenceRepository {
     suspend fun setAutoReinstallEnabled(enabled: Boolean)
     suspend fun getInstallerArg(): String
 
+    // --- Installing ---
+    suspend fun setGrantAllPermissionsOnInstall(enabled: Boolean)
+
+    /**
+     * One-shot read of [UserPreferences.grantAllPermissionsOnInstall], for the install path.
+     *
+     * A read rather than a collect, and a separate method rather than `userPreferences.first()` at
+     * each call site, for the same reason [getInstallerArg] is one: the five places that build an
+     * install command are not composables and must not hold a subscription, and a default that
+     * differs between them is the failure mode this is guarding — `false` here has to mean "the user
+     * did not ask for this", never "this caller forgot to look".
+     */
+    suspend fun shouldGrantAllPermissionsOnInstall(): Boolean
+
     // --- Customization ---
     suspend fun setAppInfoActionsOrder(order: List<AppInfoActionId>)
     suspend fun setAppInfoActionVisibility(actionId: AppInfoActionId, isVisible: Boolean)

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -147,10 +147,17 @@ interface PreferenceRepository {
      * One-shot read of [UserPreferences.grantAllPermissionsOnInstall], for the install path.
      *
      * A read rather than a collect, and a separate method rather than `userPreferences.first()` at
-     * each call site, for the same reason [getInstallerArg] is one: the five places that build an
-     * install command are not composables and must not hold a subscription, and a default that
-     * differs between them is the failure mode this is guarding — `false` here has to mean "the user
-     * did not ask for this", never "this caller forgot to look".
+     * each call site, for the same reason [getInstallerArg] is one: the rungs that build an install
+     * command are not composables and must not hold a subscription, and a default that differs
+     * between them is the failure mode this is guarding — `false` here has to mean "the user did not
+     * ask for this", never "this caller forgot to look".
+     *
+     * The five callers each resolve a *nullable* per-install answer against this, and none of them
+     * may shortcut that to `== true`: `null` means nobody was asked (a bulk restore, a background
+     * job), which is not the same as the user declining. The portable installer is the one place
+     * with a real answer — its checkbox, seeded from this value and never written back.
+     * `InstallGrantCallSitesTest` is what keeps that true across all six call sites, one of which is
+     * only reachable from a future caller and would otherwise have gone on defaulting quietly.
      */
     suspend fun shouldGrantAllPermissionsOnInstall(): Boolean
 

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -133,6 +133,12 @@ class InstallerViewModel(
     fun parsePackage(uri: Uri) {
         pendingUri = uri
         ownsInstall = true
+        // A new package is a new question. Without this the box stays ticked from the previous
+        // pick, and "grant everything" carries from an APK the user trusted to one they have not
+        // looked at yet — this VM outlives a single pick (BackupRestoreHubScreen parses through
+        // one instance repeatedly), so that is the ordinary path, not an edge case. Back to null
+        // rather than false: the saved setting is what an unanswered install follows.
+        _grantAllOverride.value = null
         // A second pick replaces the first; the first's copy has no further use. Two things can
         // hold that copy, and both have to be released here.
         //

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -15,14 +15,18 @@ import com.valhalla.thor.domain.model.isVersionDowngrade
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.domain.repository.InstallMode
 import com.valhalla.thor.domain.repository.InstallerRepository
+import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.domain.repository.SystemRepository
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.R
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
@@ -35,6 +39,7 @@ class InstallerViewModel(
     private val eventBus: InstallerEventBus,
     private val packageManager: PackageManager,
     private val systemRepository: SystemRepository,
+    private val preferenceRepository: PreferenceRepository,
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -45,6 +50,33 @@ class InstallerViewModel(
 
     private val _availableModes = MutableStateFlow(listOf(InstallMode.NORMAL))
     val availableModes: StateFlow<List<InstallMode>> = _availableModes.asStateFlow()
+
+    // The user's answer *for this install* to the GH#445 grant, or null while they have not given
+    // one. Null rather than a copy of the setting seeded at construction, so that until the box is
+    // touched it tracks Settings live rather than showing whatever the setting happened to say when
+    // this screen opened.
+    private val _grantAllOverride = MutableStateFlow<Boolean?>(null)
+
+    /**
+     * Whether this install will grant every runtime permission the package declares — the state of
+     * the installer's own checkbox.
+     *
+     * Starts at the saved setting and stays with it until the user ticks or unticks the box; from
+     * then on their answer wins for this screen and this screen only. Nothing here writes back to
+     * [PreferenceRepository], deliberately: a one-off decision about one APK must not silently
+     * become the default for every install that follows.
+     */
+    val grantAllPermissions: StateFlow<Boolean> =
+        combine(preferenceRepository.userPreferences, _grantAllOverride) { prefs, override ->
+            override ?: prefs.grantAllPermissionsOnInstall
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            // `false` is the right initial value and not merely a placeholder: it is
+            // UserPreferences' own default for this flag, so the box cannot flash ticked during
+            // the first DataStore read and mislead someone who installs before it lands.
+            initialValue = false,
+        )
 
     var currentPackageName: String? = null
         private set
@@ -188,6 +220,13 @@ class InstallerViewModel(
         _installMode.value = mode
     }
 
+    /**
+     * Records the user's answer for this install only. Does not touch the saved setting.
+     */
+    fun setGrantAllPermissions(enabled: Boolean) {
+        _grantAllOverride.value = enabled
+    }
+
     fun startInstallation() {
         val uri = pendingUri ?: return
         // No staged copy means no analysis succeeded, and installing would mean reading the URI
@@ -214,8 +253,16 @@ class InstallerViewModel(
         // happy path for the first time.
         val allowDowngrade = isDowngrade || (versionCodeUnknown && mode != InstallMode.NORMAL)
 
+        // The override, not `grantAllPermissions.value`. They agree whenever the user has touched
+        // the box, and where they differ the override is the safe one: [grantAllPermissions] is a
+        // WhileSubscribed StateFlow, so with no collector it holds its `false` initial value, and
+        // sending that would turn "the user never answered" into "the user said no" and override a
+        // setting that said yes. Passing null hands that resolution to the repository, which reads
+        // the setting itself.
+        val grantAll = _grantAllOverride.value
+
         viewModelScope.launch {
-            repository.installPackage(staged, uri, mode, allowDowngrade)
+            repository.installPackage(staged, uri, mode, allowDowngrade, grantAll)
         }
     }
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
@@ -27,14 +27,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -66,6 +69,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -96,6 +100,7 @@ fun PortableInstaller(
     val state by viewModel.installState.collectAsStateWithLifecycle(initialValue = InstallState.Idle)
     val availableModes by viewModel.availableModes.collectAsStateWithLifecycle()
     val installerMode by viewModel.installMode.collectAsStateWithLifecycle()
+    val grantAllPermissions by viewModel.grantAllPermissions.collectAsStateWithLifecycle()
 
     var lastMeta by remember { mutableStateOf<AppMetadata?>(null) }
     LaunchedEffect(state) {
@@ -543,6 +548,52 @@ fun PortableInstaller(
                                     }
                                 }
                             }
+                        }
+                    }
+
+                    // Only for the rungs that can act on it. `-g` is a shell-install flag: in
+                    // NORMAL mode the system installer asks for permissions its own way and has
+                    // never taken orders from this box, and in EXTERNAL another app does the
+                    // installing entirely. Shown there it would be a control that does nothing,
+                    // and — worse for a privacy setting — one the user could reasonably read as
+                    // proof that Thor is granting everything.
+                    if (installerMode == InstallMode.ROOT ||
+                        installerMode == InstallMode.SHIZUKU ||
+                        installerMode == InstallMode.DHIZUKU
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(16.dp))
+                                // The whole row, not just the box: a 20dp checkbox is a poor
+                                // target, and `toggleable` here keeps the row one node for
+                                // TalkBack instead of a label sitting beside an unlabelled box.
+                                .toggleable(
+                                    value = grantAllPermissions,
+                                    role = Role.Checkbox,
+                                    onValueChange = { viewModel.setGrantAllPermissions(it) }
+                                )
+                                .padding(horizontal = 12.dp, vertical = 4.dp)
+                                // Material3 applies minimumInteractiveComponentSize() to a
+                                // Checkbox only while its own onCheckedChange is non-null, so
+                                // handing the click to the row silently halves the target to
+                                // 24dp. The row it moved to has to carry the 48dp itself.
+                                .defaultMinSize(minHeight = 48.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            // null, not a second onCheckedChange: two clickable nodes here would
+                            // read to TalkBack as two controls for one answer.
+                            Checkbox(
+                                checked = grantAllPermissions,
+                                onCheckedChange = null
+                            )
+                            Text(
+                                text = stringResource(R.string.grant_all_permissions_install),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.weight(1f)
+                            )
                         }
                     }
 

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCatalog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCatalog.kt
@@ -134,6 +134,11 @@ enum class SettingsRowId(
 
     // ── Installing & sharing ────────────────────────────────────────────────────────────────────
     AUTO_REINSTALL(SettingsCategory.INSTALLING, R.string.auto_reinstall, R.string.auto_reinstall_desc),
+    GRANT_ALL_PERMISSIONS(
+        SettingsCategory.INSTALLING,
+        R.string.grant_all_permissions,
+        R.string.grant_all_permissions_desc,
+    ),
     ANY_FILE_OPENER(
         SettingsCategory.INSTALLING,
         R.string.any_file_opener,

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
@@ -450,6 +450,24 @@ fun SettingsCategoryScreen(
                         onCheckedChange = { viewModel.setAutoReinstallEnabled(it) }
                     )
 
+                    // Gated on `hasPrivilege` because there is nothing for it to change without one:
+                    // with no privilege every install goes through the system installer, which asks
+                    // for permissions the ordinary way and has never taken orders from this toggle.
+                    // Left tappable-looking with no privilege it would read as "Thor is granting
+                    // everything and I cannot stop it", which is the opposite of what it does.
+                    SettingsRowId.GRANT_ALL_PERMISSIONS -> SettingsSwitchRow(
+                        icon = R.drawable.danger,
+                        title = stringResource(R.string.grant_all_permissions),
+                        subtitle = privilegeAwareSubtitle(
+                            hasPrivilege,
+                            R.string.grant_all_permissions_desc
+                        ),
+                        checked = prefs.grantAllPermissionsOnInstall,
+                        enabled = hasPrivilege,
+                        highlighted = lit,
+                        onCheckedChange = { viewModel.setGrantAllPermissionsOnInstall(it) }
+                    )
+
                     // Reads its state from `uiState`, not `prefs`: this switch is backed by
                     // PackageManager component state rather than DataStore. See AnyFileOpenerController.
                     SettingsRowId.ANY_FILE_OPENER -> SettingsSwitchRow(

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -234,6 +234,10 @@ class SettingsViewModel(
         viewModelScope.launch { preferenceRepository.setAutoReinstallEnabled(enabled) }
     }
 
+    fun setGrantAllPermissionsOnInstall(enabled: Boolean) {
+        viewModelScope.launch { preferenceRepository.setGrantAllPermissionsOnInstall(enabled) }
+    }
+
     /**
      * Applying the locale is conditional on the write, because these two steps disagree about how
      * long they last: `applyLocale` changes the running process now, the preference is what brings

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -529,7 +529,7 @@
     <string name="auto_reinstall">إعادة التثبيت التلقائي للتطبيقات</string>
     <string name="auto_reinstall_desc">الحفاظ تلقائيًا على متجر Google Play كمثبت رئيسي لتمكين التحديثات في الخلفية</string>
     <string name="grant_all_permissions">منح كل الأذونات عند التثبيت</string>
-    <string name="grant_all_permissions_desc">منح التطبيق كل إذن يطلبه فور تثبيته، دون أي مطالبة. مُعطَّل افتراضيًا؛ وفي الحالتين تحتفظ التحديثات بالأذونات التي سبق أن منحتها</string>
+    <string name="grant_all_permissions_desc">منح التطبيق كل إذن يطلبه فور تثبيته، دون أي مطالبة — يقتصر ذلك على التثبيت عبر الروت أو Shizuku أو Dhizuku. مُعطَّل افتراضيًا، ويمكنك تغييره من المُثبِّت لعملية تثبيت واحدة؛ وفي الحالتين تحتفظ التحديثات بالأذونات التي سبق أن منحتها</string>
     <string name="grant_all_permissions_install">منح كل الأذونات المطلوبة</string>
     <string name="legacy_extension_title">تم اكتشاف امتداد قديم</string>
     <string name="legacy_extension_desc">تم تثبيت إصدار قديم من امتداد Stormbringer (باسم خاطئ \"Strombringer\") الملحق. يرجى إلغاء تثبيته لتجنب التعارض وتثبيت امتداد Stormbringer المحدث.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -528,6 +528,8 @@
     <string name="freeze_system_app_disable_failed">لا يمكن تجميد %1$s. لم يرفض أي شيء في هذا الجهاز الطلب، لذا فالأرجح أن هذا خلل في Thor وليس قيدًا من النظام. بقي التطبيق مثبّتًا دون تغيير — نرجو الإبلاغ عن المشكلة.</string>
     <string name="auto_reinstall">إعادة التثبيت التلقائي للتطبيقات</string>
     <string name="auto_reinstall_desc">الحفاظ تلقائيًا على متجر Google Play كمثبت رئيسي لتمكين التحديثات في الخلفية</string>
+    <string name="grant_all_permissions">منح كل الأذونات عند التثبيت</string>
+    <string name="grant_all_permissions_desc">منح التطبيق كل إذن يطلبه فور تثبيته، دون أي مطالبة. مُعطَّل افتراضيًا؛ وفي الحالتين تحتفظ التحديثات بالأذونات التي سبق أن منحتها</string>
     <string name="legacy_extension_title">تم اكتشاف امتداد قديم</string>
     <string name="legacy_extension_desc">تم تثبيت إصدار قديم من امتداد Stormbringer (باسم خاطئ \"Strombringer\") الملحق. يرجى إلغاء تثبيته لتجنب التعارض وتثبيت امتداد Stormbringer المحدث.</string>
     <string name="action_export">تصدير</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -530,6 +530,7 @@
     <string name="auto_reinstall_desc">الحفاظ تلقائيًا على متجر Google Play كمثبت رئيسي لتمكين التحديثات في الخلفية</string>
     <string name="grant_all_permissions">منح كل الأذونات عند التثبيت</string>
     <string name="grant_all_permissions_desc">منح التطبيق كل إذن يطلبه فور تثبيته، دون أي مطالبة. مُعطَّل افتراضيًا؛ وفي الحالتين تحتفظ التحديثات بالأذونات التي سبق أن منحتها</string>
+    <string name="grant_all_permissions_install">منح كل الأذونات المطلوبة</string>
     <string name="legacy_extension_title">تم اكتشاف امتداد قديم</string>
     <string name="legacy_extension_desc">تم تثبيت إصدار قديم من امتداد Stormbringer (باسم خاطئ \"Strombringer\") الملحق. يرجى إلغاء تثبيته لتجنب التعارض وتثبيت امتداد Stormbringer المحدث.</string>
     <string name="action_export">تصدير</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -494,6 +494,8 @@
     <string name="freeze_system_app_disable_failed">No se puede congelar %1$s. Nada en este dispositivo ha rechazado la petición, así que es más probable que sea un fallo de Thor que una restricción. La aplicación sigue instalada y sin cambios: informa del problema, por favor.</string>
     <string name="auto_reinstall">Reinstalación automática de apps</string>
     <string name="auto_reinstall_desc">Mantener automáticamente Google Play Store como el instalador registrado para permitir actualizaciones en segundo plano</string>
+    <string name="grant_all_permissions">Conceder todos los permisos al instalar</string>
+    <string name="grant_all_permissions_desc">Dar a la aplicación todos los permisos que solicita en cuanto se instala, sin preguntar. Desactivado de forma predeterminada; en ambos casos, las actualizaciones conservan los permisos que ya habías concedido</string>
     <string name="legacy_extension_title">Extensión heredada detectada</string>
     <string name="legacy_extension_desc">Se ha detectado una versión heredada de la extensión Stormbringer (escrita incorrectamente como \"Strombringer\"). Por favor, desinstálala para evitar conflictos e instala la versión actualizada.</string>
     <string name="action_export">Exportar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -496,6 +496,7 @@
     <string name="auto_reinstall_desc">Mantener automáticamente Google Play Store como el instalador registrado para permitir actualizaciones en segundo plano</string>
     <string name="grant_all_permissions">Conceder todos los permisos al instalar</string>
     <string name="grant_all_permissions_desc">Dar a la aplicación todos los permisos que solicita en cuanto se instala, sin preguntar. Desactivado de forma predeterminada; en ambos casos, las actualizaciones conservan los permisos que ya habías concedido</string>
+    <string name="grant_all_permissions_install">Conceder todos los permisos solicitados</string>
     <string name="legacy_extension_title">Extensión heredada detectada</string>
     <string name="legacy_extension_desc">Se ha detectado una versión heredada de la extensión Stormbringer (escrita incorrectamente como \"Strombringer\"). Por favor, desinstálala para evitar conflictos e instala la versión actualizada.</string>
     <string name="action_export">Exportar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -495,7 +495,7 @@
     <string name="auto_reinstall">Reinstalación automática de apps</string>
     <string name="auto_reinstall_desc">Mantener automáticamente Google Play Store como el instalador registrado para permitir actualizaciones en segundo plano</string>
     <string name="grant_all_permissions">Conceder todos los permisos al instalar</string>
-    <string name="grant_all_permissions_desc">Dar a la aplicación todos los permisos que solicita en cuanto se instala, sin preguntar. Desactivado de forma predeterminada; en ambos casos, las actualizaciones conservan los permisos que ya habías concedido</string>
+    <string name="grant_all_permissions_desc">Dar a la aplicación todos los permisos que solicita en cuanto se instala, sin preguntar; solo en instalaciones con root, Shizuku o Dhizuku. Desactivado de forma predeterminada, y el instalador permite cambiarlo para una sola instalación; en ambos casos, las actualizaciones conservan los permisos que ya habías concedido</string>
     <string name="grant_all_permissions_install">Conceder todos los permisos solicitados</string>
     <string name="legacy_extension_title">Extensión heredada detectada</string>
     <string name="legacy_extension_desc">Se ha detectado una versión heredada de la extensión Stormbringer (escrita incorrectamente como \"Strombringer\"). Por favor, desinstálala para evitar conflictos e instala la versión actualizada.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -494,6 +494,8 @@
     <string name="freeze_system_app_disable_failed">Impossible de geler %1$s. Rien sur cet appareil n\'a refusé la demande : il s\'agit donc plus probablement d\'un bogue de Thor que d\'une restriction. L\'application est restée installée et intacte — merci de le signaler.</string>
     <string name="auto_reinstall">Réinstallation automatique d\'applications</string>
     <string name="auto_reinstall_desc">Conserver automatiquement Google Play Store comme installateur enregistré pour activer les mises à jour en arrière-plan</string>
+    <string name="grant_all_permissions">Accorder toutes les autorisations à l\'installation</string>
+    <string name="grant_all_permissions_desc">Donner à l\'application toutes les autorisations qu\'elle demande dès son installation, sans invite. Désactivé par défaut ; dans les deux cas, les mises à jour conservent les autorisations déjà accordées</string>
     <string name="legacy_extension_title">Extension obsolète détectée</string>
     <string name="legacy_extension_desc">Une version obsolète de l\'extension Stormbringer (orthographiée par erreur \"Strombringer\") est installée. Veuillez la désinstaller pour éviter les conflits et installer la version mise à jour.</string>
     <string name="action_export">Exporter</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -495,7 +495,7 @@
     <string name="auto_reinstall">Réinstallation automatique d\'applications</string>
     <string name="auto_reinstall_desc">Conserver automatiquement Google Play Store comme installateur enregistré pour activer les mises à jour en arrière-plan</string>
     <string name="grant_all_permissions">Accorder toutes les autorisations à l\'installation</string>
-    <string name="grant_all_permissions_desc">Donner à l\'application toutes les autorisations qu\'elle demande dès son installation, sans invite. Désactivé par défaut ; dans les deux cas, les mises à jour conservent les autorisations déjà accordées</string>
+    <string name="grant_all_permissions_desc">Donner à l\'application toutes les autorisations qu\'elle demande dès son installation, sans invite ; uniquement pour les installations via root, Shizuku ou Dhizuku. Désactivé par défaut, et l\'installateur permet de le modifier pour une seule installation ; dans les deux cas, les mises à jour conservent les autorisations déjà accordées</string>
     <string name="grant_all_permissions_install">Accorder toutes les autorisations demandées</string>
     <string name="legacy_extension_title">Extension obsolète détectée</string>
     <string name="legacy_extension_desc">Une version obsolète de l\'extension Stormbringer (orthographiée par erreur \"Strombringer\") est installée. Veuillez la désinstaller pour éviter les conflits et installer la version mise à jour.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -496,6 +496,7 @@
     <string name="auto_reinstall_desc">Conserver automatiquement Google Play Store comme installateur enregistré pour activer les mises à jour en arrière-plan</string>
     <string name="grant_all_permissions">Accorder toutes les autorisations à l\'installation</string>
     <string name="grant_all_permissions_desc">Donner à l\'application toutes les autorisations qu\'elle demande dès son installation, sans invite. Désactivé par défaut ; dans les deux cas, les mises à jour conservent les autorisations déjà accordées</string>
+    <string name="grant_all_permissions_install">Accorder toutes les autorisations demandées</string>
     <string name="legacy_extension_title">Extension obsolète détectée</string>
     <string name="legacy_extension_desc">Une version obsolète de l\'extension Stormbringer (orthographiée par erreur \"Strombringer\") est installée. Veuillez la désinstaller pour éviter les conflits et installer la version mise à jour.</string>
     <string name="action_export">Exporter</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -29,6 +29,8 @@
     <string name="show_extensions_tile_desc">Pokaż Rozszerzenia na ekranie głównym</string>
     <string name="auto_reinstall">Automatyczna reinstalacja aplikacji</string>
     <string name="auto_reinstall_desc">Automatycznie zachowuj Google Play Store jako zarejestrowany instalator, aby umożliwić aktualizacje w tle</string>
+    <string name="grant_all_permissions">Przyznaj wszystkie uprawnienia przy instalacji</string>
+    <string name="grant_all_permissions_desc">Nadaj aplikacji wszystkie żądane uprawnienia zaraz po instalacji, bez pytania. Domyślnie wyłączone; w obu przypadkach aktualizacje zachowują już przyznane uprawnienia</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Domyślna karta</string>
     <string name="default_tab_desc">Ekran otwierany przez aplikację Thor po uruchomieniu</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -30,7 +30,7 @@
     <string name="auto_reinstall">Automatyczna reinstalacja aplikacji</string>
     <string name="auto_reinstall_desc">Automatycznie zachowuj Google Play Store jako zarejestrowany instalator, aby umożliwić aktualizacje w tle</string>
     <string name="grant_all_permissions">Przyznaj wszystkie uprawnienia przy instalacji</string>
-    <string name="grant_all_permissions_desc">Nadaj aplikacji wszystkie żądane uprawnienia zaraz po instalacji, bez pytania. Domyślnie wyłączone; w obu przypadkach aktualizacje zachowują już przyznane uprawnienia</string>
+    <string name="grant_all_permissions_desc">Nadaj aplikacji wszystkie żądane uprawnienia zaraz po instalacji, bez pytania — tylko przy instalacji przez root, Shizuku lub Dhizuku. Domyślnie wyłączone, a w instalatorze można to zmienić dla pojedynczej instalacji; w obu przypadkach aktualizacje zachowują już przyznane uprawnienia</string>
     <string name="grant_all_permissions_install">Przyznaj wszystkie żądane uprawnienia</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Domyślna karta</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -31,6 +31,7 @@
     <string name="auto_reinstall_desc">Automatycznie zachowuj Google Play Store jako zarejestrowany instalator, aby umożliwić aktualizacje w tle</string>
     <string name="grant_all_permissions">Przyznaj wszystkie uprawnienia przy instalacji</string>
     <string name="grant_all_permissions_desc">Nadaj aplikacji wszystkie żądane uprawnienia zaraz po instalacji, bez pytania. Domyślnie wyłączone; w obu przypadkach aktualizacje zachowują już przyznane uprawnienia</string>
+    <string name="grant_all_permissions_install">Przyznaj wszystkie żądane uprawnienia</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Domyślna karta</string>
     <string name="default_tab_desc">Ekran otwierany przez aplikację Thor po uruchomieniu</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -38,6 +38,7 @@
     <string name="auto_reinstall_desc">Preservar automaticamente a Google Play Store como instalador registrado, para permitir atualizações em segundo plano</string>
     <string name="grant_all_permissions">Conceder todas as permissões ao instalar</string>
     <string name="grant_all_permissions_desc">Dar ao aplicativo todas as permissões que ele pede assim que for instalado, sem perguntar. Desativado por padrão; nos dois casos, as atualizações mantêm as permissões já concedidas</string>
+    <string name="grant_all_permissions_install">Conceder todas as permissões solicitadas</string>
     <string name="default_tab">Aba padrão</string>
     <string name="default_tab_desc">A tela que o Thor abre ao iniciar</string>
     <string name="biometric_lock_desc">Exigir autenticação ao iniciar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -37,7 +37,7 @@
     <string name="auto_reinstall">Reinstalar aplicativos automaticamente</string>
     <string name="auto_reinstall_desc">Preservar automaticamente a Google Play Store como instalador registrado, para permitir atualizações em segundo plano</string>
     <string name="grant_all_permissions">Conceder todas as permissões ao instalar</string>
-    <string name="grant_all_permissions_desc">Dar ao aplicativo todas as permissões que ele pede assim que for instalado, sem perguntar. Desativado por padrão; nos dois casos, as atualizações mantêm as permissões já concedidas</string>
+    <string name="grant_all_permissions_desc">Dar ao aplicativo todas as permissões que ele pede assim que for instalado, sem perguntar — apenas em instalações com root, Shizuku ou Dhizuku. Desativado por padrão, e o instalador permite alterar isso para uma única instalação; nos dois casos, as atualizações mantêm as permissões já concedidas</string>
     <string name="grant_all_permissions_install">Conceder todas as permissões solicitadas</string>
     <string name="default_tab">Aba padrão</string>
     <string name="default_tab_desc">A tela que o Thor abre ao iniciar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -36,6 +36,8 @@
     <string name="show_extensions_tile_desc">Mostrar Extensões na tela inicial</string>
     <string name="auto_reinstall">Reinstalar aplicativos automaticamente</string>
     <string name="auto_reinstall_desc">Preservar automaticamente a Google Play Store como instalador registrado, para permitir atualizações em segundo plano</string>
+    <string name="grant_all_permissions">Conceder todas as permissões ao instalar</string>
+    <string name="grant_all_permissions_desc">Dar ao aplicativo todas as permissões que ele pede assim que for instalado, sem perguntar. Desativado por padrão; nos dois casos, as atualizações mantêm as permissões já concedidas</string>
     <string name="default_tab">Aba padrão</string>
     <string name="default_tab_desc">A tela que o Thor abre ao iniciar</string>
     <string name="biometric_lock_desc">Exigir autenticação ao iniciar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -30,7 +30,7 @@
     <string name="auto_reinstall">Reinstalar aplicações automaticamente</string>
     <string name="auto_reinstall_desc">Preservar automaticamente a Google Play Store como instalador registado, para permitir atualizações em segundo plano</string>
     <string name="grant_all_permissions">Conceder todas as permissões ao instalar</string>
-    <string name="grant_all_permissions_desc">Dar à aplicação todas as permissões que pede assim que for instalada, sem perguntar. Desativado por predefinição; em ambos os casos, as atualizações mantêm as permissões já concedidas</string>
+    <string name="grant_all_permissions_desc">Dar à aplicação todas as permissões que pede assim que for instalada, sem perguntar — apenas em instalações com root, Shizuku ou Dhizuku. Desativado por predefinição, e o instalador permite alterá-lo para uma única instalação; em ambos os casos, as atualizações mantêm as permissões já concedidas</string>
     <string name="grant_all_permissions_install">Conceder todas as permissões pedidas</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Separador predefinido</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -29,6 +29,8 @@
     <string name="show_extensions_tile_desc">Mostrar Extensões no ecrã principal</string>
     <string name="auto_reinstall">Reinstalar aplicações automaticamente</string>
     <string name="auto_reinstall_desc">Preservar automaticamente a Google Play Store como instalador registado, para permitir atualizações em segundo plano</string>
+    <string name="grant_all_permissions">Conceder todas as permissões ao instalar</string>
+    <string name="grant_all_permissions_desc">Dar à aplicação todas as permissões que pede assim que for instalada, sem perguntar. Desativado por predefinição; em ambos os casos, as atualizações mantêm as permissões já concedidas</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Separador predefinido</string>
     <string name="default_tab_desc">O ecrã que o Thor abre ao arrancar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -31,6 +31,7 @@
     <string name="auto_reinstall_desc">Preservar automaticamente a Google Play Store como instalador registado, para permitir atualizações em segundo plano</string>
     <string name="grant_all_permissions">Conceder todas as permissões ao instalar</string>
     <string name="grant_all_permissions_desc">Dar à aplicação todas as permissões que pede assim que for instalada, sem perguntar. Desativado por predefinição; em ambos os casos, as atualizações mantêm as permissões já concedidas</string>
+    <string name="grant_all_permissions_install">Conceder todas as permissões pedidas</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Separador predefinido</string>
     <string name="default_tab_desc">O ecrã que o Thor abre ao arrancar</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -486,6 +486,8 @@
     <string name="freeze_system_app_disable_failed">无法冻结 %1$s。本设备并未拒绝该请求，所以这更可能是 Thor 的缺陷，而不是系统限制。该应用仍保持安装且未做改动——请反馈此问题。</string>
     <string name="auto_reinstall">自动重新安装应用</string>
     <string name="auto_reinstall_desc">自动保留 Google Play 商店作为主安装程序，以启用后台更新</string>
+    <string name="grant_all_permissions">安装时授予全部权限</string>
+    <string name="grant_all_permissions_desc">应用安装后立即获得其请求的全部权限，不再询问。默认关闭；无论开启与否，更新都会保留你已经授予的权限</string>
     <string name="legacy_extension_title">检测到旧版扩展</string>
     <string name="legacy_extension_desc">已安装旧版 Stormbringer 扩展（拼写错误为 \"Strombringer\"）。请将其卸载以避免冲突，并安装更新的 Stormbringer 扩展。</string>
     <string name="action_export">导出</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -488,6 +488,7 @@
     <string name="auto_reinstall_desc">自动保留 Google Play 商店作为主安装程序，以启用后台更新</string>
     <string name="grant_all_permissions">安装时授予全部权限</string>
     <string name="grant_all_permissions_desc">应用安装后立即获得其请求的全部权限，不再询问。默认关闭；无论开启与否，更新都会保留你已经授予的权限</string>
+    <string name="grant_all_permissions_install">授予其请求的全部权限</string>
     <string name="legacy_extension_title">检测到旧版扩展</string>
     <string name="legacy_extension_desc">已安装旧版 Stormbringer 扩展（拼写错误为 \"Strombringer\"）。请将其卸载以避免冲突，并安装更新的 Stormbringer 扩展。</string>
     <string name="action_export">导出</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -487,7 +487,7 @@
     <string name="auto_reinstall">自动重新安装应用</string>
     <string name="auto_reinstall_desc">自动保留 Google Play 商店作为主安装程序，以启用后台更新</string>
     <string name="grant_all_permissions">安装时授予全部权限</string>
-    <string name="grant_all_permissions_desc">应用安装后立即获得其请求的全部权限，不再询问。默认关闭；无论开启与否，更新都会保留你已经授予的权限</string>
+    <string name="grant_all_permissions_desc">应用安装后立即获得其请求的全部权限，不再询问；仅适用于通过 Root、Shizuku 或 Dhizuku 的安装。默认关闭，并且可在安装器中为单次安装临时更改；无论开启与否，更新都会保留你已经授予的权限</string>
     <string name="grant_all_permissions_install">授予其请求的全部权限</string>
     <string name="legacy_extension_title">检测到旧版扩展</string>
     <string name="legacy_extension_desc">已安装旧版 Stormbringer 扩展（拼写错误为 \"Strombringer\"）。请将其卸载以避免冲突，并安装更新的 Stormbringer 扩展。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="auto_reinstall">Auto Reinstall Apps</string>
     <string name="auto_reinstall_desc">Automatically preserve Google Play Store as the installer of record to enable background updates</string>
     <string name="grant_all_permissions">Grant All Permissions on Install</string>
-    <string name="grant_all_permissions_desc">Give an app every permission it requests the moment it is installed, with no prompt. Off by default; either way, updates keep the permissions you had already granted</string>
+    <string name="grant_all_permissions_desc">Give an app every permission it requests the moment it is installed, with no prompt — root, Shizuku and Dhizuku installs only. Off by default, and the installer lets you change it for a single install; either way, updates keep the permissions you had already granted</string>
     <string name="grant_all_permissions_install">Grant all requested permissions</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Default Tab</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="show_extensions_tile_desc">Show Extensions on the home screen</string>
     <string name="auto_reinstall">Auto Reinstall Apps</string>
     <string name="auto_reinstall_desc">Automatically preserve Google Play Store as the installer of record to enable background updates</string>
+    <string name="grant_all_permissions">Grant All Permissions on Install</string>
+    <string name="grant_all_permissions_desc">Give an app every permission it requests the moment it is installed, with no prompt. Off by default; either way, updates keep the permissions you had already granted</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Default Tab</string>
     <string name="default_tab_desc">The screen Thor opens on at launch</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="auto_reinstall_desc">Automatically preserve Google Play Store as the installer of record to enable background updates</string>
     <string name="grant_all_permissions">Grant All Permissions on Install</string>
     <string name="grant_all_permissions_desc">Give an app every permission it requests the moment it is installed, with no prompt. Off by default; either way, updates keep the permissions you had already granted</string>
+    <string name="grant_all_permissions_install">Grant all requested permissions</string>
     <!-- Options reuse the four navigation labels above (home / apps / freezer / settings). -->
     <string name="default_tab">Default Tab</string>
     <string name="default_tab_desc">The screen Thor opens on at launch</string>

--- a/app/src/test/java/com/valhalla/thor/data/repository/StagedInstallTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/StagedInstallTest.kt
@@ -386,6 +386,12 @@ class StagedInstallTest {
     }
 
     // ---- integrityGuardedInstall ---------------------------------------------------------
+    //
+    // The install commands below are opaque payloads, not specimens: `integrityGuardedInstall`
+    // prefixes whatever string it is handed and never parses it, so these literals say nothing about
+    // what Thor emits. Do not read the `-r -g` in them as current — the grant is opt-in as of GH#445
+    // and the real command is a `pm install-create` session either way (`installViaSessionCommand`).
+    // They are left as-is deliberately: rewriting them would imply this function cares what it wraps.
 
     @Test
     fun `the hash check runs before pm install, not after`() {

--- a/app/src/test/java/com/valhalla/thor/data/source/local/InstallGrantCallSitesTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/InstallGrantCallSitesTest.kt
@@ -199,6 +199,47 @@ class InstallGrantCallSitesTest {
         )
     }
 
+    /**
+     * One [InstallerViewModel] outlives one pick — `BackupRestoreHubScreen` parses through a single
+     * instance repeatedly, and `parsePackage` is written for that case, cancelling the previous
+     * analysis and discarding its staged copy. The override has to be discarded with them, or a
+     * ticked box carries "grant everything" from an APK the user trusted onto the next one they
+     * have not looked at yet.
+     *
+     * Back to `null`, not `false`: an install nobody answered for follows the saved setting, and
+     * `false` would answer for them in the other direction.
+     */
+    @Test
+    fun `a new package clears the previous package's answer`() {
+        val source = stripComments(sourceOf(VIEW_MODEL))
+        val parse = source.substringAfter("fun parsePackage(").substringBefore("\n    private")
+
+        // The slice, before it is trusted. `substringBefore` returns everything when its delimiter
+        // is gone, so a rename downstream would silently widen this to the rest of the file and the
+        // assertions below would start passing on a reset made somewhere else entirely.
+        assertTrue(
+            "the parsePackage slice missed its own body — the extraction is reading the wrong span",
+            parse.contains("analysisJob")
+        )
+        assertFalse(
+            "the parsePackage slice ran past the end of the function, so this test no longer says " +
+                "where the reset happens",
+            parse.contains("fun startInstallation")
+        )
+
+        assertTrue(
+            "parsePackage does not reset _grantAllOverride, so the checkbox answer for one APK " +
+                "silently applies to the next one picked in the same installer session.",
+            parse.contains("_grantAllOverride.value = null")
+        )
+        assertFalse(
+            "parsePackage resets the override to a concrete answer. Null is the reset: it means " +
+                "nobody was asked about this package, which is what defers to the saved setting.",
+            parse.contains("_grantAllOverride.value = false") ||
+                parse.contains("_grantAllOverride.value = true")
+        )
+    }
+
     @Test
     fun `the installer never writes the setting`() {
         // The user's requirement, and not something the type system defends: the setter is on the

--- a/app/src/test/java/com/valhalla/thor/data/source/local/InstallGrantCallSitesTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/InstallGrantCallSitesTest.kt
@@ -1,0 +1,373 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.source.local
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * A source-text sweep over the GH#445 grant: every place that builds an install command must decide
+ * the `-g` question on purpose, and none may decide it by accident.
+ *
+ * [InstallSessionCommandsTest] proves what [installViaSessionCommand] *does* with the answer it is
+ * given. Nothing there — and nothing anywhere reachable from a JVM test — proves that the five
+ * callers hand it the right one. Each of those five needs a live root shell or a Shizuku/Dhizuku
+ * binder to run, and [com.valhalla.thor.presentation.installer.InstallerViewModel] cannot be
+ * constructed off-device at all: it takes a `PackageManager`, which is abstract, and this module
+ * carries no mocking library. So the wiring is exactly the part with no behavioural coverage, and
+ * it is also the part where the regressions are one-token edits that compile:
+ *
+ *  - dropping the `grantAllPermissions =` argument, which silently falls back to the parameter
+ *    default and stops honouring the setting;
+ *  - writing `grantAllPermissions == true` or `?: false` instead of
+ *    `?: shouldGrantAllPermissionsOnInstall()`, which reads "nobody asked" as "the user said no"
+ *    and overrides someone who had turned the setting *on*;
+ *  - sending the installer's displayed value instead of the user's override, which turns a
+ *    WhileSubscribed StateFlow's `false` initial value into an answer.
+ *
+ * None of those is subtle logic. All three would have passed the suite that shipped GH#445 — that
+ * suite was green, and two of its assertions described the defect as correct behaviour.
+ *
+ * ### What it is worth, and what it is not
+ *
+ * It proves a shape, not a behaviour: that the argument is present and is not one of the known
+ * wrong spellings. It cannot tell whether `-g` reaches `pm`, whether the shell accepts it, or what
+ * the platform does with it. It will not survive a large refactor of these call sites either — and
+ * that is intended. If the shape stops describing the code, somebody has to come back here and
+ * decide again, deliberately, what each install rung asks for.
+ *
+ * ### Anti-vacuity
+ *
+ * A sweep that reads nothing is green and proves nothing, which is the failure mode of this whole
+ * genre. Three guards stand against it, each its own test so that losing one is visible: the sweep
+ * asserts *which* files it found call sites in (not merely that it found some), the forbidden-form
+ * detector is run against a synthetic body that carries each wrong spelling, and the extractor is
+ * pointed at a call that does not exist so that "found nothing" and "found everything" cannot look
+ * alike.
+ */
+class InstallGrantCallSitesTest {
+
+    /** How a call site is allowed to arrive at its answer. */
+    private enum class Resolution {
+        /** Takes a nullable answer and falls back to `shouldGrantAllPermissionsOnInstall()`. */
+        FROM_SETTING,
+
+        /**
+         * Takes a required, non-nullable answer from its caller.
+         *
+         * For a class that cannot read the setting — no `PreferenceRepository`, no `suspend` — and
+         * so would have to invent one. Requiring the answer pushes the decision to somebody who can
+         * make it; defaulting it would answer for them, silently.
+         */
+        FROM_CALLER,
+    }
+
+    /**
+     * Every file that may contain a call to [installViaSessionCommand], relative to
+     * `src/main/java/com/valhalla/thor`, and how each is allowed to decide the grant.
+     *
+     * Asserted as a set equality rather than a lower bound: a *new* file building an install command
+     * is precisely the event this list exists to interrupt. `data/source/local/
+     * InstallSessionCommands.kt` is absent on purpose — it declares the function rather than calling
+     * it, and is filtered out by name below.
+     *
+     * `ShizukuReflector.kt` is on this list because this sweep put it there. It builds an install
+     * command and had no caller, so nobody noticed when the GH#445 fix turned the constant `-g` into
+     * a parameter and left this one site taking the default — which is to say, silently ignoring the
+     * setting. The fix that shipped in five places had missed a sixth. That is the entire argument
+     * for a sweep over a hand-written list of call sites.
+     */
+    private val expectedCallSites = mapOf(
+        "data/gateway/RootSystemGateway.kt" to Resolution.FROM_SETTING,
+        "data/gateway/ShizukuSystemGateway.kt" to Resolution.FROM_SETTING,
+        "data/gateway/DhizukuSystemGateway.kt" to Resolution.FROM_SETTING,
+        "data/repository/InstallerRepositoryImpl.kt" to Resolution.FROM_SETTING,
+        "data/source/local/shizuku/ShizukuReflector.kt" to Resolution.FROM_CALLER,
+    )
+
+    /**
+     * Spellings that turn "the caller gave no answer" into "the caller said no".
+     *
+     * The parameter is `Boolean?` for one reason: `null` means the caller has nobody to ask and the
+     * saved setting decides. Every form here erases that third state, and every one of them
+     * compiles, type-checks and reads as reasonable at a glance.
+     */
+    private val forbiddenForms = listOf(
+        "grantAllPermissions == true",
+        "grantAllPermissions != true",
+        "grantAllPermissions == false",
+        "grantAllPermissions ?: false",
+        "grantAllPermissions ?: true",
+    )
+
+    @Test
+    fun `every install command names the grant explicitly`() {
+        val sites = callSites()
+        assertTrue("the sweep found no call sites at all", sites.isNotEmpty())
+
+        for ((path, call) in sites) {
+            assertTrue(
+                "$path builds an install command without saying what to do about the permission " +
+                    "grant, so it falls back to the parameter default and stops honouring the " +
+                    "setting (GH#445):\n$call",
+                call.contains("grantAllPermissions =")
+            )
+        }
+    }
+
+    @Test
+    fun `the sweep read the files it claims to have read`() {
+        assertEquals(
+            "the set of files building an install command has changed; each new one has to decide " +
+                "the GH#445 grant question deliberately, so add it here once you have checked it",
+            expectedCallSites.keys,
+            callSites().map { it.first }.toSet()
+        )
+    }
+
+    @Test
+    fun `no caller collapses a missing answer into a refusal`() {
+        for (path in expectedCallSites.keys + VIEW_MODEL) {
+            val source = stripComments(sourceOf(path))
+            for (form in forbiddenForms) {
+                assertFalse(
+                    "$path writes `$form`. A null grantAllPermissions means nobody was asked, not " +
+                        "that the user said no — this spelling overrides anyone who had turned the " +
+                        "setting on. Resolve with `?: shouldGrantAllPermissionsOnInstall()`.",
+                    source.contains(form)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the resolution goes through the saved setting`() {
+        // Every rung that can receive a null has to say what a null means, and there is exactly one
+        // right answer. Checked per file rather than globally so that a rung which stopped
+        // resolving — and started passing the raw nullable somewhere that reads it as false — is
+        // named rather than hidden by its neighbours still doing it correctly.
+        for ((path, resolution) in expectedCallSites) {
+            if (resolution != Resolution.FROM_SETTING) continue
+            val source = stripComments(sourceOf(path))
+            assertTrue(
+                "$path takes a nullable grant answer but never falls back to the saved setting",
+                source.contains("?: preferenceRepository.shouldGrantAllPermissionsOnInstall()")
+            )
+        }
+    }
+
+    @Test
+    fun `a site that cannot read the setting demands an answer instead of inventing one`() {
+        for ((path, resolution) in expectedCallSites) {
+            if (resolution != Resolution.FROM_CALLER) continue
+            val source = stripComments(sourceOf(path))
+            assertTrue(
+                "$path no longer takes a required grant answer",
+                source.contains("grantAllPermissions: Boolean,")
+            )
+            // A default is the whole failure mode: this class has no way to read the setting, so
+            // any default it carries is an answer given on the user's behalf by whoever last edited
+            // this line. `= false` reads as the cautious choice and is not — it disagrees with a
+            // user who turned the setting on, and does so without saying anything.
+            assertFalse(
+                "$path defaults its grant answer. It cannot read the setting, so a default here " +
+                    "answers for the user rather than deferring to them — make the caller say.",
+                source.contains("grantAllPermissions: Boolean =") ||
+                    source.contains("grantAllPermissions: Boolean? ")
+            )
+        }
+    }
+
+    @Test
+    fun `the installer sends the user's answer, not the value on screen`() {
+        val source = stripComments(sourceOf(VIEW_MODEL))
+
+        assertFalse(
+            "InstallerViewModel sends `grantAllPermissions.value` to the repository. That is a " +
+                "WhileSubscribed StateFlow: with no collector it holds its `false` initial value, " +
+                "so an install started without a live screen would claim the user declined. Send " +
+                "`_grantAllOverride.value`, which is null until they actually answer.",
+            source.contains("grantAllPermissions.value")
+        )
+        assertTrue(
+            "InstallerViewModel no longer reads the per-install override",
+            source.contains("_grantAllOverride.value")
+        )
+    }
+
+    @Test
+    fun `the installer never writes the setting`() {
+        // The user's requirement, and not something the type system defends: the setter is on the
+        // same repository the screen already injects, so writing it back is one line away and would
+        // turn a one-off decision about one APK into the default for every install that follows.
+        for (path in listOf(VIEW_MODEL, "presentation/installer/PortableInstaller.kt")) {
+            assertFalse(
+                "$path calls setGrantAllPermissionsOnInstall. The per-install checkbox is seeded " +
+                    "from the setting and must never write back to it.",
+                stripComments(sourceOf(path)).contains("setGrantAllPermissionsOnInstall")
+            )
+        }
+    }
+
+    // ---- anti-vacuity ----
+
+    @Test
+    fun `the sweep can actually fail`() {
+        val missingArgument = """
+            val command = installViaSessionCommand(
+                apks = staged,
+                userId = thorUserId,
+                canDowngrade = canDowngrade,
+                installerArg = installerArg,
+            )
+        """.trimIndent()
+        val call = extractCall(missingArgument, 0)
+        assertFalse(
+            "the detector accepts a call with no grantAllPermissions argument, so the sweep proves " +
+                "nothing",
+            call.contains("grantAllPermissions =")
+        )
+
+        for (form in forbiddenForms) {
+            assertTrue(
+                "the detector does not notice `$form`",
+                stripComments("val x = $form\n").contains(form)
+            )
+        }
+    }
+
+    @Test
+    fun `the extractor reports nothing when there is nothing to find`() {
+        assertTrue(
+            "the extractor invents call sites, so an empty result and a full one look alike",
+            occurrencesOf("thisFunctionDoesNotExist(", "val a = 1\nval b = 2\n").isEmpty()
+        )
+    }
+
+    @Test
+    fun `comment stripping does not read Thor's opinion of the code`() {
+        // These files argue about `-g` at length in prose, including quoting the forbidden forms to
+        // explain why they are wrong. A sweep that reads the comments would fail on the very
+        // sentences warning against the bug.
+        val prose = "// never write grantAllPermissions == true here\nval ok = 1\n"
+        assertFalse(stripComments(prose).contains("grantAllPermissions == true"))
+        assertTrue(stripComments(prose).contains("val ok = 1"))
+
+        val block = "/* grantAllPermissions ?: false */\nval ok = 1\n"
+        assertFalse(stripComments(block).contains("grantAllPermissions ?: false"))
+        assertTrue(stripComments(block).contains("val ok = 1"))
+    }
+
+    // ---- machinery ----
+
+    /** Every `installViaSessionCommand(` call in main source, as `relative path to call text`. */
+    private fun callSites(): List<Pair<String, String>> =
+        mainSourceRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { it.name != DECLARATION_FILE }
+            .sortedBy { it.path }
+            .flatMap { file ->
+                val relative = file.relativeTo(mainSourceRoot).path
+                val source = stripComments(file.readText())
+                occurrencesOf(NEEDLE, source).map { relative to extractCall(source, it) }
+            }
+            .toList()
+
+    private fun occurrencesOf(needle: String, source: String): List<Int> {
+        val found = mutableListOf<Int>()
+        var from = source.indexOf(needle)
+        while (from >= 0) {
+            found += from
+            from = source.indexOf(needle, from + needle.length)
+        }
+        return found
+    }
+
+    /**
+     * The call starting at [start], up to and including the parenthesis that closes its argument
+     * list.
+     *
+     * Depth counting rather than a line budget: `installViaSessionCommand` is called with nested
+     * calls in its arguments (`tempFiles.map { SessionApk(…) }`), so a fixed number of lines would
+     * either truncate one site or run into the next statement. Comments are stripped before this
+     * runs, so the only parentheses left are code; a `(` inside a string literal would fool it, and
+     * none of these five calls contains one.
+     */
+    private fun extractCall(source: String, start: Int): String {
+        val open = source.indexOf('(', start)
+        if (open < 0) return source.substring(start)
+        var depth = 0
+        for (i in open until source.length) {
+            when (source[i]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) return source.substring(start, i + 1)
+                }
+            }
+        }
+        return source.substring(start)
+    }
+
+    /**
+     * [source] with `//` and `/* … */` comments removed.
+     *
+     * A few lines rather than a Kotlin lexer, and it would mishandle `//` inside a string literal —
+     * none of the swept files has one on a line that mentions the grant, and
+     * `the sweep read the files it claims to have read` would notice if stripping ever ate a real
+     * call site.
+     */
+    private fun stripComments(source: String): String {
+        val withoutBlocks = source.replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")
+        return withoutBlocks.lines().joinToString("\n") { line ->
+            val marker = line.indexOf("//")
+            if (marker >= 0) line.substring(0, marker) else line
+        }
+    }
+
+    private fun sourceOf(relativePath: String): String {
+        val file = File(mainSourceRoot, relativePath)
+        assertTrue("$relativePath does not exist at ${file.absolutePath}", file.isFile)
+        return file.readText()
+    }
+
+    /**
+     * `src/main/java/com/valhalla/thor`, found by walking up from the working directory.
+     *
+     * Gradle runs unit tests from the module directory — `<repo>/app` — but nothing guarantees it;
+     * Android Studio and `--tests` runs have both been seen starting a level up. Returning a
+     * plausible-looking missing directory instead of throwing would turn every assertion in this
+     * file into a green no-op, which is the precise failure this class exists to avoid.
+     */
+    private val mainSourceRoot: File by lazy {
+        val marker = "src/main/java/com/valhalla/thor"
+        val tried = mutableListOf<String>()
+        var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+
+        var hops = 0
+        while (hops < 8) {
+            val here = dir ?: break
+            for (candidate in listOf(File(here, marker), File(here, "app/$marker"))) {
+                if (candidate.isDirectory) return@lazy candidate
+                tried += candidate.path
+            }
+            dir = here.parentFile
+            hops++
+        }
+
+        throw AssertionError(
+            "could not locate $marker from ${System.getProperty("user.dir")}; tried:\n" +
+                tried.joinToString("\n")
+        )
+    }
+
+    private companion object {
+        const val NEEDLE = "installViaSessionCommand("
+        const val DECLARATION_FILE = "InstallSessionCommands.kt"
+        const val VIEW_MODEL = "presentation/installer/InstallerViewModel.kt"
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/source/local/InstallSessionCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/InstallSessionCommandsTest.kt
@@ -62,8 +62,9 @@ class InstallSessionCommandsTest {
         apks: List<SessionApk> = listOf(base),
         userId: Int = 10,
         canDowngrade: Boolean = false,
+        grantAllPermissions: Boolean = false,
         installerArg: String = "",
-    ) = installViaSessionCommand(apks, userId, canDowngrade, installerArg)
+    ) = installViaSessionCommand(apks, userId, canDowngrade, grantAllPermissions, installerArg)
 
     // --- the defect itself: no path may reach pm ---
 
@@ -174,16 +175,52 @@ class InstallSessionCommandsTest {
     }
 
     /**
-     * `-r` is what makes this an update rather than `INSTALL_FAILED_ALREADY_EXISTS`, and `-g` is
-     * what grants the runtime permissions the installed app declares. They belong on
+     * `-r` is what makes this an update rather than `INSTALL_FAILED_ALREADY_EXISTS`. It belongs on
      * `install-create`, not on `install-write`: the session's parameters are fixed when it is
      * created, so a flag written on a later verb is silently ignored.
      */
     @Test
-    fun `the update and grant flags are set when the session is created`() {
+    fun `the update flag is set when the session is created`() {
         val createLine = command().lineSequence().first { it.startsWith("CREATE_OUT=") }
         assertTrue("-r was dropped: this stops being an update", createLine.contains(" -r"))
-        assertTrue("-g was dropped: the app installs with no permissions", createLine.contains(" -g"))
+    }
+
+    /**
+     * GH#445, and the test that used to assert the defect.
+     *
+     * `-g` is `INSTALL_GRANT_ALL_REQUESTED_PERMISSIONS`: every runtime permission the package
+     * declares, granted at install time, with no prompt and nothing in the UI saying so. It was
+     * unconditional here, which is how apps installed through Thor came up already holding location
+     * and contacts. The old assertion read `"-g was dropped: the app installs with no permissions"`
+     * — a failure message that describes the *correct* behaviour as a bug, which is exactly why the
+     * suite stayed green over a privacy defect.
+     *
+     * Permissive, so opt-in, and the same shape as [`downgrade is opt-in`] one test below.
+     */
+    @Test
+    fun `granting every requested permission is opt-in`() {
+        assertFalse(
+            "-g appeared without being asked for: this is GH#445",
+            command().contains(" -g")
+        )
+        assertTrue(command(grantAllPermissions = true).contains(" -g"))
+    }
+
+    /**
+     * The grant, when it is asked for, has to be a parameter of the *session*.
+     *
+     * Same reason `-r` is checked on the create line: `install-write` and `install-commit` take the
+     * session as given. A `-g` that landed on either would be dropped without a word, and the toggle
+     * would read as on while granting nothing.
+     */
+    @Test
+    fun `the grant flag is set when the session is created`() {
+        val script = command(grantAllPermissions = true)
+        val createLine = script.lineSequence().first { it.startsWith("CREATE_OUT=") }
+        assertTrue(createLine.contains(" -g"))
+        assertFalse(
+            script.lineSequence().any { !it.startsWith("CREATE_OUT=") && it.contains(" -g") }
+        )
     }
 
     /** `-d` is permissive-only, so it must appear exactly when it was asked for and never otherwise. */
@@ -197,23 +234,34 @@ class InstallSessionCommandsTest {
      * The same fusion hazard the deleted `installCommand` guarded against, which the root script
      * did not. `getInstallerArg()` returns `" -i com.android.vending"` with a leading space; a
      * caller passing it trimmed — or a future `getInstallerArg` that stops padding — would emit
-     * `-g-i com.android.vending`, which `pm` answers with a usage error that surfaces to the user as
+     * `-r-i com.android.vending`, which `pm` answers with a usage error that surfaces to the user as
      * a plain install failure with no hint that the attribution flag is what broke it.
+     *
+     * Checked with the grant both off and on, because the flag `-i` follows is no longer a constant:
+     * it is `-g` when the user has opted in and `-r` when they have not, so a re-spacing that only
+     * held in one of the two would break on whichever half nobody tested.
      */
     @Test
     fun `the installer attribution cannot fuse onto the preceding flag`() {
-        val padded = command(installerArg = playInstallerArg)
-        val trimmed = command(installerArg = playInstallerArg.trim())
+        for (grant in listOf(false, true)) {
+            val padded = command(grantAllPermissions = grant, installerArg = playInstallerArg)
+            val trimmed =
+                command(grantAllPermissions = grant, installerArg = playInstallerArg.trim())
 
-        assertEquals(padded, trimmed)
-        assertFalse("the -i argument fused onto -g", padded.contains("-g-i"))
-        assertTrue(padded.contains(" -i com.android.vending "))
+            assertEquals(padded, trimmed)
+            assertFalse("the -i argument fused onto -r", padded.contains("-r-i"))
+            assertFalse("the -i argument fused onto -g", padded.contains("-g-i"))
+            assertTrue(padded.contains(" -i com.android.vending "))
+        }
     }
 
     /** Auto-reinstall off is the default, and must add nothing at all — not even a stray space. */
     @Test
     fun `no installer argument means no installer argument`() {
-        assertTrue(command().contains("pm install-create -r -g --user 10 2>&1"))
+        assertTrue(command().contains("pm install-create -r --user 10 2>&1"))
+        assertTrue(
+            command(grantAllPermissions = true).contains("pm install-create -r -g --user 10 2>&1")
+        )
     }
 
     // --- the failure handling that keeps a failure legible and a session from leaking ---
@@ -336,6 +384,12 @@ class InstallSessionCommandsTest {
      * Spelled out in full rather than asserted piecewise on purpose. Everything above checks one
      * property at a time and would pass for a script that satisfied all of them separately while
      * being a different script; this is the one place the whole thing is visible at once.
+     *
+     * Asserted with `grantAllPermissions = true` because that — and only that — is what the hand-
+     * built script did. GH#445 made the grant a user setting; opting into it must still produce the
+     * historical script character for character, so the toggle stays a toggle and does not quietly
+     * become a second install path. The default form is pinned by
+     * [`the same script without the permission grant`] below, and the two differ by ` -g` alone.
      */
     @Test
     fun `the script the root gateway used to build by hand`() {
@@ -343,6 +397,39 @@ class InstallSessionCommandsTest {
             (
             set -o pipefail
             CREATE_OUT=${'$'}(pm install-create -r -g --user 0 2>&1)
+            SID=${'$'}(printf '%s\n' "${'$'}CREATE_OUT" | sed -n 's/.*\[\([0-9]*\)\].*/\1/p')
+            if [ -z "${'$'}SID" ]; then echo "pm install-create failed: ${'$'}CREATE_OUT" 1>&2; exit 101; fi
+            WERR=${'$'}(cat '/data/cache/install/base.apk' | pm install-write -S 4096 "${'$'}SID" 'base.apk' - 2>&1 1>/dev/null) || { pm install-abandon "${'$'}SID" 2>/dev/null; echo "pm install-write failed: ${'$'}WERR" 1>&2; exit 102; }
+            COMMIT=${'$'}(pm install-commit "${'$'}SID" 2>&1)
+            case "${'$'}COMMIT" in
+              *Success*) exit 0 ;;
+              *) pm install-abandon "${'$'}SID" 2>/dev/null; echo "pm install-commit failed: ${'$'}COMMIT" 1>&2; exit 103 ;;
+            esac
+            )
+
+        """.trimIndent()
+
+        assertEquals(
+            expected,
+            installViaSessionCommand(listOf(base), userId = 0, grantAllPermissions = true)
+        )
+    }
+
+    /**
+     * What Thor actually runs now, spelled out for the same reason as the test above: the default is
+     * the path essentially every install takes, so it is the one that has to be legible at a glance.
+     *
+     * Pinned as a whole script rather than as "the other one minus `-g`" so that a change to the
+     * grant cannot be mistaken for a change to anything else. The `-r` is still there — an update
+     * still replaces the installed package, and replacing it does not disturb permissions the user
+     * had already granted, which is the half of GH#445 that had to keep working.
+     */
+    @Test
+    fun `the same script without the permission grant`() {
+        val expected = """
+            (
+            set -o pipefail
+            CREATE_OUT=${'$'}(pm install-create -r --user 0 2>&1)
             SID=${'$'}(printf '%s\n' "${'$'}CREATE_OUT" | sed -n 's/.*\[\([0-9]*\)\].*/\1/p')
             if [ -z "${'$'}SID" ]; then echo "pm install-create failed: ${'$'}CREATE_OUT" 1>&2; exit 101; fi
             WERR=${'$'}(cat '/data/cache/install/base.apk' | pm install-write -S 4096 "${'$'}SID" 'base.apk' - 2>&1 1>/dev/null) || { pm install-abandon "${'$'}SID" 2>/dev/null; echo "pm install-write failed: ${'$'}WERR" 1>&2; exit 102; }

--- a/app/src/test/java/com/valhalla/thor/data/source/local/InstallSessionCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/InstallSessionCommandsTest.kt
@@ -354,7 +354,11 @@ class InstallSessionCommandsTest {
     @Test
     fun `paths are escaped here, and only here`() {
         val awkward = SessionApk("/data/cache/it's here/base.apk", sizeBytes = 1)
-        val script = installViaSessionCommand(listOf(awkward), userId = 0)
+        val script = installViaSessionCommand(
+            listOf(awkward),
+            userId = 0,
+            grantAllPermissions = false,
+        )
 
         assertTrue(
             "single quotes in a path must be neutralised, not passed through: $script",
@@ -370,7 +374,7 @@ class InstallSessionCommandsTest {
      */
     @Test(expected = IllegalArgumentException::class)
     fun `an install with no APK is refused`() {
-        installViaSessionCommand(emptyList(), userId = 0)
+        installViaSessionCommand(emptyList(), userId = 0, grantAllPermissions = false)
     }
 
     // --- the extraction is behaviour-preserving for the one rung that already worked ---
@@ -416,8 +420,9 @@ class InstallSessionCommandsTest {
     }
 
     /**
-     * What Thor actually runs now, spelled out for the same reason as the test above: the default is
-     * the path essentially every install takes, so it is the one that has to be legible at a glance.
+     * What Thor actually runs now, spelled out for the same reason as the test above: with the
+     * setting off and the installer's box unticked this is the path essentially every install takes,
+     * so it is the one that has to be legible at a glance.
      *
      * Pinned as a whole script rather than as "the other one minus `-g`" so that a change to the
      * grant cannot be mistaken for a change to anything else. The `-r` is still there — an update
@@ -442,6 +447,9 @@ class InstallSessionCommandsTest {
 
         """.trimIndent()
 
-        assertEquals(expected, installViaSessionCommand(listOf(base), userId = 0))
+        assertEquals(
+            expected,
+            installViaSessionCommand(listOf(base), userId = 0, grantAllPermissions = false),
+        )
     }
 }

--- a/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/PerUserCommandsTest.kt
@@ -225,9 +225,11 @@ class PerUserCommandsTest {
 
     // `installCommand` used to be tested here, across ten cases. It is gone, and so are they —
     // its invariants moved to `InstallSessionCommandsTest` along with the builder that replaced it,
-    // `installViaSessionCommand`. That file asserts the same `--user`, the same constant `-r -g`,
-    // the same opt-in `-d`, the same installer-argument fusion guard, the same path ordering and the
-    // same refusal of an empty set.
+    // `installViaSessionCommand`. That file asserts the same `--user`, the same constant `-r`, the
+    // same opt-in `-d`, the same installer-argument fusion guard, the same path ordering and the
+    // same refusal of an empty set. One invariant did not survive the move intact: `-g` used to be
+    // as constant as `-r` and is now opt-in per GH#445, so it is asserted there the way `-d` is,
+    // absent unless asked for.
     //
     // Worth recording why the move happened, because these tests were green the whole time. They
     // pinned `pm install-multiple --user 10 -r -g …` exactly, character for character — and

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -629,6 +629,18 @@ class FakePreferenceRepository(
 
     override suspend fun getInstallerArg(): String = ""
 
+    override suspend fun setGrantAllPermissionsOnInstall(enabled: Boolean) {
+        write { it.copy(grantAllPermissionsOnInstall = enabled) }
+    }
+
+    // Reads the stored value rather than returning a constant `false`: this is the seam GH#445 ran
+    // through, so a fake that answers "no" whatever was written would let a caller that never
+    // forwards the preference pass every test. Straight off `prefs` rather than through
+    // `userPreferences`, which [firstReadDelayMs] can hold open — that delay models a slow *startup*
+    // read and has nothing to say about a one-shot read on the install path.
+    override suspend fun shouldGrantAllPermissionsOnInstall(): Boolean =
+        prefs.value.grantAllPermissionsOnInstall
+
     override suspend fun setAppInfoActionsOrder(order: List<AppInfoActionId>) {
         write { it.copy(appInfoActionsOrder = order) }
     }


### PR DESCRIPTION
Fixes #445.

## The bug

Every privileged install built `pm install-create -r -g`. `-g` is
`INSTALL_GRANT_ALL_REQUESTED_PERMISSIONS`: the package comes up with location,
contacts, microphone and everything else it declares already granted, with no
prompt. The platform installer never does this, so the grant was invisible —
nothing in the UI said it had happened, and the only place it showed up was the
app's own permission screen after the fact. That is how the reporter found it,
after data had already reached three proprietary apps.

There is exactly one such site in the app. Checked and cleared, for the record:
`DhizukuSystemGateway`'s `pm install -r -d -i …` has no `-g`;
`InstallerRepositoryImpl`'s `SessionParams(MODE_FULL_INSTALL)` sets no grant
flag; `ShizukuReflector`'s `installFlags = 0x00400000` is
`INSTALL_ALL_WHITELIST_RESTRICTED_PERMISSIONS` on `installExistingPackage`, not
an install-time grant.

## What this does

Two controls, and the relationship between them is the design.

**The default** — `UserPreferences.grantAllPermissionsOnInstall`, **off**,
surfaced as a switch under **Settings → Installing**, below Auto Reinstall. The
row is gated on `hasPrivilege`: with no privilege every install goes through the
system installer, which asks the ordinary way and has never taken orders from
this toggle, and a live-looking switch there would read as "Thor is granting
everything and I cannot stop it".

Off by default is the fix, not a preference of mine: on by default would leave
the reported leak live for everyone who never finds the switch.

**The per-install answer** — a checkbox in the portable installer, seeded from
the setting, that the user may flip for that install alone. A default is the
wrong shape for a question whose right answer changes per APK: the person
restoring a hundred apps wants the grant, the same person sideloading one
unknown APK does not. It never writes back to DataStore — a decision about one
APK must not quietly become the rule for every install after it.

It renders only for ROOT/SHIZUKU/DHIZUKU. NORMAL hands the APK to the platform
installer, which asks for permissions its own way, and EXTERNAL has no session
to flag; a checkbox there would be a control over nothing.

`-r` on its own does not touch permissions already granted, so an update keeps
what the user had chosen. Dropping `-g` costs nothing on the update path and
only stops the silent grant on the new-install one — which is what the reporter
asked for.

## The nullable is the invariant

The answer travels as `Boolean?`. `null` means **nobody was asked** — a bulk
restore, a background job, an archive restore with no UI in front of it — and
every rung resolves it with `?: shouldGrantAllPermissionsOnInstall()`.

Collapsing that to `== true` or `?: false` would read a missing answer as a
refusal and override a user who had deliberately turned the setting on. That is
the one way this change could reintroduce a silent decision after #445 removed
one, so the forbidden forms are asserted against rather than left to review.

Same reason `startInstallation()` sends `_grantAllOverride.value` and not the
resolved `grantAllPermissions.value`: the latter is a `WhileSubscribed`
StateFlow, so with no live collector it holds its `false` initial value, and
sending that would turn "never answered" into "said no".

And the same reason `parsePackage()` resets the override to `null`. One
`InstallerViewModel` outlives one pick — it already cancels the previous
analysis and discards its staged copy there, and `BackupRestoreHubScreen`
parses through a single instance from two places — so without the reset a
ticked box carried "grant everything" from an APK the user trusted onto the
next one they had not looked at yet. (Found by CodeRabbit.)

`installViaSessionCommand`'s `grantAllPermissions` is **required, with no
default**, as is `ShizukuReflector.installPackage`'s. Both used to carry
`= false` under a KDoc telling callers never to rely on it, which is a rule a
reviewer enforces rather than the compiler. That the default pointed the safe
way is not the point: a caller that silently takes `false` overrides a user who
turned the setting on.

## A sixth call site the first fix had missed

The new sweep caught one: `ShizukuReflector.installPackage` builds its own
install command and was taking the new `grantAllPermissions = false` default,
so it ignored the setting outright. It has no callers today, which is exactly
why it would have stayed wrong — nothing would have surfaced it. Its parameter
is now required and undefaulted, so no future caller can inherit a silent
answer.

## Scope note: the fallback rung is deliberately not wired

`InstallerRepositoryImpl`'s `PackageInstaller.SessionParams` path — the
fallback, reached only when the shell rung returns false — ignores both
controls. `SessionParams` exposes no public grant flag (the shell's `-g` is a
bit in the hidden `installFlags` field), `Bypass` has no `setField`, and a
session created with a flag the caller may not set fails outright rather than
degrading. Wiring it would turn a convenience toggle into an install that stops
working. That rung has never granted anything and is not the rung #445 was
about. Consequence, documented in a comment there: with the toggle on or the
box ticked, a package that lands on the fallback comes up ungranted.

## Tests

Two tests asserted the defect. One failed with `"-g was dropped: the app
installs with no permissions"` — describing the correct behaviour as a bug,
which is exactly why the suite stayed green over a privacy hole. That assertion
is now inverted into `granting every requested permission is opt-in`, and the
golden root-script test keeps its byte-for-byte guarantee by passing
`grantAllPermissions = true`, with a sibling golden pinning the new default
form.

`grantAllPermissions` sits **before** `installerArg` in the signature on
purpose: the pre-existing positional call in the test helper then fails to
compile rather than silently binding a `String` to the new `Boolean`.

`InstallGrantCallSitesTest` is a source-text sweep in the house style of
`ObserverCallSitesTest`. `InstallerViewModel` takes an abstract `PackageManager`
and the module has no mocking library, so it is not JVM-constructible; the sweep
is what there is instead of pretending behavioural coverage exists. It pins all
six call sites, forbids the collapsing forms, requires the one site that cannot
read the setting to demand an answer instead of inventing one, and asserts the
installer never writes the preference. Three anti-vacuity tests keep it from
passing by finding nothing — it earned its place on the first run by failing on
`ShizukuReflector`.

## Verification

- `:app:testFossDebugUnitTest --rerun-tasks` — **1790 tests, 0 failures, 0
  errors, 0 skipped** (counts parsed from `build/test-results/**/*.xml`)
- `:app:lintStoreRelease` — BUILD SUCCESSFUL, no `MissingTranslation`
- Strings added and reworded in all eight in-app locales
  (`en ar es fr pl pt pt-rBR zh-rCN`)
- Not device-tested; the install rungs need real privilege.

## Not in this PR

The reporter's third suggestion — a one-time popup on the next update asking
users to review permissions granted while the bug was live — is a separate
scope call and is left for @trinadhthatakula to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
