### PR TITLE
feat: add consent-controlled legacy APK installs and clearer settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       maven:
         patterns:
           - "*"
+    ignore:
+      # alpha27 removed the ToggleButtonDefaults method used by Asgard 2.0.0 and
+      # reintroduced a startup crash after the earlier alpha26 compatibility pin.
+      # Keep this exact-version exclusion until Asgard is compatible; other updates
+      # remain eligible and must pass the connected-button UI regression tests.
+      - dependency-name: "androidx.compose.material3:material3"
+        versions: [ "1.5.0-alpha27" ]
 
   # Keep GitHub Actions versions current/patched (esp. actions used in the
   # keystore-bearing release workflows). Grouped into one weekly PR.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -397,7 +397,11 @@ dependencies {
     implementation(libs.androidx.compose.animation)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
+    implementation(libs.androidx.material3) {
+        // Do not let a BOM/transitive update silently replace Asgard's compatible runtime ABI.
+        version { strictly(libs.versions.material3.get()) }
+        because("Asgard 2.0.0 calls ToggleButtonDefaults.toggleButtonColors, removed in alpha27")
+    }
     implementation(libs.androidx.material.icons.extended)
     testImplementation(libs.junit)
     testImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
+++ b/app/src/main/java/com/valhalla/thor/data/gateway/RootSystemGateway.kt
@@ -1297,8 +1297,15 @@ class RootSystemGateway internal constructor(
         canDowngrade: Boolean,
         grantAllPermissions: Boolean? = null,
         execution: PrivilegeExecutionContext = PrivilegeExecutionContext(),
+        bypassLowTargetSdkBlock: Boolean = false,
     ): Result<Unit> {
-        return installViaSession(apkPaths, canDowngrade, grantAllPermissions, execution)
+        return installViaSession(
+            apkPaths,
+            canDowngrade,
+            grantAllPermissions,
+            execution,
+            bypassLowTargetSdkBlock,
+        )
     }
 
     /**
@@ -1325,6 +1332,7 @@ class RootSystemGateway internal constructor(
         canDowngrade: Boolean,
         grantAllPermissions: Boolean?,
         execution: PrivilegeExecutionContext,
+        bypassLowTargetSdkBlock: Boolean = false,
     ): Result<Unit> {
         if (apkPaths.isEmpty()) {
             return Result.failure(Exception("No APK paths provided for install"))
@@ -1350,6 +1358,7 @@ class RootSystemGateway internal constructor(
                 grantAllPermissions = grantAllPermissions
                     ?: preferenceRepository.shouldGrantAllPermissionsOnInstall(),
                 installerArg = preferenceRepository.getInstallerArg(),
+                bypassLowTargetSdkBlock = bypassLowTargetSdkBlock,
             ),
             execution,
             INSTALL_SESSION,

--- a/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/AppAnalyzerImpl.kt
@@ -414,7 +414,11 @@ class AppAnalyzerImpl(
             version = archiveInfo.versionName ?: "Unknown",
             versionCode = archiveInfo.longVersionCode,
             iconPath = persistIcon(iconBitmap, archiveInfo.packageName, archiveInfo.longVersionCode),
-            permissions = archiveInfo.requestedPermissions?.toList() ?: emptyList()
+            permissions = archiveInfo.requestedPermissions?.toList() ?: emptyList(),
+            // [archiveInfo] was parsed from bundleFile itself for a monolithic APK, or from the
+            // selected identity candidate extracted from that same staged bundle. Never source
+            // this security-sensitive policy input from manifest.json/info.json sidecars.
+            targetSdk = parsedArchiveTargetSdk(archiveInfo),
         )
     }
 
@@ -474,6 +478,15 @@ class AppAnalyzerImpl(
         return bitmap
     }
 }
+
+/**
+ * Reads the target SDK only from Android's parsed APK representation.
+ *
+ * Kept separate from sidecar parsing so policy callers cannot accidentally substitute an archive
+ * manifest's JSON declaration for the APK that the installer will receive.
+ */
+internal fun parsedArchiveTargetSdk(archiveInfo: PackageInfo): Int? =
+    archiveInfo.applicationInfo?.targetSdkVersion
 
 /** How long a staged input may sit unclaimed before the next analysis reclaims its disk. */
 internal const val STAGED_PACKAGE_TTL_MILLIS = 60L * 60L * 1000L

--- a/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/InstallerRepositoryImpl.kt
@@ -30,6 +30,7 @@ import com.valhalla.thor.domain.InstallerEventBus
 import com.valhalla.thor.domain.model.ObbPlacement
 import com.valhalla.thor.domain.model.PrivilegeExecutionContext
 import com.valhalla.thor.domain.model.StagedPackage
+import com.valhalla.thor.domain.model.supportsLowTargetSdkBypass
 import com.valhalla.thor.domain.repository.InstallMode
 import com.valhalla.thor.domain.repository.InstallerRepository
 import com.valhalla.thor.util.UiText
@@ -83,7 +84,7 @@ class InstallerRepositoryImpl(
     @Named("io") private val ioDispatcher: CoroutineDispatcher,
     // Only installWithExternal() uses this: handing the URI to the system's installer chooser is a
     // UI hand-off, so it stays on main. Note this is plain Main, not Main.immediate.
-    @Named("main") private val mainDispatcher: CoroutineDispatcher
+    @Named("main") private val mainDispatcher: CoroutineDispatcher,
 ) : InstallerRepository {
 
     // The in-process installer. Its sessions are created by Thor's own uid, so the platform's
@@ -91,6 +92,11 @@ class InstallerRepositoryImpl(
     // for by name rather than arrived at by leaving an argument off.
     private val defaultInstaller =
         InstallerHandle.unprivileged(context.packageManager.packageInstaller)
+
+    /** Narrow test seam for the shell result; production retains [ShizukuHelper.execute]. */
+    internal var executeShizukuShell: (String) -> Pair<Int, String?> = { command ->
+        ShizukuHelper.execute(command)
+    }
 
     /**
      * Given an on-disk copy of the installer input, return the ordered list of APK
@@ -139,8 +145,18 @@ class InstallerRepositoryImpl(
         execution: PrivilegeExecutionContext,
         onInvocationStarted: () -> Unit,
         onInstallSucceeded: () -> Unit,
+        bypassLowTargetSdkBlock: Boolean,
     ) =
         withContext(ioDispatcher) {
+            if (
+                bypassLowTargetSdkBlock &&
+                !supportsLowTargetSdkBypass(mode, Build.VERSION.SDK_INT)
+            ) {
+                eventBus.emit(
+                    InstallState.Error(UiText.StringResource(R.string.legacy_install_unsupported))
+                )
+                return@withContext
+            }
             onInvocationStarted()
             try {
                 // Refuse before installing, not after. An archive whose game data cannot be placed
@@ -165,14 +181,25 @@ class InstallerRepositoryImpl(
                 when (mode) {
                     InstallMode.ROOT -> {
                         installWithRoot(
-                            staged, canDowngrade, grantAllPermissions, execution, onInstallSucceeded,
+                            staged,
+                            canDowngrade,
+                            grantAllPermissions,
+                            execution,
+                            onInstallSucceeded,
+                            bypassLowTargetSdkBlock,
                         )
                     }
 
                     InstallMode.SHIZUKU -> {
                         // 1. Try Shell command first
-                        val shellSuccess = try {
-                            installWithShizuku(staged, canDowngrade, grantAllPermissions, onInstallSucceeded)
+                        val shellAttempt = try {
+                            installWithShizuku(
+                                staged,
+                                canDowngrade,
+                                grantAllPermissions,
+                                onInstallSucceeded,
+                                bypassLowTargetSdkBlock,
+                            )
                         } catch (e: Throwable) {
                             if (e is CancellationException) throw e
                             // A refusal is a verdict about the archive, not a failure of this rung.
@@ -182,11 +209,23 @@ class InstallerRepositoryImpl(
                             // that make up the two ladders all do this; ROOT and NORMAL have no
                             // fallback and already propagate.
                             if (e is InstallRefusedException) throw e
-                            Logger.e("InstallerRepo", "Shizuku shell install failed with exception, trying reflection", e)
-                            false
+                            Logger.e("InstallerRepo", "Shizuku shell install failed with exception", e)
+                            ShizukuInstallAttempt(false, e.message)
                         }
 
-                        if (!shellSuccess) {
+                        if (!shellAttempt.succeeded) {
+                            if (bypassLowTargetSdkBlock) {
+                                eventBus.emit(
+                                    InstallState.Error(
+                                        UiText.DynamicString(
+                                            shellAttempt.failureReason
+                                                ?.takeIf { it.isNotBlank() }
+                                                ?: "Shizuku install failed"
+                                        )
+                                    )
+                                )
+                                return@withContext
+                            }
                             Logger.d("InstallerRepo", "Shizuku shell install failed. Trying reflection fallback...")
                             // 2. Try Reflection
                             val privilegedInstaller = try {
@@ -612,6 +651,7 @@ class InstallerRepositoryImpl(
         grantAllPermissions: Boolean?,
         execution: PrivilegeExecutionContext,
         onInstallSucceeded: () -> Unit,
+        bypassLowTargetSdkBlock: Boolean,
     ) {
         eventBus.emit(InstallState.Installing(0f))
 
@@ -635,13 +675,17 @@ class InstallerRepositoryImpl(
             val apkPaths = tempFiles.map { it.file.absolutePath }
             // The gateway resolves a null against the saved setting; this rung has no reason to
             // resolve it first, and doing so would put a second copy of that rule in the app.
-            val result = if (apkPaths.size == 1) {
+            val result = if (apkPaths.size == 1 && !bypassLowTargetSdkBlock) {
                 rootGateway.installApp(
                     apkPaths[0], canDowngrade, grantAllPermissions, execution,
                 )
             } else {
                 rootGateway.installMultipleApks(
-                    apkPaths, canDowngrade, grantAllPermissions, execution,
+                    apkPaths,
+                    canDowngrade,
+                    grantAllPermissions,
+                    execution,
+                    bypassLowTargetSdkBlock,
                 )
             }
 
@@ -659,12 +703,18 @@ class InstallerRepositoryImpl(
         }
     }
 
+    private data class ShizukuInstallAttempt(
+        val succeeded: Boolean,
+        val failureReason: String? = null,
+    )
+
     private suspend fun installWithShizuku(
         staged: StagedPackage,
         canDowngrade: Boolean,
         grantAllPermissions: Boolean?,
         onInstallSucceeded: () -> Unit,
-    ): Boolean {
+        bypassLowTargetSdkBlock: Boolean,
+    ): ShizukuInstallAttempt {
         eventBus.emit(InstallState.Installing(0f))
 
         // Shared storage, because the *shell* has to be able to read these files: uid 2000 cannot
@@ -687,7 +737,7 @@ class InstallerRepositoryImpl(
 
         if (tempFiles.isNullOrEmpty()) {
             tempDir.deleteRecursively()
-            return false
+            return ShizukuInstallAttempt(false, "Failed to extract or copy installation files")
         }
 
         eventBus.emit(InstallState.Installing(0.5f))
@@ -742,22 +792,23 @@ class InstallerRepositoryImpl(
                 canDowngrade = canDowngrade,
                 grantAllPermissions = grantAll,
                 installerArg = installerArg,
+                bypassLowTargetSdkBlock = bypassLowTargetSdkBlock,
             )
-            val result = ShizukuHelper.execute(integrityGuardedInstall(digests, command))
+            val result = executeShizukuShell(integrityGuardedInstall(digests, command))
 
             if (result.first == 0) {
                 onInstallSucceeded()
                 eventBus.emit(InstallState.Installing(1.0f))
                 eventBus.emit(InstallState.Success)
-                true
+                ShizukuInstallAttempt(true)
             } else {
                 Logger.e("InstallerRepo", "Shizuku shell install failed: ${result.second}")
-                false
+                ShizukuInstallAttempt(false, result.second)
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Logger.e("InstallerRepo", "Shizuku shell install failed with exception: ${e.message}", e)
-            false
+            ShizukuInstallAttempt(false, e.message)
         } finally {
             tempDir.deleteRecursively()
         }

--- a/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
+++ b/app/src/main/java/com/valhalla/thor/data/repository/PreferenceRepositoryImpl.kt
@@ -208,6 +208,7 @@ class PreferenceRepositoryImpl(
         // Installing
         val GRANT_ALL_PERMISSIONS_ON_INSTALL =
             booleanPreferencesKey("grant_all_permissions_on_install")
+        val ALLOW_LEGACY_APK_INSTALL = booleanPreferencesKey("allow_legacy_apk_install")
 
         // Customization
         val APP_INFO_ACTIONS_ORDER = stringPreferencesKey("app_info_actions_order")
@@ -433,6 +434,15 @@ class PreferenceRepositoryImpl(
 
     override suspend fun shouldGrantAllPermissionsOnInstall(): Boolean =
         userPreferences.first().grantAllPermissionsOnInstall
+
+    override suspend fun setAllowLegacyApkInstall(enabled: Boolean) {
+        context.dataStore.guardedWrite(SETTINGS_STORE) {
+            it[Keys.ALLOW_LEGACY_APK_INSTALL] = enabled
+        }
+    }
+
+    override suspend fun shouldAllowLegacyApkInstall(): Boolean =
+        userPreferences.first().allowLegacyApkInstall
 
     // --- Customization ---
 
@@ -675,6 +685,7 @@ internal fun Preferences.toUserPreferences(
         extensionConsentAccepted = prefs[Keys.EXTENSION_CONSENT_ACCEPTED] ?: false,
         autoReinstallEnabled = prefs[Keys.AUTO_REINSTALL_ENABLED] ?: false,
         grantAllPermissionsOnInstall = prefs[Keys.GRANT_ALL_PERMISSIONS_ON_INSTALL] ?: false,
+        allowLegacyApkInstall = prefs[Keys.ALLOW_LEGACY_APK_INSTALL] ?: false,
         exportDirUri = prefs[Keys.EXPORT_DIR_URI],
         appInfoActionsOrder = AppInfoActionId.fromSavedNamesOrDefault(
             prefs[Keys.APP_INFO_ACTIONS_ORDER]?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }

--- a/app/src/main/java/com/valhalla/thor/data/source/local/InstallSessionCommands.kt
+++ b/app/src/main/java/com/valhalla/thor/data/source/local/InstallSessionCommands.kt
@@ -100,6 +100,8 @@ internal const val SESSION_COMMIT_FAILED_EXIT_CODE = 103
  * @param installerArg the attribution flag, e.g. `" -i com.android.vending"`, with or without its
  *   leading space. Re-spaced here so it cannot fuse onto the flag before it — which used to be a
  *   constant `-g` and is now `-g` or `-r`, so the hazard did not go away with the constant.
+ * @param bypassLowTargetSdkBlock adds the shell-only Android 14+ low-target install bypass to
+ *   `install-create`. Callers must authorize it for the current execution mode before passing it.
  * @return a script whose exit code is 0 on success, or one of
  *   [SESSION_CREATE_FAILED_EXIT_CODE] / [SESSION_WRITE_FAILED_EXIT_CODE] /
  *   [SESSION_COMMIT_FAILED_EXIT_CODE], with the `pm` output on stderr.
@@ -110,18 +112,21 @@ internal fun installViaSessionCommand(
     canDowngrade: Boolean = false,
     grantAllPermissions: Boolean,
     installerArg: String = "",
+    bypassLowTargetSdkBlock: Boolean = false,
 ): String {
     require(apks.isNotEmpty()) { "installViaSessionCommand needs at least one APK" }
 
     val downgrade = if (canDowngrade) " -d" else ""
     val grant = if (grantAllPermissions) " -g" else ""
     val installer = installerArg.trim().let { if (it.isEmpty()) "" else " $it" }
+    val bypassLowTargetSdk = if (bypassLowTargetSdkBlock) " --bypass-low-target-sdk-block" else ""
 
     val sb = StringBuilder()
     sb.append("(\n")
     sb.append("set -o pipefail\n")
     sb.append("CREATE_OUT=\$(pm install-create -r").append(grant).append(installer)
-        .append(" --user ").append(userId).append(downgrade).append(" 2>&1)\n")
+        .append(bypassLowTargetSdk).append(" --user ").append(userId).append(downgrade)
+        .append(" 2>&1)\n")
     // install-create prints "Success: created install session [<id>]".
     sb.append("SID=\$(printf '%s\\n' \"\$CREATE_OUT\" | sed -n 's/.*\\[\\([0-9]*\\)\\].*/\\1/p')\n")
     sb.append("if [ -z \"\$SID\" ]; then echo \"pm install-create failed: \$CREATE_OUT\" 1>&2; exit ")

--- a/app/src/main/java/com/valhalla/thor/domain/model/AppMetadata.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/AppMetadata.kt
@@ -16,5 +16,13 @@ data class AppMetadata(
     val version: String,
     val versionCode: Long?,
     val iconPath: String?,
-    val permissions: List<String> = emptyList()
+    val permissions: List<String> = emptyList(),
+    /**
+     * The APK manifest's target SDK, or null when no APK could be parsed.
+     *
+     * This deliberately has no sidecar equivalent: bundle JSON is untrusted metadata and must not
+     * enable an install-policy exception. A parsed APK may legitimately report 0, which remains a
+     * known value rather than being rewritten to null.
+     */
+    val targetSdk: Int? = null,
 )

--- a/app/src/main/java/com/valhalla/thor/domain/model/LowTargetSdkInstallPolicy.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/LowTargetSdkInstallPolicy.kt
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import com.valhalla.thor.domain.repository.InstallMode
+
+/**
+ * Android's default target-SDK floor for new installs, not the APK's minSdkVersion.
+ * OEM package-manager restrictions can still differ; the installer must preserve their errors.
+ */
+internal fun minimumInstallTargetSdk(deviceSdk: Int): Int? = when {
+    deviceSdk >= 35 -> 24
+    deviceSdk == 34 -> 23
+    else -> null
+}
+
+/** Only shell/root can retain the bypass flag on production Android builds. */
+internal fun supportsLowTargetSdkBypass(mode: InstallMode, deviceSdk: Int): Boolean =
+    deviceSdk >= 34 && (mode == InstallMode.ROOT || mode == InstallMode.SHIZUKU)
+
+/** Unknown/sidecar-only metadata is not evidence on which to offer privileged consent. */
+internal fun requiresLowTargetSdkBypass(targetSdk: Int?, deviceSdk: Int): Boolean {
+    val minimum = minimumInstallTargetSdk(deviceSdk) ?: return false
+    return targetSdk != null && targetSdk in 0 until minimum
+}

--- a/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/model/UserPreferences.kt
@@ -97,6 +97,14 @@ data class UserPreferences(
      */
     val grantAllPermissionsOnInstall: Boolean = false,
 
+    /**
+     * Standing consent to bypass Android's low-target-SDK block in the interactive installer,
+     * without its extra confirmation. Off means ask before each eligible Root/Shizuku install.
+     * Background restore and reinstall paths keep their own explicit consent boundary and must
+     * not infer permission from this saved preference.
+     */
+    val allowLegacyApkInstall: Boolean = false,
+
     // Export destination (persisted SAF tree URI; null = default Downloads/Thor)
     val exportDirUri: String? = null,
 
@@ -116,5 +124,3 @@ data class UserPreferences(
      */
     val settingsLost: Boolean = false
 )
-
-

--- a/app/src/main/java/com/valhalla/thor/domain/repository/InstallerRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/InstallerRepository.kt
@@ -43,6 +43,9 @@ interface InstallerRepository {
      *   installer reports success, before publishing progress or placing OBB data. Invocation entry,
      *   global events and package presence are not proof. Session/external rungs do not call it: their
      *   asynchronous completion is not correlated here, so cancellation ownership stays unknown.
+     * @param bypassLowTargetSdkBlock requests Android's low-target SDK install bypass. It is valid
+     *   only for the Root and shell-backed Shizuku paths on Android 14 and later; unsupported modes
+     *   are rejected before the install starts.
      */
     suspend fun installPackage(
         staged: StagedPackage,
@@ -53,5 +56,6 @@ interface InstallerRepository {
         execution: PrivilegeExecutionContext = PrivilegeExecutionContext(),
         onInvocationStarted: () -> Unit = {},
         onInstallSucceeded: () -> Unit = {},
+        bypassLowTargetSdkBlock: Boolean = false,
     )
 }

--- a/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
+++ b/app/src/main/java/com/valhalla/thor/domain/repository/PreferenceRepository.kt
@@ -161,6 +161,15 @@ interface PreferenceRepository {
      */
     suspend fun shouldGrantAllPermissionsOnInstall(): Boolean
 
+    /** Persists the interactive installer's default for low-target-SDK bypass consent. */
+    suspend fun setAllowLegacyApkInstall(enabled: Boolean)
+
+    /**
+     * One-shot, fail-closed read of [UserPreferences.allowLegacyApkInstall] for the interactive
+     * installer only. Background installers must keep their explicit default of `false`.
+     */
+    suspend fun shouldAllowLegacyApkInstall(): Boolean
+
     // --- Customization ---
     suspend fun setAppInfoActionsOrder(order: List<AppInfoActionId>)
     suspend fun setAppInfoActionVisibility(actionId: AppInfoActionId, isVisible: Boolean)

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/InstallerViewModel.kt
@@ -5,14 +5,18 @@ package com.valhalla.thor.presentation.installer
 
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.valhalla.thor.domain.InstallState
 import com.valhalla.thor.domain.InstallerEventBus
 import com.valhalla.thor.domain.model.AnalyzedPackage
+import com.valhalla.thor.domain.model.AppMetadata
 import com.valhalla.thor.domain.model.PrivilegeExecutionException
 import com.valhalla.thor.domain.model.isVersionDowngrade
+import com.valhalla.thor.domain.model.requiresLowTargetSdkBypass
+import com.valhalla.thor.domain.model.supportsLowTargetSdkBypass
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.domain.repository.InstallMode
 import com.valhalla.thor.domain.repository.InstallerRepository
@@ -28,11 +32,15 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
 import org.koin.core.annotation.Named
+
+/** A warning is tied to one request, so an old dialog callback cannot approve another APK. */
+internal data class LegacyInstallConfirmation(val id: Long, val meta: AppMetadata)
 
 internal suspend fun runInstallerPresentationBoundary(
     eventBus: InstallerEventBus,
@@ -73,6 +81,29 @@ class InstallerViewModel(
     // touched it tracks Settings live rather than showing whatever the setting happened to say when
     // this screen opened.
     private val _grantAllOverride = MutableStateFlow<Boolean?>(null)
+
+    private val _legacyInstallConfirmation = MutableStateFlow<LegacyInstallConfirmation?>(null)
+    internal val legacyInstallConfirmation = _legacyInstallConfirmation.asStateFlow()
+
+    // Display only. The install decision reads the repository directly, never this potentially
+    // unsubscribed StateFlow's initial value or an old snapshot from when the sheet opened.
+    val allowLegacyApkInstall: StateFlow<Boolean> = preferenceRepository.userPreferences
+        .map { it.allowLegacyApkInstall }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    private data class InstallRequest(
+        val revision: Long,
+        val analysis: AnalyzedPackage,
+        val uri: Uri,
+        val mode: InstallMode,
+        val canDowngrade: Boolean,
+        val grantAllPermissions: Boolean?,
+    )
+
+    private var selectionRevision = 0L
+    private var nextConfirmationId = 0L
+    private var pendingLegacyRequest: InstallRequest? = null
+    private var installationJob: Job? = null
 
     /**
      * Whether this install will grant every runtime permission the package declares — the state of
@@ -129,6 +160,7 @@ class InstallerViewModel(
     private var ownsInstall = false
 
     fun resetState() {
+        invalidateLegacyConfirmation()
         viewModelScope.launch { eventBus.emit(InstallState.Idle) }
     }
 
@@ -156,6 +188,7 @@ class InstallerViewModel(
         // one instance repeatedly), so that is the ordinary path, not an edge case. Back to null
         // rather than false: the saved setting is what an unanswered install follows.
         _grantAllOverride.value = null
+        invalidateLegacyConfirmation()
         // A second pick replaces the first; the first's copy has no further use. Two things can
         // hold that copy, and both have to be released here.
         //
@@ -240,22 +273,63 @@ class InstallerViewModel(
     }
 
     fun setInstallMode(mode: InstallMode) {
+        if (mode != _installMode.value) invalidateLegacyConfirmation()
         _installMode.value = mode
+    }
+
+    private fun invalidateLegacyConfirmation() {
+        selectionRevision++
+        pendingLegacyRequest = null
+        _legacyInstallConfirmation.value = null
+    }
+
+    fun dismissLegacyInstallConfirmation(confirmationId: Long) {
+        if (_legacyInstallConfirmation.value?.id != confirmationId) return
+        pendingLegacyRequest = null
+        _legacyInstallConfirmation.value = null
+    }
+
+    /** Consumes this warning once, without ever changing the saved preference. */
+    fun confirmLegacyInstallation(confirmationId: Long) {
+        if (_legacyInstallConfirmation.value?.id != confirmationId) return
+        val request = pendingLegacyRequest ?: return
+        dismissLegacyInstallConfirmation(confirmationId)
+        if (!requestIsCurrent(request)) return
+        installationJob = viewModelScope.launch {
+            if (requestIsCurrent(request)) install(request, bypassLowTargetSdkBlock = true)
+        }
+    }
+
+    private fun requestIsCurrent(request: InstallRequest): Boolean =
+        request.revision == selectionRevision && request.analysis === analyzed &&
+            request.uri == pendingUri && request.mode == _installMode.value
+
+    private suspend fun install(request: InstallRequest, bypassLowTargetSdkBlock: Boolean) {
+        runInstallerPresentationBoundary(eventBus) {
+            repository.installPackage(
+                request.analysis.staged, request.uri, request.mode,
+                request.canDowngrade, request.grantAllPermissions,
+                bypassLowTargetSdkBlock = bypassLowTargetSdkBlock,
+            )
+        }
     }
 
     /**
      * Records the user's answer for this install only. Does not touch the saved setting.
      */
     fun setGrantAllPermissions(enabled: Boolean) {
+        if (enabled != _grantAllOverride.value) invalidateLegacyConfirmation()
         _grantAllOverride.value = enabled
     }
 
     fun startInstallation() {
+        // Repeated taps must not queue installs while the preference read or an install is active.
+        if (installationJob?.isActive == true || pendingLegacyRequest != null) return
         val uri = pendingUri ?: return
         // No staged copy means no analysis succeeded, and installing would mean reading the URI
         // a second time — the very thing the staging exists to prevent. There is nothing to
         // install here: the sheet only offers Install from ReadyToInstall.
-        val staged = analyzed?.staged ?: return
+        val analysis = analyzed ?: return
         ownsInstall = true
         val mode = _installMode.value
 
@@ -283,10 +357,32 @@ class InstallerViewModel(
         // setting that said yes. Passing null hands that resolution to the repository, which reads
         // the setting itself.
         val grantAll = _grantAllOverride.value
+        val request = InstallRequest(selectionRevision, analysis, uri, mode, allowDowngrade, grantAll)
+        val legacyInstall = supportsLowTargetSdkBypass(mode, Build.VERSION.SDK_INT) &&
+            requiresLowTargetSdkBypass(analysis.metadata.targetSdk, Build.VERSION.SDK_INT)
 
-        viewModelScope.launch {
-            runInstallerPresentationBoundary(eventBus) {
-                repository.installPackage(staged, uri, mode, allowDowngrade, grantAll)
+        installationJob = viewModelScope.launch {
+            val automaticallyAllowed = if (legacyInstall) {
+                try {
+                    withContext(ioDispatcher) { preferenceRepository.shouldAllowLegacyApkInstall() }
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (_: Exception) {
+                    // An unreadable setting is not standing consent. The ordinary warning remains
+                    // available even if a repository implementation fails outside its read guard.
+                    false
+                }
+            } else false
+            // The read may suspend while a new APK, mode, permission answer or dismissal supersedes
+            // this request. Never publish an old warning or install the old staged copy afterwards.
+            if (!requestIsCurrent(request)) return@launch
+            if (legacyInstall && !automaticallyAllowed) {
+                pendingLegacyRequest = request
+                _legacyInstallConfirmation.value = LegacyInstallConfirmation(
+                    ++nextConfirmationId, analysis.metadata,
+                )
+            } else {
+                install(request, bypassLowTargetSdkBlock = legacyInstall)
             }
         }
     }

--- a/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/installer/PortableInstaller.kt
@@ -7,6 +7,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -36,6 +37,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
@@ -52,6 +54,7 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SplitButtonDefaults
 import androidx.compose.material3.SplitButtonLayout
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -85,11 +88,95 @@ import com.valhalla.thor.data.manager.PendingInstallIntent
 import com.valhalla.thor.domain.InstallState
 import com.valhalla.thor.util.UiText
 import com.valhalla.thor.domain.repository.InstallMode
+import com.valhalla.thor.domain.model.minimumInstallTargetSdk
+import com.valhalla.thor.domain.model.requiresLowTargetSdkBypass
+import com.valhalla.thor.domain.model.supportsLowTargetSdkBypass
 import kotlinx.coroutines.delay
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import java.io.File
 import kotlin.time.Duration.Companion.milliseconds
+
+/** Explains when Android's low-target-SDK block applies to the selected package and installer. */
+@Composable
+internal fun LegacyInstallOptions(
+    meta: AppMetadata,
+    mode: InstallMode,
+    automaticallyAllowed: Boolean,
+    deviceSdk: Int = Build.VERSION.SDK_INT,
+) {
+    val targetSdk = meta.targetSdk ?: return
+    if (!requiresLowTargetSdkBypass(targetSdk, deviceSdk)) return
+    val minimum = minimumInstallTargetSdk(deviceSdk) ?: return
+    val supported = supportsLowTargetSdkBypass(mode, deviceSdk)
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f))
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(
+                R.string.legacy_install_description, meta.packageName, targetSdk, minimum,
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        if (supported && automaticallyAllowed) {
+            Text(
+                text = stringResource(R.string.legacy_install_allowed_by_setting),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else if (!supported) {
+            Text(
+                text = stringResource(R.string.legacy_install_unsupported),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** Package-specific, one-time consent requested by [InstallerViewModel] when installation starts. */
+@Composable
+internal fun LegacyInstallConfirmationDialog(
+    meta: AppMetadata,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    deviceSdk: Int = Build.VERSION.SDK_INT,
+) {
+    val targetSdk = meta.targetSdk ?: return
+    if (!requiresLowTargetSdkBypass(targetSdk, deviceSdk)) return
+    val minimum = minimumInstallTargetSdk(deviceSdk) ?: return
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.legacy_install_confirm_title)) },
+        text = {
+            Text(
+                text = stringResource(
+                    R.string.legacy_install_confirm_message,
+                    meta.label, meta.packageName, targetSdk, minimum,
+                ),
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.legacy_install_allow_once))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        },
+    )
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -101,6 +188,8 @@ fun PortableInstaller(
     val availableModes by viewModel.availableModes.collectAsStateWithLifecycle()
     val installerMode by viewModel.installMode.collectAsStateWithLifecycle()
     val grantAllPermissions by viewModel.grantAllPermissions.collectAsStateWithLifecycle()
+    val allowLegacyApkInstall by viewModel.allowLegacyApkInstall.collectAsStateWithLifecycle()
+    val legacyInstallConfirmation by viewModel.legacyInstallConfirmation.collectAsStateWithLifecycle()
 
     var lastMeta by remember { mutableStateOf<AppMetadata?>(null) }
     LaunchedEffect(state) {
@@ -117,6 +206,14 @@ fun PortableInstaller(
     )
     val context = LocalContext.current
     val pendingInstallIntent = koinInject<PendingInstallIntent>()
+
+    legacyInstallConfirmation?.let { confirmation ->
+        LegacyInstallConfirmationDialog(
+            meta = confirmation.meta,
+            onConfirm = { viewModel.confirmLegacyInstallation(confirmation.id) },
+            onDismiss = { viewModel.dismissLegacyInstallConfirmation(confirmation.id) },
+        )
+    }
 
     // Auto-start installation process if intent is present
     LaunchedEffect(Unit) {
@@ -550,6 +647,12 @@ fun PortableInstaller(
                             }
                         }
                     }
+
+                    LegacyInstallOptions(
+                        meta = s.meta,
+                        mode = installerMode,
+                        automaticallyAllowed = allowLegacyApkInstall,
+                    )
 
                     // Only for the rungs that can act on it. `-g` is a shell-install flag: in
                     // NORMAL mode the system installer asks for permissions its own way and has

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCatalog.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCatalog.kt
@@ -139,6 +139,11 @@ enum class SettingsRowId(
         R.string.grant_all_permissions,
         R.string.grant_all_permissions_desc,
     ),
+    ALLOW_LEGACY_APK_INSTALL(
+        SettingsCategory.INSTALLING,
+        R.string.allow_legacy_apk_install,
+        R.string.allow_legacy_apk_install_desc,
+    ),
     ANY_FILE_OPENER(
         SettingsCategory.INSTALLING,
         R.string.any_file_opener,

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsCategoryScreen.kt
@@ -371,7 +371,7 @@ fun SettingsCategoryScreen(
                     )
 
                     // ── Freezer ─────────────────────────────────────────────────────────────────
-                    SettingsRowId.AUTO_FREEZE -> SettingsSwitchRow(
+                    SettingsRowId.AUTO_FREEZE -> SettingsExpandedSwitchRow(
                         icon = R.drawable.frozen,
                         title = stringResource(R.string.auto_freeze),
                         subtitle = privilegeAwareSubtitle(hasPrivilege, R.string.auto_freeze_desc),
@@ -381,7 +381,7 @@ fun SettingsCategoryScreen(
                         onCheckedChange = { viewModel.setAutoFreezeEnabled(it) }
                     )
 
-                    SettingsRowId.SUSPEND_INSTEAD_OF_FREEZE -> SettingsSwitchRow(
+                    SettingsRowId.SUSPEND_INSTEAD_OF_FREEZE -> SettingsExpandedSwitchRow(
                         icon = R.drawable.frozen,
                         title = stringResource(R.string.suspend_instead_of_freeze),
                         subtitle = privilegeAwareSubtitle(
@@ -398,7 +398,7 @@ fun SettingsCategoryScreen(
                         }
                     )
 
-                    SettingsRowId.SKIP_ROUTINE_FREEZE_CONFIRMATION -> SettingsSwitchRow(
+                    SettingsRowId.SKIP_ROUTINE_FREEZE_CONFIRMATION -> SettingsExpandedSwitchRow(
                         icon = R.drawable.danger,
                         title = stringResource(R.string.skip_routine_freeze_confirmation),
                         subtitle = privilegeAwareSubtitle(
@@ -411,7 +411,7 @@ fun SettingsCategoryScreen(
                         onCheckedChange = { viewModel.setSkipRoutineFreezeConfirmation(it) }
                     )
 
-                    SettingsRowId.ADD_FREEZER_TO_LAUNCHER -> SettingsSwitchRow(
+                    SettingsRowId.ADD_FREEZER_TO_LAUNCHER -> SettingsExpandedSwitchRow(
                         icon = R.drawable.frozen,
                         title = stringResource(R.string.add_freezer_to_launcher),
                         subtitle = privilegeAwareSubtitle(
@@ -468,6 +468,20 @@ fun SettingsCategoryScreen(
                         onCheckedChange = { viewModel.setGrantAllPermissionsOnInstall(it) }
                     )
 
+                    // This remains enabled even without an available provider. A provider is
+                    // required to use the bypass, but never to turn a previously enabled setting
+                    // back off.
+                    SettingsRowId.ALLOW_LEGACY_APK_INSTALL -> SettingsSwitchRow(
+                        icon = R.drawable.danger,
+                        title = stringResource(R.string.allow_legacy_apk_install),
+                        subtitle = stringResource(R.string.allow_legacy_apk_install_desc),
+                        checked = prefs.allowLegacyApkInstall,
+                        highlighted = lit,
+                        titleMaxLines = Int.MAX_VALUE,
+                        subtitleMaxLines = Int.MAX_VALUE,
+                        onCheckedChange = { viewModel.setAllowLegacyApkInstall(it) }
+                    )
+
                     // Reads its state from `uiState`, not `prefs`: this switch is backed by
                     // PackageManager component state rather than DataStore. See AnyFileOpenerController.
                     SettingsRowId.ANY_FILE_OPENER -> SettingsSwitchRow(
@@ -487,7 +501,7 @@ fun SettingsCategoryScreen(
                     // responds. Tappable, the refusal in `setBiometricLock` can answer with a toast
                     // that names what is missing. `checked` stays bound to the preference, so a
                     // refused tap settles straight back.
-                    SettingsRowId.BIOMETRIC_LOCK -> SettingsSwitchRow(
+                    SettingsRowId.BIOMETRIC_LOCK -> SettingsExpandedSwitchRow(
                         icon = R.drawable.round_key,
                         title = stringResource(R.string.biometric_lock),
                         subtitle = if (state.canUseBiometric) {

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsComponents.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsComponents.kt
@@ -49,14 +49,16 @@ import com.valhalla.thor.R
  * does not forward `subtitleMaxLines` to the `AsgardListRow` underneath it, which is the one thing
  * these rows exist to get right.
  *
- * ## Two lines of subtitle, and no marquee
+ * ## Compact by default, and no marquee
  *
- * Every subtitle here is `maxLines = 2`. The previous switch row was `maxLines = 1` with an opt-in
+ * Subtitles default to `maxLines = 2`. [SettingsExpandedSwitchRow] keeps Freezer explanations and
+ * security-sensitive choices fully readable, including at larger font scales and in longer locales.
+ * The previous switch row was `maxLines = 1` with an opt-in
  * `basicMarquee` that started on a tap *on the subtitle text* — a nested clickable inside a row
  * whose whole surface already toggles the switch, so the gesture that revealed the description was
  * a tap that looked exactly like the one that changed the setting. Nine call sites opted in; the
- * other rows just truncated. Two lines fit every description Thor ships, in all five locales, so
- * the scrolling text had nothing left to reveal.
+ * other rows just truncated. Compact defaults are retained for those rows; this is not a blanket
+ * claim that every description fits at every locale, width, or font scale.
  */
 
 /** The tinted circle that carries a row's glyph. */
@@ -152,6 +154,8 @@ internal fun SettingsSwitchRow(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     highlighted: Boolean = false,
+    titleMaxLines: Int = 1,
+    subtitleMaxLines: Int = 2,
     onCheckedChange: (Boolean) -> Unit,
 ) {
     Row(
@@ -178,8 +182,8 @@ internal fun SettingsSwitchRow(
             SettingsIconBox(icon)
             Spacer(Modifier.width(16.dp))
             Column {
-                RowTitle(title)
-                RowSubtitle(subtitle)
+                RowTitle(title, maxLines = titleMaxLines)
+                RowSubtitle(subtitle, maxLines = subtitleMaxLines)
             }
         }
         Spacer(Modifier.width(8.dp))
@@ -194,6 +198,38 @@ internal fun SettingsSwitchRow(
             enabled = enabled
         )
     }
+}
+
+/**
+ * A switch whose explanation must stay readable before the user changes it.
+ *
+ * Let the row grow instead of using a fixed three-line cap: that would still truncate translated
+ * text at larger font scales. The parent category scrolls, and the row remains one switch target;
+ * reading its description never requires a tap that could also change the setting.
+ */
+@Composable
+internal fun SettingsExpandedSwitchRow(
+    @DrawableRes icon: Int,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    highlighted: Boolean = false,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    SettingsSwitchRow(
+        icon = icon,
+        title = title,
+        subtitle = subtitle,
+        checked = checked,
+        modifier = modifier,
+        enabled = enabled,
+        highlighted = highlighted,
+        titleMaxLines = Int.MAX_VALUE,
+        subtitleMaxLines = Int.MAX_VALUE,
+        onCheckedChange = onCheckedChange,
+    )
 }
 
 /**
@@ -239,26 +275,29 @@ internal fun SettingsPickerRow(
     }
 }
 
-/** One line, always. A wrapped title stops the row scanning as a list. */
+/** Compact by default; consent-affecting settings can keep their complete label visible. */
 @Composable
-private fun RowTitle(title: String) {
+private fun RowTitle(title: String, maxLines: Int = 1) {
     Text(
         title,
+        // Expanded copy uses the whole text column, with consistent rendered/semantic bounds.
+        modifier = if (maxLines == Int.MAX_VALUE) Modifier.fillMaxWidth() else Modifier,
         style = MaterialTheme.typography.titleMedium,
         fontWeight = FontWeight.Bold,
-        maxLines = 1,
+        maxLines = maxLines,
         overflow = TextOverflow.Ellipsis
     )
 }
 
-/** Two lines. See this file's header for why that number and not one. */
+/** Two lines by default, with an explicit allowance for a complete security description. */
 @Composable
-private fun RowSubtitle(subtitle: String) {
+private fun RowSubtitle(subtitle: String, maxLines: Int = 2) {
     Text(
         subtitle,
+        modifier = if (maxLines == Int.MAX_VALUE) Modifier.fillMaxWidth() else Modifier,
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        maxLines = 2,
+        maxLines = maxLines,
         overflow = TextOverflow.Ellipsis
     )
 }

--- a/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/valhalla/thor/presentation/settings/SettingsViewModel.kt
@@ -248,6 +248,10 @@ class SettingsViewModel(
         viewModelScope.launch { preferenceRepository.setGrantAllPermissionsOnInstall(enabled) }
     }
 
+    fun setAllowLegacyApkInstall(enabled: Boolean) {
+        viewModelScope.launch { preferenceRepository.setAllowLegacyApkInstall(enabled) }
+    }
+
     /**
      * Applying the locale is conditional on the write, because these two steps disagree about how
      * long they last: `applyLocale` changes the running process now, the preference is what brings

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -28,7 +28,7 @@
     <string name="dynamic_colors">ألوان ديناميكية</string>
     <string name="dynamic_colors_desc">تكامل Material You</string>
     <string name="biometric_lock">قفل القياسات الحيوية</string>
-    <string name="biometric_lock_desc">يتطلب المصادقة عند التشغيل</string>
+    <string name="biometric_lock_desc">يتطلب المصادقة عند التشغيل. عند تفعيل القفل، تُحظر لقطات الشاشة وتسجيل الشاشة في Thor وتُخفى معاينته في التطبيقات الأخيرة.</string>
     <string name="biometric_not_available">المقاييس الحيوية غير مسجلة أو غير متوفرة</string>
     <string name="active_engine">المحرك النشط</string>
     <string name="active_engine_desc">التبديل بين الموفرين المتاحين</string>
@@ -360,6 +360,11 @@
     <string name="exit">خروج</string>
     <string name="title_thor_installer">مثبت Thor</string>
     <string name="install_analyzing">جارٍ تحليل الحزمة…</string>
+    <string name="legacy_install_description">يستهدف %1$s إصدار SDK %2$d. يحظر هذا الإصدار من Android عادةً عمليات التثبيت الجديدة للتطبيقات التي تستهدف إصدار SDK أقل من %3$d.</string>
+    <string name="legacy_install_confirm_title">السماح بتثبيت تطبيق قديم؟</string>
+    <string name="legacy_install_confirm_message">يستهدف %1$s‏ (%2$s) إصدار SDK %3$d، وهو أقل من الحد الأدنى للتثبيت وهو SDK %4$d. قد يؤدي تجاوز حظر الأمان هذا إلى تعريض جهازك وبياناتك للخطر. قد تحصل التطبيقات القديمة على الأذونات وقت التثبيت وفق نموذج الأذونات القديم الخاص بها. لا تتابع إلا إذا كنت تثق بملف APK هذا. ينطبق هذا على هذا التثبيت فقط؛ وتظل التوقيع وتوافق الجهاز وفحوصات Android الأخرى سارية.</string>
+    <string name="legacy_install_allow_once">ثبّت هذه المرة</string>
+    <string name="legacy_install_unsupported">يتطلب تثبيت التطبيقات القديمة Android 14 أو أحدث وRoot أو Shizuku. لا يمكن للأوضاع العادي وDhizuku والخارجي تطبيق هذا التجاوز.</string>
     <string name="install_downgrade_warning">سيؤدي هذا إلى خفض إصدار التطبيق.</string>
     <string name="install_downgrade_code_explainer">رمز الإصدار %1$s أقل من المثبَّت %2$s. يرتّب Android التحديثات حسب رمز الإصدار لا حسب اسم الإصدار، لذا قد يبدو التطبيق أحدث وهو في الواقع خفض للإصدار.</string>
     <string name="install_update_warning">سيؤدي هذا إلى تحديث التطبيق الحالي.</string>

--- a/app/src/main/res/values-ar/strings_settings.xml
+++ b/app/src/main/res/values-ar/strings_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="allow_legacy_apk_install">السماح بتثبيت ملفات APK القديمة دون سؤال</string>
+    <string name="allow_legacy_apk_install_desc">في مثبّت Thor، اسمح تلقائيًا بملفات APK التي تستهدف إصدارات Android الأقدم. Root أو Shizuku فقط. يتجاوز حظر أمان Android؛ قد تعرض التطبيقات القديمة جهازك وبياناتك للخطر. عند إيقافه، اسأل قبل كل تثبيت لتطبيق قديم.</string>
+    <string name="legacy_install_allowed_by_setting">مسموح به بواسطة إعداد المثبّت. تم إيقاف التأكيد الإضافي.</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -28,7 +28,7 @@
     <string name="dynamic_colors">Colores dinámicos</string>
     <string name="dynamic_colors_desc">Integración con Material You</string>
     <string name="biometric_lock">Bloqueo biométrico</string>
-    <string name="biometric_lock_desc">Requerir autenticación al iniciar</string>
+    <string name="biometric_lock_desc">Exigir autenticación al iniciar. Al activarlo, se bloquean las capturas y grabaciones de pantalla de Thor y se oculta su vista previa en las aplicaciones recientes.</string>
     <string name="biometric_not_available">Biometría no registrada o disponible</string>
     <string name="active_engine">Motor activo</string>
     <string name="active_engine_desc">Cambiar entre proveedores disponibles</string>
@@ -338,6 +338,11 @@
     <string name="exit">Salir</string>
     <string name="title_thor_installer">Instalador Thor</string>
     <string name="install_analyzing">Analizando paquete…</string>
+    <string name="legacy_install_description">%1$s está dirigido al SDK %2$d. Esta versión de Android normalmente bloquea las nuevas instalaciones por debajo del SDK %3$d.</string>
+    <string name="legacy_install_confirm_title">¿Permitir instalación heredada?</string>
+    <string name="legacy_install_confirm_message">%1$s (%2$s) está dirigido al SDK %3$d, por debajo del mínimo de instalación del SDK %4$d. Omitir este bloqueo de seguridad puede poner en riesgo tu dispositivo y tus datos. Las aplicaciones antiguas pueden recibir permisos durante la instalación conforme a su modelo de permisos heredado. Continúa solo si confías en este APK. Esto se aplica únicamente a esta instalación; la firma, la compatibilidad del dispositivo y otras comprobaciones de Android siguen aplicándose.</string>
+    <string name="legacy_install_allow_once">Instalar esta vez</string>
+    <string name="legacy_install_unsupported">La instalación heredada requiere Android 14 o una versión posterior, y Root o Shizuku. Los modos normal, Dhizuku y externo no pueden aplicar esta excepción.</string>
     <string name="install_downgrade_warning">Esto degradará la aplicación.</string>
     <string name="install_downgrade_code_explainer">El código de versión %1$s es inferior al instalado %2$s. Android ordena las actualizaciones por código de versión, no por nombre de versión: una aplicación puede parecer más reciente y aun así ser una degradación.</string>
     <string name="install_update_warning">Esto actualizará la aplicación existente.</string>

--- a/app/src/main/res/values-es/strings_settings.xml
+++ b/app/src/main/res/values-es/strings_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="allow_legacy_apk_install">Permitir instalar APK antiguos sin preguntar</string>
+    <string name="allow_legacy_apk_install_desc">En el instalador de Thor, permite automáticamente APK destinados a versiones anteriores de Android. Solo Root o Shizuku. Omite el bloqueo de seguridad de Android; las aplicaciones antiguas pueden poner en riesgo tu dispositivo y tus datos. Si está desactivado, pregunta antes de cada instalación heredada.</string>
+    <string name="legacy_install_allowed_by_setting">Permitido por la configuración del instalador. La confirmación adicional está desactivada.</string>
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -28,7 +28,7 @@
     <string name="dynamic_colors">Couleurs dynamiques</string>
     <string name="dynamic_colors_desc">Intégration Material You</string>
     <string name="biometric_lock">Verrouillage biométrique</string>
-    <string name="biometric_lock_desc">Exiger une authentification au lancement</string>
+    <string name="biometric_lock_desc">Exiger une authentification au lancement. Une fois activé, le verrouillage bloque les captures et enregistrements d’écran de Thor et masque son aperçu dans les applications récentes.</string>
     <string name="biometric_not_available">Biométrie non enregistrée ou indisponible</string>
     <string name="active_engine">Moteur actif</string>
     <string name="active_engine_desc">Passer d\'un fournisseur à l\'autre</string>
@@ -338,6 +338,11 @@
     <string name="exit">Quitter</string>
     <string name="title_thor_installer">Installateur Thor</string>
     <string name="install_analyzing">Analyse du paquet…</string>
+    <string name="legacy_install_description">%1$s cible le SDK %2$d. Cette version d\'Android bloque normalement les nouvelles installations sous le SDK %3$d.</string>
+    <string name="legacy_install_confirm_title">Autoriser l\'installation héritée ?</string>
+    <string name="legacy_install_confirm_message">%1$s (%2$s) cible le SDK %3$d, inférieur au minimum d\'installation du SDK %4$d. Contourner ce blocage de sécurité peut mettre votre appareil et vos données en danger. Les anciennes applications peuvent recevoir des autorisations lors de l\'installation selon leur ancien modèle d\'autorisations. Ne continuez que si vous faites confiance à cet APK. Cela s\'applique uniquement à cette installation ; la signature, la compatibilité de l\'appareil et les autres vérifications Android restent applicables.</string>
+    <string name="legacy_install_allow_once">Installer cette fois-ci</string>
+    <string name="legacy_install_unsupported">L\'installation héritée nécessite Android 14 ou version ultérieure, ainsi que Root ou Shizuku. Les modes normal, Dhizuku et externe ne peuvent pas appliquer cette exception.</string>
     <string name="install_downgrade_warning">Cela va rétrograder l\'application.</string>
     <string name="install_downgrade_code_explainer">Le code de version %1$s est inférieur au %2$s installé. Android ordonne les mises à jour par code de version, et non par nom de version : une application peut sembler plus récente tout en étant une rétrogradation.</string>
     <string name="install_update_warning">Cela va mettre à jour l\'application existante.</string>

--- a/app/src/main/res/values-fr/strings_settings.xml
+++ b/app/src/main/res/values-fr/strings_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="allow_legacy_apk_install">Autoriser l\'installation des APK anciens sans demander</string>
+    <string name="allow_legacy_apk_install_desc">Dans le programme d\'installation de Thor, autorisez automatiquement les APK ciblant d\'anciennes versions d\'Android. Root ou Shizuku uniquement. Contourne le blocage de sécurité d\'Android ; les anciennes applications peuvent mettre votre appareil et vos données en danger. Lorsqu\'il est désactivé, demandez confirmation avant chaque installation héritée.</string>
+    <string name="legacy_install_allowed_by_setting">Autorisé par le réglage de votre programme d\'installation. La confirmation supplémentaire est désactivée.</string>
+</resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -42,7 +42,7 @@
     <string name="dynamic_colors">Kolory dynamiczne</string>
     <string name="dynamic_colors_desc">Integracja z Material You</string>
     <string name="biometric_lock">Blokada biometryczna</string>
-    <string name="biometric_lock_desc">Wymagaj uwierzytelnienia po uruchomieniu</string>
+    <string name="biometric_lock_desc">Wymagaj uwierzytelnienia przy uruchomieniu. Włączona blokada uniemożliwia robienie zrzutów i nagrywanie ekranu aplikacji Thor oraz ukrywa jej podgląd na liście ostatnich aplikacji.</string>
     <string name="biometric_not_available">Biometria niedostępna lub bez zapisanych danych</string>
     <string name="active_engine">Aktywny silnik</string>
     <string name="active_engine_desc">Przełączaj między dostępnymi dostawcami</string>
@@ -567,6 +567,11 @@
     <string name="exit">Wyjdź</string>
     <string name="title_thor_installer">Instalator Thor</string>
     <string name="install_analyzing">Analizowanie pakietu…</string>
+    <string name="legacy_install_description">%1$s jest przeznaczona dla SDK %2$d. Ta wersja Androida zwykle blokuje nowe instalacje aplikacji poniżej SDK %3$d.</string>
+    <string name="legacy_install_confirm_title">Zezwolić na instalację starszej aplikacji?</string>
+    <string name="legacy_install_confirm_message">%1$s (%2$s) jest przeznaczona dla SDK %3$d, poniżej minimalnego SDK %4$d wymaganego do instalacji. Ominięcie tej blokady bezpieczeństwa może narazić urządzenie i dane na ryzyko. Starsze aplikacje mogą otrzymać uprawnienia podczas instalacji zgodnie ze swoim starszym modelem uprawnień. Kontynuuj tylko, jeśli ufasz temu plikowi APK. Dotyczy to tylko tej instalacji; podpis, zgodność urządzenia i inne kontrole Androida nadal obowiązują.</string>
+    <string name="legacy_install_allow_once">Zainstaluj tym razem</string>
+    <string name="legacy_install_unsupported">Instalacja starszych aplikacji wymaga Androida 14 lub nowszego oraz Roota albo Shizuku. Tryby zwykły, Dhizuku i zewnętrzny nie mogą zastosować tego obejścia.</string>
     <string name="install_downgrade_warning">Spowoduje to instalację starszej wersji aplikacji.</string>
     <!-- %1$s and %2$s are version codes. They are deliberately %s, not %d: %d is localised by
          java.util.Formatter (Arabic-Indic digits under ar-EG, for example), and these same two

--- a/app/src/main/res/values-pl/strings_settings.xml
+++ b/app/src/main/res/values-pl/strings_settings.xml
@@ -11,6 +11,10 @@
     <string name="settings_category_security">Bezpieczeństwo</string>
     <string name="settings_category_about">Informacje i wsparcie</string>
 
+    <string name="allow_legacy_apk_install">Zezwalaj na instalowanie starszych plików APK bez pytania</string>
+    <string name="allow_legacy_apk_install_desc">W instalatorze Thora automatycznie zezwalaj na instalację plików APK przeznaczonych dla starszych wersji Androida. Tylko Root lub Shizuku. Omija blokadę bezpieczeństwa Androida; starsze aplikacje mogą narazić urządzenie i dane na ryzyko. Gdy opcja jest wyłączona, pytaj przed każdą instalacją starszej aplikacji.</string>
+    <string name="legacy_install_allowed_by_setting">Zezwolono przez ustawienie instalatora. Dodatkowe potwierdzenie jest wyłączone.</string>
+
     <!-- ── Index chrome ──────────────────────────────────────────────────────────────────── -->
     <string name="settings_search_hint">Szukaj w ustawieniach…</string>
     <string name="settings_search_no_results">Nic w Ustawieniach nie pasuje do „%1$s”.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -41,7 +41,7 @@
     <string name="grant_all_permissions_install">Conceder todas as permissões solicitadas</string>
     <string name="default_tab">Aba padrão</string>
     <string name="default_tab_desc">A tela que o Thor abre ao iniciar</string>
-    <string name="biometric_lock_desc">Exigir autenticação ao iniciar</string>
+    <string name="biometric_lock_desc">Exigir autenticação ao iniciar. Quando ativado, o bloqueio impede capturas e gravações da tela do Thor e oculta a prévia nos apps recentes.</string>
     <string name="built_with_precision">CONSTRUÍDO COM PRECISÃO PARA USUÁRIOS AVANÇADOS</string>
 
     <!-- Language picker -->
@@ -288,6 +288,11 @@
     <!-- Freezer entry point / Installer -->
     <string name="manage_freezer">Gerenciar o Congelador</string>
     <string name="install_analyzing">Analisando o pacote…</string>
+    <string name="legacy_install_description">%1$s tem como destino o SDK %2$d. Esta versão do Android normalmente bloqueia novas instalações abaixo do SDK %3$d.</string>
+    <string name="legacy_install_confirm_title">Permitir instalação de aplicativo antigo?</string>
+    <string name="legacy_install_confirm_message">%1$s (%2$s) tem como destino o SDK %3$d, abaixo do mínimo de instalação do SDK %4$d. Ignorar este bloqueio de segurança pode colocar seu dispositivo e seus dados em risco. Aplicativos antigos podem receber permissões no momento da instalação segundo seu modelo de permissões antigo. Continue apenas se confiar neste APK. Isso se aplica somente a esta instalação; a assinatura, a compatibilidade do dispositivo e outras verificações do Android continuam valendo.</string>
+    <string name="legacy_install_allow_once">Instalar desta vez</string>
+    <string name="legacy_install_unsupported">A instalação de aplicativos antigos requer Android 14 ou mais recente e Root ou Shizuku. Os modos normal, Dhizuku e externo não podem aplicar esta substituição.</string>
     <string name="install_downgrade_warning">Isso vai reverter o aplicativo para uma versão anterior.</string>
     <string name="install_downgrade_code_explainer">O código de versão %1$s é inferior ao %2$s instalado. O Android ordena as atualizações pelo código de versão, não pelo nome da versão — um aplicativo pode parecer mais recente e ainda assim ser uma reversão.</string>
     <string name="install_update_warning">Isso vai atualizar o aplicativo existente.</string>

--- a/app/src/main/res/values-pt-rBR/strings_settings.xml
+++ b/app/src/main/res/values-pt-rBR/strings_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="allow_legacy_apk_install">Permitir instalações de APKs antigos sem perguntar</string>
+    <string name="allow_legacy_apk_install_desc">No instalador do Thor, permita automaticamente APKs destinados a versões mais antigas do Android. Somente Root ou Shizuku. Ignora o bloqueio de segurança do Android; aplicativos antigos podem colocar seu dispositivo e dados em risco. Quando desativado, pergunte antes de cada instalação de aplicativo antigo.</string>
+    <string name="legacy_install_allowed_by_setting">Permitido pela configuração do instalador. A confirmação adicional está desativada.</string>
+</resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -42,7 +42,7 @@
     <string name="dynamic_colors">Cores dinâmicas</string>
     <string name="dynamic_colors_desc">Integração com o Material You</string>
     <string name="biometric_lock">Bloqueio biométrico</string>
-    <string name="biometric_lock_desc">Exigir autenticação ao arrancar</string>
+    <string name="biometric_lock_desc">Exigir autenticação ao iniciar. Quando ativo, o bloqueio impede capturas e gravações do ecrã do Thor e oculta a pré-visualização nas aplicações recentes.</string>
     <string name="biometric_not_available">Biometria não configurada ou indisponível</string>
     <string name="active_engine">Motor ativo</string>
     <string name="active_engine_desc">Alternar entre os fornecedores disponíveis</string>
@@ -558,6 +558,11 @@
     <string name="exit">Sair</string>
     <string name="title_thor_installer">Instalador do Thor</string>
     <string name="install_analyzing">A analisar o pacote…</string>
+    <string name="legacy_install_description">%1$s destina-se ao SDK %2$d. Esta versão do Android normalmente bloqueia novas instalações abaixo do SDK %3$d.</string>
+    <string name="legacy_install_confirm_title">Permitir instalação antiga?</string>
+    <string name="legacy_install_confirm_message">%1$s (%2$s) destina-se ao SDK %3$d, abaixo do mínimo de instalação do SDK %4$d. Contornar este bloqueio de segurança pode colocar o seu dispositivo e os seus dados em risco. As aplicações antigas podem receber permissões durante a instalação segundo o respetivo modelo de permissões antigo. Continue apenas se confiar neste APK. Isto aplica-se apenas a esta instalação; a assinatura, a compatibilidade do dispositivo e outras verificações do Android continuam a aplicar-se.</string>
+    <string name="legacy_install_allow_once">Instalar desta vez</string>
+    <string name="legacy_install_unsupported">A instalação antiga requer Android 14 ou mais recente e Root ou Shizuku. Os modos normal, Dhizuku e externo não podem aplicar esta exceção.</string>
     <string name="install_downgrade_warning">Isto vai reverter a aplicação para uma versão anterior.</string>
     <!-- %1$s and %2$s are version codes. They are deliberately %s, not %d: %d is localised by
          java.util.Formatter (Arabic-Indic digits under ar-EG, for example), and these same two

--- a/app/src/main/res/values-pt/strings_settings.xml
+++ b/app/src/main/res/values-pt/strings_settings.xml
@@ -21,6 +21,10 @@
     <string name="settings_category_security">Segurança</string>
     <string name="settings_category_about">Sobre e apoio</string>
 
+    <string name="allow_legacy_apk_install">Permitir instalações de APK antigas sem perguntar</string>
+    <string name="allow_legacy_apk_install_desc">No instalador do Thor, permitir automaticamente APK destinadas a versões mais antigas do Android. Apenas Root ou Shizuku. Ignora o bloqueio de segurança do Android; as aplicações antigas podem pôr o dispositivo e os dados em risco. Quando desativado, perguntar antes de cada instalação antiga.</string>
+    <string name="legacy_install_allowed_by_setting">Permitido pela definição do instalador. A confirmação adicional está desativada.</string>
+
     <!-- ── Index chrome ──────────────────────────────────────────────────────────────────── -->
     <string name="settings_search_hint">Pesquisar nas definições…</string>
     <string name="settings_search_no_results">Nada nas Definições corresponde a «%1$s».</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -27,7 +27,7 @@
     <string name="dynamic_colors">动态色彩</string>
     <string name="dynamic_colors_desc">Material You 集成</string>
     <string name="biometric_lock">生物识别锁定</string>
-    <string name="biometric_lock_desc">启动时需要验证</string>
+    <string name="biometric_lock_desc">启动时要求身份验证。启用后，将禁止截取或录制 Thor 的屏幕，并隐藏其在最近任务中的预览。</string>
     <string name="biometric_not_available">生物识别未注册或不可用</string>
     <string name="active_engine">活动引擎</string>
     <string name="active_engine_desc">在可用提供者之间切换</string>
@@ -333,6 +333,11 @@
     <string name="exit">退出</string>
     <string name="title_thor_installer">Thor 安装器</string>
     <string name="install_analyzing">正在解析包…</string>
+    <string name="legacy_install_description">%1$s 的目标 SDK 为 %2$d。此 Android 版本通常会阻止目标 SDK 低于 %3$d 的新安装。</string>
+    <string name="legacy_install_confirm_title">允许安装旧版应用吗？</string>
+    <string name="legacy_install_confirm_message">%1$s（%2$s）的目标 SDK 为 %3$d，低于 SDK %4$d 的安装最低要求。绕过此安全限制可能会使你的设备和数据面临风险。旧版应用可能会根据其旧版权限模型在安装时获得权限。仅当你信任此 APK 时才继续。此设置仅适用于本次安装；签名、设备兼容性及其他 Android 检查仍然适用。</string>
+    <string name="legacy_install_allow_once">仅此次安装</string>
+    <string name="legacy_install_unsupported">安装旧版应用需要 Android 14 或更高版本，以及 Root 或 Shizuku。普通、Dhizuku 和外部模式无法应用此覆盖设置。</string>
     <string name="install_downgrade_warning">这将降级该应用。</string>
     <string name="install_downgrade_code_explainer">版本号 %1$s 低于已安装的 %2$s。Android 按版本号（versionCode）而非版本名称排序更新，因此应用看起来较新仍可能是降级。</string>
     <string name="install_update_warning">这将更新现有应用。</string>

--- a/app/src/main/res/values-zh-rCN/strings_settings.xml
+++ b/app/src/main/res/values-zh-rCN/strings_settings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="allow_legacy_apk_install">允许无需询问即可安装旧版 APK</string>
+    <string name="allow_legacy_apk_install_desc">在 Thor 的安装器中，自动允许安装面向较旧 Android 版本的 APK。仅限 Root 或 Shizuku。此操作会绕过 Android 的安全拦截；旧版应用可能会使你的设备和数据面临风险。关闭后，每次安装旧版应用前都会询问。</string>
+    <string name="legacy_install_allowed_by_setting">已由你的安装器设置允许。额外确认已关闭。</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <string name="dynamic_colors">Dynamic Colors</string>
     <string name="dynamic_colors_desc">Material You integration</string>
     <string name="biometric_lock">Biometric Lock</string>
-    <string name="biometric_lock_desc">Require auth on launch</string>
+    <string name="biometric_lock_desc">Require authentication on launch. When enabled, blocks screenshots and screen recording of Thor and hides its Recents preview.</string>
     <string name="biometric_not_available">Biometrics not enrolled or available</string>
     <string name="active_engine">Active Engine</string>
     <string name="active_engine_desc">Switch between available providers</string>
@@ -613,6 +613,11 @@
     <string name="exit">Exit</string>
     <string name="title_thor_installer">Thor Installer</string>
     <string name="install_analyzing">Analyzing Package…</string>
+    <string name="legacy_install_description">%1$s targets SDK %2$d. This Android version normally blocks new installs below SDK %3$d.</string>
+    <string name="legacy_install_confirm_title">Allow legacy installation?</string>
+    <string name="legacy_install_confirm_message">%1$s (%2$s) targets SDK %3$d, below the install minimum of SDK %4$d. Bypassing this security block can put your device and data at risk. Older apps may receive permissions at install time under their legacy permission model. Only continue if you trust this APK. This applies to this installation only; signature, device compatibility and other Android checks still apply.</string>
+    <string name="legacy_install_allow_once">Install this time</string>
+    <string name="legacy_install_unsupported">Legacy installation requires Android 14 or newer and Root or Shizuku. Normal, Dhizuku and external modes cannot apply this override.</string>
     <string name="install_downgrade_warning">This will downgrade the app.</string>
     <!-- %1$s and %2$s are version codes. They are deliberately %s, not %d: %d is localised by
          java.util.Formatter (Arabic-Indic digits under ar-EG, for example), and these same two

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -15,6 +15,10 @@
     <string name="settings_category_security">Security</string>
     <string name="settings_category_about">About &amp; support</string>
 
+    <string name="allow_legacy_apk_install">Allow legacy APK installs without asking</string>
+    <string name="allow_legacy_apk_install_desc">In Thor’s installer, automatically allow APKs targeting older Android versions. Root or Shizuku only. Bypasses Android’s security block; older apps can put your device and data at risk. When off, ask before each legacy install.</string>
+    <string name="legacy_install_allowed_by_setting">Allowed by your installer setting. The extra confirmation is turned off.</string>
+
     <!-- ── Index chrome ──────────────────────────────────────────────────────────────────── -->
     <string name="settings_search_hint">Search settings…</string>
     <string name="settings_search_no_results">Nothing in Settings matches “%1$s”.</string>

--- a/app/src/test/java/com/valhalla/thor/data/gateway/RootSystemGatewayRoutingTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/gateway/RootSystemGatewayRoutingTest.kt
@@ -136,6 +136,50 @@ class RootSystemGatewayRoutingTest {
     }
 
     @Test
+    fun `low target bypass reaches the root session for one APK`() = runTest {
+        val apk = File.createTempFile("thor-bypass-one", ".apk").apply { writeText("apk") }
+        try {
+            val executor = RecordingRootCommandExecutor()
+
+            gateway(executor).installMultipleApks(
+                apkPaths = listOf(apk.absolutePath),
+                canDowngrade = false,
+                bypassLowTargetSdkBlock = true,
+            ).getOrThrow()
+
+            val command = executor.commands.single().text
+            assertEquals(1, Regex("--bypass-low-target-sdk-block").findAll(command).count())
+            assertTrue(command.contains("pm install-create"))
+            assertTrue(command.contains("cat '${apk.absolutePath}' | pm install-write"))
+        } finally {
+            apk.delete()
+        }
+    }
+
+    @Test
+    fun `low target bypass reaches the root session for every split`() = runTest {
+        val base = File.createTempFile("thor-bypass-base", ".apk").apply { writeText("base") }
+        val split = File.createTempFile("thor-bypass-split", ".apk").apply { writeText("split") }
+        try {
+            val executor = RecordingRootCommandExecutor()
+
+            gateway(executor).installMultipleApks(
+                apkPaths = listOf(base.absolutePath, split.absolutePath),
+                canDowngrade = false,
+                bypassLowTargetSdkBlock = true,
+            ).getOrThrow()
+
+            val command = executor.commands.single().text
+            assertEquals(1, Regex("--bypass-low-target-sdk-block").findAll(command).count())
+            assertTrue(command.contains("cat '${base.absolutePath}' | pm install-write"))
+            assertTrue(command.contains("cat '${split.absolutePath}' | pm install-write"))
+        } finally {
+            base.delete()
+            split.delete()
+        }
+    }
+
+    @Test
     fun `permission app-op probe preserves context and throws typed routing failure`() = runTest {
         val failure = ShellLaneBusy(PrivilegeExecutionLane.ARCHIVE)
         val executor = RecordingRootCommandExecutor(failure = failure)

--- a/app/src/test/java/com/valhalla/thor/data/repository/AppAnalyzerMetadataTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/AppAnalyzerMetadataTest.kt
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.data.repository
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AppAnalyzerMetadataTest {
+
+    @Test
+    fun `target SDK comes from the parsed APK application info`() {
+        val parsedBaseApk = PackageInfo().apply {
+            applicationInfo = ApplicationInfo().apply { targetSdkVersion = 23 }
+        }
+
+        assertEquals(23, parsedArchiveTargetSdk(parsedBaseApk))
+    }
+
+    @Test
+    fun `selected bundle base retains its parsed target SDK`() {
+        // `readMetadata` extracts the selected identity candidate to its scratch APK before it
+        // reaches this helper. The sidecar plan chooses that base, but never supplies this value.
+        val parsedSelectedBundleBase = PackageInfo().apply {
+            applicationInfo = ApplicationInfo().apply { targetSdkVersion = 28 }
+        }
+
+        assertEquals(28, parsedArchiveTargetSdk(parsedSelectedBundleBase))
+    }
+
+    @Test
+    fun `missing parsed APK application info leaves target SDK unknown`() {
+        assertNull(parsedArchiveTargetSdk(PackageInfo()))
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/data/repository/PrivilegeExecutionProductionPathTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/PrivilegeExecutionProductionPathTest.kt
@@ -10,6 +10,7 @@ import android.content.pm.PackageInfo
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.valhalla.thor.R
 import com.valhalla.thor.data.gateway.DhizukuSystemGateway
 import com.valhalla.thor.data.gateway.RootSystemGateway
 import com.valhalla.thor.data.gateway.ShizukuSystemGateway
@@ -18,6 +19,7 @@ import com.valhalla.thor.data.gateway.root.RootCommandExecutor
 import com.valhalla.thor.data.gateway.root.RootCommandResult
 import com.valhalla.thor.data.source.local.dhizuku.DhizukuReflector
 import com.valhalla.thor.data.source.local.shizuku.ShizukuReflector
+import com.valhalla.thor.data.source.local.shizuku.Shizuku as ShizukuHelper
 import com.valhalla.thor.data.util.ApksMetadataGenerator
 import com.valhalla.thor.domain.InstallState
 import com.valhalla.thor.domain.InstallerEventBus
@@ -271,6 +273,109 @@ class PrivilegeExecutionProductionPathTest {
     }
 
     @Test
+    fun `unsupported low target bypass is refused before installer invocation`() = runTest {
+        for (mode in listOf(InstallMode.NORMAL, InstallMode.DHIZUKU, InstallMode.EXTERNAL)) {
+            val fixture = installerRepository(IllegalStateException("root must not run"))
+            var invocationStarted = false
+
+            fixture.repository.installPackage(
+                staged = fixture.staged,
+                uri = Uri.fromFile(fixture.staged.file),
+                mode = mode,
+                bypassLowTargetSdkBlock = true,
+                onInvocationStarted = { invocationStarted = true },
+            )
+
+            assertFalse("$mode must not begin an install", invocationStarted)
+            assertEquals(0, fixture.executor.installCalls)
+            assertEquals(
+                InstallState.Error(UiText.StringResource(R.string.legacy_install_unsupported)),
+                fixture.bus.latest,
+            )
+        }
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `pre Android 14 low target bypass is refused before root side effects`() = runTest {
+        val fixture = installerRepository(IllegalStateException("root must not run"))
+        var invocationStarted = false
+
+        fixture.repository.installPackage(
+            staged = fixture.staged,
+            uri = Uri.fromFile(fixture.staged.file),
+            mode = InstallMode.ROOT,
+            bypassLowTargetSdkBlock = true,
+            onInvocationStarted = { invocationStarted = true },
+        )
+
+        assertFalse(invocationStarted)
+        assertEquals(0, fixture.executor.installCalls)
+        assertEquals(
+            InstallState.Error(UiText.StringResource(R.string.legacy_install_unsupported)),
+            fixture.bus.latest,
+        )
+    }
+
+    @Test
+    fun `opted in Shizuku shell failure is terminal and keeps raw pm reason`() = runTest {
+        val rawPmReason = "Failure [INSTALL_FAILED_DEPRECATED_SDK_VERSION: App package must target at least SDK 23]"
+        var shellCalls = 0
+        val fixture = installerRepository(
+            failure = IllegalStateException("root must not run"),
+            executeShizukuShell = {
+                shellCalls++
+                1 to rawPmReason
+            },
+        )
+
+        fixture.repository.installPackage(
+            staged = fixture.staged,
+            uri = Uri.fromFile(fixture.staged.file),
+            mode = InstallMode.SHIZUKU,
+            bypassLowTargetSdkBlock = true,
+        )
+
+        assertEquals(1, shellCalls)
+        assertEquals(0, fixture.executor.installCalls)
+        assertEquals(InstallState.Error(UiText.DynamicString(rawPmReason)), fixture.bus.latest)
+    }
+
+    @Test
+    fun `opted in root single APK uses the bypass-capable session route`() = runTest {
+        val preferences = FakePreferenceRepository()
+        val executor = SuccessfulRecordingExecutor()
+        val root = RootSystemGateway(context, executor, preferences, Dispatchers.Unconfined).also {
+            it.userIdProvider = { 0 }
+        }
+        val repository = InstallerRepositoryImpl(
+            context = context,
+            eventBus = InstallerEventBus(),
+            rootGateway = root,
+            shizukuReflector = ShizukuReflector(context),
+            preferenceRepository = preferences,
+            obbInstaller = ObbInstaller(context, FakeSystemRepository(), Dispatchers.Unconfined),
+            ioDispatcher = Dispatchers.Unconfined,
+            mainDispatcher = Dispatchers.Unconfined,
+        )
+        val staged = StagedPackage(
+            temporaryFolder.newFile("root-bypass.apk").apply { writeText("apk") },
+            "base.apk",
+        )
+
+        repository.installPackage(
+            staged = staged,
+            uri = Uri.fromFile(staged.file),
+            mode = InstallMode.ROOT,
+            bypassLowTargetSdkBlock = true,
+        )
+
+        val command = executor.commands.single().text
+        assertEquals(1, Regex("--bypass-low-target-sdk-block").findAll(command).count())
+        assertTrue(command.contains("pm install-create"))
+    }
+
+    @Test
     fun `AppArchiveInstallerImpl keeps every execution failure identity`() = runTest {
         allExecutionFailures().forEach { failure ->
             val fixture = archiveInstaller(failure)
@@ -359,6 +464,7 @@ class PrivilegeExecutionProductionPathTest {
                 execution: com.valhalla.thor.domain.model.PrivilegeExecutionContext,
                 onInvocationStarted: () -> Unit,
                 onInstallSucceeded: () -> Unit,
+                bypassLowTargetSdkBlock: Boolean,
             ) {
                 onInvocationStarted()
                 entered.complete(Unit)
@@ -527,7 +633,12 @@ class PrivilegeExecutionProductionPathTest {
         sourceDir = File(temporaryFolder.root, "missing-${System.nanoTime()}.apk").absolutePath,
     )
 
-    private fun installerRepository(failure: Throwable): InstallerFixture {
+    private fun installerRepository(
+        failure: Throwable,
+        executeShizukuShell: (String) -> Pair<Int, String?> = { command ->
+            ShizukuHelper.execute(command)
+        },
+    ): InstallerFixture {
         val preferences = FakePreferenceRepository()
         val executor = AlwaysFailExecutor(failure)
         val root = RootSystemGateway(context, executor, preferences, Dispatchers.Unconfined).also {
@@ -545,6 +656,7 @@ class PrivilegeExecutionProductionPathTest {
             ioDispatcher = Dispatchers.Unconfined,
             mainDispatcher = Dispatchers.Unconfined,
         )
+        repository.executeShizukuShell = executeShizukuShell
         val staged = StagedPackage(
             temporaryFolder.newFile("install-${System.nanoTime()}.apk").apply { writeText("apk") },
             "sample.apk",
@@ -613,6 +725,15 @@ class PrivilegeExecutionProductionPathTest {
         }
     }
 
+    private class SuccessfulRecordingExecutor : RootCommandExecutor {
+        val commands = mutableListOf<RootCommand>()
+
+        override suspend fun execute(command: RootCommand): RootCommandResult {
+            commands += command
+            return RootCommandResult(0, emptyList(), emptyList())
+        }
+    }
+
     private class QueuedDispatcher : CoroutineDispatcher() {
         private val pending = ArrayDeque<Runnable>()
 
@@ -640,6 +761,7 @@ class PrivilegeExecutionProductionPathTest {
             execution: com.valhalla.thor.domain.model.PrivilegeExecutionContext,
             onInvocationStarted: () -> Unit,
             onInstallSucceeded: () -> Unit,
+            bypassLowTargetSdkBlock: Boolean,
         ) {
             calls++
             withContext(entryDispatcher) {
@@ -663,6 +785,7 @@ class PrivilegeExecutionProductionPathTest {
             execution: com.valhalla.thor.domain.model.PrivilegeExecutionContext,
             onInvocationStarted: () -> Unit,
             onInstallSucceeded: () -> Unit,
+            bypassLowTargetSdkBlock: Boolean,
         ) {
             onInvocationStarted()
             invocationEntered = true
@@ -687,6 +810,7 @@ class PrivilegeExecutionProductionPathTest {
             execution: com.valhalla.thor.domain.model.PrivilegeExecutionContext,
             onInvocationStarted: () -> Unit,
             onInstallSucceeded: () -> Unit,
+            bypassLowTargetSdkBlock: Boolean,
         ) {
             onInvocationStarted()
             calls++

--- a/app/src/test/java/com/valhalla/thor/data/repository/ToUserPreferencesTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/repository/ToUserPreferencesTest.kt
@@ -110,6 +110,16 @@ class ToUserPreferencesTest {
         assertEquals(DefaultTab.HOME, prefs.defaultTab)
         assertFalse(prefs.hasShownDisabledAppsPrompt)
         assertFalse(prefs.biometricLockEnabled)
+        assertFalse(prefs.allowLegacyApkInstall)
+    }
+
+    @Test
+    fun `legacy APK install consent is restored from settings and defaults closed`() {
+        assertFalse(emptyPreferences().toUserPreferences().allowLegacyApkInstall)
+
+        val settings = preferencesOf(Keys.ALLOW_LEGACY_APK_INSTALL to true)
+
+        assertTrue(settings.toUserPreferences().allowLegacyApkInstall)
     }
 
     /** Every entry round-trips, so a rename of one is caught here rather than on a user's device. */

--- a/app/src/test/java/com/valhalla/thor/data/source/local/InstallSessionCommandsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/data/source/local/InstallSessionCommandsTest.kt
@@ -64,7 +64,15 @@ class InstallSessionCommandsTest {
         canDowngrade: Boolean = false,
         grantAllPermissions: Boolean = false,
         installerArg: String = "",
-    ) = installViaSessionCommand(apks, userId, canDowngrade, grantAllPermissions, installerArg)
+        bypassLowTargetSdkBlock: Boolean = false,
+    ) = installViaSessionCommand(
+        apks,
+        userId,
+        canDowngrade,
+        grantAllPermissions,
+        installerArg,
+        bypassLowTargetSdkBlock,
+    )
 
     // --- the defect itself: no path may reach pm ---
 
@@ -172,6 +180,30 @@ class InstallSessionCommandsTest {
             10,
             Regex("--user (\\d+)").find(command(userId = 10))?.groupValues?.get(1)?.toIntOrNull()
         )
+    }
+
+    @Test
+    fun `low target SDK bypass is opt-in and belongs only to session creation`() {
+        val normal = command()
+        assertFalse(normal.contains("--bypass-low-target-sdk-block"))
+
+        val bypassed = command(bypassLowTargetSdkBlock = true)
+        assertEquals(1, Regex("--bypass-low-target-sdk-block").findAll(bypassed).count())
+        val createLine = bypassed.lineSequence().first { it.startsWith("CREATE_OUT=") }
+        assertTrue(createLine.contains("--bypass-low-target-sdk-block"))
+        assertFalse(
+            bypassed.lineSequence().filter { it.contains("pm install-write") || it.contains("pm install-commit") }
+                .any { it.contains("--bypass-low-target-sdk-block") }
+        )
+    }
+
+    @Test
+    fun `low target SDK bypass keeps every split in the session`() {
+        val script = command(listOf(base, split), bypassLowTargetSdkBlock = true)
+
+        assertTrue(script.contains("cat '${base.path}' | pm install-write"))
+        assertTrue(script.contains("cat '${split.path}' | pm install-write"))
+        assertEquals(2, Regex("\\| pm install-write -S").findAll(script).count())
     }
 
     /**

--- a/app/src/test/java/com/valhalla/thor/domain/model/AppMetadataTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/AppMetadataTest.kt
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AppMetadataTest {
+
+    @Test
+    fun `target SDK is unknown by default for sidecar-only metadata`() {
+        val metadata = AppMetadata(
+            label = "Example",
+            packageName = "com.example.app",
+            version = "1.0",
+            versionCode = null,
+            iconPath = null,
+        )
+
+        assertNull(metadata.targetSdk)
+    }
+
+    @Test
+    fun `a parsed APK target SDK preserves zero as a real value`() {
+        val metadata = AppMetadata(
+            label = "Example",
+            packageName = "com.example.app",
+            version = "1.0",
+            versionCode = 1L,
+            iconPath = null,
+            targetSdk = 0,
+        )
+
+        assertEquals(0, metadata.targetSdk)
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/domain/model/LowTargetSdkInstallPolicyTest.kt
+++ b/app/src/test/java/com/valhalla/thor/domain/model/LowTargetSdkInstallPolicyTest.kt
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025-2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.domain.model
+
+import com.valhalla.thor.domain.repository.InstallMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LowTargetSdkInstallPolicyTest {
+    @Test
+    fun `Android 14 blocks below 23 and Android 15 and 16 below 24`() {
+        assertNull(minimumInstallTargetSdk(33))
+        assertEquals(23, minimumInstallTargetSdk(34))
+        assertEquals(24, minimumInstallTargetSdk(35))
+        assertEquals(24, minimumInstallTargetSdk(36))
+        assertTrue(requiresLowTargetSdkBypass(22, 34))
+        assertFalse(requiresLowTargetSdkBypass(23, 34))
+        for (deviceSdk in 35..36) {
+            assertTrue(requiresLowTargetSdkBypass(23, deviceSdk))
+            assertFalse(requiresLowTargetSdkBypass(24, deviceSdk))
+        }
+    }
+
+    @Test
+    fun `unknown and negative target SDK never enable consent`() {
+        for (deviceSdk in 33..36) {
+            assertFalse(requiresLowTargetSdkBypass(null, deviceSdk))
+            assertFalse(requiresLowTargetSdkBypass(-1, deviceSdk))
+        }
+        assertFalse(requiresLowTargetSdkBypass(22, 33))
+    }
+
+    @Test
+    fun `parsed target zero is a legacy target not unknown metadata`() {
+        for (deviceSdk in 34..36) {
+            assertTrue(requiresLowTargetSdkBypass(0, deviceSdk))
+        }
+    }
+
+    @Test
+    fun `only Root and Shizuku on Android 14 or later support the override`() {
+        for (deviceSdk in 24..36) {
+            for (mode in InstallMode.entries) {
+                assertEquals(
+                    "$mode on API $deviceSdk",
+                    deviceSdk >= 34 && mode in listOf(InstallMode.ROOT, InstallMode.SHIZUKU),
+                    supportsLowTargetSdkBypass(mode, deviceSdk),
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/ViewModelTestDoubles.kt
@@ -764,6 +764,13 @@ class FakePreferenceRepository(
     override suspend fun shouldGrantAllPermissionsOnInstall(): Boolean =
         prefs.value.grantAllPermissionsOnInstall
 
+    override suspend fun setAllowLegacyApkInstall(enabled: Boolean) {
+        write { it.copy(allowLegacyApkInstall = enabled) }
+    }
+
+    override suspend fun shouldAllowLegacyApkInstall(): Boolean =
+        prefs.value.allowLegacyApkInstall
+
     override suspend fun setAppInfoActionsOrder(order: List<AppInfoActionId>) {
         write { it.copy(appInfoActionsOrder = order) }
     }

--- a/app/src/test/java/com/valhalla/thor/presentation/home/components/DashboardHeaderConnectedButtonGroupTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/home/components/DashboardHeaderConnectedButtonGroupTest.kt
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.home.components
+
+import android.app.Application
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import com.valhalla.thor.R
+import com.valhalla.thor.domain.model.AppListType
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [36])
+class DashboardHeaderConnectedButtonGroupTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun appTypeSwitcherRendersAndForwardsUserAndSystemSelections() {
+        val selectedType = mutableStateOf(AppListType.USER)
+        val selections = mutableListOf<AppListType>()
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val user = context.getString(R.string.chip_user)
+        val system = context.getString(R.string.chip_system)
+
+        rule.setContent {
+            MaterialTheme {
+                DashboardHeader(
+                    isRoot = false,
+                    isShizuku = false,
+                    isDhizuku = false,
+                    activeMode = null,
+                    isPrivilegeReady = true,
+                    selectedType = selectedType.value,
+                    onTypeChanged = {
+                        selections += it
+                        selectedType.value = it
+                    },
+                    onPrivilegeChanged = {},
+                    onRestrictedStatusClick = {},
+                    onNavigateToQueue = {},
+                )
+            }
+        }
+
+        rule.onNodeWithContentDescription(system).assertIsDisplayed().performClick()
+        rule.onNodeWithContentDescription(user).assertIsDisplayed().performClick()
+
+        rule.runOnIdle {
+            assertEquals(listOf(AppListType.SYSTEM, AppListType.USER), selections)
+            assertEquals(AppListType.USER, selectedType.value)
+        }
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/installer/InstallerViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/installer/InstallerViewModelTest.kt
@@ -24,13 +24,16 @@ import com.valhalla.thor.domain.model.ShellLaneBusy
 import com.valhalla.thor.domain.model.ShellLaneDegraded
 import com.valhalla.thor.domain.model.ShellTransportDied
 import com.valhalla.thor.domain.model.StagedPackage
+import com.valhalla.thor.domain.model.UserPreferences
 import com.valhalla.thor.domain.repository.AppAnalyzer
 import com.valhalla.thor.domain.repository.InstallMode
 import com.valhalla.thor.domain.repository.InstallerRepository
+import com.valhalla.thor.domain.repository.PreferenceRepository
 import com.valhalla.thor.presentation.FakePreferenceRepository
 import com.valhalla.thor.presentation.FakeSystemRepository
 import com.valhalla.thor.presentation.MainDispatcherRule
 import com.valhalla.thor.util.UiText
+import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -40,6 +43,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertThrows
@@ -129,7 +133,233 @@ class InstallerViewModelTest {
         fixture!!.assertRealInstallCall()
     }
 
-    private fun fixture(failure: Throwable): Fixture {
+    @Test
+    fun `saved off asks once before legacy Root install`() = runTest {
+        val fixture = fixture(targetSdk = 23)
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val confirmation = fixture.viewModel.legacyInstallConfirmation.value!!
+        assertEquals(fixture.analyzed.metadata, confirmation.meta)
+        assertTrue(fixture.repository.calls.isEmpty())
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        assertTrue(fixture.repository.calls.isEmpty())
+    }
+
+    @Test
+    fun `confirming legacy install starts exactly once without writing the saved setting`() = runTest {
+        val fixture = fixture(targetSdk = 23)
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val confirmation = fixture.viewModel.legacyInstallConfirmation.value!!
+        fixture.viewModel.confirmLegacyInstallation(confirmation.id)
+        fixture.viewModel.confirmLegacyInstallation(confirmation.id)
+        runCurrent()
+        assertTrue(fixture.repository.calls.single().bypassLowTargetSdkBlock)
+        assertEquals(0, fixture.preferences.legacyWrites)
+    }
+
+    @Test
+    fun `saved on installs legacy Shizuku without a StateFlow collector and keeps permission choice`() = runTest {
+        val fixture = fixture(targetSdk = 23, allowLegacyApkInstall = true)
+        fixture.parseReadyPackage()
+        fixture.viewModel.setInstallMode(InstallMode.SHIZUKU)
+        fixture.viewModel.setGrantAllPermissions(false)
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val call = fixture.repository.calls.single()
+        assertEquals(InstallMode.SHIZUKU, call.mode)
+        assertTrue(call.bypassLowTargetSdkBlock)
+        assertEquals(false, call.grantAllPermissions)
+    }
+
+    @Test
+    fun `dismissing and turning saved consent off restore the legacy prompt`() = runTest {
+        val fixture = fixture(targetSdk = 23)
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        fixture.viewModel.dismissLegacyInstallConfirmation(fixture.viewModel.legacyInstallConfirmation.value!!.id)
+        assertNull(fixture.viewModel.legacyInstallConfirmation.value)
+        fixture.preferences.setAllowLegacyApkInstall(true)
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        assertTrue(fixture.repository.calls.single().bypassLowTargetSdkBlock)
+        fixture.preferences.setAllowLegacyApkInstall(false)
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        assertTrue(fixture.viewModel.legacyInstallConfirmation.value != null)
+    }
+
+    @Test
+    fun `stale legacy confirmation callbacks cannot approve a changed selection`() = runTest {
+        val fixture = fixture(targetSdk = 23)
+        fixture.parseReadyPackage()
+        fixture.viewModel.setInstallMode(InstallMode.SHIZUKU)
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val stale = fixture.viewModel.legacyInstallConfirmation.value!!.id
+        fixture.viewModel.setGrantAllPermissions(false)
+        fixture.viewModel.confirmLegacyInstallation(stale)
+        runCurrent()
+        assertTrue(fixture.repository.calls.isEmpty())
+    }
+
+    @Test
+    fun `a failed confirmed legacy install requires fresh confirmation`() = runTest {
+        val fixture = fixture(
+            failure = ShellLaneBusy(PrivilegeExecutionLane.INTERACTIVE),
+            targetSdk = 23,
+        )
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val first = fixture.viewModel.legacyInstallConfirmation.value!!.id
+        fixture.viewModel.confirmLegacyInstallation(first)
+        runCurrent()
+        assertEquals(1, fixture.repository.calls.size)
+
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val retry = fixture.viewModel.legacyInstallConfirmation.value!!.id
+        assertTrue(retry > first)
+    }
+
+    @Test
+    fun `legacy setting read failure fails closed to confirmation`() = runTest {
+        val fixture = fixture(targetSdk = 23, legacyReadHook = { throw IOException("unreadable") })
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+
+        assertEquals(1, fixture.preferences.legacyReadCalls)
+        assertTrue(fixture.repository.calls.isEmpty())
+        assertTrue(fixture.viewModel.legacyInstallConfirmation.value != null)
+    }
+
+    @Test
+    fun `legacy setting read cancellation propagates`() = runTest {
+        val cancellation = CancellationException("cancel read")
+        val fixture = fixture(targetSdk = 23, legacyReadHook = { throw cancellation })
+        fixture.parseReadyPackage()
+
+        val completion = fixture.startAndObserveCompletion()
+        runCurrent()
+
+        val propagated = completion.await()
+        assertTrue(propagated is CancellationException)
+        assertEquals(cancellation.message, propagated?.message)
+        assertTrue(fixture.repository.calls.isEmpty())
+    }
+
+    @Test
+    fun `superseded legacy setting read cannot install or publish a stale confirmation`() = runTest {
+        val gate = CompletableDeferred<Boolean>()
+        val fixture = fixture(targetSdk = 23, legacyReadHook = { gate.await() })
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        fixture.viewModel.setInstallMode(InstallMode.NORMAL)
+        gate.complete(true)
+        runCurrent()
+
+        assertTrue(fixture.repository.calls.isEmpty())
+        assertNull(fixture.viewModel.legacyInstallConfirmation.value)
+    }
+
+    @Test
+    fun `stale confirmation ID after dismiss cannot approve a new request`() = runTest {
+        val fixture = fixture(targetSdk = 23)
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val dismissed = fixture.viewModel.legacyInstallConfirmation.value!!.id
+        fixture.viewModel.dismissLegacyInstallConfirmation(dismissed)
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val current = fixture.viewModel.legacyInstallConfirmation.value!!
+
+        fixture.viewModel.confirmLegacyInstallation(dismissed)
+        runCurrent()
+
+        assertTrue(fixture.repository.calls.isEmpty())
+        assertEquals(current, fixture.viewModel.legacyInstallConfirmation.value)
+    }
+
+    @Test
+    fun `repeated install taps during legacy setting read produce one read and no invocation`() = runTest {
+        val gate = CompletableDeferred<Boolean>()
+        val fixture = fixture(targetSdk = 23, legacyReadHook = { gate.await() })
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+
+        assertEquals(1, fixture.preferences.legacyReadCalls)
+        assertTrue(fixture.repository.calls.isEmpty())
+        gate.complete(false)
+        runCurrent()
+    }
+
+    @Test
+    fun `target zero is eligible for saved-off legacy confirmation`() = runTest {
+        val fixture = fixture(targetSdk = 0)
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        val confirmation = fixture.viewModel.legacyInstallConfirmation.value!!
+        fixture.viewModel.confirmLegacyInstallation(confirmation.id)
+        runCurrent()
+
+        assertTrue(fixture.repository.calls.single().bypassLowTargetSdkBlock)
+    }
+
+    @Test
+    fun `unknown modern and unsupported modes never bypass even when saved on`() = runTest {
+        for ((target, mode) in listOf(
+            null to InstallMode.ROOT,
+            24 to InstallMode.ROOT,
+            23 to InstallMode.NORMAL,
+            23 to InstallMode.DHIZUKU,
+            23 to InstallMode.EXTERNAL,
+        )) {
+            val fixture = fixture(targetSdk = target, allowLegacyApkInstall = true)
+            fixture.parseReadyPackage()
+            fixture.viewModel.setInstallMode(mode)
+            fixture.viewModel.startInstallation()
+            runCurrent()
+            assertFalse(fixture.repository.calls.single().bypassLowTargetSdkBlock)
+        }
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `Android 14 accepts target 23 without a bypass`() = runTest {
+        val fixture = fixture(targetSdk = 23)
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        assertFalse(fixture.repository.calls.single().bypassLowTargetSdkBlock)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `older Android never bypasses even when saved on`() = runTest {
+        val fixture = fixture(targetSdk = 22, allowLegacyApkInstall = true)
+        fixture.parseReadyPackage()
+        fixture.viewModel.startInstallation()
+        runCurrent()
+        assertFalse(fixture.repository.calls.single().bypassLowTargetSdkBlock)
+    }
+
+    private fun fixture(
+        failure: Throwable? = null,
+        targetSdk: Int? = null,
+        allowLegacyApkInstall: Boolean = false,
+        legacyReadHook: (suspend () -> Boolean)? = null,
+    ): Fixture {
         val uri = "content://com.example.provider/package.apk".toUri()
         val staged = StagedPackage(
             file = temporaryFolder.newFile("package-${fixtureNumber++}.apk"),
@@ -142,11 +372,13 @@ class InstallerViewModelTest {
                 version = "1.0",
                 versionCode = 1L,
                 iconPath = null,
+                targetSdk = targetSdk,
             ),
             staged = staged,
         )
         val analyzer = SuccessfulAnalyzer(analyzed)
         val repository = FailingInstallerRepository(failure)
+        val preferences = TrackingPreferenceRepository(allowLegacyApkInstall, legacyReadHook)
         val eventBus = InstallerEventBus()
         val application = ApplicationProvider.getApplicationContext<Application>()
         val viewModel = InstallerViewModel(
@@ -155,10 +387,10 @@ class InstallerViewModelTest {
             eventBus = eventBus,
             packageManager = application.packageManager,
             systemRepository = FakeSystemRepository(),
-            preferenceRepository = FakePreferenceRepository(),
+            preferenceRepository = preferences,
             ioDispatcher = mainDispatcherRule.dispatcher,
         )
-        return Fixture(viewModel, analyzer, repository, eventBus, analyzed, uri)
+        return Fixture(viewModel, analyzer, repository, eventBus, analyzed, uri, preferences)
     }
 
     private fun Fixture.parseReadyPackage() {
@@ -203,7 +435,29 @@ class InstallerViewModelTest {
         val eventBus: InstallerEventBus,
         val analyzed: AnalyzedPackage,
         val uri: Uri,
+        val preferences: TrackingPreferenceRepository,
     )
+
+    private class TrackingPreferenceRepository(
+        initialAllowLegacyApkInstall: Boolean,
+        private val readHook: (suspend () -> Boolean)? = null,
+        private val delegate: FakePreferenceRepository = FakePreferenceRepository(
+            UserPreferences(allowLegacyApkInstall = initialAllowLegacyApkInstall),
+        ),
+    ) : PreferenceRepository by delegate {
+        var legacyWrites = 0
+        var legacyReadCalls = 0
+
+        override suspend fun setAllowLegacyApkInstall(enabled: Boolean) {
+            legacyWrites++
+            delegate.setAllowLegacyApkInstall(enabled)
+        }
+
+        override suspend fun shouldAllowLegacyApkInstall(): Boolean {
+            legacyReadCalls++
+            return readHook?.invoke() ?: delegate.shouldAllowLegacyApkInstall()
+        }
+    }
 
     private class SuccessfulAnalyzer(
         private val analyzed: AnalyzedPackage,
@@ -219,7 +473,7 @@ class InstallerViewModelTest {
     }
 
     private class FailingInstallerRepository(
-        private val failure: Throwable,
+        private val failure: Throwable?,
     ) : InstallerRepository {
         val calls = mutableListOf<InstallCall>()
 
@@ -232,10 +486,11 @@ class InstallerViewModelTest {
             execution: PrivilegeExecutionContext,
             onInvocationStarted: () -> Unit,
             onInstallSucceeded: () -> Unit,
+            bypassLowTargetSdkBlock: Boolean,
         ) {
             onInvocationStarted()
-            calls += InstallCall(staged, uri, mode, canDowngrade, grantAllPermissions)
-            throw failure
+            calls += InstallCall(staged, uri, mode, canDowngrade, grantAllPermissions, bypassLowTargetSdkBlock)
+            if (failure != null) throw failure
         }
     }
 
@@ -245,5 +500,6 @@ class InstallerViewModelTest {
         val mode: InstallMode,
         val canDowngrade: Boolean,
         val grantAllPermissions: Boolean?,
+        val bypassLowTargetSdkBlock: Boolean,
     )
 }

--- a/app/src/test/java/com/valhalla/thor/presentation/installer/LegacyInstallOptionsTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/installer/LegacyInstallOptionsTest.kt
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.installer
+
+import android.app.Application
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import com.valhalla.thor.R
+import com.valhalla.thor.domain.model.AppMetadata
+import com.valhalla.thor.domain.repository.InstallMode
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [36])
+class LegacyInstallOptionsTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun legacyRootInstallShowsWarningWhenAutomaticApprovalIsOff() {
+        setOptions()
+
+        rule.onNodeWithText(description()).assertIsDisplayed()
+        rule.onNodeWithText(allowedBySetting()).assertDoesNotExist()
+    }
+
+    @Test
+    fun savedAutomaticApprovalIsExplainedForSupportedInstaller() {
+        setOptions(automaticallyAllowed = true)
+
+        rule.onNodeWithText(description()).assertIsDisplayed()
+        rule.onNodeWithText(allowedBySetting()).assertIsDisplayed()
+    }
+
+    @Test
+    fun confirmationDialogCallsConfirmForThisPackage() {
+        var confirmations = 0
+        var dismissals = 0
+        setConfirmationDialog(
+            onConfirm = { confirmations++ },
+            onDismiss = { dismissals++ },
+        )
+
+        rule.onNodeWithText(confirmTitle()).assertIsDisplayed()
+        rule.onNodeWithText(confirmMessage()).assertIsDisplayed()
+        rule.onNodeWithText(allowOnce()).performClick()
+
+        rule.runOnIdle {
+            assertEquals(1, confirmations)
+            assertEquals(0, dismissals)
+        }
+    }
+
+    @Test
+    fun confirmationDialogCancelCallsDismissWithoutConfirming() {
+        var confirmations = 0
+        var dismissals = 0
+        setConfirmationDialog(
+            onConfirm = { confirmations++ },
+            onDismiss = { dismissals++ },
+        )
+
+        rule.onNodeWithText(context().getString(R.string.cancel)).performClick()
+
+        rule.runOnIdle {
+            assertEquals(0, confirmations)
+            assertEquals(1, dismissals)
+        }
+    }
+
+    @Test
+    fun everyUnsupportedInstallerModeExplainsWhyItCannotBypass() {
+        val selectedMode = mutableStateOf(InstallMode.NORMAL)
+        rule.setContent {
+            MaterialTheme {
+                LegacyInstallOptions(
+                    meta = legacyMeta(),
+                    mode = selectedMode.value,
+                    automaticallyAllowed = true,
+                    deviceSdk = DEVICE_SDK,
+                )
+            }
+        }
+
+        for (mode in listOf(InstallMode.NORMAL, InstallMode.DHIZUKU, InstallMode.EXTERNAL)) {
+            rule.runOnIdle { selectedMode.value = mode }
+            rule.onNodeWithText(description()).assertIsDisplayed()
+            rule.onNodeWithText(unsupported()).assertIsDisplayed()
+            rule.onNodeWithText(allowedBySetting()).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun warningIsHiddenBeforeAndroid14ForSafeAndUnknownTargets() {
+        rule.setContent {
+            MaterialTheme {
+                LegacyInstallOptions(legacyMeta(), InstallMode.ROOT, false, deviceSdk = 33)
+                LegacyInstallOptions(legacyMeta(targetSdk = 23), InstallMode.ROOT, false, deviceSdk = DEVICE_SDK)
+                LegacyInstallOptions(legacyMeta(targetSdk = null), InstallMode.ROOT, false, deviceSdk = DEVICE_SDK)
+            }
+        }
+
+        rule.onNodeWithText(description()).assertDoesNotExist()
+        rule.onNodeWithText(unsupported()).assertDoesNotExist()
+    }
+
+    @Test
+    fun warningAndAutomaticApprovalExplanationRemainVisibleOnNarrowLargeTextSurface() {
+        rule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(LocalDensity.current.density, 1.5f)) {
+                MaterialTheme {
+                    Surface(Modifier.width(280.dp)) {
+                        LegacyInstallOptions(legacyMeta(), InstallMode.ROOT, true, deviceSdk = DEVICE_SDK)
+                    }
+                }
+            }
+        }
+
+        rule.onNodeWithText(description()).assertIsDisplayed()
+        rule.onNodeWithText(allowedBySetting()).assertIsDisplayed()
+    }
+
+    private fun setOptions(
+        mode: InstallMode = InstallMode.ROOT,
+        automaticallyAllowed: Boolean = false,
+    ) {
+        rule.setContent {
+            MaterialTheme {
+                LegacyInstallOptions(legacyMeta(), mode, automaticallyAllowed, DEVICE_SDK)
+            }
+        }
+    }
+
+    private fun setConfirmationDialog(
+        onConfirm: () -> Unit,
+        onDismiss: () -> Unit,
+    ) {
+        rule.setContent {
+            MaterialTheme {
+                LegacyInstallConfirmationDialog(
+                    meta = legacyMeta(),
+                    onConfirm = onConfirm,
+                    onDismiss = onDismiss,
+                    deviceSdk = DEVICE_SDK,
+                )
+            }
+        }
+    }
+
+    private fun legacyMeta(
+        label: String = "Example",
+        packageName: String = "com.example.legacy",
+        targetSdk: Int? = 22,
+    ) = AppMetadata(
+        label = label,
+        packageName = packageName,
+        version = "1.0",
+        versionCode = 1L,
+        iconPath = null,
+        targetSdk = targetSdk,
+    )
+
+    private fun context() = ApplicationProvider.getApplicationContext<Application>()
+
+    private fun allowOnce() = context().getString(R.string.legacy_install_allow_once)
+    private fun confirmTitle() = context().getString(R.string.legacy_install_confirm_title)
+    private fun unsupported() = context().getString(R.string.legacy_install_unsupported)
+    private fun allowedBySetting() = context().getString(R.string.legacy_install_allowed_by_setting)
+    private fun description() = context().getString(
+        R.string.legacy_install_description, "com.example.legacy", 22, 23,
+    )
+    private fun confirmMessage() = context().getString(
+        R.string.legacy_install_confirm_message, "Example", "com.example.legacy", 22, 23,
+    )
+
+    private companion object {
+        const val DEVICE_SDK = 34
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/settings/LegacyInstallSettingRowTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/settings/LegacyInstallSettingRowTest.kt
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings
+
+import android.app.Application
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import com.valhalla.thor.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [36])
+// Real font metrics are required for overflow assertions; legacy graphics uses stub text widths.
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class LegacyInstallSettingRowTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun legacyInstallSettingKeepsItsFullWarningAtLargeTextAndIsOneEnabledSwitch() {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val title = context.getString(R.string.allow_legacy_apk_install)
+        val subtitle = context.getString(R.string.allow_legacy_apk_install_desc)
+        val checked = mutableStateOf(false)
+        val changes = mutableListOf<Boolean>()
+
+        rule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(LocalDensity.current.density, 1.5f)) {
+                MaterialTheme {
+                    Surface(Modifier.width(320.dp)) {
+                        Column(Modifier.verticalScroll(rememberScrollState())) {
+                            SettingsSwitchRow(
+                                icon = R.drawable.danger,
+                                title = title,
+                                subtitle = subtitle,
+                                checked = checked.value,
+                                titleMaxLines = Int.MAX_VALUE,
+                                subtitleMaxLines = Int.MAX_VALUE,
+                                onCheckedChange = {
+                                    changes += it
+                                    checked.value = it
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        val titleNode = rule.onNodeWithText(title, useUnmergedTree = true).assertIsDisplayed()
+        val subtitleNode = rule.onNodeWithText(subtitle, useUnmergedTree = true).assertIsDisplayed()
+        titleNode.assertHasNoTruncation()
+        subtitleNode.assertHasNoTruncation()
+
+        val hasSwitchRole = SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Switch)
+        rule.onAllNodes(hasSwitchRole).assertCountEquals(1)
+        rule.onNode(hasSwitchRole).assertIsEnabled().assertIsOff().performClick()
+        rule.onNode(hasSwitchRole).assertIsOn()
+        rule.runOnIdle { assertEquals(listOf(true), changes) }
+    }
+
+    private fun SemanticsNodeInteraction.assertHasNoTruncation() {
+        val layouts = mutableListOf<TextLayoutResult>()
+        val action = checkNotNull(
+            fetchSemanticsNode().config[SemanticsActions.GetTextLayoutResult].action
+        )
+
+        assertTrue(action(layouts))
+        assertEquals(1, layouts.size)
+        val layout = layouts.single()
+        val diagnostic = "text=${layout.layoutInput.text}, size=${layout.size}, " +
+            "constraints=${layout.layoutInput.constraints}, lines=${layout.lineCount}, " +
+            "overflowWidth=${layout.didOverflowWidth}, overflowHeight=${layout.didOverflowHeight}"
+        assertFalse(diagnostic, layout.hasVisualOverflow)
+        assertFalse(layout.didOverflowWidth)
+        assertFalse(layout.didOverflowHeight)
+        assertFalse((0 until layout.lineCount).any(layout::isLineEllipsized))
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsCatalogTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsCatalogTest.kt
@@ -84,6 +84,19 @@ class SettingsCatalogTest {
         }
     }
 
+    @Test
+    fun legacyApkInstallPreferenceIsNextToTheOtherInstallerSecuritySwitch() {
+        assertEquals(
+            listOf(
+                SettingsRowId.AUTO_REINSTALL,
+                SettingsRowId.GRANT_ALL_PERMISSIONS,
+                SettingsRowId.ALLOW_LEGACY_APK_INSTALL,
+                SettingsRowId.ANY_FILE_OPENER,
+            ),
+            SettingsRowId.rowsIn(SettingsCategory.INSTALLING),
+        )
+    }
+
     /**
      * No two categories answer to the same route id.
      *

--- a/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsExpandedSwitchRowTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsExpandedSwitchRowTest.kt
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings
+
+import android.app.Application
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import com.valhalla.thor.R
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [36], qualifiers = "w800dp-h1280dp")
+// Stub font widths cannot detect the truncation these regressions protect against.
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SettingsExpandedSwitchRowTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun translatedExplanationsRemainCompleteOnNarrowScreensAtDoubleTextSize() {
+        assertLocalizedRowsFit(width = 320.dp, fontScale = 2f)
+    }
+
+    @Test
+    fun translatedExplanationsRemainCompleteOnLargerScreensAtLargeTextSize() {
+        assertLocalizedRowsFit(width = 600.dp, fontScale = 1.5f)
+    }
+
+    @Test
+    fun expandedRowRemainsOneSwitchAndReportsTheRequestedStateOncePerTap() {
+        val checked = mutableStateOf(false)
+        val changes = mutableListOf<Boolean>()
+
+        rule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(LocalDensity.current.density, 1.5f)) {
+                MaterialTheme {
+                    Surface(Modifier.width(320.dp)) {
+                        Column(Modifier.verticalScroll(rememberScrollState()).padding(horizontal = 24.dp)) {
+                            SettingsExpandedSwitchRow(
+                                icon = R.drawable.round_key,
+                                title = stringResource(R.string.biometric_lock),
+                                subtitle = stringResource(R.string.biometric_lock_desc),
+                                checked = checked.value,
+                                onCheckedChange = {
+                                    changes += it
+                                    checked.value = it
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        rule.onAllNodes(hasSwitchRole).assertCountEquals(1)
+        rule.onNode(hasSwitchRole).assertIsEnabled().assertIsOff().performClick()
+        rule.onNode(hasSwitchRole).assertIsOn().performClick()
+        rule.onNode(hasSwitchRole).assertIsOff()
+
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        rule.onNodeWithText(application.getString(R.string.biometric_lock_desc), useUnmergedTree = true)
+            .performTouchInput { click() }
+        rule.onNode(hasSwitchRole).assertIsOn()
+        // The decorative Switch sits at the trailing edge; touching it must reach the row once.
+        rule.onNode(hasSwitchRole).performTouchInput { click(percentOffset(0.9f, 0.5f)) }
+        rule.onNode(hasSwitchRole).assertIsOff()
+        rule.runOnIdle { assertEquals(listOf(true, false, true, false), changes) }
+    }
+
+    @Test
+    fun disabledExpandedRowDoesNotChangeTheSetting() {
+        val changes = mutableListOf<Boolean>()
+
+        rule.setContent {
+            MaterialTheme {
+                SettingsExpandedSwitchRow(
+                    icon = R.drawable.frozen,
+                    title = stringResource(R.string.suspend_instead_of_freeze),
+                    subtitle = stringResource(R.string.suspend_instead_of_freeze_desc),
+                    checked = false,
+                    enabled = false,
+                    onCheckedChange = { changes += it },
+                )
+            }
+        }
+
+        rule.onAllNodes(hasSwitchRole).assertCountEquals(1)
+        rule.onNode(hasSwitchRole).assertIsNotEnabled().assertIsOff().performClick()
+        rule.runOnIdle { assertEquals(emptyList<Boolean>(), changes) }
+    }
+
+    private fun assertLocalizedRowsFit(width: Dp, fontScale: Float) {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val localizedContexts = localeTags.map { tag ->
+            val locale = Locale.forLanguageTag(tag)
+            val configuration = Configuration(application.resources.configuration).apply {
+                setLocale(locale)
+                setLayoutDirection(locale)
+            }
+            application.createConfigurationContext(configuration)
+        }
+        val selectedContext = mutableStateOf(localizedContexts.first())
+
+        // Reuse one composition per viewport instead of launching a new activity for every row.
+        rule.setContent {
+            val context = selectedContext.value
+            val layoutDirection = if (context.resources.configuration.locales[0].language == "ar") {
+                LayoutDirection.Rtl
+            } else {
+                LayoutDirection.Ltr
+            }
+            CompositionLocalProvider(
+                LocalContext provides context,
+                LocalConfiguration provides context.resources.configuration,
+                LocalLayoutDirection provides layoutDirection,
+                LocalDensity provides Density(LocalDensity.current.density, fontScale),
+            ) {
+                MaterialTheme {
+                    Surface(Modifier.width(width).height(600.dp).testTag(VIEWPORT_TAG)) {
+                        Column(Modifier.verticalScroll(rememberScrollState()).padding(horizontal = 24.dp)) {
+                            expandedRows.forEach { row ->
+                                SettingsExpandedSwitchRow(
+                                    icon = row.icon,
+                                    title = stringResource(row.title),
+                                    subtitle = stringResource(row.subtitle),
+                                    checked = false,
+                                    onCheckedChange = {},
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        localizedContexts.forEach { context ->
+            rule.runOnIdle { selectedContext.value = context }
+            val tag = context.resources.configuration.locales[0].toLanguageTag()
+            val direction = if (tag == "ar") LayoutDirection.Rtl else LayoutDirection.Ltr
+            val case = "locale=$tag, width=$width, fontScale=$fontScale"
+            rule.onNodeWithTag(VIEWPORT_TAG).assertWidthIsEqualTo(width)
+
+            expandedRows.forEach { row ->
+                val title = context.getString(row.title)
+                val subtitle = context.getString(row.subtitle)
+                rule.onNodeWithText(title, useUnmergedTree = true).assertHasNoTruncation(case, direction)
+                rule.onNodeWithText(subtitle, useUnmergedTree = true).assertHasNoTruncation(case, direction)
+            }
+
+            // Longer rows may extend beyond the viewport, but their complete text must be reachable.
+            rule.onNodeWithText(context.getString(expandedRows.last().subtitle), useUnmergedTree = true)
+                .performScrollTo()
+                .assertIsDisplayed()
+        }
+    }
+
+    private fun SemanticsNodeInteraction.assertHasNoTruncation(case: String, direction: LayoutDirection) {
+        val layouts = mutableListOf<TextLayoutResult>()
+        val action = checkNotNull(fetchSemanticsNode().config[SemanticsActions.GetTextLayoutResult].action)
+        assertTrue(action(layouts))
+        assertEquals(1, layouts.size)
+        val layout = layouts.single()
+        val diagnostic = "$case, text=${layout.layoutInput.text}, size=${layout.size}, " +
+            "constraints=${layout.layoutInput.constraints}, lines=${layout.lineCount}, " +
+            "paragraphWidth=${layout.multiParagraph.width}, paragraphHeight=${layout.multiParagraph.height}, " +
+            "maxIntrinsicWidth=${layout.multiParagraph.maxIntrinsicWidth}, " +
+            "overflowWidth=${layout.didOverflowWidth}, overflowHeight=${layout.didOverflowHeight}, " +
+            "lineBounds=" + (0 until layout.lineCount).joinToString { line ->
+                "[$line: ${layout.getLineLeft(line)}..${layout.getLineRight(line)}, " +
+                    "start=${layout.getLineStart(line)}, end=${layout.getLineEnd(line)}, " +
+                    "visibleEnd=${layout.getLineEnd(line, visibleEnd = true)}, " +
+                    "ellipsized=${layout.isLineEllipsized(line)}]"
+            }
+        assertEquals(diagnostic, direction, layout.layoutInput.layoutDirection)
+        assertFalse(diagnostic, layout.hasVisualOverflow)
+        assertFalse(diagnostic, layout.didOverflowWidth)
+        assertFalse(diagnostic, layout.didOverflowHeight)
+        assertFalse(diagnostic, (0 until layout.lineCount).any(layout::isLineEllipsized))
+    }
+
+    private data class ExpandedRow(val icon: Int, val title: Int, val subtitle: Int)
+
+    private companion object {
+        const val VIEWPORT_TAG = "expanded-settings-viewport"
+        val hasSwitchRole = SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Switch)
+        val localeTags = listOf("en", "ar", "es", "fr", "pl", "pt", "pt-BR", "zh-CN")
+        val expandedRows = listOf(
+            ExpandedRow(R.drawable.frozen, R.string.auto_freeze, R.string.auto_freeze_desc),
+            ExpandedRow(R.drawable.frozen, R.string.suspend_instead_of_freeze, R.string.suspend_instead_of_freeze_desc),
+            ExpandedRow(R.drawable.danger, R.string.skip_routine_freeze_confirmation, R.string.skip_routine_freeze_confirmation_desc),
+            ExpandedRow(R.drawable.frozen, R.string.add_freezer_to_launcher, R.string.add_freezer_to_launcher_desc),
+            ExpandedRow(R.drawable.round_key, R.string.biometric_lock, R.string.biometric_lock_desc),
+        )
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsPickerRowConnectedButtonGroupTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsPickerRowConnectedButtonGroupTest.kt
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 Trinadh Thatakula <github.com/trinadhthatakula/Thor>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.valhalla.thor.presentation.settings
+
+import android.app.Application
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.valhalla.asgard.components.ConnectedButtonGroupItem
+import com.valhalla.thor.R
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [36])
+class SettingsPickerRowConnectedButtonGroupTest {
+
+    @get:Rule val rule = createComposeRule()
+
+    @Test
+    fun labeledPickerRendersAndForwardsSelectionChanges() {
+        val selectedIndex = mutableIntStateOf(0)
+        val selections = mutableListOf<Int>()
+
+        rule.setContent {
+            MaterialTheme {
+                SettingsPickerRow(
+                    icon = R.drawable.theme_panel,
+                    title = "Theme",
+                    subtitle = "Choose Thor's appearance",
+                    items = listOf(
+                        ConnectedButtonGroupItem.Label("Light"),
+                        ConnectedButtonGroupItem.Label("Dark"),
+                    ),
+                    selectedIndex = selectedIndex.intValue,
+                    onItemSelected = {
+                        selections += it
+                        selectedIndex.intValue = it
+                    },
+                )
+            }
+        }
+
+        rule.onNodeWithText("Dark").assertIsDisplayed().performClick()
+        rule.onNodeWithText("Light").assertIsDisplayed().performClick()
+
+        rule.runOnIdle {
+            assertEquals(listOf(1, 0), selections)
+            assertEquals(0, selectedIndex.intValue)
+        }
+    }
+}

--- a/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/valhalla/thor/presentation/settings/SettingsViewModelTest.kt
@@ -147,6 +147,26 @@ class SettingsViewModelTest {
         assertEquals(TaskNavigationRequest.Rejected(open.taskId), requests[1])
     }
 
+    @Test
+    fun `legacy APK install setting is persisted through preferences`() = runTest {
+        val preferences = FakePreferenceRepository()
+        val vm = viewModel(
+            freezer = FakeFreezerRepository(),
+            preferences = preferences,
+            controller = FakePrivilegeSweepController(),
+            candidates = emptyMap(),
+            targets = TaskNavigationTargets(ProvisionalTaskIdentityRegistry()),
+        )
+        backgroundScope.launch(mainDispatcherRule.dispatcher) { vm.uiState.collect {} }
+        runCurrent()
+        assertEquals(false, vm.uiState.value.prefs.allowLegacyApkInstall)
+
+        vm.setAllowLegacyApkInstall(true)
+        runCurrent()
+
+        assertTrue(vm.uiState.value.prefs.allowLegacyApkInstall)
+    }
+
     private fun viewModel(
         freezer: FakeFreezerRepository,
         preferences: FakePreferenceRepository,

--- a/docs/analysis/community-feature-request-assessment-2026-09.md
+++ b/docs/analysis/community-feature-request-assessment-2026-09.md
@@ -1,0 +1,307 @@
+# Thor community feature-request assessment
+
+- **Working snapshot:** 2026-09-10 (targeted implementation updates; not a new full backlog sweep)
+- **Assessment baseline:** `origin/dev` at `d091ecb7`. Doctor was subsequently synced to `dev` at
+  `504e3418`, then `5c9672e6` after the web-only Dependabot sync in
+  [PR #463](https://github.com/trinadhthatakula/Thor/pull/463). These synchronizations alone do not
+  revalidate every historical assessment below.
+- **First selected implementation:** TG-001, on `feat/legacy-apk-install` from `dev` at `504e3418`.
+  Implemented locally with passing test/lint gates and an API-36 package-manager smoke test.
+  End-to-end device acceptance and Store-policy review remain open; nothing is claimed released.
+- **Next selected implementations:** RD-001 and RD-004, locally on the same feature branch.
+  Screenshot-protection copy and fully expanded Freezer/security switch explanations are implemented;
+  native-layout tests, full unit tests, both lint gates, and debug APK assembly pass.
+  App-lock/screenshot-protection behavior is unchanged. The maintainer confirmed all settings changes
+  in the tested debug APK on a physical device on 2026-09-10; these changes remain unmerged/unreleased.
+- **Sources loaded so far:** live GitHub issues, `docs/follow-ups/`, `docs/feature-request-roadmap.md`, `README.md`, current source and release history, Thor-Extensions branch state, and the public FAQ.
+- **Manual intake so far:** the maintainer's 2026-09-09 Telegram and Reddit excerpts below; more
+  messages can be appended without changing the evidence rules.
+
+This is a living intake and assessment, not a final roadmap.  It deliberately separates what a user
+asked for from what is actually unbuilt, because an open issue can be fully shipped, a merged change
+can still need device validation, and a historical document can describe a superseded state.
+
+## Status vocabulary
+
+| Status | Meaning |
+|---|---|
+| `implementation gap` | A defined, unbuilt capability remains. |
+| `scope decision` | The request is real, but product, safety, privacy, or policy choices must be made before estimating it. |
+| `deferred` | Known work deliberately postponed; it is not a promise of imminent delivery. |
+| `partially shipped` | Some requested outcome exists; the residual must be named precisely. |
+| `validation-bound` | Code exists, but a device/OEM/privilege check is still required before calling it delivered. |
+| `awaiting release` | Merged into `dev`, but not included in a stable release. |
+| `in progress — extension` | Active implementation is happening in a separate extension; integration, signing, release, and validation are still outstanding. |
+| `brainstorming required` | Some capability exists, but the remaining user outcome has competing plausible designs and no selected target behavior. |
+| `closeable` | The issue remains open even though its achievable scope shipped or was explicitly declined. |
+| `non-feature` | A bug, operational item, feedback thread, or external dependency; keep it out of feature ranking. |
+| `documentation stale` | An older source states a status superseded by current code or release evidence; retain it as historical context, not current truth. |
+
+## Live GitHub tracker snapshot
+
+The tracker had 12 open issues at the snapshot: nine labelled `enhancement`, one installer bug,
+one CI/link-check item, and the Shizu Store feedback thread.  The table records the **remaining**
+need, not merely the original title.
+
+| Source | Normalized request | Assessment | Evidence and next action |
+|---|---|---|---|
+| [GH #445](https://github.com/trinadhthatakula/Thor/issues/445) | Do not silently grant every requested runtime permission during privileged installs; consider helping affected users review past grants. | `awaiting release` for the safety fix; the retrospective prompt is a separate `scope decision`. | PR #446 removed the default `-g` behavior and added an opt-in setting/per-install control. It is in this `dev` snapshot but no stable tag contains it. Keep the issue open through a stable release, then close it or explicitly split the historical-permission notice. |
+| [GH #390](https://github.com/trinadhthatakula/Thor/issues/390) | Work around HyperOS/MIUI isolation that rejects updates to existing system apps from Thor. | `validation-bound` / `scope decision`. | Some Xiaomi ROMs reportedly expose **Developer Options → Update system apps**, which may control this exact operation. Verify its exact path, ROM/version availability, and effect on the reporter's `INSTALL_FAILED_HYPEROS_ISOLATION_VIOLATION` before considering installer spoofing. If it resolves the failure, clear device guidance/capability detection is preferable to impersonating another installer; if it does not, separately establish whether the remaining gate is caller identity, installer attribution, or both. This is not the unrelated **Install via USB** option. |
+| [GH #382](https://github.com/trinadhthatakula/Thor/issues/382) | Select a work mode and authorize Dhizuku without manual permission setup. | `partially shipped`. | In-app Dhizuku grant and refresh shipped in v1.95.1, and the existing selector chooses among available modes. The request's literal “show/select unavailable modes” half is not met because the selector is built from available modes only. Ask whether the shipped in-app grant resolves the reporter's need; otherwise split and scope the unavailable-provider UX. |
+| [GH #209](https://github.com/trinadhthatakula/Thor/issues/209) | VirusTotal scan for install archives and installed apps. | `in progress — extension`. | The separate S.H.I.E.L.D. extension is under active development on Thor-Extensions' unmerged [`feat/virus-scanner-extension`](https://github.com/trinadhthatakula/Thor-Extensions/tree/feat/virus-scanner-extension) branch. It is not merged, signed/catalog-published, or released, so keep the issue open and track extension integration, API-key/privacy UX, release, and validation rather than scheduling a base-app scanner. |
+| [GH #178](https://github.com/trinadhthatakula/Thor/issues/178) | User-defined app tags for browsing/filtering; pair with per-app notes. | `implementation gap`. | Permission filters and Freeze Profiles are not general app tags. The two Reddit requests remove the old “zero demand” rationale; tags and notes should share one Room migration and app-list surface. Clarify tags-for-browsing versus custom grouping/sorting during intake. |
+| [GH #164](https://github.com/trinadhthatakula/Thor/issues/164) | Export APK/APKS/XAPK to a chosen folder. | `closeable`. | Folder export, APK/APKS/XAPK, and XAPK OBB support are in stable v1.95.1. Loose split folders remain an explicit decline. Close with that scope rather than silently implying every interpretation shipped. |
+| [GH #161](https://github.com/trinadhthatakula/Thor/issues/161) | Make Thor appear for `.apks` files opened from Samsung My Files. | `partially shipped`, `validation-bound`. | The opt-in broad alias shipped, but the actual Samsung `pm query-activities`/open-with diagnostic is unrun. Keep open until the reporter-device result decides whether a narrow MIME change is enough. `ACTION_SEND` is a separate, currently unimplemented route. |
+| [GH #130](https://github.com/trinadhthatakula/Thor/issues/130) | Friendly installer labels and a chart tap-through to apps from that installer. | `brainstorming required`. | Labels and named-legend chart-to-filter navigation shipped, but the desired residual is not selected. Brainstorm whether the priority is direct bar-segment interaction, an explorable aggregate/unknown-source path, or voluntary user provenance annotations. Android may still report `com.android.shell` or no installer for shell installs, which Thor cannot reconstruct as factual historical provenance. |
+| [GH #58](https://github.com/trinadhthatakula/Thor/issues/58) | Lock *other* apps behind authentication. | `deferred`. | This is distinct from Thor's own biometric lock. Launch detection, overlay, foreground service, boot persistence, OEM behavior, and Play-policy exposure are all new; Dhizuku has no per-launch route. The maintainer reconfirmed on 2026-09-09 that it stays deferred. |
+| [GH #55](https://github.com/trinadhthatakula/Thor/issues/55) | Freeze profiles plus a process manager. | `partially shipped`, residual `deferred`. | Profiles shipped. A RAM/CPU process manager remains a fragile Root/Shizuku-only parser with no Dhizuku path. Split or retitle the issue so the delivered profiles do not obscure the remaining process request; separately assess a smaller “is running” flag. |
+| [GH #337](https://github.com/trinadhthatakula/Thor/issues/337) | External-link checker failures. | `non-feature`. | Operational/CI handling only; exclude from this assessment. |
+| [GH #279](https://github.com/trinadhthatakula/Thor/issues/279) | Shizu Store feedback/comments. | `non-feature`. | Intentional public feedback thread, not a product request. Keep open and mine only genuinely new requests that appear there. |
+
+### Focused status notes from the 2026-09-09 maintainer clarification
+
+#### GH #390 — HyperOS/MIUI system-app updates: configuration and diagnosis first
+
+The relevant Xiaomi control is reported as **Settings → Additional settings → Developer options →
+Update system apps**; some ROMs use close wording such as **Allow updating system apps**.  It is not
+**Install via USB**, and it is not a recommendation to disable MIUI/HyperOS optimization.
+
+The first-line support flow for the exact
+`INSTALL_FAILED_HYPEROS_ISOLATION_VIOLATION` error should be: preserve the raw error, explain that
+the setting is Xiaomi-specific and may be absent or differently translated, ask the user to enable
+it and retry, then collect the model, region, HyperOS/MIUI version, target package, and privilege
+mode.  [AppManager #1484](https://github.com/MuntashirAkon/AppManager/issues/1484) independently
+records the same error and reports success after enabling the control; [APKMirror Installer
+#311](https://github.com/illogical-robot/apkmirror-public/issues/311) has HyperOS 2 reports that
+also distinguish this problem from HyperOS optimization.
+
+That is strong enough to recommend troubleshooting guidance, not to claim universal behavior.
+The setting is OEM/ROM/version/package dependent and does not bypass signing lineage, version or
+downgrade rules, split/ABI requirements, Android's low-target-SDK block, or other Package Manager
+checks.  Thor should not claim it can read or change this vendor Developer Option.  Do a physical
+off/on comparison on an affected Xiaomi device before considering any narrow privileged retry; do
+not ship arbitrary installer-ID presets or a general installer-spoofing switch.  `-i` changes
+installer attribution, not a trustworthy caller identity.
+
+#### GH #209 — VirusTotal: active extension work, not a deferred core feature
+
+The feature is in development as the separate **S.H.I.E.L.D.** extension.  The Thor-Extensions
+`feat/virus-scanner-extension` branch is unmerged and unreleased, so it is not proof of an
+available scanner; it moves the remaining work into the extension workstream: extension API and
+integration behavior, signing/catalog publication, API-key and privacy consent UX, rate-limit
+handling, and device/release validation.  Keep #209 open until that work is available to users.
+
+#### GH #130 — choose the remaining outcome before closing it
+
+v1.95.1 already supplies friendly installer labels and named-legend navigation into the matching
+app-list filter.  The issue should remain open for a short design decision rather than being
+treated as a defect or automatically closed.  Viable directions are:
+
+1. Make the visual distribution-bar segments directly selectable, with accessible equivalents and
+   a deliberate behavior for tiny slices.
+2. Make **Other** explorable through an all-sources/unknown-source sheet, rather than pretending
+   its aggregate has one installer identifier.
+3. If real demand remains, add user-authored provenance annotations as clearly non-Android-derived
+   metadata; this is a separate Room/backup/editing feature, not a fix for Android attribution.
+
+Android can legitimately return `com.android.shell`, a missing source, or an unavailable installer
+label.  Thor must not infer a historical installer such as InstallWithOptions where Android did not
+record one.
+
+#### GH #58 — stays deferred
+
+No new implementation decision is implied by the existing request.  Keep the tracker and this
+assessment at `deferred` until demand or support/policy requirements change materially.
+
+## Existing community and documentation signal
+
+The older roadmap and follow-up index are useful evidence, but neither is a current truth source on
+its own.  The last broad follow-up sweep predates recent `dev` changes, and many retained rows are
+kept specifically to preserve the reasoning for a shipped decision.
+
+| Canonical opportunity | Sources already found | Provisional position before new message imports |
+|---|---|---|
+| Tags + per-app notes | GH #178; Reddit r/howtomen record; follow-up index | One combined app-list/Room migration. Genuine gap with corroborated demand. |
+| Process visibility / process manager | GH #55; Reddit request | Keep the lightweight “is running” flag separate from live RAM/CPU statistics. Neither should be treated as Dhizuku-compatible without evidence. |
+| App lock | GH #58; feature roadmap | Defer: high ongoing platform/policy burden, not a small extension of Thor's own biometric lock. |
+| VirusTotal integration | GH #209; feature roadmap; S.H.I.E.L.D. extension branch | `in progress — extension`, not a base-app scanner commitment. Track extension signing/catalog publication, API-key and privacy UX, integration hooks, and validation. |
+| Change/update history | Reddit follow-up | One shared event-history data model, not two isolated features. Needs a current code re-check before sizing. |
+| Abandoned-app notifications | Reddit follow-up | Existing usage-access plumbing reduces setup cost, but usage query, scheduling, notification behavior, and product wording remain. |
+| Permission grant/revoke | Reddit follow-up; current Permission Manager | Thor now exposes per-package permission toggles through all three privilege gateways. Treat the original grant/revoke ask as shipped subject to Android/platform limits; a broader App Ops manager would be a separate new request. |
+| Backup/restore and XAPK behavior | README promise; follow-ups; GH #164/#51 history | The current release contains the feature work, but documented Root/Shizuku/OEM acceptance checks remain unrun. Keep hardware validation outside the feature-priority score rather than re-listing it as a new feature. |
+| Editing `packages.xml`, batch install, authenticated extension trigger | README Upcoming Features | Standing promises with no sufficient design/evidence yet. Keep as unscoped candidates, not ranked commitments. |
+
+### Residual candidates from `docs/follow-ups`
+
+These are the historical community/standing asks that still warrant intake after stale or shipped rows
+are removed.  They are deliberately not yet ordered: the missing Telegram and Reddit imports may
+change the demand signal.
+
+| Candidate | Status before new imports | What must be resolved before it can be ranked |
+|---|---|---|
+| Change history + update history | `implementation gap` | Design one event/history model; current scans overwrite version facts, so two separate screens would duplicate the same storage work. |
+| Abandoned-app notifications | `implementation gap` | Decide the usage interval, query cadence, notification behavior, privacy copy, and action affordances. Existing usage-access setup lowers plumbing cost but does not settle the product behavior. |
+| Lightweight running-app signal | `implementation gap`, unsized | Name the privileged API/command and an honest unsupported-mode fallback before treating it as the cheap half of a process manager. |
+| Interactive, sort-aware scrollbar scrubber | `implementation gap` | The non-interactive indicator shipped. Define real bucket semantics for each sort family and preserve list ordering/locales. |
+| Editing `packages.xml` | `scope decision` | No design, issue, or safe supported use case is recorded. |
+| Batch install | `scope decision` | Define archive selection, ordering, confirmation, failure/retry behavior, privilege modes, and interaction with the existing installer queue. |
+| Authenticated extension trigger | `scope decision` | Replace the removed exported deep link with an explicit-component or nonce-authenticated handoff; security model precedes UX. |
+
+### Product decisions and validation debt kept outside feature ranking
+
+| Item | Why it is not a normal feature-score row |
+|---|---|
+| “Remove this system app for my user, preserving data” | A consent path remains after the unsafe freeze escalation was removed. Its watchlist semantics, inverse operation, headless callers, and hardware reproduction are product/safety decisions first. |
+| Freezer rows that cannot thaw | Auto-pruning genuinely uninstalled packages shipped. Any remaining “remove anyway” escape hatch changes destructive behavior and needs an explicit policy. |
+| Release logging and subscription-downgrade replacement mode | Both are product/privacy or billing-policy choices with tests needed before implementation. They should not be inflated by community-request counts. |
+| Backup/restore, XAPK/OBB, cross-privilege suspend, and Samsung My Files | Code/release evidence exists, while specific hardware/OEM/privilege checks remain unrun. These are acceptance gates, not proof of an empty feature backlog. |
+| Engineering-only follow-ups | `BulkFreezeRunner` test seams, `code_cache` behavior, Perfetto work, Vercel deployment, and Odin items were reviewed but belong to engineering/upstream tracking rather than community feature scoring. |
+
+## Evidence and conflict handling
+
+- The live tracker is a snapshot of 2026-09-09.  Issue state alone is never capability evidence.
+- `docs/feature-request-roadmap.md` explicitly says its broad review is from July with only a
+  partial August re-check, so it is historical sizing/context rather than a September status source.
+- `docs/follow-ups/README.md` was last broadly swept on 2026-08-19.  It remains useful for user
+  rationale and unrun acceptance checklists, but current code and release history override a
+  contradictory implementation claim.
+- #382: the available-mode selector is in `SettingsScreen` / `DashboardHeader`; the in-app Dhizuku
+  request is implemented by `DhizukuHelper.requestPermission` and released in v1.95.1.
+- #445: PR #446 is merged into this `dev` snapshot.  Its default-off setting and one-install choice
+  are wired through `InstallerViewModel` and each Root, Shizuku, and Dhizuku session path; no stable
+  release tag contains that merge yet.
+- #390: do not confuse Xiaomi's **Update system apps** Developer Options control with **Install via
+  USB** or system optimization.  The former is a reported first-line workaround for this exact
+  vendor error; its availability and effect need an affected-device off/on comparison before Thor
+  can make anything stronger than conditional troubleshooting guidance.
+- #209: the older feature roadmap and follow-up index say deferred, but the current FAQ and the
+  unmerged Thor-Extensions `feat/virus-scanner-extension` branch show active extension work.  The
+  implementation is neither merged nor released, so `in progress — extension` is not `shipped`.
+- #164: `BundleFormat`, `ExportBottomSheet`, and `ObbInstaller` evidence the output formats and OBB
+  path; v1.95.1 release notes confirm the released scope.  Retain the documented device-validation
+  debt rather than inferring every mode/OEM path has run.
+- #130: `InstallerDistribution`, `HomeScreen`, and `AppListViewModel` implement labels and
+  named-legend chart-to-filter navigation.  The remaining Android attribution limit is source data,
+  while direct chart interaction and aggregate-source exploration require a maintainer design choice.
+- Runtime permission grant/revoke is current code (`TogglePermissionUseCase`, `PermissionManager`,
+  and all three gateway implementations).  A request for arbitrary Android App Ops is broader and
+  must be recorded as a new scope if it arises.
+
+## Manual Telegram and Reddit intake
+
+Paste each message verbatim into the task conversation.  This document will preserve a normalized
+row and retain enough source context to distinguish repeated demand from duplicate implementation
+work.
+
+| ID | Channel / date | Verbatim source retained externally | Normalized request | Related canonical opportunity | Demand signal | Current capability / gap | Status | Questions before ranking |
+|---|---|---|---|---|---|---|---|---|
+| TG-001 | Telegram / 2026-09-09 | Task conversation | Let a Shizuku user install an APK rejected on Android 16 for its old SDK level (reported target/SDK 23 on Galaxy S24 Ultra). | Low-target-SDK installation override | 1 report | This is a `targetSdkVersion` block, not `minSdkVersion`: Android 16 reports `INSTALL_FAILED_DEPRECATED_SDK_VERSION` below target API 24. Root and Shizuku shell can use the bypass; Dhizuku, normal, and external modes cannot. | `validation-bound`: implemented locally, not merged/released | Follow [implementation and acceptance record](../follow-ups/legacy-target-sdk-installation.md); end-to-end device acceptance and Store-policy review remain open. |
+| TG-002 | Telegram / 2026-09-09 | Task conversation | Fix a mobile-responsiveness problem on thor.trinadhthatakula.com in Android Brave. | Website mobile layout | 1 report | No URL, screenshot, viewport, or affected section supplied. `/follow-ups-report.html` is a plausible narrow-screen risk: its sticky header does not reflow and its search input has a 260px minimum width. | `needs reproduction` | Which page/section, Brave version, viewport/font scale, and expected versus actual layout? |
+| RD-001 | Reddit: onlytanmoy / imported 2026-09-09 | Task conversation | Explain why Thor blocks screenshots. | Biometric-lock discoverability | 1 report | Biometric-lock copy now explains launch authentication, screenshot/recording protection and the hidden Recents preview in all eight locales; its row expands fully. `FLAG_SECURE` behavior is unchanged, including after authentication. | `implemented locally; automated and physical-device settings checks passed` | Maintainer confirmed the settings changes in the debug APK on a physical device on 2026-09-10. Not merged/released; screenshot/recording/Recents security testing is not implied. If screenshots remain blocked with app lock disabled, collect a separate reproduction. |
+| RD-002 | Reddit: onlytanmoy / imported 2026-09-09 | Task conversation | Explain the first top-right Home control that appears to do nothing. | Privilege-mode control discoverability | 1 report | The status icon cycles available privilege modes when more than one is ready; otherwise it opens the privilege check. The action has weak visual affordance. | `discoverability` | Which modes were available, and did its icon/change state update? Is a label, tooltip, or mode picker clearer than silent cycling? |
+| RD-003 | Reddit: onlytanmoy / imported 2026-09-09 | Task conversation | Make App Distribution “Other” useful when tapped. | Installer-distribution drill-down | 1 report | “Other” intentionally groups several/null installer identities, while current filtering accepts exactly one installer id; it therefore has no click handler. | `UX / scope decision` | Should it open a multi-source filter, an explanatory sheet, or remain noninteractive with clearer affordance? |
+| RD-004 | Reddit: onlytanmoy / imported 2026-09-09 | Task conversation | Prevent Settings → Freezer descriptions from truncating; user suggests three lines or a detailed explanation before toggling. | Settings readability / accessibility | 1 report | All four Freezer switches now use fully wrapping titles and descriptions. A shared expanded row preserves one switch target and lets the scrolling category grow at larger text sizes. Other settings retain their compact defaults. | `implemented locally; automated and physical-device settings checks passed` | Native text-layout checks pass in all eight locales at narrow/large-text sizes, including enabled/disabled and touch semantics. Maintainer confirmed the settings changes in the debug APK on a physical device on 2026-09-10. Not merged/released. No extra tap or bottom sheet is needed to read the explanation. |
+| RD-005 | Reddit / imported 2026-09-09 | Task conversation | Name the active apps in the “N of N apps are active; freeze them?” confirmation. | Bulk-freeze confirmation detail | 1 report | The dialog counts enabled apps but does not render their labels. | `implementation gap`, likely small | How many names should be shown before truncation, and should the full selectable list be visible in a sheet? |
+
+### Triage notes for the newly imported requests
+
+#### TG-001 — legacy target-SDK installation
+
+**Selected by the maintainer as the first implementation on 2026-09-09.** Work is isolated in Doctor
+on `feat/legacy-apk-install`. The [implementation and acceptance record](../follow-ups/legacy-target-sdk-installation.md)
+tracks the actual verification separately from this intake snapshot.
+
+Android 15 raised the install floor to target API 24; Android 16 inherits it.  A target-23 APK can
+produce:
+
+```text
+INSTALL_FAILED_DEPRECATED_SDK_VERSION:
+App package must target at least SDK version 24, but found 23
+```
+
+The documented Android escape hatch is `adb install --bypass-low-target-sdk-block`; Thor's matching
+session command is `pm install-create --bypass-low-target-sdk-block`.  The platform only retains that
+hidden flag for system/root/shell or a debuggable-build caller.  Therefore this is feasible only on
+Thor's Root and ADB/wireless-Shizuku shell paths, not Dhizuku or ordinary installation paths.
+
+First capture the actual installer error and inspect the APK manifest: the requested option applies
+only if it is this low-*target*-SDK block, not a generic answer to every old-APK failure.
+Selected UX, amended by the maintainer: the installer warns and asks for confirmation when Install
+is tapped for an eligible old-target APK. **Settings → Installing → Allow legacy APK installs
+without asking** is off by default; deliberately enabling it skips that confirmation for eligible
+Root/Shizuku installs while retaining the inline warning. One-time approval never enables the
+setting, and background restore/reinstall behavior is unchanged. It must never silently retry a
+failed ordinary install. Test on the reporter's
+Android 16 device with a known-safe target-23 APK, split and monolithic packages, update/fresh install,
+and all privilege modes.  Official reference: [Android 15 minimum target API level](https://developer.android.com/about/versions/15/behavior-changes-all#minimum-target-api-level).
+
+#### TG-002 — website responsiveness
+
+No implementation should be selected until the reporter supplies a URL/section and a screenshot or
+short recording.  The most concrete code candidate is
+`web/public/follow-ups-report.html`: its header packs a badge, long title, and two labelled theme
+buttons into a non-wrapping row, and its mobile media query does not alter that header.  The normal
+Astro pages have mobile breakpoints, so a report against a different page cannot be inferred from
+this candidate.
+
+Ask for the exact URL (including `#section`), device/Android/Brave version, a full-screen capture,
+whether the issue is clipping, overlap, horizontal scroll, tiny content, or a dead interaction, and
+the page zoom/font-size setting.
+
+#### Reddit UI findings
+
+- Screenshot blocking is expected while Thor's biometric lock is armed or authentication is pending:
+  `HomeActivity` applies `FLAG_SECURE` to prevent Recents, screenshots, and recording from exposing
+  app data.  If the lock is off and the problem persists, it becomes a device-reproduction bug.
+  The 2026-09-10 local change explains this in all eight biometric-lock descriptions without
+  changing the security behavior; the explanation remains visible after wrapping.
+- The first Home control is the privilege-mode status icon.  It silently cycles available modes on a
+  normal tap and opens Privilege Check on long press; this is a discoverability/feedback problem
+  unless a device trace shows no mode change.
+- “Other” is intentionally not clickable today because it is an aggregate with no single installer
+  id.  Making it actionable requires a multi-source/unknown-source filter or an explanatory surface.
+- The default Settings subtitle renderer retains its two-line limit, but the selected 2026-09-10
+  implementation opts all Freezer switches and biometric lock into a fully expanded row. A fixed
+  three-line allowance can still truncate longer translations at larger font scales. The category
+  already scrolls, and reading the explanation does not add a competing tap action.
+- The bulk-freeze confirmation has the selected `AppInfo` values and currently discards their labels.
+  This is a small UX request once a localized list/truncation rule is agreed.
+
+#### RD-001 / RD-004 verification — 2026-09-10
+
+- `SettingsExpandedSwitchRowTest` covers five rows across eight locales at 320dp/2x text and
+  600dp/1.5x text, with the category's actual 24dp side padding: 80 row/locale/viewport combinations.
+  Native font metrics verify no overflow or ellipsis, Arabic RTL, and scroll reachability. Additional
+  checks preserve a single switch, semantic/touch activation, and disabled no-callback behavior.
+- Expanded text occupies the available column. This also avoids Compose 1.12.0's reconstructed
+  semantic paragraph reporting the maximum constraint width against a short label's intrinsic size.
+  The overflow assertions remain strict rather than suppressing that mismatch.
+- The focused run passed 34 tests, including the existing app-lock/cold-start and legacy-warning tests.
+- `test lintFossDebug lintStoreRelease assembleFossDebug` passed with JDK 21, serial execution and a
+  command-line-only 4 GiB Kotlin compiler heap. Both variants passed 2,731 tests across 229 suites,
+  with no failures/errors/skips. Lint has zero errors or `MissingTranslation` findings; existing
+  warnings remain (66 FOSS / 53 Store). The FOSS debug APK was assembled.
+- **Physical-device settings acceptance:** on 2026-09-10, the maintainer confirmed that all settings
+  changes in the tested debug APK display and behave correctly on a physical device, including the
+  screenshot-protection explanation and expanded Freezer descriptions. Device model, OS, font scale
+  and locale were not supplied; this is not an exhaustive device/font/locale matrix.
+- This confirmation does not establish screenshot/recording/Recents security behavior or TG-001's
+  end-to-end legacy APK installation acceptance. These settings changes are prepared for PR review on
+  `feat/legacy-apk-install` and are not yet merged or released; the existing app-lock behavior was not changed.
+
+## Rules for the final consolidated ranking
+
+1. Count independent people and channels, not duplicate wording or GitHub reactions alone.
+2. Score the **remaining capability**, not a whole historical issue whose easiest half already shipped.
+3. Preserve mode boundaries: Root, Shizuku, Dhizuku, and unprivileged Android do not have the same APIs.
+4. Treat a hardware/OEM validation matrix as a release gate, not evidence that the underlying feature is unbuilt.
+5. Keep safety, privacy, security, and Play-policy decisions visible; never bury them in a generic effort estimate.
+6. Do not turn a README “Upcoming” bullet into a delivery promise until a use case, scope, and acceptance criteria exist.
+
+## Immediate next actions
+
+1. Complete TG-001's end-to-end device acceptance and release-policy review before calling it delivered.
+2. Append the next Telegram and Reddit messages to the intake table and merge duplicates into canonical opportunities.
+3. Re-check any older documentation claim that conflicts with current `dev` before assigning an implementation status.
+4. Produce a cross-source priority order only after the manual imports are complete.
+5. Separately clean up tracker state for closeable issues; that is administrative work, not evidence of new feature delivery.

--- a/docs/follow-ups/README.md
+++ b/docs/follow-ups/README.md
@@ -186,6 +186,16 @@ renumber breaks those silently with nothing to catch it.
 
 ---
 
+## Current implementation — 2026-09-10
+
+This targeted update does not re-sweep the historical ranking below.
+
+| Item | Tier | Status |
+|---|---|---|
+| [TG-001: Legacy target-SDK installation](legacy-target-sdk-installation.md) | 0/1 | Implemented locally on `feat/legacy-apk-install`, including a default-off saved setting and per-install confirmation. Updated test/lint gates pass; an earlier API-36 shell/root package-manager smoke test passed. Not merged/released; full Thor/Shizuku/Samsung device acceptance and Store-policy review remain open. |
+| [RD-001: Explain screenshot protection](../analysis/community-feature-request-assessment-2026-09.md#reddit-ui-findings) | 0/1 | Implemented locally on the same feature branch in all eight locales. Biometric-lock copy explains screenshots, recording and Recents protection; authentication and `FLAG_SECURE` behavior are unchanged. Full unit tests, both lint gates and debug APK assembly pass. Maintainer confirmed physical-device settings acceptance on 2026-09-10; this is not screenshot/recording/Recents security testing. Not merged/released. |
+| [RD-004: Readable Freezer descriptions](../analysis/community-feature-request-assessment-2026-09.md#reddit-ui-findings) | 0/1 | Implemented locally: four Freezer switches and biometric lock use fully wrapping titles/descriptions while retaining one switch target. Native-layout checks pass across eight locales at 320dp/2x and 600dp/1.5x, including RTL and touch/disabled semantics. Full test/lint gates pass. Maintainer confirmed physical-device settings acceptance on 2026-09-10. Not merged/released. |
+
 ## Do next — every open item, ranked
 
 Ranked by **impact × ease**: what buys the most for the least. This is the answer to *"what should I

--- a/docs/follow-ups/legacy-target-sdk-installation.md
+++ b/docs/follow-ups/legacy-target-sdk-installation.md
@@ -114,7 +114,7 @@ matrix. The device-installation and Store-policy checklist below remains open.
 
 ### API-36 package-manager smoke test
 
-A disposable, headless, read-only instance of `Thor_Root_API36` was used with snapshots disabled
+A disposable, headless instance of `Thor_Root_API36` was used with snapshots disabled
 for the initial implementation on 2026-09-09. This platform-only evidence was not repeated for the
 subsequent setting/prompt revision.
 Fingerprint: `google/sdk_gphone64_arm64/emu64a:16/BE2A.250530.026.F3/13894323:userdebug/dev-keys`.
@@ -131,7 +131,7 @@ For both verified shell UID 2000 and root UID 0, the streamed session sequence
 
 Root identity was established with emulator `adb root`, not an Odin integration run. This verifies
 the platform flag and streaming-session mechanism, **not** Thor's full UI/Odin/Shizuku integration
-or a production OEM build. The fixture was uninstalled and the read-only emulator shut down without
+or a production OEM build. The fixture was uninstalled and the disposable emulator shut down without
 saving its state. No app was installed on the connected physical phone.
 
 ## Device acceptance still required

--- a/docs/follow-ups/legacy-target-sdk-installation.md
+++ b/docs/follow-ups/legacy-target-sdk-installation.md
@@ -1,0 +1,160 @@
+# Legacy target-SDK installation (TG-001)
+
+Status: implemented locally on `feat/legacy-apk-install`; not merged or released. End-to-end device
+acceptance and Store-policy review remain open.
+Baseline: `dev` at `504e3418`, 2026-09-09.
+
+## Request and boundaries
+
+A Telegram user with a Galaxy S24 Ultra on Android 16 wants to install a target-23 APK using Shizuku.
+This concerns Android's minimum **target SDK for new installs**, not an APK's `minSdkVersion`.
+
+- Android 14 normally blocks targets below API 23. Android 15/16 normally block targets below API 24.
+- The override is `pm install-create --bypass-low-target-sdk-block` on Root/Shizuku shell sessions.
+- Normal, Dhizuku, and external installs cannot apply this override. Android below API 34 does not
+  support this flag. OEM-specific package-manager restrictions can still differ.
+- Signature, ABI, split consistency, version/downgrade, device compatibility, and Xiaomi system-app
+  update restrictions are independent; this option does not bypass them or guarantee the app runs.
+
+Official platform guidance: [Android 15 minimum target API level](https://developer.android.com/about/versions/15/behavior-changes-all#minimum-target-api-level).
+
+## Implementation
+
+The portable installer identifies APKs whose parsed target is below the known platform floor. The
+target comes from the already-staged APK/selected bundle base, never untrusted sidecar metadata.
+Unknown target SDK does not authorize a bypass.
+
+**Maintainer amendment, 2026-09-09 UTC:** Settings → Installing now includes **Allow legacy APK
+installs without asking**, off by default. The full setting title and security description remain
+visible rather than being ellipsized. This replaces the first implementation's per-install checkbox.
+
+- **Setting off:** tapping Install for an eligible Root/Shizuku APK opens a warning naming the app,
+  package, target SDK, and platform floor. Nothing is installed until **Install this time** is
+  accepted. Cancel leaves the installer ready and does not change the saved setting.
+- **Setting on:** tapping Install automatically supplies the bypass for eligible APKs and skips the
+  extra confirmation. The inline target-SDK warning remains, together with the saved-setting status.
+- Turning the setting off restores the prompt on the next install. Its authoritative value is read
+  for each attempt; an unreadable preference fails closed to asking, rather than assuming consent.
+
+One-time approval never enables the setting. Confirmation IDs and selection revisions prevent stale
+callbacks or delayed preference reads from authorizing another APK, mode, permission answer, or
+dismissed sheet. An install attempt consumes one-time approval; retries require a new confirmation
+unless the user has enabled the saved setting.
+
+The warning explains that older apps can receive permissions under their legacy permission model.
+Neither this setting nor confirmation enables the separate `-g` option. The setting applies to the
+interactive installer, not background/headless restore/reinstall callers, whose default remains no
+bypass. Normal/Dhizuku/external modes never receive it. Shizuku shell failure with an approved
+override remains terminal and preserves the shell error; it cannot fall back to reflection/normal
+installation that drops the selected option. Root retains its existing session path.
+
+## Local verification
+
+The saved-setting/confirmation-on-Install revision, including the Asgard compatibility correction
+below, passed the following on 2026-09-09 UTC with JDK 21. These results supersede the earlier counts:
+
+```sh
+./gradlew --no-daemon test lintFossDebug lintStoreRelease assembleFossDebug \
+  compileFossDebugAndroidTestKotlin --max-workers=1 --console=plain
+```
+
+- FOSS and Store: **2,727 tests each**, zero failures, errors, or skips (228 suites per variant).
+- Lint: zero errors and zero `MissingTranslation` findings. Existing warning totals remain 66 for
+  FOSS Debug and 53 for Store Release; dependency/toolchain hints also remain.
+- FOSS Debug APK assembly and Android-test Kotlin compilation passed. Instrumentation tests were
+  compiled, not executed.
+- Coverage includes API-floor boundaries, parsed target `0` versus unknown, target metadata,
+  default-off confirmation-on-Install, saved opt-in/no-repeat behavior, one-time approval without
+  preference writes, cancel/retry behavior, stale confirmation IDs, delayed/failed/cancelled preference
+  reads, duplicate taps, and persistence/catalog wiring. Command tests cover default-off flags,
+  Root one-APK/split propagation, and terminal Shizuku failure.
+- The new setting's full title and security description pass native-rendered Robolectric text-layout
+  checks at 320dp width and 1.5× font scale, with one enabled, accessible switch. Installer warning
+  and confirmation UI tests also pass. These are automated checks, not on-device UI acceptance.
+- All eight locales contain the setting, saved-setting status, and confirmation text, with matching
+  formatted placeholders.
+
+### Home/Settings startup regression discovered during acceptance
+
+The maintainer's subsequent launch log exposed a separate Asgard/Material 3 binary incompatibility:
+`ConnectedButtonGroup` in Asgard 2.0.0 calls `ToggleButtonDefaults.toggleButtonColors`, which Material
+3 `1.5.0-alpha27` renamed to `colors` without retaining the old binary method. The September 8
+dependency update (`eada3844`) had undone the earlier alpha26 compatibility fix (`5479b643`). The
+failure occurs in the Home header, before any legacy APK install is requested.
+
+The catalog now restores `1.5.0-alpha26`; a strict runtime constraint prevents a BOM/transitive
+dependency from silently raising it, and Dependabot excludes the exact known-broken alpha27 version.
+Other versions remain eligible but must pass the new real-Asgard Home-header and Settings-picker UI
+regressions. Both tests reproduced the reported `NoSuchMethodError` before the pin and passed after
+it. The previous green suite did not render these controls, so it did not establish startup safety.
+The full test/lint/build gates above passed again with this dependency fix, including both new UI
+tests in each variant. On-device relaunch has not been performed by the agent.
+
+### PR verification update — 2026-09-10
+
+After syncing the feature branch with `dev` at `5c9672e6` (the web-only dependency updates in
+[PR #463](https://github.com/trinadhthatakula/Thor/pull/463)), the combined legacy-installer,
+settings-readability and crash-fix changes passed the required gates again:
+
+```sh
+./gradlew test lintFossDebug lintStoreRelease assembleFossDebug \
+  --console=plain --no-parallel --max-workers=1 \
+  '-Pkotlin.daemon.jvmargs=-Xmx4g -XX:+UseG1GC'
+```
+
+JDK 21 was used. The FOSS Debug and Store Debug reports each contain **2,731 tests across 229
+suites**, with zero failures, errors or skips. Lint reports zero errors and zero `MissingTranslation`
+findings; existing warning totals remain 66 for FOSS Debug and 53 for Store Release. These counts
+supersede the earlier 2,727-test checkpoint. Gradle reused unchanged task outputs/cache entries.
+
+The maintainer confirmed that all settings changes in the debug APK display and behave correctly on
+a physical device. That confirms the settings UI, not end-to-end legacy APK installation through
+Thor/Root/Shizuku, screenshot/recording/Recents security testing, or an exhaustive device/locale/font
+matrix. The device-installation and Store-policy checklist below remains open.
+
+### API-36 package-manager smoke test
+
+A disposable, headless, read-only instance of `Thor_Root_API36` was used with snapshots disabled
+for the initial implementation on 2026-09-09. This platform-only evidence was not repeated for the
+subsequent setting/prompt revision.
+Fingerprint: `google/sdk_gphone64_arm64/emu64a:16/BE2A.250530.026.F3/13894323:userdebug/dev-keys`.
+The fixture was a purpose-built, signed APK with no code or requested permissions:
+`com.valhalla.thor.test.legacytarget.tg001`, version 1, min SDK 23, target SDK 23.
+
+For both verified shell UID 2000 and root UID 0, the streamed session sequence
+(`pm install-create` → `cat ... | pm install-write -S ... -` → `pm install-commit`) gave:
+
+| Session flags | Fresh-install result |
+|---|---|
+| `-r --user 0` | `INSTALL_FAILED_DEPRECATED_SDK_VERSION: App package must target at least SDK version 24, but found 23` |
+| `-r --bypass-low-target-sdk-block --user 0` | `Success`; package presence confirmed with `pm path` |
+
+Root identity was established with emulator `adb root`, not an Odin integration run. This verifies
+the platform flag and streaming-session mechanism, **not** Thor's full UI/Odin/Shizuku integration
+or a production OEM build. The fixture was uninstalled and the read-only emulator shut down without
+saving its state. No app was installed on the connected physical phone.
+
+## Device acceptance still required
+
+Use only known-safe, purpose-built APKs, and record device/ROM, build, privilege UID/mode, package,
+target SDK, version code, exact error, and outcome. Use a clean test profile/package for fresh-install
+checks: updates to an already-installed legacy app can have different platform behavior.
+
+- [ ] Android 14: target 22 (and a valid parsed target-0 fixture if available) is blocked without
+  consent and installable with an authorized override;
+  target 23 needs no override.
+- [ ] Android 15/16: target 23 is blocked by default and succeeds with consent through Root and
+  ADB/wireless Shizuku. Repeat on the reporter's physical Android 16 Samsung device.
+- [ ] Monolithic APK and a valid legacy split set use the same session flag; fresh install and update
+  preserve their distinct behavior.
+- [ ] With the setting off: cancel the warning, change mode, pick another APK, dismiss/reopen, and
+  retry after failure. Each eligible attempt requires fresh confirmation; stale callbacks do nothing.
+- [ ] Enable the setting manually: eligible installs skip the confirmation while retaining the
+  inline warning. Disable it: the next eligible install asks again. Restart Thor to verify the
+  saved setting persists; a failed setting write must not imply that it was saved.
+- [ ] Normal/Dhizuku/external modes never apply the override. Disconnected Shizuku and a rejected
+  shell install report failure without switching to another installer.
+- [ ] Verify signing mismatch, ABI mismatch, and unrelated OEM refusal remain failures; check that
+  permission grants are governed by Android's permission model and the separate grant option.
+- [ ] Review Store-distribution policy and localized warning wording before release. No policy
+  approval or physical-device acceptance is implied by the implementation or local tests.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,9 @@ lifecycleRuntimeKtx = "2.11.0"
 activityCompose = "1.13.0"
 composeBom = "2026.08.00"
 lottieCompose = "6.7.1"
-material3 = "1.5.0-alpha27"
+# Asgard 2.0.0 calls ToggleButtonDefaults.toggleButtonColors, removed in alpha27.
+# Upgrade only with a compatible Asgard release and passing connected-button UI tests.
+material3 = "1.5.0-alpha26"
 kotlinxSerializationJson = "1.11.0"
 splashscreen = "1.2.0"
 shizuku = "13.1.5"


### PR DESCRIPTION
## What & why

Address the community requests to install older-target APKs with explicit consent, explain Thor's screenshot protection, and make Freezer settings descriptions readable. Include the Asgard/Material3 startup-crash fix found while testing this work.

Targets `dev` from `feat/legacy-apk-install`. The branch includes the merged web dependency sync from #463; this PR makes no additional web dependency changes and does not bump `versionCode`.

## Changes

- Parse the staged APK/base APK's target SDK and support `--bypass-low-target-sdk-block` through Android 14+ Root/Shizuku install sessions only. This does not bypass signature, ABI, downgrade, or OEM system-app restrictions.
- Add **Allow legacy APK installs without asking**, off by default. Otherwise require an app-specific **Install this time** confirmation; retain the inline warning when the saved setting is enabled. Keep runtime-permission grants separate.
- Guard against stale confirmations, changed selections/modes, duplicate taps, and failed preference reads. Background callers remain default-off; approved Shizuku failures do not silently fall back to a path that drops the requested option.
- Fully wrap Freezer/security setting titles and descriptions, preserve one accessible switch target, and explain screenshot/recording/Recents protection in all eight locales without changing app-lock behavior.
- Restore and strictly pin Material3 `1.5.0-alpha26` for Asgard `2.0.0`, exclude the known-incompatible alpha27 update, and add real Home/Settings connected-button render/selection regressions. The Asgard upgrade remains separate.
- Add the consolidated GitHub/Telegram/Reddit assessment and explicit implementation/validation follow-ups. No community issues are automatically closed by this PR.

## Testing

- [x] Required local gates plus debug APK assembly passed on JDK 21:

  ```sh
  ./gradlew test lintFossDebug lintStoreRelease assembleFossDebug \
    --console=plain --no-parallel --max-workers=1 \
    '-Pkotlin.daemon.jvmargs=-Xmx4g -XX:+UseG1GC'
  ```

- [x] FOSS Debug and Store Debug: **2,731 tests each**, 229 suites each; zero failures, errors, or skips. Gradle reused unchanged task outputs/cache entries.
- [x] FOSS Debug / Store Release lint: zero errors and zero `MissingTranslation`; existing warnings remain at 66 / 53.
- [x] Native text-layout checks cover five expanded rows across eight locales and two viewport/font configurations (80 combinations), including actual category padding, Arabic RTL, scrolling, touch semantics, and disabled behavior.
- [x] Maintainer ran the debug APK on a physical device and confirmed all settings changes display and behave correctly.
- [x] Earlier API-36 package-manager smoke checks verified target-23 rejection by default and installation with the flag under shell UID 2000 and root UID 0. This was platform/session evidence, not an end-to-end Thor/Odin/Shizuku test.
- [x] `git diff --check` passes.

## Remaining acceptance before release

- [ ] End-to-end legacy APK installation through Thor under Root and Shizuku, including Android 14/15/16, Samsung/OEM behavior, split APKs, consent retry/cancellation, and unsupported-mode boundaries.
- [ ] Store-distribution policy and localized security-warning review.

The settings-device confirmation does not establish legacy-install success, screenshot/recording/Recents security behavior, or an exhaustive device/font/locale matrix. Detailed evidence and the remaining checklist are in `docs/follow-ups/legacy-target-sdk-installation.md`.

## Screenshots

Physical-device acceptance was provided by the maintainer; no screenshot or recording was supplied.

## Checklist

- [x] Changes are scoped to the stated purpose; local IDE files are excluded.
- [x] User-facing documentation and validation status are updated.
- [x] PR targets `dev`; permanent branches are unchanged.
- [x] Standard feature/fix PR: no `versionCode` bump or release artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing apps targeting older Android versions on Android 14+ through Root or Shizuku.
  * Added one-time confirmation prompts and an optional setting to allow legacy APK installations without repeated prompts.
  * Added clear warnings when the selected installation mode or device cannot support the override.
  * Added target SDK details to package analysis.

* **UI Improvements**
  * Improved installer and settings descriptions for readability on large text and narrow screens.
  * Clarified biometric lock protections across supported languages.

* **Documentation**
  * Added documentation covering legacy APK installation behavior and current feature status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->