### PR TITLE
chore(web): sync merged Dependabot updates into dev

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3124,16 +3124,16 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+      "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
+        "css-what": "^7.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "nth-check": "^2.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
@@ -3153,9 +3153,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+      "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -4980,18 +4980,18 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+      "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
-        "css-select": "^5.1.0",
+        "css-select": "^6.0.0",
         "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
+        "css-what": "^7.0.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
+        "sax": "1.6.1"
       },
       "bin": {
         "svgo": "bin/svgo.js"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/mdx": "^8.0.0",
         "@astrojs/sitemap": "^3.7.4",
-        "astro": "^7.2.10"
+        "astro": "^7.3.2"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
@@ -2819,14 +2819,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.2.10",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.10.tgz",
-      "integrity": "sha512-uPtD+nK6kQXugyq4kiMPwj9OI3Sae6HSerA5X+fuv2CPaDwxmokFPPFlGRKIAXH0QAKu+zot2q6yrLG61wFmqg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.3.2.tgz",
+      "integrity": "sha512-ysTcdpGP61XZpHoMRYC/CK19DQ94qkBvzXMtXEo0gEqPNkmOU/Tv++CtWmzaI4nF2Ck8RXFdiWvdlTWa2oOr9w==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.4.0",
         "@astrojs/internal-helpers": "0.11.0",
-        "@astrojs/markdown-satteri": "0.4.0",
+        "@astrojs/markdown-satteri": "0.4.1",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2876,7 +2876,7 @@
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
-        "zod": "^4.3.6"
+        "zod": "^4.5.4"
       },
       "bin": {
         "astro": "bin/astro.mjs"
@@ -2900,6 +2900,18 @@
         "@astrojs/markdown-remark": {
           "optional": true
         }
+      }
+    },
+    "node_modules/astro/node_modules/@astrojs/markdown-satteri": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.1.tgz",
+      "integrity": "sha512-EniHbFNa6SQHDih7JnpPos3NWXO6hdt4raBcOosfGmlfc3gP9CI/sESA3VOf1PgJZ7SFfewlZW9Livn0JugEZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "satteri": "^0.10.3"
       }
     },
     "node_modules/axe-core": {
@@ -3774,9 +3786,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -6171,9 +6183,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@astrojs/mdx": "^8.0.0",
     "@astrojs/sitemap": "^3.7.4",
-    "astro": "^7.2.10"
+    "astro": "^7.3.2"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",


### PR DESCRIPTION
## Summary

Bring the missing web Dependabot updates merged into `master` back to `dev`, without merging unrelated release-branch changes or downgrading newer dependencies already on `dev`.

- Backport svgo 4.1.0 from #460 with the original commit provenance.
- Adapt #462: Astro 7.3.2 and js-yaml 4.3.2, including Astro's required markdown-satteri 0.4.1 and zod 4.5.4 dependencies.
- Retain sharp 0.35.4 and fast-uri 3.1.7, which were already present on `dev`.
- Preserve `dev`'s newer MDX 8.0.0, sitemap 3.7.4, and Node types 26.4.1.

Only `web/package.json` and `web/package-lock.json` change. No Android dependencies, version codes, release metadata, or ongoing feature work are included.

## Verification

- `npm ci`
- `npm run check:types`: 55 files, zero errors/warnings/hints.
- `npm run build`: link, content-claim, markup, sitemap, and screenshot checks pass.
- `npm test`: 304 tests across 17 files pass.
- `npm run check:a11y`: 11 pages, zero failing nodes.
- `npm audit`: zero vulnerabilities.
- `./gradlew test lintFossDebug lintStoreRelease --no-parallel --max-workers=1 '-Pkotlin.daemon.jvmargs=-Xmx4g -XX:+UseG1GC'`: passes with JDK 21; zero lint errors or MissingTranslation findings. Existing lint warnings remain (66 FOSS / 53 Store). Android unit-test results were reused from the valid Gradle build cache.
- `git diff --check`

The first parallel Android gate attempt exhausted the default Kotlin compiler heap. The serial rerun with a command-line-only 4 GiB compiler heap passed; no project build settings were changed.

No merge or deployment is performed by this PR preparation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Astro framework dependency to version 7.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->