### PR TITLE
fix(privilege): exclude broker authorization self-grants

### DIFF
--- a/app/src/main/java/com/valhalla/thor/domain/model/SelfPermissions.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/SelfPermissions.kt
@@ -3,6 +3,13 @@
 
 package com.valhalla.thor.domain.model
 
+/** Permissions that authorize Thor to use a separate privilege broker's API. */
+private val BROKER_AUTHORIZATION_PERMISSIONS = setOf(
+    "moe.shizuku.manager.permission.API_V23",
+    "shizuku.permission.API_V23",
+    "com.rosan.dhizuku.permission.API",
+)
+
 /**
  * What the running OS says about one permission **Thor's own manifest declares**.
  *
@@ -67,14 +74,15 @@ data class SelfGrantPlan(
 /**
  * Which of Thor's own declared permissions a privileged `pm grant` could actually change.
  *
- * **The device is asked, and no name is hardcoded.** Thor's manifest is the input, so a permission
- * added to it later is covered without a second edit here — the failure mode of a hand-kept list is
- * that the list and the manifest agree on the day they are written and never again. It also means
- * the answer is honest per device rather than per build: on a Pixel this returns
- * `POST_NOTIFICATIONS` alone, on HyperOS it returns that and
+ * The device classifies ordinary manifest declarations, so adding an ordinary runtime permission
+ * later is covered without a second edit here. Broker authorization permissions are the narrow
+ * exception: their names are excluded because they authorize Thor to use another app's API and must
+ * go through that broker's explicit consent flow. The remaining answer is honest per device rather
+ * than per build: on a Pixel this returns `POST_NOTIFICATIONS` alone, on HyperOS it returns that and
  * [GET_INSTALLED_APPS_PERMISSION], and on API 28 it returns neither of them.
  *
- * The three rejections all exist because `pm grant` *fails* on them, and a privileged command issued
+ * The four rejections all exist because `pm grant` is either invalid or semantically wrong for them,
+ * and a privileged command issued
  * once per attempt per permission is not free — it is a round trip through the root shell or the
  * Shizuku binder, on a path that runs while the user is waiting for the app list:
  *
@@ -89,6 +97,9 @@ data class SelfGrantPlan(
  *    app-op the user toggles under "Install unknown apps". Sending either to `pm grant` would be a
  *    guaranteed failure wearing the shape of a real attempt.
  * 3. **Already held.** Re-granting is a no-op that still costs the round trip.
+ * 4. **Broker authorization.** Shizuku and Dhizuku grant access through their own explicit consent
+ *    APIs. A Root fallback can execute Thor's action without either authorization, but must not use
+ *    that unrelated privilege to grant access to another broker silently.
  *
  * A [SelfPermissionDeclaration.Unknown] is not a rejection: it is left out of [toGrant] *and*
  * recorded in [SelfGrantPlan.hasUnanswered], so the run can be repeated.
@@ -112,7 +123,11 @@ fun planSelfGrant(permissions: List<SelfPermission>): SelfGrantPlan {
             SelfPermissionDeclaration.Unknown -> hasUnanswered = true
             SelfPermissionDeclaration.Undefined -> Unit
             is SelfPermissionDeclaration.Declared -> {
-                if (declaration.permission.isDangerous && !permission.isGranted) {
+                if (
+                    declaration.permission.isDangerous &&
+                    !permission.isGranted &&
+                    permission.name !in BROKER_AUTHORIZATION_PERMISSIONS
+                ) {
                     toGrant += permission.name
                 }
             }

--- a/app/src/test/java/com/valhalla/thor/domain/model/SelfPermissionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/SelfPermissionsTest.kt
@@ -17,9 +17,10 @@ import org.junit.Test
  * already-held one succeeds while changing nothing. All three cost a round trip through the root
  * shell or the Shizuku binder, on a path that runs while the user is waiting for the app list.
  *
- * The device is asked and no name is hardcoded in the production rule, so the interesting cases here
- * are whole devices rather than single permissions: the same Thor manifest yields one grant on a
- * Pixel, two on HyperOS and none on API 28. Pure for the usual reason — `PackageManager` is abstract
+ * The device classifies ordinary permissions dynamically, so the interesting cases here are whole
+ * devices rather than single permissions: the same Thor manifest yields one grant on a Pixel, two on
+ * HyperOS and none on API 28. Broker authorization permissions are the explicit exception because
+ * they belong to their brokers' consent flows. Pure for the usual reason — `PackageManager` is abstract
  * and `:app` has no mocking library by policy — so "a HyperOS device on Android 13" is nothing more
  * exotic here than a list of [SelfPermission].
  */
@@ -32,6 +33,9 @@ class SelfPermissionsTest {
     private val queryAllPackages = "android.permission.QUERY_ALL_PACKAGES"
     private val packageUsageStats = "android.permission.PACKAGE_USAGE_STATS"
     private val requestInstallPackages = "android.permission.REQUEST_INSTALL_PACKAGES"
+    private val legacyShizukuApi = "shizuku.permission.API_V23"
+    private val shizukuApi = "moe.shizuku.manager.permission.API_V23"
+    private val dhizukuApi = "com.rosan.dhizuku.permission.API"
 
     /** Defined by this OS, `dangerous`, and therefore requestable — the only grantable shape. */
     private fun runtime(name: String, granted: Boolean = false) = SelfPermission(
@@ -129,6 +133,39 @@ class SelfPermissionsTest {
         )
         assertTrue(plan.toGrant.isEmpty())
         assertFalse(plan.hasUnanswered)
+    }
+
+    @Test
+    fun legacyShizukuBrokerAuthorizationIsNotSelfGrantable() {
+        val plan = planSelfGrant(
+            listOf(
+                runtime(legacyShizukuApi),
+                runtime(postNotifications),
+            )
+        )
+        assertEquals(listOf(postNotifications), plan.toGrant)
+    }
+
+    @Test
+    fun shizukuBrokerAuthorizationIsNotSelfGrantable() {
+        val plan = planSelfGrant(
+            listOf(
+                runtime(shizukuApi),
+                runtime(postNotifications),
+            )
+        )
+        assertEquals(listOf(postNotifications), plan.toGrant)
+    }
+
+    @Test
+    fun dhizukuBrokerAuthorizationIsNotSelfGrantable() {
+        val plan = planSelfGrant(
+            listOf(
+                runtime(dhizukuApi),
+                runtime(postNotifications),
+            )
+        )
+        assertEquals(listOf(postNotifications), plan.toGrant)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- I prevent Root-backed self-grants from silently authorizing Shizuku or Dhizuku broker APIs.
- I preserve ordinary privileged self-grants such as notification permission.
- I cover the current Shizuku permission, Thor's legacy manifest declaration, and Dhizuku authorization with exact regression tests.

## Root cause

`SelfPermissionGranter` planned every unheld dangerous manifest permission for `pm grant`. Because Shizuku contributes `moe.shizuku.manager.permission.API_V23` through its manifest, a privilege-state refresh could let Root grant Shizuku access without the broker's explicit consent flow.

## Verification

- Focused RED reproduced the real Shizuku permission entering `toGrant`.
- Focused GREEN: 12/12 tests.
- Full forced JVM suite: 1,793 tests, 0 failures/errors/skips.
- `assembleFossDebug`: successful.
- Independent scoped re-review: no remaining actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic permission grants for Shizuku and Dhizuku broker authorization permissions.
  * Continued allowing eligible ordinary runtime permissions to be granted as expected.
  * Clarified permission handling for device-dependent and broker-specific authorization cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->